### PR TITLE
[WIP] Content: Add Case Studes

### DIFF
--- a/_communities/boone-logan-and-mingo.md
+++ b/_communities/boone-logan-and-mingo.md
@@ -1,0 +1,54 @@
+---
+title: Boone, Logan, and Mingo Counties, West Virginia
+layout: community
+permalink: /communities/boone-logan-and-mingo/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/campbell.md
+++ b/_communities/campbell.md
@@ -1,0 +1,54 @@
+---
+title: Campbell County, Wyoming
+layout: community
+permalink: /communities/campbell/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/desoto.md
+++ b/_communities/desoto.md
@@ -1,0 +1,54 @@
+---
+title: DeSoto Parish, Louisiana
+layout: community
+permalink: /communities/desoto/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/elko-and-eureka.md
+++ b/_communities/elko-and-eureka.md
@@ -1,0 +1,54 @@
+---
+title: Elko and Eureka Counties, Nevada
+layout: community
+permalink: /communities/elko-and-eureka/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/greenlee.md
+++ b/_communities/greenlee.md
@@ -1,0 +1,54 @@
+---
+title: Greenlee County, Arizona
+layout: community
+permalink: /communities/greenlee/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/humbolt-and-lander.md
+++ b/_communities/humbolt-and-lander.md
@@ -1,0 +1,54 @@
+---
+title: Humbolt and Lander Counties, Nevada
+layout: community
+permalink: /communities/humboldt-and-lander/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/kern.md
+++ b/_communities/kern.md
@@ -1,0 +1,54 @@
+---
+title: Kern County, California
+layout: community
+permalink: /communities/kern/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/marquette.md
+++ b/_communities/marquette.md
@@ -1,0 +1,54 @@
+---
+title: Marquette County, Michigan
+layout: community
+permalink: /communities/marquette/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/north-slope.md
+++ b/_communities/north-slope.md
@@ -1,7 +1,7 @@
 ---
 title: North Slope Borough, Alaska
 layout: community
-permalink: /communities/nor/
+permalink: /communities/north-slope/
 resource: oil
 nav_items:
   - name: intro
@@ -20,14 +20,14 @@ nav_items:
     title: Data Availablity
 ---
 
-<h3><a name="intro" class="communities_content-heading js-comm_section">North Slope Borough, Alaska</a></h3>
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
 
 The United States has experienced rapid change in domestic oil production since 2008, when crude oil production reached a low of 3.98 million bbl/day.[^1] Fast forward five years, and the United States had nearly doubled its daily production output, with Texas and North Dakota driving much of the growth.[^2] [^3] Alaska—which was the fourth largest state producer of crude oil in 2013—did not experience the same production boom, with crude oil output in steady decline throughout the past decade.[^4] In spite of that downward trend, the nation’s largest oil-producing county is Alaska’s North Slope Borough.[^5]
 
 
 <h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
 
-The North Slope Borough is the country’s largest organized local jurisdiction, spanning more than 94,000 miles north of the Arctic Circle. Its 9,686 residents, most of whom are Inupiat Alaskan Natives, are spread across eight separate communities.[^6] The northern coast of Alaska was documented as a potential oil-producing region as early as 1900. However, the borough’s government was not formally incorporated until 1972, soon after the discovery of oil at Prudhoe Bay, the largest single oil field in North America.[^7] 
+The North Slope Borough is the country’s largest organized local jurisdiction, spanning more than 94,000 miles north of the Arctic Circle. Its 9,686 residents, most of whom are Inupiat Alaskan Natives, are spread across eight separate communities.[^6] The northern coast of Alaska was documented as a potential oil-producing region as early as 1900. However, the borough’s government was not formally incorporated until 1972, soon after the discovery of oil at Prudhoe Bay, the largest single oil field in North America.[^7]
 
 Oil production increased dramatically in 1977 with the opening of the Alaska Pipeline, which provided the first economically viable way to transport large amounts of crude oil from the North Slope to market. In 1994, ARCO identified another significant deposit at the Alpine Field, located on state land east of the Colville River and extending into the federally administered National Petroleum Reserve of Alaska. The North Slope’s Prudhoe Bay, Alpine Field, and Kuparuk River constitute the majority of the state of Alaska’s oil production. Today, the borough’s oil reserve base is extensive, with approximately six billion barrels of proved oil.[^8]
 
@@ -53,12 +53,12 @@ At the state level, the Alaska government collects oil-related revenue for the b
 * Oil and gas corporate net income tax is set at a maximum of 9.4% on Alaskan income more than $90,000. In 2013, $434 million was deposited in the state’s General Fund from this tax.
 
 Alaskan residents also receive annual dividend payments from the state’s Permanent Fund, based on a five-year average of the fund’s performance. The state established the Permanent Fund in 1976 as construction of the Alaska Pipeline concluded. Twenty-five percent of revenue from mineral leases on state-owned lands and from federal mineral revenue-sharing payments go into the Permanent Fund for investment. In 2013, Alaskan residents each received $900 as a result of this payout.[^19]
- 
+
 <h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
 
 Oil extraction also incurs certain fiscal costs. Oil exploration and development on the North Slope requires infrastructure, including airports, docks, pads and roads, ports, production-related facilities, pipelines, and gravel islands, for example.[^20] The North Slope Borough is responsible for maintaining approximately 100 miles of roads, as well as boat ramps, boat landings, port facilities, nine public airports, and thousands of miles of winter trails and roads.[^21]
 
-In terms of transportation infrastructure in the borough, Dalton Highway is the only permanent road connecting the North Slope Borough to the main Alaska Marine Highway system. Dalton Highway was originally financed and constructed by the oil and gas industry, and is still mainly used as an industrial road. However, the Alaska Department of Transportation reported spending approximately $15,260 per mile annually on maintenance for Dalton Highway at the time of the last comprehensive borough transportation plan. Oil companies are required to maintain seasonal ice routes used for industry traffic in the winter, but these routes cost the borough approximately $100,000 per mile to initially construct in the Prudhoe Bay region.[^22] 
+In terms of transportation infrastructure in the borough, Dalton Highway is the only permanent road connecting the North Slope Borough to the main Alaska Marine Highway system. Dalton Highway was originally financed and constructed by the oil and gas industry, and is still mainly used as an industrial road. However, the Alaska Department of Transportation reported spending approximately $15,260 per mile annually on maintenance for Dalton Highway at the time of the last comprehensive borough transportation plan. Oil companies are required to maintain seasonal ice routes used for industry traffic in the winter, but these routes cost the borough approximately $100,000 per mile to initially construct in the Prudhoe Bay region.[^22]
 
 Unlike many other Alaska municipalities, the North Slope Borough is responsible for its airports, which serve the local population as well as a range of commercial and recreational visitors.[^23] Annual costs for airport maintenance across the North Slope are about $1.4 million per year, including spending on airports and landing strips that are labeled as “unrestricted,” or permissible for oil and gas industry use.[^24] It is unclear what percentage of the annual airport maintenance budget is spent specifically on support activities for the oil and gas industry.
 
@@ -102,7 +102,7 @@ The table below highlights the data sources used to compile this county case stu
   </tbody>
 </table>
 
-<h3 class="communities_content-heading">Notes:</h3> 
+<h3 class="communities_content-heading">Notes:</h3>
 [^1]: Barrels are noted as “bbl” when used as a unit of measure.
 [^2]: [Department of Energy, U.S. Domestic Oil Production Exceeds Imports for First Time in 18 Years](http://energy.gov/articles/us-domestic-oil-production-exceeds-imports-first-time-18-years)
 [^3]: [U.S. Energy Information Administration, Crude Oil Production](http://www.eia.gov/dnav/pet/pet_crd_crpdn_adc_mbbl_a.htm)

--- a/_communities/pima.md
+++ b/_communities/pima.md
@@ -1,0 +1,54 @@
+---
+title: Pima County, Arizona
+layout: community
+permalink: /communities/pima/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/st-louis.md
+++ b/_communities/st-louis.md
@@ -1,0 +1,54 @@
+---
+title: St. Louis County, Minnesota
+layout: community
+permalink: /communities/st-louis/
+resource: oil
+nav_items:
+  - name: intro
+    title: Introduction
+  - name: geolo
+    title: Geology & History
+  - name: produ
+    title: Production
+  - name: emplo
+    title: Employment
+  - name: reven
+    title: Revenues
+  - name: costs
+    title: Costs
+  - name: data
+    title: Data Availablity
+---
+
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
+
+Intro Content[^1]
+
+
+<h3><a name="geolo" class="communities_content-heading js-comm_section">Geology and History</a></h3>
+
+Geology and History Content
+
+<h3><a name="produ" class="communities_content-heading js-comm_section">Production</a></h3>
+
+Production Content
+
+<h3><a name="emplo" class="communities_content-heading js-comm_section">Employment</a></h3>
+
+Employment Content
+
+<h3><a name="reven" class="communities_content-heading js-comm_section">Revenues</a></h3>
+
+Revenues Content
+
+<h3><a name="costs" class="communities_content-heading js-comm_section">Costs</a></h3>
+
+Cost Content
+
+
+<h3><a name="data" class="communities_content-heading js-comm_section">Data Availability</a></h3>
+
+Data Content
+
+<h3 class="communities_content-heading">Notes:</h3>
+[^1]: Dummy footnote. [Dummy footnote link](http://google.com)

--- a/_communities/tarrant-and-johnson.md
+++ b/_communities/tarrant-and-johnson.md
@@ -1,7 +1,7 @@
 ---
 title: Tarrant and Johnson Counties, Texas
 layout: community
-permalink: /communities/tar/
+permalink: /communities/tarrant-and-johnson/
 resource: gas
 nav_items:
   - name: intro
@@ -20,7 +20,7 @@ nav_items:
     title: Data Availablity
 ---
 
-<h3><a name="intro" class="communities_content-heading js-comm_section">Tarrant and Johnson Counties, Texas</a></h3>
+<h3><a name="intro" class="communities_content-heading js-comm_section">{{ page.title }}</a></h3>
 
 Texas leads the country in natural gas production, generating more gas on an annual basis than the next three highest-producing states combined (Louisiana, Oklahoma, and Wyoming).[^1] Tarrant and Johnson counties contribute significantly to Texas’s natural gas production due to their geographic positioning atop the rich reserves of the Barnett Shale field in the Bend Arch-Fort Worth Basin.
 
@@ -95,7 +95,7 @@ The table below highlights the data sources used to compile this county narrativ
 </table>
 
 
-<h3 class="communities_content-heading">Notes:</h3> 
+<h3 class="communities_content-heading">Notes:</h3>
 
 [^1]: U.S. Energy Administration, [Natural Gas Gross Withdrawals and Production](http://www.eia.gov/dnav/ng/ng_prod_sum_a_EPG0_VGM_mmcf_a.htm)
 [^2]: U.S. Energy Administration, [Review of Emerging Resources – U.S. Shale Gas and Shale Oil Plays](http://www.eia.gov/analysis/studies/usshalegas/), 2011
@@ -114,7 +114,7 @@ The table below highlights the data sources used to compile this county narrativ
 [^15]: Texas General Land Office, [Permanent School Fund](http://www.glo.texas.gov/what-we-do/state-lands/permanent-school-fund/index.html)
 [^16]: Texas General Land Office, [Oil & Natural Gas](http://www.glo.texas.gov/what-we-do/energy-and-minerals/oil_gas/)
 [^17]: Tarrant County Texas, [FAQ’s – Property Tax and Mineral Tax](http://access.tarrantcounty.com/en/tax/property-tax/FAQs-Property-Tax.html)
-[^18]: [Johnson County Financial Report, 2012](http://www.johnsoncountytx.org/webadmin/uploads/fy12-cafr_001.pdf) 
+[^18]: [Johnson County Financial Report, 2012](http://www.johnsoncountytx.org/webadmin/uploads/fy12-cafr_001.pdf)
 [^19]: [Tarrant County Financial Report, 2012](http://access.tarrantcounty.com/content/dam/main/auditor/FinancialAccountingReports/Annual%20Financial%20Reports/CAFR/FY2013_Comprehensive_Annual_Financial_Report.pdf)
 [^20]: Texas Department of Transportation, [Impact of Energy Development Activities on the Texas Transportation Infrastructure](http://ftp.dot.state.tx.us/pub/txdot-info/energy/testimony_062612.pdf)
 [^21]: Texas Water Development Board, [Water For Texas 2012 State Water Plan](http://www.twdb.texas.gov/publications/state_water_plan/2012/2012_SWP.pdf)

--- a/_includes/community_selector.html
+++ b/_includes/community_selector.html
@@ -3,12 +3,52 @@
 
   <optgroup label="Natural Gas">
     <option
-      {% if page.permalink == '/communities/tar/' %}selected{% endif %}
-      value="tar">Tarrant &amp; Johnson Counties, Texas</option>
+      {% if page.permalink == '/communities/tarrant-and-johnson/' %}selected{% endif %}
+      value="tarrant-and-johnson">Tarrant &amp; Johnson Counties, Texas</option>
   </optgroup>
   <optgroup label="Oil">
     <option
-      {% if page.permalink == '/communities/nor/' %}selected{% endif %}
-      value="nor">North Slope Borough, Alaska</option>
+      {% if page.permalink == '/communities/north-slope/' %}selected{% endif %}
+      value="north-slope">North Slope Borough, Alaska</option>
+    <option
+      {% if page.permalink == '/communities/greenlee/' %}selected{% endif %}
+      value="greenlee">Greenlee County, Arizona</option>
+    <option
+      {% if page.permalink == '/communities/pima/' %}selected{% endif %}
+      value="pima">Pima County, Arizona</option>
+    <option
+      {% if page.permalink == '/communities/kern/' %}selected{% endif %}
+      value="kern">Kern County, California</option>
+    <option
+      {% if page.permalink == '/communities/desoto/' %}selected{% endif %}
+      value="desoto">DeSoto Parish, Louisiana</option>
+    <option
+      {% if page.permalink == '/communities/marquette/' %}selected{% endif %}
+      value="marquette">Marquette County, Michigan</option>
+    <option
+      {% if page.permalink == '/communities/st-louis/' %}selected{% endif %}
+      value="st-louis">St. Louis County, Minnesota</option>
+    <option
+      {% if page.permalink == '/communities/elko-and-eureka/' %}selected{% endif %}
+      value="elko-and-eureka">Elko and Eureka Counties, Nevada</option>
+    <option
+      {% if page.permalink == '/communities/humboldt-and-lander/' %}selected{% endif %}
+      value="humboldt-and-lander">Humboldt and Lander Counties, Nevada</option>
+    <option
+      {% if page.permalink == '/communities/campbell/' %}selected{% endif %}
+      value="campbell">Campbell County, Wyoming</option>
+    <option
+      {% if page.permalink == '/communities/boone-logan-and-mingo/' %}selected{% endif %}
+      value="boone-logan-and-mingo">Boone, Logan, and Mingo Counties, West Virginia</option>
   </optgroup>
 </select>
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Addresses #758 

I have stubbed out the content for the 12 case studies. I few notes for you @nicoleslaw:
* I have left all of the new 10 case studies as default `resource: oil`. Change this and the icon will change.
* when you change this, it will not change the resource that it is listed under in the selector. I can get to this after all the resources have been assigned/content added.
* If you change a section heading in an h3 tag, please change its corresponding `nav_item` 
