### PR TITLE
use datatype metadata

### DIFF
--- a/_data/datatypes.yml
+++ b/_data/datatypes.yml
@@ -54,7 +54,7 @@ revenue:
         regiontype: onshore
         region: true
       value: Revenue
-      geo: FIPS # group by county
+      geo: +FIPS # group by county
 
     - url: /data/offshore/revenues.tsv
       params:

--- a/_data/datatypes.yml
+++ b/_data/datatypes.yml
@@ -43,6 +43,7 @@ revenue:
     offshore: true
     counties:
       regiontype: onshore
+      region: true
   data:
     - url: /data/regional/resource-revenues.tsv
       value: Revenue

--- a/_data/datatypes.yml
+++ b/_data/datatypes.yml
@@ -46,12 +46,15 @@ revenue:
   data:
     - url: /data/regional/resource-revenues.tsv
       value: Revenue
+
     - url: /data/county/by-state/:region/resource-revenues.tsv
+      subregions: /data/county/by-state/:region/counties.tsv
       params:
         regiontype: onshore
         region: true
       value: Revenue
       geo: FIPS # group by county
+
     - url: /data/offshore/revenues.tsv
       params:
         regiontype: offshore
@@ -69,10 +72,12 @@ production:
     - Product
   data:
     - url: /data/state/production.tsv
+      subregions: /data/county/by-state/:region/counties.tsv
       params:
         regiontype: onshore
       value: Volume
       geo: State
+
     - url: /data/offshore/production.tsv
       params:
         regiontype: offshore

--- a/_data/datatypes.yml
+++ b/_data/datatypes.yml
@@ -1,0 +1,101 @@
+# this YAML file should have one key per "data type" on the resources page.
+# the spec for each looks like this:
+#
+# slug:
+#   # the human-readable name of this data type (e.g. "Revenue")
+#   name: Name of Type
+#
+#   # if true, disable this option in the <select> element
+#   disabled: false
+#
+#   # determines which geographical features will be visible on the map
+#   geo:
+#     (states|offshore): true
+#     counties:
+#       (filters)
+#
+#   # an optional list of hierarchies within this data type
+#   hierarchy:
+#     - Product
+#
+#   # a list of data URLs, least specific to most, with optional filters that
+#   # will only match on specific parameter combinations
+#   data:
+#     - url: /path/to/data/:parameter.tsv
+#       # the "value" column to sum on
+#       value: Value
+#       # the optional column on which to group by geographic region
+#       geo: Region
+#       params:
+#         (filters)
+#     - url: /some/other/path.tsv
+#
+# Conventions:
+#
+# * (filters) is a hash in which each key is one that should exist in the
+#   parameters for a given view. A value of `true` indicates that the key
+#   should just be present; other values will require a equality with `==`.
+
+revenue:
+  name: Revenue
+  geo:
+    states: true
+    offshore: true
+    counties:
+      regiontype: onshore
+  data:
+    - url: /data/regional/resource-revenues.tsv
+      value: Revenue
+    - url: /data/county/by-state/:region/resource-revenues.tsv
+      params:
+        regiontype: onshore
+        region: true
+      value: Revenue
+      geo: FIPS # group by county
+    - url: /data/offshore/revenues.tsv
+      params:
+        regiontype: offshore
+      value: Revenue
+
+production:
+  name: Production
+  disabled: true
+  geo:
+    states: true
+    offshore: true
+    counties:
+      regiontype: onshore
+  hierarchy:
+    - Product
+  data:
+    - url: /data/state/production.tsv
+      params:
+        regiontype: onshore
+      value: Volume
+      geo: State
+    - url: /data/offshore/production.tsv
+      params:
+        regiontype: offshore
+      value: Volume
+      geo: Area
+
+exports:
+  name: Exports
+  geo:
+    states: true
+  data:
+    - url: /data/state/exports-by-industry.tsv
+      value: Value
+      geo: State
+
+jobs:
+  name: Jobs
+  disabled: true
+  geo:
+    states: true
+  varies:
+    - Type
+  data:
+    - url: /data/state/gdp.tsv
+      geo: State
+      value: GDP

--- a/js/components/eiti-map.js
+++ b/js/components/eiti-map.js
@@ -410,14 +410,15 @@
         );
       }
 
-      return mesh === 'true'
-        ? [getMesh(d, obj, filter)]
-        : (mesh && d.objects[mesh])
-          ? topojson.feature(d, obj).features
-            .concat([getMesh(d, d.objects[mesh], filter)])
-          : topojson.feature(d, obj).features;
+      features = topojson.feature(d, obj).features;
+
+      if (mesh) {
+        features.push(d.objects[mesh]
+          ? getMesh(d, d.objects[mesh], filter)
+          : getMesh(d, obj, filter));
+      }
     } else {
-      var features = [];
+      features = [];
       var keys = Object.keys(d.objects);
       var meshIds = (mesh || '').split(',');
       for (key in d.objects) {
@@ -426,8 +427,8 @@
           features.push(getMesh(d, d.objects[key], filter));
         }
       }
-      return features;
     }
+    return features;
   }
 
   function getMesh(topology, object, filter) {

--- a/js/pages/resources.js
+++ b/js/pages/resources.js
@@ -332,6 +332,8 @@
       console.log('nested data:', nested);
 
       var domain = d3.extent(d3.values(nested));
+      // ensure that the domain min is <= 0
+      if (domain[0] > 0) domain[0] = 0;
       var scale = d3.scale.linear()
         .domain(domain)
         .range(['#ddd', '#000'])

--- a/js/pages/resources.js
+++ b/js/pages/resources.js
@@ -144,7 +144,7 @@
      * @return void
      */
     navigateToParameters: function(params) {
-      params = _.extend(this.params, params);
+      params = _.extend({}, this.params, params);
       var path = [
         params.resource,
         params.datatype,
@@ -197,7 +197,9 @@
         params = _.extend(params, query);
       }
 
+      this.diff = diffObject(this.params, params);
       this.params = params;
+
       console.log('resource():', params);
       this.update(params);
     },
@@ -238,10 +240,11 @@
       }
 
       var type = this.dataTypes[params.datatype];
+      var geo = type.spec.geo;
 
-      if (type.spec.geo) {
-        for (var geoType in type.spec.geo) {
-          var visible = type.matchesParams(type.spec.geo[geoType], params);
+      if (geo && this.diff.region) {
+        for (var geoType in geo) {
+          var visible = type.matchesParams(geo[geoType], params);
           var layer = d3.select(map)
             .selectAll('g.' + geoType)
             .attr('data-load', visible)
@@ -672,6 +675,18 @@
     var index = select.selectedIndex;
     var option = select.options[index];
     return option.label;
+  }
+
+  function diffObject(a, b) {
+    var diff = {};
+    var key;
+    for (key in a) {
+      if (b[key] != a[key]) diff[key] = true;
+    }
+    for (key in b) {
+      if (!diff[key] && b[key] != a[key]) diff[key] = true;
+    }
+    return diff;
   }
 
 })(this);

--- a/js/pages/resources.js
+++ b/js/pages/resources.js
@@ -298,7 +298,8 @@
         that.loadDataRequest = null;
 
         if (error) {
-          return console.error('unable to load data from %s:', url, error.responseText);
+          console.error('unable to load data from %s:', url, error.responseText);
+          data = [];
         }
 
         // console.warn('loadData() loaded data:', data);
@@ -332,9 +333,6 @@
       params = params || this.params;
 
       var where = {};
-      if (params.region) {
-        where.Region = params.region;
-      }
       if (params.resource && params.resource !== 'all') {
         where.Resource = params.resource;
       }
@@ -351,7 +349,7 @@
       }
 
       var filtered = _.filter(data, where);
-      // console.warn('behold, your data: ', where, filtered);
+      console.warn('behold, your data: ', where, filtered);
       this.updateMap(filtered, params);
       this.updateOutputs(filtered, params);
     },
@@ -412,13 +410,15 @@
           that.subregionRequest = null;
 
           if (error) {
-            return console.error('unable to load subregions:', error.responseText);
+            console.error('unable to load subregions:', error.responseText);
+            subregions = [];
+          } else {
+            // console.warn('loaded subregions:', subregions);
+            subregions.sort(function(a, b) {
+              return d3.ascending(a.name, b.name);
+            });
           }
 
-          // console.warn('loaded subregions:', subregions);
-          subregions.sort(function(a, b) {
-            return d3.ascending(a.name, b.name);
-          });
           options = options.data(subregions);
           options.exit().remove();
           options.enter().append('option')

--- a/js/pages/resources.js
+++ b/js/pages/resources.js
@@ -242,7 +242,7 @@
       var type = this.dataTypes[params.datatype];
       var geo = type.spec.geo;
 
-      if (geo && this.diff.region) {
+      if (geo) {
         for (var geoType in geo) {
           var visible = type.matchesParams(geo[geoType], params);
           var layer = d3.select(map)
@@ -251,10 +251,11 @@
             .attr('data-filter', (geoType === 'counties')
               ? ('properties.state === "' + params.region + '"')
               : null);
+          console.log('layer:', geoType, layer.node());
         }
         map.load();
       } else {
-        console.warn('no geo info for this type:', type);
+        console.warn('no geo info for this type:', type, this.diff);
       }
 
       var spec = type.getDataSpec(params);
@@ -281,7 +282,7 @@
       });
 
       var nested = nest.map(data);
-      // console.log('nested data:', nested);
+      console.log('nested data:', nested);
 
       var domain = d3.extent(d3.values(nested));
       var scale = d3.scale.linear()
@@ -297,7 +298,7 @@
             if (d.id in nested) {
               return scale(nested[d.id]);
             }
-            // console.warn('no data for', d.id);
+            console.warn('no data for', d.id);
             return null;
           });
 

--- a/js/pages/resources.js
+++ b/js/pages/resources.js
@@ -238,9 +238,25 @@
       }
 
       var type = this.dataTypes[params.datatype];
+
+      if (type.spec.geo) {
+        for (var geoType in type.spec.geo) {
+          var visible = type.matchesParams(type.spec.geo[geoType], params);
+          var layer = d3.select(map)
+            .selectAll('g.' + geoType)
+            .attr('data-load', visible)
+            .attr('data-filter', (geoType === 'counties')
+              ? ('properties.state === "' + params.region + '"')
+              : null);
+        }
+        map.load();
+      } else {
+        console.warn('no geo info for this type:', type);
+      }
+
       var spec = type.getDataSpec(params);
 
-      var groupKey = spec.region || 'Region';
+      var groupKey = spec.geo || 'Region';
       var sumKey = spec.value;
 
       if (!groupKey || !sumKey) {
@@ -282,7 +298,7 @@
             return null;
           });
 
-        // console.log('zooming to:', featureId);
+        console.log('zooming to:', featureId);
         map.zoomTo(featureId);
       });
     },
@@ -647,7 +663,6 @@
       var onload;
       map.addEventListener('load', onload = function(e) {
         map.removeEventListener('load', onload);
-        map.loaded = true;
         callback(map);
       });
     }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "yargs": "^3.7.1"
   },
   "devDependencies": {
+    "mocha": "^2.3.3"
   },
   "scripts": {
     "test": "mocha",

--- a/pages/resources.html
+++ b/pages/resources.html
@@ -32,7 +32,7 @@ permalink: /resources/
       <form class="subregions">
         <label>
           <select id="subregion-selector">
-            <option value="">All</option>
+            <option value="">All Counties</option>
           </select>
         </label>
       </form>
@@ -108,13 +108,11 @@ permalink: /resources/
             data-object="states"
             data-mesh="true">
           </g>
-          <!--
           <g class="onshore counties" data-url="us-topology.json"
             data-mesh="true"
             data-object="counties"
             data-title="properties.county">
           </g>
-          -->
         </svg>
 
       </div>

--- a/pages/resources.html
+++ b/pages/resources.html
@@ -97,21 +97,20 @@ permalink: /resources/
         <svg is="eiti-map" id="region-map" simplify="1e-2"
           projection="albersCustom" data-path="/data/geo/">
           <g class="offshore areas" data-url="offshore-simple.json"
+            data-layer-type="offshore"
             data-title="properties.name"
             data-mesh="true">
           </g>
           <g class="onshore states" data-url="us-topology.json"
             data-object="states"
-            data-title="properties.name || properties.abbr">
-          </g>
-          <g class="onshore states" data-url="us-topology.json"
-            data-object="states"
+            data-title="properties.name || properties.abbr"
             data-mesh="true">
           </g>
           <g class="onshore counties" data-url="us-topology.json"
-            data-mesh="true"
             data-object="counties"
-            data-title="properties.county">
+            data-filter-template="properties.state === '{region}'"
+            data-title="properties.county"
+            data-mesh="true">
           </g>
         </svg>
 

--- a/pages/resources.html
+++ b/pages/resources.html
@@ -50,10 +50,9 @@ permalink: /resources/
           <div class="group_inline-right">
             <form>
               <select id="datatype-selector" name="datatype">
-                <option value="revenue">Revenues</option>
-                <option disabled value="production">Production</option>
-                <option value="exports">Exports</option>
-                <option disabled value="jobs">Jobs</option>
+                {% for datatype in site.data.datatypes %}
+                <option value="{{ datatype[0] }}"{% if datatype[1].disabled %} disabled{% endif %}>{{ datatype[1].name }}</option>
+                {% endfor %}
               </select>
             </form>
           </div>


### PR DESCRIPTION
This PR is a proposal for how we can handle the problem of different data types having drastically different URLs and structures (column names, etc.). It puts all of the data types into a Jekyll site data file (`_data/datatypes.yml`) and uses that both to output the `<select>` element for choosing a data type and introduces a `DataType` class on the JavaScript side that determines the data URL from each data type's "spec".

Let me know what you think, @gemfarmer!