### PR TITLE
Mobile Nav Bugs – Round 1

### DIFF
--- a/_sass/blocks/_header.scss
+++ b/_sass/blocks/_header.scss
@@ -26,10 +26,15 @@
 header,
 .header {
   @include outer-container($max-width);
+
   margin-bottom: $base-padding-large;
   margin-top: $base-padding;
   margin-left: $base-padding;
   margin-right: $base-padding;
+
+  @include respond-to(huge-plus-up) {
+    @include outer-container($max-width);
+  }
 }
 
 .header-image_link {
@@ -92,7 +97,6 @@ header,
   @include heading('para-md');
   display: inline-block;
   float: right;
-  padding-right: $base-padding;
 
   @include respond-to(huge-plus-up) {
     padding-right: 0;
@@ -107,7 +111,8 @@ header,
   font-weight: $weight-light;
 }
 
-.header-nav_item:last-child {
+.header-nav_item:last-child,
+.header-nav_item_top:last-child {
   padding-right: 0;
 }
 

--- a/js/components/glossary.js
+++ b/js/components/glossary.js
@@ -26,7 +26,8 @@ var defaultSelectors = {
   toggle: '.js-glossary-toggle',
   term: '.term',
   accordionButton: '.accordion__button',
-  navToggle: '[data-toggler="nav-drawer"]'
+  navToggle: '[data-toggler="nav-drawer"]',
+  navDrawer: '#nav-drawer'
 };
 
 /**
@@ -46,6 +47,7 @@ function Glossary(selectors) {
   self.$search = this.$body.find('.glossary__search');
   self.$accordionButton = $(self.selectors.accordionButton);
   self.$navToggle =  document.querySelector(self.selectors.navToggle);
+  self.$navDrawer = $(self.selectors.navDrawer);
 
   // Initialize state
   self.isOpen = false;
@@ -132,7 +134,9 @@ Glossary.prototype.hide = function() {
   this.isOpen = false;
   accessibility.removeTabindex(this.$body);
 
-  this.$navToggle.click();
+  if (this.$navDrawer.attr('aria-hidden') == 'false') {
+    this.$navToggle.click();
+  }
 };
 
 /** Remove existing filters on input */

--- a/styleguide/section-blocks.html
+++ b/styleguide/section-blocks.html
@@ -38,38 +38,50 @@
         </a>
         <ul class="kss-nav__menu-child">
             <li class="kss-nav__menu-item">
-              <a href="section-blocks.html#kssref-blocks-banner">
+              <a href="section-blocks.html#kssref-blocks-about">
                 <span class="kss-nav__ref">1.1</span
+                ><span class="kss-nav__name">About</span>
+              </a>
+            </li>
+            <li class="kss-nav__menu-item">
+              <a href="section-blocks.html#kssref-blocks-about">
+                <span class="kss-nav__ref">1.1</span
+                ><span class="kss-nav__name"></span>
+              </a>
+            </li>
+            <li class="kss-nav__menu-item">
+              <a href="section-blocks.html#kssref-blocks-banner">
+                <span class="kss-nav__ref">1.2</span
                 ><span class="kss-nav__name">US Bar Disclaimer Banner</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-case-studies">
-                <span class="kss-nav__ref">1.2</span
+                <span class="kss-nav__ref">1.3</span
                 ><span class="kss-nav__name">Case Studies</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-explore">
-                <span class="kss-nav__ref">1.3</span
+                <span class="kss-nav__ref">1.4</span
                 ><span class="kss-nav__name">Explore</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-footer">
-                <span class="kss-nav__ref">1.4</span
+                <span class="kss-nav__ref">1.5</span
                 ><span class="kss-nav__name">Footer</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-header">
-                <span class="kss-nav__ref">1.5</span
+                <span class="kss-nav__ref">1.6</span
                 ><span class="kss-nav__name">Header</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-how-it-works">
-                <span class="kss-nav__ref">1.6</span
+                <span class="kss-nav__ref">1.7</span
                 ><span class="kss-nav__name">How it Works</span>
               </a>
             </li>
@@ -134,13 +146,57 @@
 
 
       </div>
+      <section id="kssref-blocks-about" class="kss-section kss-section--depth-2">
+
+    <div class="kss-style">
+      <h2 class="kss-title kss-title--level-2">
+        <a class="kss-title__permalink" href="#kssref-blocks-about">
+          <span class="kss-title__ref">
+              1.1
+            <span class="kss-title__permalink-hash">
+                #blocks.about
+            </span>
+          </span>
+          About
+        </a>
+      </h2>
+
+
+      <div class="kss-description">
+        <p>Styles for the page at /about/</p>
+
+      </div>
+    </div>
+
+
+      </section>
+      <section id="kssref-blocks-about" class="kss-section kss-section--depth-2">
+
+    <div class="kss-style">
+      <h2 class="kss-title kss-title--level-2">
+        <a class="kss-title__permalink" href="#kssref-blocks-about">
+          <span class="kss-title__ref">
+              1.1
+            <span class="kss-title__permalink-hash">
+                #blocks.about
+            </span>
+          </span>
+          
+        </a>
+      </h2>
+
+
+    </div>
+
+
+      </section>
       <section id="kssref-blocks-banner" class="kss-section kss-section--depth-2">
 
     <div class="kss-style">
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-banner">
           <span class="kss-title__ref">
-              1.1
+              1.2
             <span class="kss-title__permalink-hash">
                 #blocks.banner
             </span>
@@ -184,7 +240,7 @@ input from the American people.</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-case-studies">
           <span class="kss-title__ref">
-              1.2
+              1.3
             <span class="kss-title__permalink-hash">
                 #blocks.case-studies
             </span>
@@ -208,7 +264,7 @@ input from the American people.</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-case-studies.content">
           <span class="kss-title__ref">
-              1.2.1
+              1.3.1
             <span class="kss-title__permalink-hash">
                 #blocks.case-studies.content
             </span>
@@ -232,7 +288,7 @@ input from the American people.</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-case-studies.intro">
           <span class="kss-title__ref">
-              1.2.2
+              1.3.2
             <span class="kss-title__permalink-hash">
                 #blocks.case-studies.intro
             </span>
@@ -256,7 +312,7 @@ input from the American people.</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-explore">
           <span class="kss-title__ref">
-              1.3
+              1.4
             <span class="kss-title__permalink-hash">
                 #blocks.explore
             </span>
@@ -281,7 +337,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-footer">
           <span class="kss-title__ref">
-              1.4
+              1.5
             <span class="kss-title__permalink-hash">
                 #blocks.footer
             </span>
@@ -305,7 +361,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-header">
           <span class="kss-title__ref">
-              1.5
+              1.6
             <span class="kss-title__permalink-hash">
                 #blocks.header
             </span>
@@ -373,7 +429,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works">
           <span class="kss-title__ref">
-              1.6
+              1.7
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works
             </span>
@@ -397,7 +453,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.forms">
           <span class="kss-title__ref">
-              1.6.1
+              1.7.1
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.forms
             </span>
@@ -417,7 +473,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.intro">
           <span class="kss-title__ref">
-              1.6.2
+              1.7.2
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.intro
             </span>
@@ -437,7 +493,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.intro">
           <span class="kss-title__ref">
-              1.6.2
+              1.7.2
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.intro
             </span>
@@ -461,7 +517,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.steps">
           <span class="kss-title__ref">
-              1.6.3
+              1.7.3
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.steps
             </span>
@@ -485,7 +541,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.subpage_involved">
           <span class="kss-title__ref">
-              1.6.4
+              1.7.4
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.subpage_involved
             </span>
@@ -510,7 +566,7 @@ media links on how to become involved</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.subpage_nav">
           <span class="kss-title__ref">
-              1.6.5
+              1.7.5
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.subpage_nav
             </span>
@@ -535,7 +591,7 @@ like subpages</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.subpage_steps">
           <span class="kss-title__ref">
-              1.6.6
+              1.7.6
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.subpage_steps
             </span>


### PR DESCRIPTION
Fixes #913 and #915 

Other smaller stylistic nav bugs will be addressed in a separate PR.

Preview: https://federalist.18f.gov/preview/18F/doi-extractives-data/mobile-nav-bugs/

This PR...
* makes it so that the mobile nav opens and closes only when it is supposed to
* centers the header on desktop
* eliminates padding on the right side of the header.

@meiqimichelle ready for review
