### PR TITLE
Show exports data on the US map

### DIFF
--- a/views/resource.html
+++ b/views/resource.html
@@ -60,11 +60,11 @@
 
           <div class="group_inline-right">
             <form>
-              <select>
-                <option value="revenue">Revenues</option>
-                <option value="production">Production</option>
-                <option value="exports">Exports</option>
-                <option value="jobs">Jobs</option>
+              <select name="datatype" onchange="location.href = location.href.replace('{{ request.params.datatype }}', this.value);">
+                <option value="revenue"{% if request.params.datatype == 'revenue' %} selected{% endif %}>Revenues</option>
+                <option value="production"{% if request.params.datatype == 'production' %} selected{% endif %}>Production</option>
+                <option value="exports"{% if request.params.datatype == 'exports' %} selected{% endif %}>Exports</option>
+                <option value="jobs"{% if request.params.datatype == 'jobs' %} selected{% endif %}>Jobs</option>
               </select>
             </form>
           </div>

--- a/views/resource.html
+++ b/views/resource.html
@@ -198,10 +198,11 @@
   var year, valuesByYear;
 
   var formatDollars = d3.format('$,');
+  var dataURL;
 
 {% if request.params.state %}
 
-  var dataURL = '/data/county/by-state/{{ request.params.state }}/resource-revenues.tsv';
+  dataURL = '/data/county/by-state/{{ request.params.state }}/resource-revenues.tsv';
   var regionField = 'FIPS';
   var pathSelector = '.counties path.feature';
   // FIXME: these should have the right IDs
@@ -209,7 +210,7 @@
 
 {% else %}
 
-  var dataURL = '/data/regional/resource-revenues.tsv';
+  dataURL = '/data/regional/resource-revenues.tsv';
   var regionField = 'Region';
   var pathSelector = 'path.feature';
   var featureId = dl.accessor('id');
@@ -219,6 +220,15 @@
 {% if request.params.datatype == 'revenue' %}
 
   var sumField = 'Revenue';
+  var aggregate = function(d) {
+    return d3.sum(d, dl.accessor(sumField));
+  };
+
+{% elif request.params.datatype == 'exports' %}
+
+  dataURL = '/data/state/exports-by-industry.tsv';
+  var regionField = 'State';
+  var sumField = 'Value';
   var aggregate = function(d) {
     return d3.sum(d, dl.accessor(sumField));
   };

--- a/views/resource.html
+++ b/views/resource.html
@@ -62,9 +62,9 @@
             <form>
               <select name="datatype" onchange="location.href = location.href.replace('{{ request.params.datatype }}', this.value);">
                 <option value="revenue"{% if request.params.datatype == 'revenue' %} selected{% endif %}>Revenues</option>
-                <option value="production"{% if request.params.datatype == 'production' %} selected{% endif %}>Production</option>
+                <option disabled value="production"{% if request.params.datatype == 'production' %} selected{% endif %}>Production</option>
                 <option value="exports"{% if request.params.datatype == 'exports' %} selected{% endif %}>Exports</option>
-                <option value="jobs"{% if request.params.datatype == 'jobs' %} selected{% endif %}>Jobs</option>
+                <option disabled value="jobs"{% if request.params.datatype == 'jobs' %} selected{% endif %}>Jobs</option>
               </select>
             </form>
           </div>


### PR DESCRIPTION
This gets us part way there with #553 by filling in colors on the map for states when you visit `/resources/all/exports/US`:

![image](https://cloud.githubusercontent.com/assets/113896/9921572/bdbcf360-5c93-11e5-8048-d6186cf91a39.png)

as well as the resource-specific national views, like `/resources/minerals/exports/US`:

![image](https://cloud.githubusercontent.com/assets/113896/9921579/ddf2608e-5c93-11e5-97c1-208dbfee5a2a.png)

It also activates the "data type" drop-down so that you can select Revenues and Exports, and disables the other two options for now. As mentioned in #597, the logic determining which data gets displayed on each page is a mess, but this'll work for now.