### PR TITLE
New case studies layout

### DIFF
--- a/_case-studies/boone-logan-and-mingo.md
+++ b/_case-studies/boone-logan-and-mingo.md
@@ -5,7 +5,7 @@ permalink: /case-studies/boone-logan-and-mingo/
 resource: coal
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ

--- a/_case-studies/campbell.md
+++ b/_case-studies/campbell.md
@@ -5,7 +5,7 @@ permalink: /case-studies/campbell/
 resource: coal
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ
@@ -126,4 +126,3 @@ The table below highlights the data sources used to compile this narrative, as w
 [^27]: [Campbell County Coal Belt Transportation Study](http://www.ccgov.net/DocumentCenter/Home/View/1910), 2010
 [^28]: Ibid.
 [^29]: [Campbell County and Wyoming DOT, [Campbell County Coal Belt Transportation Study](http://www.ccgov.net/DocumentCenter/Home/View/1910), 2010, p. 5
-

--- a/_case-studies/default.md
+++ b/_case-studies/default.md
@@ -4,7 +4,7 @@ layout: case-studies
 permalink: /case-studies/
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: reven
     title: Revenue sustainability
   - name: county-rev
@@ -15,7 +15,7 @@ nav_items:
     title: Data
 ---
 
-<h3 class="case_studies_content-icon">
+<!-- <h3 class="case_studies_content-icon">
   <i class="icon-oil"></i>
   <i class="icon-gas"></i>
   <i class="icon-coal"></i>
@@ -23,9 +23,9 @@ nav_items:
   <i class="icon-copper"></i>
   <i class="icon-iron"></i>
   <a name="intro" class="case_studies_content-heading js-cs_section">Six commodities</a>
-</h3>
+</h3> -->
 
-<h3><a name="intro" class="case_studies_content-heading js-cs_section">Introduction</a></h3>
+<h3><a name="intro" class="case_studies_content-heading js-cs_section">Overview</a></h3>
 
 While extractive industries made up 2.6% of the U.S. GDP in 2013, they play a much larger role in some local communities. For example, extractive industries make up more than a third of Wyoming’s GDP.[^1] At the county level, certain communities and local economies may be even more dependent on extractive industries.
 

--- a/_case-studies/default.md
+++ b/_case-studies/default.md
@@ -6,7 +6,7 @@ nav_items:
   - name: intro
     title: Top
   - name: reven
-    title: Revenue sustainability
+    title: Revenue Sustainability
   - name: county-rev
     title: Revenue
   - name: county-cos
@@ -30,43 +30,6 @@ nav_items:
 While extractive industries made up 2.6% of the U.S. GDP in 2013, they play a much larger role in some local communities. For example, extractive industries make up more than a third of Wyoming’s GDP.[^1] At the county level, certain communities and local economies may be even more dependent on extractive industries.
 
 This section includes 12 case studies that provide a snapshot of communities that have led the U.S. in producing oil, gas, coal, gold, iron, or copper over the last decade. These case studies shed light on the economic and fiscal effects of oil, gas, and mineral extraction on local communities, including revenue sustainability.
-
-<!-- #### Choose a community to get started
-
-<ul class="case_studies_content-select">
-  <ul>
-    <p class="para-lg">Coal</p>
-    <li><a href="{{ site.baseurl }}/case-studies/boone-logan-and-mingo">Boone, Logan, and Mingo Counties, West Virginia</a></li>
-    <li><a href="{{ site.baseurl }}/case-studies/campbell/">Campbell County, Wyoming</a></li>
-  </ul>
-  <ul>
-  <p class="para-lg">Copper</p>
-    <li><a href="{{ site.baseurl }}/case-studies/greenlee">Greenlee County, Arizona</a></li>
-    <li><a href="{{ site.baseurl }}/case-studies/pima/">Pima County, Arizona</a></li>
-  </ul>
-  <ul>
-  <p class="para-lg">Gold</p>
-    <li><a href="{{ site.baseurl }}/case-studies/elko-and-eureka">Elko and Eureka Counties, Nevada</a></li>
-    <li><a href="{{ site.baseurl }}/case-studies/humboldt-and-lander/">Humboldt and Lander Counties, Nevada</a></li>
-  </ul>
-  <ul>
-  <p class="para-lg">Iron</p>
-    <li><a href="{{ site.baseurl }}/case-studies/marquette">Marquette County, Michigan</a></li>
-    <li><a href="{{ site.baseurl }}/case-studies/st-louis/">St. Louis County, Minnesota</a></li>
-  </ul>
-  <ul>
-  <p class="para-lg">Gas</p>
-    <li><a href="{{ site.baseurl }}/case-studies/desoto">DeSoto Parish, Louisiana</a></li>
-    <li><a href="{{ site.baseurl }}/case-studies/tarrant-and-johnson/">Tarrant &amp; Johnson Counties, Texas</a></li>
-  </ul>
-  <ul>
-  <p class="para-lg">Oil</p>
-    <li><a href="{{ site.baseurl }}/case-studies/kern">Kern County, California</a></li>
-    <li><a href="{{ site.baseurl }}/case-studies/north-slope">North Slope Borough, Alaska</a></li>
-  </ul>
-</ul>
-
-#### Or, read more about how to interpret these studies: -->
 
 <h3><a name="reven" class="case_studies_content-heading js-cs_section">Revenue sustainability</a></h3>
 

--- a/_case-studies/default.md
+++ b/_case-studies/default.md
@@ -25,6 +25,10 @@ nav_items:
   <a name="intro" class="case_studies_content-heading js-cs_section">Six commodities</a>
 </h3> -->
 
+<h1 class="case_studies_intro-heading">How do extractive industries impact communities like mine?</h1>
+
+<p class="case_studies_intro-para">In some communities, extractive industries play a much larger role than in others. These narratives provide  snapshots into twelve communities that, over the last decade, have led in production of one of six resources: iron, copper, gold, coal, oil, and natural gas.</p>
+
 <h3><a name="intro" class="case_studies_content-heading js-cs_section">Overview</a></h3>
 
 While extractive industries made up 2.6% of the U.S. GDP in 2013, they play a much larger role in some local communities. For example, extractive industries make up more than a third of Wyoming’s GDP.[^1] At the county level, certain communities and local economies may be even more dependent on extractive industries.

--- a/_case-studies/desoto.md
+++ b/_case-studies/desoto.md
@@ -5,7 +5,7 @@ permalink: /case-studies/desoto/
 resource: gas
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ
@@ -124,4 +124,3 @@ The DeSoto Parish Emergency Medical Services (EMS) Department formed in 2001, fu
 [^23]: [Louisiana Statewide Transportation Plan, Chapter 7: Transportation Plan Development](http://wwwsp.dotd.la.gov/Inside_LaDOTD/Divisions/Multimodal/Transportation_Plan/2003%20Statewide%20Transportation%20Plan/10%20Chapter%207%20-%20Transportation%20Plan%20Development.pdf), 2003, p. 7-50
 [^24]: Louisiana Department of Natural Resources, [Louisiana Hydraulic Fracturing State Review](http://dnr.louisiana.gov/assets/OC/haynesville_shale/071311_stronger_review.pdf), 2011, p. 16
 [^25]: DeSoto Parish EMS, [Our History](http://www.desotoparishems.com/#!our-history/c17ox)
-

--- a/_case-studies/elko-and-eureka.md
+++ b/_case-studies/elko-and-eureka.md
@@ -5,7 +5,7 @@ permalink: /case-studies/elko-and-eureka/
 resource: gold
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ
@@ -105,4 +105,3 @@ The table below highlights the data sources used to compile this narrative, as w
 [^10]: Ibid.
 [^11]: Nevada Department of Taxation, [Understanding Nevada’s Fiscal System: Taxes on Patented Mines and Proceeds of Minerals (PDF)](http://www.unce.unr.edu/publications/files/cd/2013/fs1334.pdf), table 2
 [^12]: Ibid.; [County of Eureka: Comprehensive Annual Financial Report (PDF)](http://www.co.eureka.nv.us/audit/Eureka%20FS%202012.pdf), 2012; [Elko County (PDF)](http://www.elkocountynv.net/departments/fiscal_affairs/docs/Elko_County_2012_Audit1.pdf), 2012
-

--- a/_case-studies/greenlee.md
+++ b/_case-studies/greenlee.md
@@ -5,7 +5,7 @@ permalink: /case-studies/greenlee/
 resource: copper
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ
@@ -103,4 +103,3 @@ The table below highlights data sources used to compile this narrative, as well 
 [^14]: Arizona Department of Revenue, [June 2012 Tax Facts (PDF)](http://www.azdor.gov/Portals/0/TaxFacts/0612Taxfact.pdf), p. 7
 [^15]: Greenlee County, Arizona, [Annual Financial Report](http://azmemory.azlibrary.gov/cdm/ref/collection/statepubs/id/15685), FY 2013, p. 10
 [^16]: [Southern Greenlee County Small Area Transportation Study, Addendum to Transportation Plan (PDF)](http://www.co.greenlee.az.us/engineering/roads/Greenlee%20Addendum%20Final%20Report%200809.pdf), p. 5
-

--- a/_case-studies/humbolt-and-lander.md
+++ b/_case-studies/humbolt-and-lander.md
@@ -5,7 +5,7 @@ permalink: /case-studies/humboldt-and-lander/
 resource: gold
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ

--- a/_case-studies/kern.md
+++ b/_case-studies/kern.md
@@ -5,7 +5,7 @@ permalink: /case-studies/kern/
 resource: oil
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ

--- a/_case-studies/marquette.md
+++ b/_case-studies/marquette.md
@@ -5,7 +5,7 @@ permalink: /case-studies/marquette/
 resource: iron
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ
@@ -99,4 +99,3 @@ The table below highlights the data sources used to compile this narrative, as w
 [^10]: [Marquette County Administrator’s 2013 Budget Summary (PDF)](http://www.co.marquette.mi.us/departments/administrator/docs/Budget2013/ADM_SUMMARY.pdf), p. 2
 [^11]: Ibid.
 [^12]: Ibid.
-

--- a/_case-studies/north-slope.md
+++ b/_case-studies/north-slope.md
@@ -5,7 +5,7 @@ permalink: /case-studies/north-slope/
 resource: oil
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ

--- a/_case-studies/pima.md
+++ b/_case-studies/pima.md
@@ -5,7 +5,7 @@ permalink: /case-studies/pima/
 resource: copper
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ
@@ -102,4 +102,3 @@ The table below highlights data sources used to compile this narrative, as well 
 [^13]: Arizona Department of Revenue, [2014 Annual Report (PDF)](https://www.azdor.gov/Portals/0/AnnualReports/FY14%20Annual%20Report%20W.pdf), p. 39, table 7
 [^14]: State of Arizona, [2013 Tax Handbook (PDF)](http://www.azleg.gov/jlbc/13taxbook/13taxbk.pdf), p. 8, table 4
 [^15]: Pima County, Arizona, [Comprehensive Annual Financial Report (PDF)](http://webcms.pima.gov/UserFiles/Servers/Server_6/File/Government/Finance%20and%20Risk%20Management/Reports/audited%20financial%20reports/CAFR/CAFR%202013.pdf), 2013, p. 131
-

--- a/_case-studies/st-louis.md
+++ b/_case-studies/st-louis.md
@@ -5,7 +5,7 @@ permalink: /case-studies/st-louis/
 resource: iron
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ
@@ -111,4 +111,3 @@ The table below highlights data sources used to compile this narrative, as well 
 [^16]: Minnesota Department of Natural Resources, [Mineland Reclamation](http://www.dnr.state.mn.us/lands_minerals/mineland_reclamation/index.html)
 [^17]: Ibid.
 [^18]: Minnesota Department of Natural Resources, [Where Funds are Spent (PDF)](http://files.dnr.state.mn.us/aboutdnr/budget/fy12-13/budget_spent.pdf), 2012–2013, p. 3
-

--- a/_case-studies/tarrant-and-johnson.md
+++ b/_case-studies/tarrant-and-johnson.md
@@ -5,7 +5,7 @@ permalink: /case-studies/tarrant-and-johnson/
 resource: gas
 nav_items:
   - name: intro
-    title: Introduction
+    title: Top
   - name: geolo
     title: Geology and history
   - name: produ
@@ -124,4 +124,3 @@ The table below highlights the data sources used to compile this county narrativ
 [^25]: Texas’s fiscal year spans from September 1 of the previous year through August 31 of the current year.
 [^26]: Railroad Commission of Texas, [Oil and Gas Regulation and Cleanup Program, Annual Report – Fiscal Year 2013](http://www.rrc.texas.gov/media/18795/ofcu2013.pdf)
 [^27]: Specific fiscal costs to municipalities not specified. Ibid.
-

--- a/_includes/case-studies/_selector.html
+++ b/_includes/case-studies/_selector.html
@@ -1,7 +1,7 @@
 <select onchange="window.location = '{{ site.baseurl }}/case-studies/' + this.value + '/'">
   <option
   {% if page.permalink == '/case-studies/' %}selected{% endif %}
-  value="#">Select a community</option>
+  value="#">Overview</option>
   <optgroup label="Coal">
     <option
       {% if page.permalink == '/case-studies/boone-logan-and-mingo/' %}selected{% endif %}

--- a/_layouts/case-studies.html
+++ b/_layouts/case-studies.html
@@ -22,22 +22,7 @@ layout: default
 		  <h3 class="case_studies_content-icon"><i class="icon-iron"></i>Iron</h3>
 		{% endif %}
 
-			<!-- {% if page.resource == 'oil' %}
-			  <h3 class="case_studies_content-icon"><i class="icon-oil"></i>Oil</h3>
-			{% elsif page.resource == 'gas' %}
-				<h3 class="case_studies_content-icon"><i class="icon-gas"></i>Natural Gas</h3>
-			{% elsif page.resource == 'coal' %}
-				<h3 class="case_studies_content-icon"><i class="icon-coal"></i>Coal</h3>
-			{% elsif page.resource == 'gold' %}
-				<h3 class="case_studies_content-icon"><i class="icon-gold"></i>Gold</h3>
-			{% elsif page.resource == 'copper' %}
-				<h3 class="case_studies_content-icon"><i class="icon-copper"></i>Copper</h3>
-			{% elsif page.resource == 'iron' %}
-				<h3 class="case_studies_content-icon"><i class="icon-iron"></i>Iron</h3>
-			{% endif %} -->
-
-
-		  {{content | markdownify}}
+	  {{content | markdownify}}
 
 	</article>
 

--- a/_layouts/case-studies.html
+++ b/_layouts/case-studies.html
@@ -2,12 +2,15 @@
 layout: default
 ---
 
-
-{% include case-studies/_intro.html %}
+<!-- {% include case-studies/_intro.html %} -->
 
 <section class="container-outer case_studies_content">
 
 	<article class="container-left-7">
+
+		<h1 class="case_studies_intro-heading">How do extractive industries impact communities like mine?</h1>
+
+		<p class="case_studies_intro-para">In some communities, extractive industries play a much larger role than in others. These narratives provide  snapshots into twelve communities that, over the last decade, have led in production of one of six resources: iron, copper, gold, coal, oil, and natural gas.</p>
 
 			{% if page.resource == 'oil' %}
 			  <h3 class="case_studies_content-icon"><i class="icon-oil"></i>Oil</h3>
@@ -28,23 +31,40 @@ layout: default
 
 	</article>
 
-	<div class="container-right-5 sticky_nav">
+	<div class="container-right-5">
 
-	  <nav class="sticky_nav-nav">
+		<label>Choose a community page
+			<div class="case_studies_intro-select">
+				{% include case-studies/_selector.html %}
+			</div>
+		</label>
 
-	    <ul>
-	      {% if page.nav_items %}
-	      	{% for item in page.nav_items %}
-		        {% if item.name == page.nav_items[0].name %}
-		          <li class="sticky_nav-nav_item js-cs_nav_item active {{item.name}}"><a href="#{{item.name}}">{{item.title}}</a></li>
-		        {% else %}
-		          <li class="sticky_nav-nav_item js-cs_nav_item {{item.name}}"><a href="#{{item.name}}">{{item.title}}</a></li>
-		        {% endif %}
-		      {% endfor %}
-	      {% endif %}
-	    </ul>
+		<div class="u-centered">
 
-	  </nav>
+      <img src="{{ site.baseurl }}/img/counties/12-map.png" alt="Map with locations of the twelve communities given in-depth coverage in this section of the site." class="case_studies_intro-image">
+      <img src="{{ site.baseurl }}/img/counties/12-map-icons.png" alt="Key for map with the icons for the six commodities given in-depth coverage in this section of the site." class="case_studies_intro-image case_studies_intro-image_key">
+
+    </div>
+
+		<div class="sticky_nav">
+
+		  <nav class="sticky_nav-nav">
+
+		    <ul>
+		      {% if page.nav_items %}
+		      	{% for item in page.nav_items %}
+			        {% if item.name == page.nav_items[0].name %}
+			          <li class="sticky_nav-nav_item js-cs_nav_item active {{item.name}}"><a href="#{{item.name}}">{{item.title}}</a></li>
+			        {% else %}
+			          <li class="sticky_nav-nav_item js-cs_nav_item {{item.name}}"><a href="#{{item.name}}">{{item.title}}</a></li>
+			        {% endif %}
+			      {% endfor %}
+		      {% endif %}
+		    </ul>
+
+		  </nav>
+
+		</div>
 
 	</div>
 

--- a/_layouts/case-studies.html
+++ b/_layouts/case-studies.html
@@ -8,11 +8,21 @@ layout: default
 
 	<article class="container-left-7">
 
-		<h1 class="case_studies_intro-heading">How do extractive industries impact communities like mine?</h1>
+		{% if page.resource == 'oil' %}
+		  <h3 class="case_studies_content-icon"><i class="icon-oil"></i>Oil</h3>
+		{% elsif page.resource == 'gas' %}
+		  <h3 class="case_studies_content-icon"><i class="icon-gas"></i>Natural Gas</h3>
+		{% elsif page.resource == 'coal' %}
+		  <h3 class="case_studies_content-icon"><i class="icon-coal"></i>Coal</h3>
+		{% elsif page.resource == 'gold' %}
+		  <h3 class="case_studies_content-icon"><i class="icon-gold"></i>Gold</h3>
+		{% elsif page.resource == 'copper' %}
+		  <h3 class="case_studies_content-icon"><i class="icon-copper"></i>Copper</h3>
+		{% elsif page.resource == 'iron' %}
+		  <h3 class="case_studies_content-icon"><i class="icon-iron"></i>Iron</h3>
+		{% endif %}
 
-		<p class="case_studies_intro-para">In some communities, extractive industries play a much larger role than in others. These narratives provide  snapshots into twelve communities that, over the last decade, have led in production of one of six resources: iron, copper, gold, coal, oil, and natural gas.</p>
-
-			{% if page.resource == 'oil' %}
+			<!-- {% if page.resource == 'oil' %}
 			  <h3 class="case_studies_content-icon"><i class="icon-oil"></i>Oil</h3>
 			{% elsif page.resource == 'gas' %}
 				<h3 class="case_studies_content-icon"><i class="icon-gas"></i>Natural Gas</h3>
@@ -24,7 +34,7 @@ layout: default
 				<h3 class="case_studies_content-icon"><i class="icon-copper"></i>Copper</h3>
 			{% elsif page.resource == 'iron' %}
 				<h3 class="case_studies_content-icon"><i class="icon-iron"></i>Iron</h3>
-			{% endif %}
+			{% endif %} -->
 
 
 		  {{content | markdownify}}

--- a/_layouts/case-studies.html
+++ b/_layouts/case-studies.html
@@ -65,5 +65,5 @@ layout: default
 
 </section>
 
-
+<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
 <script src="{{ site.baseurl }}/js/pages/case-studies.js"></script>

--- a/_sass/blocks/case-studies/_intro.scss
+++ b/_sass/blocks/case-studies/_intro.scss
@@ -27,9 +27,9 @@
 }
 
 .case_studies_intro-image_key {
-  border-top: 4px solid $mid-gray;
-  margin-top: $base-padding-large;
-  padding-top: $base-padding;
+  border-top: 2px solid $mid-gray;
+  margin-top: $base-padding;
+  padding-top: $base-padding-lite;
 }
 
 .case_studies_intro-select {

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -1,7 +1,8 @@
 .sticky_nav {
   left: percentage(7 / 12);
+  padding-top: $base-padding-extra;
   padding-left: $base-padding-extra;
-  position: absolute;
+  // position: absolute;
   top: 0;
 
   @include respond-to(medium-down) {
@@ -10,7 +11,7 @@
 }
 
 .sticky_nav-nav {
-  margin-top: $base-padding-extra;
+  // margin-top: $base-padding-extra;
 }
 
 .sticky_nav-nav_item {

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -1,17 +1,11 @@
 .sticky_nav {
-  left: percentage(7 / 12);
   padding-top: $base-padding-extra;
   padding-left: $base-padding-extra;
-  // position: absolute;
   top: 0;
 
   @include respond-to(medium-down) {
     display: none;
   }
-}
-
-.sticky_nav-nav {
-  // margin-top: $base-padding-extra;
 }
 
 .sticky_nav-nav_item {

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -1,6 +1,6 @@
 .sticky_nav {
-  padding-top: $base-padding-extra;
   padding-left: $base-padding-extra;
+  padding-top: $base-padding-extra;
   top: 0;
 
   @include respond-to(medium-down) {

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -50,7 +50,7 @@
     }
   }
 
-  stickyNav = new StickyNav();
+  var stickyNav = new StickyNav();
 
   findScrollPositions();
   stickyNav.setPositions();

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -23,7 +23,7 @@
       main: document.querySelector('main')
     }
     this.height = this.elems.sticky.clientHeight;
-    this.offset = this.elems.sticky.offsetTop
+    this.offset = this.elems.sticky.offsetTop;
   };
 
   StickyNav.prototype = {
@@ -31,7 +31,7 @@
       this.mainOffset = this.elems.main.offsetTop;
       this.mainHeight = this.elems.main.clientHeight;
       this.diffTop = scrollTop - this.mainOffset - this.offset;
-      this.diffBottom = scrollTop + this.height - this.mainHeight - this.mainOffset
+      this.diffBottom = scrollTop + this.height - this.mainHeight - this.mainOffset;
     },
     update: function(){
       if (this.diffTop >= 0){

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -20,7 +20,7 @@
     this.elems = {
       sticky : document.querySelector('.sticky_nav'),
       main: document.querySelector('main')
-    }
+    };
     this.height = this.elems.sticky.clientHeight;
     this.offset = this.elems.sticky.offsetTop;
   };
@@ -47,7 +47,7 @@
         this.elems.sticky.style.position = 'static';
       }
     }
-  }
+  };
 
   var stickyNav = new StickyNav();
 

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -1,0 +1,72 @@
+(function(exports) {
+
+  var scrollLeft,
+    scrollTop,
+    sections;
+
+  var findScrollPositions = function(){
+    scrollLeft = (window.pageXOffset !== undefined)
+      ? window.pageXOffset
+      : (document.documentElement
+        || document.body.parentNode
+        || document.body).scrollLeft;
+    scrollTop = (window.pageYOffset !== undefined)
+      ? window.pageYOffset
+      : (document.documentElement
+        || document.body.parentNode
+        || document.body).scrollTop;
+  };
+
+  console.log('in', window)
+
+
+  StickyNav = function() {
+    this.elems = {
+      sticky : document.querySelector('.sticky_nav'),
+      main: document.querySelector('main')
+    }
+    this.height = this.elems.sticky.clientHeight;
+    this.offset = this.elems.sticky.offsetTop
+  };
+
+  StickyNav.prototype = {
+    setPositions : function () {
+      this.mainOffset = this.elems.main.offsetTop;
+      this.mainHeight = this.elems.main.clientHeight;
+      this.diffTop = scrollTop - this.mainOffset - this.offset;
+      this.diffBottom = scrollTop + this.height - this.mainHeight - this.mainOffset
+    },
+    update: function(){
+      if (this.diffTop >= 0){
+        this.elems.sticky.style.position = 'fixed';
+        this.elems.sticky.style.top = 0;
+        if (this.diffBottom >= 0){
+          this.elems.sticky.style.position = 'absolute';
+          this.elems.sticky.style.top = this.mainHeight - this.height - 50 + 'px';
+        } else {
+          this.elems.sticky.style.position = 'fixed';
+          this.elems.sticky.style.top = 0;
+        }
+      } else {
+        this.elems.sticky.style.position = 'static';
+      }
+    }
+  }
+
+  stickyNav = new StickyNav();
+
+  findScrollPositions();
+  stickyNav.setPositions();
+  stickyNav.update();
+
+  window.addEventListener('scroll', function() {
+    findScrollPositions();
+    stickyNav.setPositions();
+    stickyNav.update();
+  });
+
+
+  exports.stickyNav = stickyNav;
+
+
+})(this);

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -1,8 +1,7 @@
 (function(exports) {
 
   var scrollLeft,
-    scrollTop,
-    sections;
+    scrollTop;
 
   var findScrollPositions = function(){
     scrollLeft = (window.pageXOffset !== undefined)
@@ -17,7 +16,7 @@
         || document.body).scrollTop;
   };
 
-  StickyNav = function() {
+  var StickyNav = function() {
     this.elems = {
       sticky : document.querySelector('.sticky_nav'),
       main: document.querySelector('main')

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -17,9 +17,6 @@
         || document.body).scrollTop;
   };
 
-  console.log('in', window)
-
-
   StickyNav = function() {
     this.elems = {
       sticky : document.querySelector('.sticky_nav'),

--- a/js/pages/case-studies.js
+++ b/js/pages/case-studies.js
@@ -1,7 +1,7 @@
 (function() {
     var scrollLeft,
       scrollTop,
-      sections;
+
     var findScrollPositions = function(){
       scrollLeft = (window.pageXOffset !== undefined)
         ? window.pageXOffset

--- a/js/pages/case-studies.js
+++ b/js/pages/case-studies.js
@@ -64,43 +64,7 @@
       }
     };
 
-    // var setStickyPos = function () {
-    //   var stickyNav = document.querySelector('.sticky_nav'),
-    //       cscOffsetTop = caseStudiesContent.offsetTop;
-
-    //   // scrollDifference is the difference in height between
-    //   // the location of the top of the window and
-    //   // the top of the 'case_studies_content' div
-    //   var scrollDifference = scrollTop - cscOffsetTop;
-    //   console.log(stickyNav)
-    //   var combinedOffset = cscOffsetTop + caseStudiesContent.offsetHeight;
-    //   var stickyNavHeight = stickyNav.clientHeight;
-
-    //   // scrollTopFooterOffset is the combined height of the content
-    //   // offsets less the height the sticky div
-    //   // and the content's bottom padding
-    //   // when scrollTop is greater than scrollTopFooterOffset 'top'
-    //   // property of stickyFooter should be set to scrollTopFooterOffset
-    //   var scrollTopFooterOffset = combinedOffset - stickyNavHeight - 50;
-
-    //   if (scrollDifference >= 0){
-    //     stickyNav.style.position = 'fixed';
-    //     stickyNav.style.top = 0;
-    //     if (scrollTop > scrollTopFooterOffset){
-    //       stickyNav.style.position = 'absolute';
-    //       stickyNav.style.top = scrollTopFooterOffset - cscOffsetTop + 'px';
-    //     } else {
-    //       stickyNav.style.position = 'fixed';
-    //       stickyNav.style.top = 0;
-    //     }
-    //   } else {
-    //     stickyNav.style.position = 'absolute';
-    //   }
-    // };
-
     window.onscroll = function() {
-        // findScrollPositions();
-        // setStickyPos();
         chooseNavByScroll();
     };
     window.onresize = function(){

--- a/js/pages/case-studies.js
+++ b/js/pages/case-studies.js
@@ -16,8 +16,6 @@
     };
     var caseStudiesContent = document.querySelector('.case_studies_content');
 
-
-
     var removeActive = function(){
       var caseStudiesNavItems = document.querySelectorAll('.js-cs_nav_item');
       for (var i = 0; i < caseStudiesNavItems.length; i++) {
@@ -66,43 +64,43 @@
       }
     };
 
-    var setStickyPos = function () {
-      var stickyNav = document.querySelector('.sticky_nav'),
-          cscOffsetTop = caseStudiesContent.offsetTop;
+    // var setStickyPos = function () {
+    //   var stickyNav = document.querySelector('.sticky_nav'),
+    //       cscOffsetTop = caseStudiesContent.offsetTop;
 
-      // scrollDifference is the difference in height between
-      // the location of the top of the window and
-      // the top of the 'case_studies_content' div
-      var scrollDifference = scrollTop - cscOffsetTop;
+    //   // scrollDifference is the difference in height between
+    //   // the location of the top of the window and
+    //   // the top of the 'case_studies_content' div
+    //   var scrollDifference = scrollTop - cscOffsetTop;
+    //   console.log(stickyNav)
+    //   var combinedOffset = cscOffsetTop + caseStudiesContent.offsetHeight;
+    //   var stickyNavHeight = stickyNav.clientHeight;
 
-      var combinedOffset = cscOffsetTop + caseStudiesContent.offsetHeight;
-      var stickyNavHeight = stickyNav.clientHeight;
+    //   // scrollTopFooterOffset is the combined height of the content
+    //   // offsets less the height the sticky div
+    //   // and the content's bottom padding
+    //   // when scrollTop is greater than scrollTopFooterOffset 'top'
+    //   // property of stickyFooter should be set to scrollTopFooterOffset
+    //   var scrollTopFooterOffset = combinedOffset - stickyNavHeight - 50;
 
-      // scrollTopFooterOffset is the combined height of the content
-      // offsets less the height the sticky div
-      // and the content's bottom padding
-      // when scrollTop is greater than scrollTopFooterOffset 'top'
-      // property of stickyFooter should be set to scrollTopFooterOffset
-      var scrollTopFooterOffset = combinedOffset - stickyNavHeight - 50;
-
-      if (scrollDifference >= 0){
-        stickyNav.style.position = 'fixed';
-        stickyNav.style.top = 0;
-        if (scrollTop > scrollTopFooterOffset){
-          stickyNav.style.position = 'absolute';
-          stickyNav.style.top = scrollTopFooterOffset - cscOffsetTop + 'px';
-        } else {
-          stickyNav.style.position = 'fixed';
-          stickyNav.style.top = 0;
-        }
-      } else {
-        stickyNav.style.position = 'absolute';
-      }
-    };
+    //   if (scrollDifference >= 0){
+    //     stickyNav.style.position = 'fixed';
+    //     stickyNav.style.top = 0;
+    //     if (scrollTop > scrollTopFooterOffset){
+    //       stickyNav.style.position = 'absolute';
+    //       stickyNav.style.top = scrollTopFooterOffset - cscOffsetTop + 'px';
+    //     } else {
+    //       stickyNav.style.position = 'fixed';
+    //       stickyNav.style.top = 0;
+    //     }
+    //   } else {
+    //     stickyNav.style.position = 'absolute';
+    //   }
+    // };
 
     window.onscroll = function() {
-        findScrollPositions();
-        setStickyPos();
+        // findScrollPositions();
+        // setStickyPos();
         chooseNavByScroll();
     };
     window.onresize = function(){

--- a/js/pages/case-studies.js
+++ b/js/pages/case-studies.js
@@ -1,6 +1,7 @@
 (function() {
     var scrollLeft,
       scrollTop,
+      sections;
 
     var findScrollPositions = function(){
       scrollLeft = (window.pageXOffset !== undefined)

--- a/styleguide/section-blocks.html
+++ b/styleguide/section-blocks.html
@@ -38,38 +38,50 @@
         </a>
         <ul class="kss-nav__menu-child">
             <li class="kss-nav__menu-item">
-              <a href="section-blocks.html#kssref-blocks-banner">
+              <a href="section-blocks.html#kssref-blocks-about">
                 <span class="kss-nav__ref">1.1</span
+                ><span class="kss-nav__name">About</span>
+              </a>
+            </li>
+            <li class="kss-nav__menu-item">
+              <a href="section-blocks.html#kssref-blocks-about">
+                <span class="kss-nav__ref">1.1</span
+                ><span class="kss-nav__name"></span>
+              </a>
+            </li>
+            <li class="kss-nav__menu-item">
+              <a href="section-blocks.html#kssref-blocks-banner">
+                <span class="kss-nav__ref">1.2</span
                 ><span class="kss-nav__name">US Bar Disclaimer Banner</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-case-studies">
-                <span class="kss-nav__ref">1.2</span
+                <span class="kss-nav__ref">1.3</span
                 ><span class="kss-nav__name">Case Studies</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-explore">
-                <span class="kss-nav__ref">1.3</span
+                <span class="kss-nav__ref">1.4</span
                 ><span class="kss-nav__name">Explore</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-footer">
-                <span class="kss-nav__ref">1.4</span
+                <span class="kss-nav__ref">1.5</span
                 ><span class="kss-nav__name">Footer</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-header">
-                <span class="kss-nav__ref">1.5</span
+                <span class="kss-nav__ref">1.6</span
                 ><span class="kss-nav__name">Header</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-how-it-works">
-                <span class="kss-nav__ref">1.6</span
+                <span class="kss-nav__ref">1.7</span
                 ><span class="kss-nav__name">How it Works</span>
               </a>
             </li>
@@ -134,13 +146,57 @@
 
 
       </div>
+      <section id="kssref-blocks-about" class="kss-section kss-section--depth-2">
+
+    <div class="kss-style">
+      <h2 class="kss-title kss-title--level-2">
+        <a class="kss-title__permalink" href="#kssref-blocks-about">
+          <span class="kss-title__ref">
+              1.1
+            <span class="kss-title__permalink-hash">
+                #blocks.about
+            </span>
+          </span>
+          About
+        </a>
+      </h2>
+
+
+      <div class="kss-description">
+        <p>Styles for the page at /about/</p>
+
+      </div>
+    </div>
+
+
+      </section>
+      <section id="kssref-blocks-about" class="kss-section kss-section--depth-2">
+
+    <div class="kss-style">
+      <h2 class="kss-title kss-title--level-2">
+        <a class="kss-title__permalink" href="#kssref-blocks-about">
+          <span class="kss-title__ref">
+              1.1
+            <span class="kss-title__permalink-hash">
+                #blocks.about
+            </span>
+          </span>
+          
+        </a>
+      </h2>
+
+
+    </div>
+
+
+      </section>
       <section id="kssref-blocks-banner" class="kss-section kss-section--depth-2">
 
     <div class="kss-style">
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-banner">
           <span class="kss-title__ref">
-              1.1
+              1.2
             <span class="kss-title__permalink-hash">
                 #blocks.banner
             </span>
@@ -184,7 +240,7 @@ input from the American people.</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-case-studies">
           <span class="kss-title__ref">
-              1.2
+              1.3
             <span class="kss-title__permalink-hash">
                 #blocks.case-studies
             </span>
@@ -208,7 +264,7 @@ input from the American people.</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-case-studies.content">
           <span class="kss-title__ref">
-              1.2.1
+              1.3.1
             <span class="kss-title__permalink-hash">
                 #blocks.case-studies.content
             </span>
@@ -232,7 +288,7 @@ input from the American people.</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-case-studies.intro">
           <span class="kss-title__ref">
-              1.2.2
+              1.3.2
             <span class="kss-title__permalink-hash">
                 #blocks.case-studies.intro
             </span>
@@ -256,7 +312,7 @@ input from the American people.</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-explore">
           <span class="kss-title__ref">
-              1.3
+              1.4
             <span class="kss-title__permalink-hash">
                 #blocks.explore
             </span>
@@ -281,7 +337,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-footer">
           <span class="kss-title__ref">
-              1.4
+              1.5
             <span class="kss-title__permalink-hash">
                 #blocks.footer
             </span>
@@ -305,7 +361,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-header">
           <span class="kss-title__ref">
-              1.5
+              1.6
             <span class="kss-title__permalink-hash">
                 #blocks.header
             </span>
@@ -373,7 +429,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works">
           <span class="kss-title__ref">
-              1.6
+              1.7
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works
             </span>
@@ -397,7 +453,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.forms">
           <span class="kss-title__ref">
-              1.6.1
+              1.7.1
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.forms
             </span>
@@ -417,7 +473,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.intro">
           <span class="kss-title__ref">
-              1.6.2
+              1.7.2
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.intro
             </span>
@@ -437,7 +493,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.intro">
           <span class="kss-title__ref">
-              1.6.2
+              1.7.2
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.intro
             </span>
@@ -461,7 +517,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.steps">
           <span class="kss-title__ref">
-              1.6.3
+              1.7.3
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.steps
             </span>
@@ -485,7 +541,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.subpage_involved">
           <span class="kss-title__ref">
-              1.6.4
+              1.7.4
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.subpage_involved
             </span>
@@ -510,7 +566,7 @@ media links on how to become involved</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.subpage_nav">
           <span class="kss-title__ref">
-              1.6.5
+              1.7.5
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.subpage_nav
             </span>
@@ -535,7 +591,7 @@ like subpages</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.subpage_steps">
           <span class="kss-title__ref">
-              1.6.6
+              1.7.6
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.subpage_steps
             </span>


### PR DESCRIPTION
**Work in progress, do not merge**

Preview: https://federalist.18f.gov/preview/18F/doi-extractives-data/new-case-studies-layout/case-studies/
This PR starts to implement the UI tweaks in #796. Right now, it looks like:
<img width="1218" alt="screenshot 2015-11-29 20 21 53" src="https://cloud.githubusercontent.com/assets/4827522/11462864/31ea1cb8-96d7-11e5-9098-dc1fb6a02653.png">

@gemfarmer, I'm sending this your way so you can see what I changed, and also see about the best way to update the sticky nav. I didn't try to fix it since I feel like you said you wanted to improve some other things on it anyways (might be remembering wrong).