### PR TITLE
Refactor server routes and data

### DIFF
--- a/data/decorator.js
+++ b/data/decorator.js
@@ -1,0 +1,106 @@
+var Festoon = require('festoon');
+var path = __dirname;
+
+console.warn('data/decorate path:', path);
+
+module.exports = new Festoon({
+  path: path,
+  sources: {
+    // master resources (commodities) list, plus other metadata
+    resources:  'commodities.json',
+
+    // single resource: {slug, name, colors, (sub-)commodities}
+    resource: Festoon.transform('resources', function(resources, params) {
+      var slug = params.resource;
+      if (!resources.groups[slug]) return null;
+      return {
+        slug: slug,
+        name: resources.groups[slug],
+        colors: resources.colors[slug],
+        commodities: Object.keys(resources.commodities)
+          .map(function(name) {
+            return resources.commodities[name].group === slug;
+          })
+      };
+    }),
+
+    locations: {
+      onshore: '#states',
+      offshore: '#offshoreAreas'
+    },
+
+    // revenues
+    nationalRevenue: {
+      onshore: '#stateRevenues',
+      offshore: '#offshoreRevenues'
+    },
+
+    // production volumes
+    nationalProduction: {
+      onshore: '#stateProduction',
+      offshore: '#offshoreProduction'
+    },
+
+    // state data sources
+    states: 'input/geo/states.csv',
+    state: {
+      // {{ state.meta.name }}
+      meta: Festoon.findByParam('states', 'state', 'abbr'),
+      // {{ state.revenues[] }}
+      revenues: Festoon.transform.filter('stateRevenues', function(d) {
+        return d.State === this.state;
+      }),
+      // {{ state.production[] }}
+      production: Festoon.transform.filter('stateProduction', function(d) {
+        return d.State === this.state;
+      })
+    },
+
+    // topology: 'geo/us-topology.json',
+
+    counties: 'output/county/by-state/:state/counties.tsv',
+
+    allCounties: 'output/county/counties.tsv',
+
+    county: {
+      name: function(params, done) {
+        return done(null, params.county);
+      },
+      revenues: Festoon.transform.filter('countyRevenues', function(d) {
+        return d.County === this.county;
+      })
+    },
+
+    areas: '#offshoreAreas',
+    area: '#offshoreArea',
+
+    // offshore planning areas
+    offshoreAreas: 'input/geo/offshore/areas.tsv',
+    offshoreArea: {
+      // {{ area.meta.name }}
+      meta: Festoon.findByParam('offshoreAreas', 'area', 'id'),
+      // {{ area.revenues[] }}
+      // TODO: Area column should be a 3-letter ID, not name
+      revenues: Festoon.transform.filter('offshoreRevenues', function(d) {
+        return d.Area === this.area;
+      }),
+      // {{ area.production[] }}
+      // TODO: Area column should be a 3-letter ID, not name
+      production: Festoon.transform.filter('offshoreProduction', function(d) {
+        return d.Area === this.area;
+      })
+    },
+
+    // state (onshore) sources
+    stateRevenues:      'output/state/revenues-yearly.tsv',
+    stateProduction:    'output/state/volumes-yearly.tsv',
+
+    // county data sources
+    countyRevenues:     'output/county/by-state/:state/revenues-yearly.tsv',
+    allCountyRevenues:  'output/county/revenues-yearly.tsv',
+
+    // offshore (planning area) sources
+    offshoreRevenues:   'output/offshore/revenues-yearly.tsv',
+    offshoreProduction: 'output/offshore/volumes-yearly.tsv',
+  }
+});

--- a/lib/server-helpers.js
+++ b/lib/server-helpers.js
@@ -1,6 +1,7 @@
 var tito = require('tito');
 var streamify = require('stream-array');
 var dl = require('datalib');
+var fs = require('fs');
 
 /*
  * Returns a function that renders the response with the named
@@ -70,10 +71,59 @@ var api = function(source, config) {
   };
 };
 
+var addRoutes = function(app, routes, data) {
+  var _routes = [];
+
+  for (var url in routes) {
+    var route = routes[url];
+    var middleware = [];
+
+    if (route.redirect) {
+      middleware.push(redirect(route.redirect));
+    } else if (route.data && data) {
+      if (Array.isArray(route.data)) {
+        middleware.push(data.decorate.apply(data, route.data));
+      } else {
+        middleware.push(data.decorate(route.data));
+      }
+    }
+
+    if (route.view) {
+      middleware.push(view(route.view));
+    } else if (route.api) {
+      if (typeof route.api === 'object') {
+        middleware.push(api(route.api.key, route.api.params));
+      } else {
+        middleware.push(api(route.api));
+      }
+    }
+
+    _routes.push({
+      url: url,
+      middleware: middleware
+    });
+  }
+
+  // sort routes by URL descending, so more specific ones
+  // get served first
+  _routes.sort(function(a, b) {
+    return a.url > b.url
+      ? -1
+      : a.url < b.url ? 1 : 0;
+  });
+
+  _routes.forEach(function(route) {
+    app.get.apply(app, [route.url].concat(route.middleware));
+  });
+
+  return _routes;
+};
+
 module.exports = {
   view: view,
   redirect: redirect,
-  api: api
+  api: api,
+  addRoutes: addRoutes
 };
 
 function createFilter(query) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express": "^4.12.4",
     "extend": "^2.0.0",
     "festoon": "0.0.4",
+    "js-yaml": "^3.3.1",
     "mkdirp": "^0.5.0",
     "node-sass-middleware": "^0.9.0",
     "nunjucks": "^1.3.4",
@@ -38,7 +39,7 @@
   "scripts": {
     "test": "mocha",
     "start": "node server.js",
-    "watch": "watchy -w *.js,lib,node_modules -- node server.js"
+    "watch": "watchy -w *.js,lib,routes.yml -- node server.js"
   },
   "repository": {
     "type": "git",

--- a/routes.yml
+++ b/routes.yml
@@ -1,0 +1,45 @@
+/:
+  view: index
+
+/communities:
+  view: subpage
+
+/locations:
+  view: locations
+/locations/onshore:
+  redirect: /locations
+
+/locations/onshore/:state.json:
+  data: state
+  api: state
+
+/locations/onshore/:state/revenues.(csv|json):
+  data: stateRevenues
+  api:
+    key: stateRevenues
+    params:
+      filter: true
+
+/locations/onshore/:state:
+  data:
+    - state
+    - counties
+  view: state
+
+/locations/onshore/:state/:county:
+  data:
+    - state
+    - county
+  view: county
+/locations/offshore/:area:
+  data: area
+  view: offshore-area
+
+/resources:
+  view: resources
+/resources/:resource:
+  data: resource
+  view: resource
+
+/styleguide:
+  view: styleguide

--- a/server.js
+++ b/server.js
@@ -183,53 +183,9 @@ app.use(function(req, res, next) {
   next();
 }, data.decorate(['resources', 'locations']));
 
-// index
-app.get('/', view('index'));
-
-// index
-app.get('/resources', view('resources'));
-app.get('/resources/:resource',
-  data.decorate('resource'),
-  view('resource'));
-
-// styleguide
-app.get('/styleguide', view('styleguide'));
-
-// communities
-app.get('/communities', view('subpage'));
-
-// locations page
-app.get('/locations',
-  view('locations'));
-
-// redirect /locations/onshore -> /locations
-app.get('/locations/onshore', redirect('/locations'));
-
-// state data
-app.get('/locations/onshore/:state.json',
-  data.decorate('state'),
-  api('state'));
-
-// state page
-app.get('/locations/onshore/:state/revenues.(csv|json)',
-  data.decorate('stateRevenues'),
-  api('stateRevenues', {filter: true}));
-
-// state page
-app.get('/locations/onshore/:state',
-  data.decorate(['state', 'counties']),
-  view('state'));
-
-// state page
-app.get('/locations/onshore/:state/:county',
-  data.decorate(['state', 'county']),
-  view('county'));
-
-// offshore area page
-app.get('/locations/offshore/:area',
-  // XXX: {area: 'offshoreArea'} should work!
-  data.decorate('area'),
-  view('offshore-area'));
+var yaml = require('js-yaml');
+var routes = yaml.safeLoad(fs.readFileSync('routes.yml', 'utf8'));
+helpers.addRoutes(app, routes, data);
 
 app.listen(appEnv.port, appEnv.bind, function(error) {
   if (error) return console.error('error:', error);


### PR DESCRIPTION
This PR moves all of the server routes to a standalone file, `routes.yml`, and moves the data logic to `data/decorator.js`. The main goal was to make the routes easier to declar, introduce automatic sorting of route URLs (reducing the potential for issues of ordering in `server.js`), and reduce the overall size of `server.js` for maintainability.

The `routes.yml` file is structured like this:

```yaml
/url:
  view: basename

/other/url:
  data: dataSourceName
  view: other-basename
```

Only the following properties of a route URL are recognized:

* `view`: the basename of the view file. If you have `view: foo`, the view will render `views/foo.html`.
* `data`: "decorate" the request with one or more data sources from `data/decorator.js`. This can be specified as a single string (the "data key"), a list of keys (inline: `['source1', 'source2']` or with a hyphenated list), or a map (`target: source`).
* `redirect`: redirect to the named route.
* `api`: expose the data as a JSON or CSV data endpoint (needs documentation)