### PR TITLE
Adds url to oldie message.

### DIFF
--- a/static/oldie.html
+++ b/static/oldie.html
@@ -4,7 +4,7 @@
   <title>Natural Resource Revenue from U.S. Federal Lands</title>
 </head>
 <body>
-    <p>Sorry, but this site is not supported on Internet Explorer 8 and older. Please use another browser, or upgrade to a more recent version of Internet Explorer.</p>
+    <p>Sorry, but this site is not supported on Internet Explorer 8 and older. Please use another browser and navigate to https://useiti.doi.gov/, or upgrade to a more recent version of Internet Explorer.</p>
     <p>For more information on the browsers available to you, go to: <a href="http://whatbrowser.org">http://whatbrowser.org</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
Responds to user confusion around what to do when the 'oldie' message is displayed. Now they can copy-and-paste the url into a new browser instead of needing to go back, reload referencing page in new browser, and clicking again.