### PR TITLE
drawer no longer focuses on glossary trigger button when closing

### DIFF
--- a/_includes/layout/footer.html
+++ b/_includes/layout/footer.html
@@ -9,7 +9,7 @@
         <li class="footer-list_item"><a class="link-beta" href="{{ site.baseurl }}/explore/">Explore Data</a></li>
         <li class="footer-list_item"><a class="link-beta" href="{{ site.baseurl }}/communities/">Case Studies</a></li>
         <li class="footer-list_item"><a class="link-beta" href="{{ site.baseurl }}/downloads/">Downloads</a></li>
-        <li class="footer-list_item"><a class="link-beta js-glossary-toggle" href="#" title="View site glossary">Glossary</a></li>
+        <li class="footer-list_item"><a class="link-beta js-glossary-toggle" title="View site glossary">Glossary</a></li>
       </ul>
 
     </div>

--- a/js/components/glossary.js
+++ b/js/components/glossary.js
@@ -125,7 +125,6 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   this.$body.removeClass('is-open').attr('aria-hidden', 'true');
   this.$toggle.removeClass('active');
-  this.$toggle.focus();
   this.isOpen = false;
   accessibility.removeTabindex(this.$body);
 };


### PR DESCRIPTION
Addresses #651 

Previously when the glossary drawer is closed, it jumps the user to the bottom of the screen and focuses on the glossary trigger in the footer. It no longer does this! Open for review!

Preview here: https://federalist.18f.gov/preview/18F/doi-extractives-data/glossary-bug/