### PR TITLE
Update DAP snippet location

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -41,8 +41,8 @@
     });
   });
   $(document).ready(function() {
-    Tipped.create('.term-tooltip', { 
-      position: 'topright', 
+    Tipped.create('.term-tooltip', {
+      position: 'topright',
       radius: false,
       maxWidth: 200,
       offset: { y: 5 },
@@ -134,7 +134,7 @@
               $("#first").removeClass('scroll_item_active');
               $("#third").removeClass('scroll_item_active');
               $("#fourth").removeClass('scroll_item_active');
-              
+
           }
           if ($("#third1").offset().top < $(window).scrollTop() + 150) {
               $("#third").addClass('scroll_item_active');
@@ -174,7 +174,7 @@
 {% if page.title == "Data" %}
   <script src='{{ site.baseurl }}/static/js/dashboard.js'></script>
   <script type="text/javascript">
-   
+
   /*****************\
      Tab Switching
   \*****************/
@@ -219,7 +219,7 @@
         table = dashTable;
       else
         table = dashTotalsTable;
-      var sort = $(this).children('i').hasClass('fa-chevron-down') ? d3.descending : d3.ascending; 
+      var sort = $(this).children('i').hasClass('fa-chevron-down') ? d3.descending : d3.ascending;
       sort_dataTable(table,data[0],sort);
 
       //Remove arrows
@@ -231,7 +231,7 @@
       //Add Arrow
       if (table.order()==d3.ascending)
         $('i',$(this)).addClass('fa-chevron-down');
-      else 
+      else
         $('i',$(this)).addClass('fa-chevron-up');
     })
   });
@@ -267,7 +267,7 @@
   \*****************/
   $(document).ready(function(){
     $('section#tab-select a').each(function(index){
-      
+
       $(this).click(function(){
         $('#tab-select a').each(function(){
           $(this).removeClass('active');
@@ -345,5 +345,5 @@ $(document).ready(function(){
   ga('send', 'pageview');
 </script>
 
-<!-- Digital Analytics Program roll-up -->
-<script id="_fed_an_ua_tag" src="https://dvs6mwdoj87wa.cloudfront.net/dap-1.0.min.js"></script>
+<!-- Digital Analytics Program roll-up, see the data at https://analytics.usa.gov -->
+<script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -336,11 +336,14 @@ $(document).ready(function(){
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-48605964-8', 'gsa.gov');
 
   // anonymize user IPs (chops off the last IP triplet)
   ga('set', 'anonymizeIp', true);
+
+  // forces SSL even if the page were somehow loaded over http://
+  ga('set', 'forceSSL', true);
 
   ga('send', 'pageview');
 </script>


### PR DESCRIPTION
I moved the DAP snippet earlier today, as part of a [big DAP reorg](https://github.com/GSA/analytics.usa.gov/pull/105) as we prepare to launch the dashboard. 

I forgot that this site was pulling from my temporary CloudFront URL, and so I have caused you a several-hour outage (in your DAP-reported data only, not in EITI's own GA account). My apologies for this. I have replaced a copy of the DAP at the old URL, so that it will continue to work until this pull request is merged and deployed.

This PR updates the DAP location to pull from the (far nicer) new URL for our cloud-hosted copy of the DAP. (This is also a version bump of the DAP snippet, from 1.0.0 to 1.0.1.) I also added a note in the comments above, linking to the soon-to-be-launched dashboard.

Finally, I did some marginal tightening of the HTTPS settings for GA, as copied from the GA snippet we use on 18f.gsa.gov.