### PR TITLE
add Hound CI configuration

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,8 @@
+scss:
+  config_file: .scss-lint.yml
+  exclude:
+    - '_sass/lib/**/*.scss'
+
+javascript:
+  config_file: .jshintrc
+  ignore_file: .jshintignore

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,7 +1,5 @@
 scss:
   config_file: .scss-lint.yml
-  exclude:
-    - '_sass/lib/**/*.scss'
 
 javascript:
   config_file: .jshintrc

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+js/vendor/**/*.js

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,26 @@
+{
+  "asi": false,
+  "bitwise": true,
+  "browser": true,
+  "camelcase": true,
+  "curly": true,
+  "forin": true,
+  "immed": true,
+  "latedef": "nofunc",
+  "maxlen": 80,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonew": true,
+  "predef": [
+    "$",
+    "d3",
+    "eiti",
+    "jQuery",
+    "module"
+  ],
+  "quotmark": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true
+}

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,4 +1,6 @@
-scss_files: "**/*.scss"
+scss_files: '_sass/**/*.scss'
+exclude: '_sass/lib/**/*.scss'
+
 linters:
   BangFormat:
     enabled: true

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,145 @@
+scss_files: "**/*.scss"
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+  BorderZero:
+    enabled: false
+    convention: zero
+  ColorKeyword:
+    enabled: true
+    severity: warning
+  ColorVariable:
+    enabled: true
+  Comment:
+    enabled: true
+  DebugStatement:
+    enabled: true
+  DeclarationOrder:
+    enabled: true
+  DuplicateProperty:
+    enabled: true
+  ElsePlacement:
+    enabled: true
+    style: same_line
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+  EmptyRule:
+    enabled: true
+  FinalNewline:
+    enabled: true
+    present: true
+  HexLength:
+    enabled: false
+    style: short
+  HexNotation:
+    enabled: true
+    style: lowercase
+  HexValidation:
+    enabled: true
+  IdSelector:
+    enabled: true
+  ImportantRule:
+    enabled: true
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space
+    width: 2
+  LeadingZero:
+    enabled: true
+    style: include_zero
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase
+  NestingDepth:
+    enabled: true
+    max_depth: 4
+    severity: warning
+  PlaceholderInExtend:
+    enabled: false
+  PropertyCount:
+    enabled: true
+    include_nested: false
+    max_properties: 10
+  PropertySortOrder:
+    enabled: true
+    ignore_unspecified: false
+    severity: warning
+    separate_groups: false
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+    severity: warning
+  SelectorDepth:
+    enabled: true
+    max_depth: 2
+    severity: warning
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase
+  Shorthand:
+    enabled: true
+    severity: warning
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+  SingleLinePerSelector:
+    enabled: true
+  SpaceAfterComma:
+    enabled: true
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space
+  SpaceAfterPropertyName:
+    enabled: true
+  SpaceBeforeBrace:
+    enabled: true
+    style: space
+    allow_single_line_padding: false
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+  StringQuotes:
+    enabled: true
+    style: single_quotes
+  TrailingSemicolon:
+    enabled: true
+  TrailingZero:
+    enabled: false
+  UnnecessaryMantissa:
+    enabled: true
+  UnnecessaryParentReference:
+    enabled: true
+  UrlFormat:
+    enabled: true
+  UrlQuotes:
+    enabled: true
+  VariableForProperty:
+    enabled: false
+    properties: []
+  VendorPrefixes:
+    enabled: true
+    identifier_list: bourbon
+    include: []
+    exclude: []
+  ZeroUnit:
+    enabled: true
+    severity: warning
+  Compass::PropertyWithMixin:
+    enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -52,6 +52,7 @@ linters:
     allow_non_nested_indentation: false
     character: space
     width: 2
+    severity: error
   LeadingZero:
     enabled: true
     style: include_zero

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 # gem "rails"
 gem 'bourbon'
 gem 'jekyll', '2.5.3'
+gem 'scss_lint', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,12 +50,16 @@ GEM
     pygments.rb (0.6.3)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
+    rainbow (2.0.0)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.3)
     safe_yaml (1.0.4)
     sass (3.4.19)
+    scss_lint (0.42.2)
+      rainbow (~> 2.0)
+      sass (~> 3.4.15)
     thor (0.19.1)
     toml (0.1.2)
       parslet (~> 1.5.0)
@@ -67,6 +71,7 @@ PLATFORMS
 DEPENDENCIES
   bourbon
   jekyll (= 2.5.3)
+  scss_lint
 
 BUNDLED WITH
    1.10.6

--- a/README.md
+++ b/README.md
@@ -44,6 +44,46 @@ npm install --dev
 npm test
 ```
 
+## Code Style
+We use [Hound CI](https://houndci.com/) to enforce SCSS and JavaScript
+formatting conventions on new commits. You can run both of the linters with:
+
+```sh
+npm run lint
+```
+
+This runs both of the linters below in series.
+
+#### JavaScript Linting
+Hound uses [jshint](http://jshint.com/), which you can install as part of the
+npm package's `devDependencies` with:
+
+```sh
+npm install --dev
+```
+
+Or you can install it globally with `npm i -g jshint`. Then, to lint the
+JavaScript, run:
+
+```sh
+npm run lint-js
+```
+
+#### SCSS Linting
+Hound uses [scss-lint](https://github.com/brigade/scss-lint), which you can
+install with `gem install scss_lint` if you haven't already run `bundle
+install` to get Jekyll and its dependencies. To lint the SCSS files, run:
+
+```sh
+bundle exec scss-lint -c .scss-lint.yml
+```
+
+or simply:
+
+```sh
+npm run lint-scss
+```
+
 ## Roadmap
 Broadly, we are working now on:
 

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -9,7 +9,7 @@
 // .container-padded - full width container with padding
 //
 // Styleguide layout.container
-.container{
+.container {
   @include outer-container($max-width);
 }
 

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -93,6 +93,6 @@
 }
 
 .container-padded {
-  padding-top: $base-padding-extra;
   padding-bottom: $base-padding-extra;
+  padding-top: $base-padding-extra;
 }

--- a/_sass/layout/_slabs.scss
+++ b/_sass/layout/_slabs.scss
@@ -18,7 +18,7 @@
 // Styleguide layout.slabs
 
 .slab-alpha {
-  background-color: $white;
+	background-color: $white;
 }
 
 .slab-beta {

--- a/_sass/layout/_slabs.scss
+++ b/_sass/layout/_slabs.scss
@@ -18,26 +18,25 @@
 // Styleguide layout.slabs
 
 .slab-alpha {
-	background-color: $white;
+  background-color: $white;
 }
 
 .slab-beta {
-	background-color: $light-gray;
-	background-repeat: no-repeat;
+  background-color: $light-gray;
 }
 
 .slab-charlie {
-	background-color: $mid-gray;
+  background-color: $mid-gray;
 }
 
 .slab-delta {
-	background-color: $light-blue;
+  background-color: $light-blue;
 }
 
 .slab-echo {
-	background-color: $pale-blue;
+  background-color: $pale-blue;
 }
 
 .slab-foxtrot {
-	background-color: $mid-blue;
+  background-color: $mid-blue;
 }

--- a/_sass/layout/_slabs.scss
+++ b/_sass/layout/_slabs.scss
@@ -18,7 +18,7 @@
 // Styleguide layout.slabs
 
 .slab-alpha {
-	background-color: $white;
+  background-color: $white;
 }
 
 .slab-beta {

--- a/_sass/layout/_slabs.scss
+++ b/_sass/layout/_slabs.scss
@@ -23,7 +23,7 @@
 
 .slab-beta {
 	background-color: $light-gray;
-
+	background-repeat: no-repeat;
 }
 
 .slab-charlie {

--- a/_sass/layout/_utility.scss
+++ b/_sass/layout/_utility.scss
@@ -1,12 +1,12 @@
-.u-centered{
-	text-align: center;
+.u-centered {
+  text-align: center;
 }
 
 .sr-only {
-  position: absolute;
+  height: px;
   left: -10000px;
+  overflow: hidden;
+  position: absolute;
   top: auto;
   width: 1px;
-  height: px;
-  overflow: hidden;
 }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "watch": "watchy -w '_sass' -- npm run build-styleguide",
     "build-styleguide": "rm -rf styleguide && kss-node --config kss-config.json",
     "init-styleguide": "npm-exec kss-node --config kss-config.json",
-    "lint": "npm run lint-js; npm run lint-scss",
-    "lint-js": "jshint -c .jshintrc --exclude-path .jshintignore js",
-    "lint-scss": "bundle exec scss-lint -c .scss-lint.yml"
+    "lint": "(npm run lint-js; npm run lint-scss) || echo '(there were linting errors)'",
+    "lint-js": "jshint -c .jshintrc --exclude-path .jshintignore js || echo '(there were JavaScript linting errors)'",
+    "lint-scss": "bundle exec scss-lint -c .scss-lint.yml || echo '(there were SCSS linting errors)'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,15 +30,17 @@
     "yargs": "^3.7.1"
   },
   "devDependencies": {
-    "npm-exec": "^0.1.3",
+    "jshint": "^2.8.0",
     "kss": "^2.1.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "npm-exec": "^0.1.3"
   },
   "scripts": {
     "test": "mocha",
     "watch": "watchy -w '_sass' -- npm run build-styleguide",
     "build-styleguide": "rm -rf styleguide && kss-node --config kss-config.json",
-    "init-styleguide": "npm-exec kss-node --config kss-config.json"
+    "init-styleguide": "npm-exec kss-node --config kss-config.json",
+    "lint": "jshint -c .jshintrc --exclude-path .jshintignore js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "watch": "watchy -w '_sass' -- npm run build-styleguide",
     "build-styleguide": "rm -rf styleguide && kss-node --config kss-config.json",
     "init-styleguide": "npm-exec kss-node --config kss-config.json",
-    "lint": "jshint -c .jshintrc --exclude-path .jshintignore js"
+    "lint": "npm run lint-js; npm run lint-scss",
+    "lint-js": "jshint -c .jshintrc --exclude-path .jshintignore js",
+    "lint-scss": "bundle exec scss-lint -c .scss-lint.yml"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a Hound CI configuration to address #670 here. This also adds a Ruby dependency for [scss-lint](https://github.com/brigade/scss-lint), which you can use by running `bundle install`, then:

```sh
bundle exec scss-lint -c .scss-lint.yml
```

You can lint the JavaScript by installing `npm install --dev` (or just `npm install jshint`) then:

```sh
npm run lint
```

Currently, both of these will produce a slew of warnings and errors. Fixing these is not within the scope of this pull request. :wink: 