### PR TITLE
Make the revene map work w/all resources

### DIFF
--- a/js/components/eiti-map.js
+++ b/js/components/eiti-map.js
@@ -484,8 +484,13 @@
 
   function evaluator(expression) {
     return new Function(
-      'd',
-      'with (d) { return (' + expression + '); }');
+      'd', [
+        'with (d) { try { ',
+          'return (' + expression + '); ',
+        '} catch (error) { ',
+          'return null; ',
+        '} }'
+      ].join(''));
   }
 
 })(this);

--- a/views/index.html
+++ b/views/index.html
@@ -35,7 +35,7 @@
 
           <form>
             <label>Choose a location
-              {{ location_selector(locations=locations) }}
+              {{ location_selector(locations=locations, prefix='/resources/all/revenue/') }}
             </label>
           </form>
 

--- a/views/macros.html
+++ b/views/macros.html
@@ -21,10 +21,10 @@
   </table>
 {% endmacro %}
 
-{% macro location_selector(locations=[], prefix='/locations/', id=null, value=null) %}
+{% macro location_selector(locations=[], prefix='/locations/', id=null, value=null, none_option=null) %}
   <select id="{{ id }}" onchange="window.location = '{{ prefix }}' + this.value"
     data-selected="{{ value }}">
-    <option value="">States and offshore areas</option>
+    {% if none_option %}<option value="">{{ none_option }}</option>{% endif %}
     <optgroup label="States">
       {% for state in locations.onshore %}
       <!-- {{ state|jsonify }} -->

--- a/views/resource.html
+++ b/views/resource.html
@@ -23,7 +23,14 @@
       <form>
         <!-- region "{{ region|jsonify }}" -->
         <label>
-          {{ location_selector(locations=locations, prefix=location_prefix_url, value=region.id) }}
+          {{
+            location_selector(
+              locations=locations,
+              prefix=location_prefix_url,
+              value=region.id,
+              none_option='All states and offshore areas'
+            )
+          }}
         </label>
       </form>
 

--- a/views/resource.html
+++ b/views/resource.html
@@ -184,8 +184,12 @@
 
   var params = {
     resource: '{{ request.params.resource }}',
-    color: '{{ resources.colors[request.params.resource].primary }}'
+    color: '{{ resources.colors[request.params.resource].primary }}' || '#000'
   };
+
+  var filter = (params.resource && params.resource !== 'all')
+    ? function(d) { return d.Resource === params.resource; }
+    : null;
 
   var map = d3.select('#region-map');
   var slider = d3.select('#year-slider')
@@ -234,10 +238,10 @@
       return;
     }
 
-    var resource = params.resource;
-    var values = data.filter(function(d) {
-      return d.Resource === resource;
-    });
+    var values = filter
+      ? data.filter(filter)
+      : data;
+    // console.log('values:', values);
 
     valuesByYear = d3.nest()
       .key(dl.accessor('Year'))
@@ -269,7 +273,7 @@
     d3.select('#total-revenue')
       .text(formatDollars(total));
 
-    console.log('max:', max, numbers);
+    // console.log('max:', max, numbers);
 
     var scale = colorScale
       .domain([0, max]);


### PR DESCRIPTION
This PR fixes a couple of things:

1. Puts some guards in place on the map component.
1. Adds a "none" option to the location selector.
1. Fixes the display of revenues for all resources on the map, across all geographies.
1. Fixes #552