### PR TITLE
Add HTTP basic auth

### DIFF
--- a/lib/server-helpers.js
+++ b/lib/server-helpers.js
@@ -119,10 +119,18 @@ var addRoutes = function(app, routes, data) {
   return _routes;
 };
 
+var httpAuth = require('http-auth');
+var auth = function(creds) {
+  return httpAuth.connect(httpAuth.basic({}, function(user, pass, cb) {
+    return cb(user === creds.username && pass === creds.password);
+  }));
+};
+
 module.exports = {
   view: view,
   redirect: redirect,
   api: api,
+  auth: auth,
   addRoutes: addRoutes
 };
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express": "^4.12.4",
     "extend": "^2.0.0",
     "festoon": "0.0.4",
+    "http-auth": "^2.2.8",
     "js-yaml": "^3.3.1",
     "mkdirp": "^0.5.0",
     "node-sass-middleware": "^0.9.0",

--- a/server.js
+++ b/server.js
@@ -63,6 +63,15 @@ app.use('/data/commodities.json', express.static(__dirname + '/data/commodities.
 // get the data decorator
 var data = require('./data/decorator');
 
+if (process.env.HTTP_BASIC_AUTH) {
+  var bits = process.env.HTTP_BASIC_AUTH.split(':', 2);
+  var auth = helpers.auth({
+    username: bits[0],
+    password: bits[1]
+  });
+  app.use(auth);
+}
+
 // common data
 app.use(function(req, res, next) {
   // make "request" available in templates


### PR DESCRIPTION
Hey @dlapiduz, can you check my work on this? I've brought in [http-auth](https://www.npmjs.com/package/http-auth) and am using it if `process.env.HTTP_BASIC_AUTH` is set. It's assumed to take the form `username:password`.