### PR TITLE
Accordion cross browser compatibility

### DIFF
--- a/js/components/accordion.js
+++ b/js/components/accordion.js
@@ -6,7 +6,7 @@
 
   Accordion.prototype = {
     /**
-     * Used to traverse up the DOM tree to find a parent with 
+     * Used to traverse up the DOM tree to find a parent with
      * the a specific attribute
      *
      * @param String parentAttr
@@ -19,15 +19,16 @@
       while(obj.getAttribute(parentAttr)) {
           obj = obj.parentNode;
       }
-      return obj; 
+      return obj;
     },
     /**
-     * Triggered by a click handler 
+     * Triggered by a click handler
      * finds a parent node and toggles the 'accordion-open' attribute
      *
      * @return void
      */
-    toggleAccordion: function () {
+    toggleAccordion: function (e) {
+
       var e = e || window.event;
       var target = e.target || e.srcElement;
 
@@ -39,7 +40,7 @@
       accordionItem.setAttribute('accordion-open', accordionStatus);
     },
     /**
-     * Event handler that binds 
+     * Event handler that binds
      * to the toggleAccordion function
      *
      * @return void
@@ -56,7 +57,7 @@
             nextStep = true;
           }
         }
-        
+
       };
     }
   }
@@ -64,5 +65,5 @@
   var accordion = new Accordion();
 
   accordion.registerEventListeners();
-  
+
 })(this);


### PR DESCRIPTION
Makes the accordion and DYK work on Firefox. Fixes #775 
Have not checked on IE, but from research, the method used should be cross-browser.

Preview: https://federalist.18f.gov/preview/18F/doi-extractives-data/moz-accordion/resource_revenues/coal/