### PR TITLE
Cleaning

### DIFF
--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -11,7 +11,9 @@ permalink: /explore/gdp/
 
       <p>In 2013, our GDP was $16.8 trillion, making the U.S. economy the largest in the world. Overall the extractive industries account for 2.6% of the economy, outpacing utilities, agriculture, and education services in contribution to national GDP. Extractive industries totaled <a href="http://www.bea.gov/iTable/iTable.cfm?ReqID=51&step=1#reqid=51&step=51&isuri=1&5114=a&5102=1">$439 billion in real value added</a>.</p>
 
-      <h3>2013 extractive industries value-added GDP</h3>
+      <p><em>Explore GDP from 2004 to 2011 by state as a dollar value, or as a percentage of total GDP.</em></p>
+
+      <!-- <h3>2013 extractive industries value-added GDP</h3>
 
       <table>
         <tr>
@@ -46,7 +48,7 @@ permalink: /explore/gdp/
         </tr>
       </table>
 
-      <p>Extractive industries affect the economy in a number of ways, including the quantity and value of the natural resources produced, the revenue collected for public purposes, the jobs held by people working in extractive industries, and the exports that draw in money from abroad. While it can be difficult to quantify an industry’s impact on a country, these measures—production, revenue, employment, and exports—start to highlight the extractive industries’ role in the economy.</p>
+      <p>Extractive industries affect the economy in a number of ways, including the quantity and value of the natural resources produced, the revenue collected for public purposes, the jobs held by people working in extractive industries, and the exports that draw in money from abroad. While it can be difficult to quantify an industry’s impact on a country, these measures—production, revenue, employment, and exports—start to highlight the extractive industries’ role in the economy.</p> -->
     </div>
   </div>
   <section class="container-right-8">

--- a/_explore/production/production-all-lands.md
+++ b/_explore/production/production-all-lands.md
@@ -1,7 +1,7 @@
 ---
 title: All Lands Production | Explore Data
 layout: default
-permalink: /explore/production/
+permalink: /explore/all-lands-production/
 ---
 
 <div class="container-outer container-padded">
@@ -9,7 +9,7 @@ permalink: /explore/production/
   <h3> <a href="{{ site.baseurl }}/explore/">Explore Data</a> / All Lands Production</h3>
 
   <h4>From <a href="https://github.com/18F/doi-extractives-data/wiki/Information-Architecture">Information Architecture</a>:</h4>
-  
+
   <ul class="list-bullet">
 	  <li>Content and table on p. 68</li>
   </ul>

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -9,12 +9,10 @@ permalink: /explore/federal-production/
       <h5 class="subpage-breadcrumb"><a href="{{ site.baseurl }}/explore/">Explore</a> /</h5>
       <h1>Federal Production</h1>
 
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing
-        elit. Praesent eget justo sodales neque fermentum
-        consequat eu sit amet libero. Aliquam eu eleifend leo.
-        Donec sem dolor, volutpat quis tortor pretium,
-        tincidunt pretium massa. Curabitur sed euismod velit.
-        Aenean eu venenatis turpis, mattis tempus orci.</p>
+      <p>Revenue from extractive industries on federal lands totaled approximately $13.4 billion, or 0.4% of total $3,396.9 billion in revenue collected across the federal government.</p>
+
+      <p><em>Explore production on federal lands and waters from 2005 to 2014 by state and county for 28 individual products.</em></p>
+
     </div>
   </div>
   <section class="container-right-8">
@@ -27,12 +25,17 @@ permalink: /explore/federal-production/
 
         <div class="filters-heading">
           <h3>Filter revenue</h3>
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing
-      elit.</p>
+          <p>Select a product to see its production levels by its specific unit of measure.</p>
         </div>
 
         <div class="container-left-6">
-          <div class="filter">
+          <div id="product-filter" class="filter">
+            <label for="product-selector">Product</label>
+            <select id="product-selector" name="product">
+              <option value="">All products</option>
+            </select>
+          </div>
+          <!-- <div class="filter">
             <label for="commodity-group-selector">Commodity Category</label>
             <select id="commodity-group-selector" name="group">
               <option value="">All commodity categories</option>
@@ -47,16 +50,9 @@ permalink: /explore/federal-production/
             <select id="commodity-selector" name="commodity">
               <option value="">All commodities</option>
             </select>
-          </div>
+          </div> -->
         </div>
         <div class="container-right-6">
-          <div id="product-filter" class="filter">
-            <label for="product-selector">Product</label>
-            <select id="product-selector" name="product">
-              <option value="">All products</option>
-            </select>
-          </div>
-
           <div class="filter">
             <label for="region-selector">Region</label>
             <select id="region-selector" name="region">


### PR DESCRIPTION
- Comments out old text on gdp page
- Removes old drop-downs that we're not using anymore on production
- Adds summary of data text to gdp and revenues
- fixes dead all-lands production link on explore home