### PR TITLE
Makes nav items 'active' on subpages

### DIFF
--- a/_includes/layout/header.html
+++ b/_includes/layout/header.html
@@ -13,7 +13,7 @@
       </li>
       <span class="header-nav_item_link_spacer"> | </span>
       <li class="header-nav_item_top">
-        <a class="header-nav_item_link_top {% if page.permalink == '/downloads/' %}active{% endif %}" href="{{ site.baseurl }}/downloads/">Downloads</a>
+        <a class="header-nav_item_link_top {% if page.permalink contains '/downloads/' %}active{% endif %}" href="{{ site.baseurl }}/downloads/">Downloads</a>
       </li>
 
       <li class="header-nav_item_top">
@@ -26,16 +26,16 @@
       <li class="header-nav_item {% if page.title == 'Home' %}active{% endif %}">
         <a class="header-nav_item_link" href="{{ site.baseurl }}/">Home</a>
       </li>
-      <li class="header-nav_item {% if page.permalink == '/about/' %}active{% endif %}">
+      <li class="header-nav_item {% if page.permalink contains '/about/' %}active{% endif %}">
         <a class="header-nav_item_link" href="{{ site.baseurl }}/about/">About USEITI</a>
       </li>
-      <li class="header-nav_item {% if page.permalink == '/how-it-works/' %}active{% endif %}">
+      <li class="header-nav_item {% if page.permalink contains '/how-it-works/' %}active{% endif %}">
         <a class="header-nav_item_link" href="{{ site.baseurl }}/how-it-works/">How It Works</a>
       </li>
-      <li class="header-nav_item {% if page.permalink == '/explore/' %}active{% endif %}">
+      <li class="header-nav_item {% if page.permalink contains '/explore/' %}active{% endif %}">
         <a class="header-nav_item_link" href="{{ site.baseurl }}/explore/">Explore Data</a>
       </li>
-      <li class="header-nav_item {% if page.permalink == '/case-studies/' %}active{% endif %}">
+      <li class="header-nav_item {% if page.permalink contains '/case-studies/' %}active{% endif %}">
         <a class="header-nav_item_link" href="{{ site.baseurl }}/case-studies/">Case Studies</a>
       </li>
 

--- a/styleguide/section-components.html
+++ b/styleguide/section-components.html
@@ -244,7 +244,7 @@ screen sizes smaller than medium</p>
      <img class="bureau-image" src="https://eiti-dev.18f.gov/img/logos/USFWS-mark.png" alt="U.S. Fish and Wildlife Service Department of the Interior Seal">
    </div>
    <div class="bureau-right">
-     <h3>United States Fish and Wildlife Service</h3>
+     <h4>United States Fish and Wildlife Service</h4>
      <p>Mission: to work with others to conserve, protect and enhance fish, wildlife, and plants and their habitats for the continuing benefit of the American people. USFWS manages the 150 million-acre National Wildlife Refuge System primarily for the benefit of fish and wildlife; manages 70 fish hatcheries and other related facilities for endangered species recovery and to restore native fisheries populations; protects and conserves migratory birds, threatened and endangered species, and certain marine mammals; and hosts approximately 47 million visitors annually at 561 refuges located in all 50 states and 38 wetland management districts.</p>
      <p><a href="http://www.fws.gov/">Go to the USFWS website &#8594;</a></p>
    </div>
@@ -260,7 +260,7 @@ screen sizes smaller than medium</p>
      &lt;img class=&quot;bureau-image&quot; src=&quot;https://eiti-dev.18f.gov/img/logos/USFWS-mark.png&quot; alt=&quot;U.S. Fish and Wildlife Service Department of the Interior Seal&quot;&gt;
    &lt;/div&gt;
    &lt;div class=&quot;bureau-right&quot;&gt;
-     &lt;h3&gt;United States Fish and Wildlife Service&lt;/h3&gt;
+     &lt;h4&gt;United States Fish and Wildlife Service&lt;/h4&gt;
      &lt;p&gt;Mission: to work with others to conserve, protect and enhance fish, wildlife, and plants and their habitats for the continuing benefit of the American people. USFWS manages the 150 million-acre National Wildlife Refuge System primarily for the benefit of fish and wildlife; manages 70 fish hatcheries and other related facilities for endangered species recovery and to restore native fisheries populations; protects and conserves migratory birds, threatened and endangered species, and certain marine mammals; and hosts approximately 47 million visitors annually at 561 refuges located in all 50 states and 38 wetland management districts.&lt;/p&gt;
      &lt;p&gt;&lt;a href=&quot;http://www.fws.gov/&quot;&gt;Go to the USFWS website &amp;#8594;&lt;/a&gt;&lt;/p&gt;
    &lt;/div&gt;

--- a/styleguide/section-elements.html
+++ b/styleguide/section-elements.html
@@ -300,10 +300,11 @@ Select:
 <h3>Heading 3 (h3)</h3>
 <h4>Heading 4 (h4)</h4>
 <h5>Heading 5 (h5)</h5>
+<p class="para-xl">Paragraph – Extra-Large</p>
 <p class="para-lg">Paragraph – Large</p>
 <p class="para-md">Paragraph – Medium</p>
 <p class="para-sm">Paragraph – Small</p>
-<p>Paragraph – Default (Medium)</p>
+<p>Paragraph – Default (Large)</p>
         </div>
       </div>
 
@@ -313,10 +314,11 @@ Select:
 &lt;h3&gt;Heading 3 (h3)&lt;/h3&gt;
 &lt;h4&gt;Heading 4 (h4)&lt;/h4&gt;
 &lt;h5&gt;Heading 5 (h5)&lt;/h5&gt;
+&lt;p class=&quot;para-xl&quot;&gt;Paragraph – Extra-Large&lt;/p&gt;
 &lt;p class=&quot;para-lg&quot;&gt;Paragraph – Large&lt;/p&gt;
 &lt;p class=&quot;para-md&quot;&gt;Paragraph – Medium&lt;/p&gt;
 &lt;p class=&quot;para-sm&quot;&gt;Paragraph – Small&lt;/p&gt;
-&lt;p&gt;Paragraph – Default (Medium)&lt;/p&gt;</code></pre>
+&lt;p&gt;Paragraph – Default (Large)&lt;/p&gt;</code></pre>
       </div>
 
       </section>


### PR DESCRIPTION
Fixes #784 

This PR makes the global nav items "active" on subpages as well as the landing. For instance, the nav remains `how-it-works/process-overview/` as well as `how-it-works/`.

Preview: https://federalist.18f.gov/preview/18F/doi-extractives-data/active-subnavs/

@meiqimichelle, ready for review