### PR TITLE
Add selector to state and fiscal info layout

### DIFF
--- a/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
+++ b/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
@@ -1,7 +1,8 @@
 ---
 title: State Legal and Fiscal Information | How It Works
-layout: default
+layout: narrative
 permalink: /how-it-works/state-legal-fiscal-info/
+nav_description: Jump to a state
 nav_items:
   - name: ak
     title: Alaska
@@ -28,7 +29,7 @@ nav_items:
   - name: nd
     title: North Dakota
   - name: ok
-    title: Oklahome
+    title: Oklahoma
   - name: pa
     title: Pennsylvania
   - name: tx
@@ -41,368 +42,367 @@ nav_items:
     title: Wyoming
 ---
 
-<div class="container-outer container-padded">
-
-  <article class="container-left-7">
-
-    <h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
-    <h1>State Legal and Fiscal Information</h1>
-
-    <h3><a name="ak">Alaska</a></h3>
-
-    <p>The Division of Oil and Gas within the Alaska Department of Natural Resources is responsible for leasing state lands for oil, gas, and geothermal extraction. Its major functions include evaluating oil and gas resources, fielding and issuing exploration permits, conducting royalty audits, and negotiating contracts. The website for the Alaska Department of Natural Resources has significant information regarding statutes and regulations, leasing on state lands, and historical revenue collection and distribution information, as well as production data, for oil and gas. Additional information about statutes and regulations and leasing on state lands is available for mining from the Division of Land and Water. The Alaska Department of Revenue’s Tax Division collects state taxes, including the Oil and Gas Production Tax and Oil and Gas Property Tax, and administers tax laws. The website contains information about taxes collected and revenue sources and forecasts.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Alaska:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://dog.dnr.alaska.gov/index.htm">Alaska Department of Natural Resources Division of Oil and Gas</a></li>
-  		<ul>
-  			<li><a href="http://dog.dnr.alaska.gov/AboutUs/OGStatutes.htm">Oil and gas statutes and regulations</a></li>
-  			<li><a href="http://dog.dnr.alaska.gov/AboutUs/GeothermalStatutes.htm">Geothermal statutes and regulations</a></li>
-  			<li><a href="http://dog.dnr.alaska.gov/Royalty/Funds.htm#received">Oil and gas funds received and distributed</a></li>
-  		</ul>
-  		<li><a href="http://dnr.alaska.gov/mlw/index.htm">Alaska Department of Natural Resources Division of Land and Water</a></li>
-  		<ul>
-  			<li><a href="http://dnr.alaska.gov/mlw/mining/sb175.pdf">Mining regulations</a></li>
-  			<li><a href="http://dnr.alaska.gov/mlw/mining/AK_MineralPolicy.pdf">State of Alaska mineral development policies</a></li>
-  		</ul>
-  		<li><a href="http://www.tax.alaska.gov/">Alaska Department of Revenue Tax Division</a></li>
-  		<ul>
-  			<li><a href="http://www.tax.alaska.gov/programs/reports.aspx">Tax Division reports</a></li>
-  			<li><a href="http://www.tax.alaska.gov/programs/sourcebook/index.aspx">Revenue sources and forecast information</a></li>
-  		</ul>
-    </ul>
-
-    <h3><a name="az">Arizona</a></h3>
-
-    <p>The Minerals Section within the Arizona State Land Department oversees mining activities on state-trust lands by issuing permits and leases. The Minerals Section’s website contains information about the energy, mineral, and other management programs. The Arizona Department of Mines and Mineral Resources’ information is now available on the Geological Survey Mineral Resources’ webpage, where information on mineral rights, production levels, and laws and regulations can be found. The Office of the Arizona State Treasurer’s website allows visitors to create customized reports on revenue distribution.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Arizona:</p>
-
-    <ul class="list-nested">
-    	<li><a href="https://land.az.gov/divisions/natural-resources/minerals">Arizona State Land Department Minerals Section</a></li>
-  		<li><a href="http://www.azgs.az.gov/minerals.shtml">Arizona Geological Survey, Mineral Resources</a></li>
-  		<ul>
-  			<li><a href="http://repository.azgs.az.gov/sites/default/files/dlio/files/nid1639/lawregs9thed5thprintverforprintingaugust2014.pdf">Laws and Regulations: Mineral Rights in Arizona</a>, 9th edition</li>
-  		</ul>
-  		<li><a href="http://www.aztreasury.gov/local-govt/revenue-distributions/">Arizona State Treasurer revenue distribution reports</a></li>
-    </ul>
-
-    <h3><a name="ca">California</a></h3>
-
-    <p>The California Department of Conservation includes both the State Mining and Geology Board and the Division of Oil, Gas, and Geothermal Resources. The board oversees mineral resource extraction, reclaiming mine lands, and preparing geologic hazard information. The division regulates the drilling, operation, maintenance, plugging, and abandonment of oil, natural gas, and geothermal wells. Department of Conservation websites provide information on regulation, production, and programs for oil, gas, geothermal, and mining. The California Natural Resources Agency’s website has information regarding California’s renewable energy programs and goals.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in California:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://www.conservation.ca.gov/">California Department of Conservation</a></li>
-  		<ul>
-  			<li><a href="http://www.conservation.ca.gov/smgb/Pages/Index.aspx">State Mining and Geology Board</a></li>
-  			<li><a href="http://www.conservation.ca.gov/smgb/Regulations/Pages/regulations.aspx">Mining regulations</a></li>
-  			<li><a href="http://www.conservation.ca.gov/dog/Pages/Index.aspx">Division of Oil, Gas, and Geothermal Resources</a></li>
-  			<li><a href="http://www.conservation.ca.gov/dog/pubs_stats/Pages/law_regulations.aspx">Oil, gas, and geothermal laws and regulations</a></li>
-  			<li><a href="http://www.conservation.ca.gov/dog/pubs_stats/Pages/stats_prod.aspx">Oil and gas production reports</a></li>
-  			<li><a href="http://www.conservation.ca.gov/cgs/Pages/Index.aspx">California Geological Survey</a></li>
-  		</ul>
-  		<li><a href="http://resources.ca.gov/developing_renewable_energy_sources/">California Natural Resources Agency, information on renewable energy programs</a></li>
-    </ul>
-
-    <h3><a name="co">Colorado</a></h3>
-
-    <p>The Oil and Gas Conservation Commission of the state’s Department of Natural Resources oversees the development of Colorado’s oil and gas natural resources. Its website provides relevant regulatory information, monthly resource production data, quarterly levy data, and information on drilling permits. The Colorado State Land Board manages assets held in public trust for Colorado public schools and institutions, including state lands used for natural resource extraction. The Division of Reclamation Mining and Safety protects miners, the public, and the environment from current and past mining operations. The Colorado Department of Revenue collects and disburses revenue for the state; annual reports provide details on these activities.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Colorado:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://dnr.state.co.us/Pages/DNRDefault.aspx">Colorado Department of Natural Resources</a></li>
-  		<ul>
-  			<li><a href="http://cogcc.state.co.us/#/home">Oil and Gas Conservation Commission</a></li>
-  			<li><a href="http://cogcc.state.co.us/reg.html#/overview">Policies and rules</a></li>
-  			<li><a href="http://cogcc.state.co.us/data.html#/cogis">Production and levy data</a></li>
-  		</ul>
-  		<li><a href="http://trustlands.state.co.us/Pages/SLB.aspx">Colorado State Land Board</a></li>
-  		<ul>
-  			<li><a href="http://trustlands.state.co.us/Sections/Minerals/Pages/Minerals.aspx">Resource Extraction Group</a></li>
-  			<li><a href="http://trustlands.state.co.us/Projects/Pages/RenewableEnergy.aspx">Renewable energy</a></li>
-  		</ul>
-  		<li><a href="http://mining.state.co.us/Pages/Home.aspx">Division of Reclamation Mining and Safety</a></li>
-  		<ul>
-  			<li><a href="http://mining.state.co.us/Rules/Pages/home.aspx">Rules and regulations</a></li>
-  		</ul>
-  		<li><a href="https://www.colorado.gov/pacific/revenue/annual-report">Colorado Department of Revenue Annual Report</a></li>
-  		<li><a href="https://www.colorado.gov/pacific/dola/energymineral-impact-assistance-fund-eiaf">Energy / Mineral Impact Assistance Fund supported by state severance taxes</a></li>
-    </ul>
-
-    <h3><a name="il">Illinois</a></h3>
-
-    <p>The Department of Natural Resources Office of Mines and Minerals regulates natural resource exploration and development throughout the state. The Office is comprised of four divisions: Land Reclamation; Abandoned Mine Lands; Blasting, Explosives, and Aggregates; and Mine Safety and Training. The Office of Oil and Gas Resource Management is the regulatory authority responsible for permitting, drilling, operating, and plugging oil and gas production wells.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Illinois:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://www.dnr.illinois.gov/Pages/default.aspx">Illinois Department of Natural Resources</a></li>
-  		<ul>
-  			<li><a href="http://www.dnr.illinois.gov/mines/Pages/RegulationsandPublications.aspx">Mining regulations</a></li>
-  			<li><a href="http://www.dnr.illinois.gov/OilandGas/Pages/ProgramsandRegulations.aspx">Oil and gas regulations</a></li>
-  		</ul>
-  		<li><a href="http://isgs.illinois.edu/">Illinois State Geological Survey</a></li>
-  		<ul>
-  			<li><a href="http://isgs.illinois.edu/research/coal/maps">Coal production maps and data</a></li>
-  		</ul>
-  		<li><a href="http://www.ioc.state.il.us/index.cfm/resources/reports/cafr/">State of Illinois Comprehensive Annual Financial Report Archive</a></li>
-    </ul>
-
-    <h3><a name="ky">Kentucky</a></h3>
-
-    <p>The Department for Natural Resources Division of Oil and Gas regulates the oil and gas industry in the state to protect mineral owners’ rights and the sustainability of the environment. The department’s divisions of Mine Permits, Mine Reclamation and Enforcement, and Mine Safety each execute different statutory responsibilities for mineral extraction oversight. Kentucky’s Energy and Environment Cabinet established the Department for Energy Development and Independence to develop and employ sustainable energy strategies for the state.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Kentucky:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://dnr.ky.gov/Pages/default.aspx">Energy and Environment Cabinet, Department for Natural Resources</a></li>
-  		<ul>
-  			<li><a href="http://oilandgas.ky.gov/Pages/Welcome.aspx">Division of Oil and Gas</a></li>
-  			<li><a href="http://minemaps.ky.gov/">Mine Mapping Information System</a></li>
-  		</ul>
-  		<li><a href="http://energy.ky.gov/Pages/default.aspx">Energy and Environment Cabinet, State Department for Energy Development and Independence</a></li>
-  		<ul>
-  			<li><a href="http://energy.ky.gov/Programs/Pages/data.aspx">Resource data and production totals</a></li>
-  		</ul>
-  		<li><a href="http://www.lrc.ky.gov/kar/frntpage.htm">Kentucky Legislature administrative regulations</a></li>
-  		<ul>
-  			<li><a href="http://www.lrc.ky.gov/kar/title805.htm">Energy and Environment Cabinet regulations</a></li>
-  		</ul>
-  		<li><a href="http://www.uky.edu/KGS/">Kentucky Geological Survey</a></li>
-  		<ul>
-  			<li><a href="http://kgs.uky.edu/kgsmap/OGProdPlot/OGProduction.asp">Oil and gas production</a></li>
-  			<li><a href="http://kgs.uky.edu/kgsweb/DataSearching/Coal/Production/prodsearch.asp">Coal production</a></li>
-  		</ul>
-  		<li><a href="http://finance.ky.gov/services/statewideacct/Pages/ReportsandPublications.aspx">Kentucky Finance and Administration Cabinet Comprehensive Annual Financial Report Archive</a></li>
-    </ul>
-
-    <h3><a name="la">Louisiana</a></h3>
-
-    <p>The Office of Mineral Resources within the Department of Natural Resources manages natural resource extraction throughout the state and receives revenue from royalties, bonuses, rents, interest, and fees for leases for state-owned lands. The Office of Conservation and Office of Coastal Management within the department also oversee Louisiana’s oil and gas resources. The State Energy Office helps maximize Louisiana's energy potential by exploring all energy sources.</p>
-
-    <p>Learn more about natural resource production, revenue, and regulation in Louisiana:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://dnr.louisiana.gov/">Louisiana Department of Natural Resources</a></li>
-  		<ul>
-  			<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=208">Oil production</a></li>
-  			<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=209">Natural gas production</a></li>
-  			<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=213">Oil and natural gas reserves</a></li>
-  			<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=212">Royalties, rents, bonuses, and severance tax revenue</a></li>
-  		</ul>
-  		<li><a href="http://www.doa.la.gov/Pages/osr/lac/LAC-43.aspx">Office of State Register Administrative Code for natural resources</a></li>
-    </ul>
-
-    <h3><a name="mn">Minnesota</a></h3>
-
-    <p>The Division of Lands and Minerals within Minnesota’s Department of Natural Resources manages the state's mineral resources and mine development on state-owned lands to generate revenue for the state's School and University Trust Funds, local communities, and General Fund. The division ensures full reclamation of extractive sites and maintains comprehensive mineral land records.</p>
-
-    <p>Learn more about natural resource production and revenue in Minnesota:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://www.dnr.state.mn.us/index.html">Minnesota Department of Natural Resources</a></li>
-  		<ul>
-  			<li><a href="http://www.dnr.state.mn.us/lands_minerals/index.html">Division of Lands and Minerals</a></li>
-  			<li><a href="http://minarchive.dnr.state.mn.us/">Minerals data</a></li>
-  		</ul>
-  		<li><a href="http://mn.gov/mmb/accounting/reports/comprehensive-annual.jsp">Minnesota Comprehensive Annual Financial Report Archive</a></li>
-    </ul>
-
-    <h3><a name="mt">Montana</a></h3>
-
-    <p>Within Montana’s Department of Resources and Natural Conservation, the Trust Lands Management Division oversees 5.2 million acres of state land and manages all energy resource leasing. The Minerals Management Bureau manages and issues leases and permits for oil, gas, coal, and other natural resources on state lands. The Montana Board of Oil and Gas protects citizens and the environment from the negative effects of oil and gas extraction by issuing permits, inspecting wells, and conducting environmental remediation programs.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Montana:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://dnrc.mt.gov/">Montana Department of Natural Resources and Conservation</a></li>
-  		<ul>
-  			<li><a href="http://dnrc.mt.gov/divisions/trust/minerals-management">Minerals Management Bureau</a></li>
-  			<li><a href="http://bogc.dnrc.mt.gov/BoardSummaries.asp">Montana Board of Oil and Gas Conservation</a></li>
-  			<li><a href="http://bogc.dnrc.mt.gov/rulesregs.asp">Rules and regulations</a></li>
-  			<li><a href="http://bogc.dnrc.mt.gov/WebApps/DataMiner/">Wells, production, and leases data</a></li>
-  		</ul>
-  		<li><a href="https://revenue.mt.gov/home/publications">Montana Department of Revenue Tax Related Reports</a></li>
-    </ul>
-
-    <h3><a name="nv">Nevada</a></h3>
-
-    <p>The Bureau of Mining Regulation and Reclamation within the Department of Conservation and Natural Resources oversees all mining activities in the state of Nevada. The division focuses on regulation (ensuring statutory compliance), closure (confirming stabilization of all applicable mine components), and reclamation (issuing reclamation permits to all large-scale operators).</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Nevada:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://dcnr.nv.gov/">Nevada Department of Conservation and Natural Resources</a></li>
-  		<ul>
-  			<li><a href="http://ndep.nv.gov/BMRR/index.htm">Division of Environmental Protection, Bureau of Mining Regulation and Reclamation</a></li>
-  			<li><a href="http://ndep.nv.gov/BMRR/regs.htm">Statutes and regulations</a></li>
-  		</ul>
-  		<li><a href="http://www.nbmg.unr.edu/index.html">Nevada State Geological Survey</a></li>
-  		<ul>
-  			<li><a href="http://www.nbmg.unr.edu/Minerals&Energy/index.html">Minerals and energy data</a></li>
-  		</ul>
-  		<li><a href="http://controller.nv.gov/FinancialReports/CAFR_Download_Page.html">Nevada State Controller Comprehensive Annual Financial Report Archive</a></li>
-    </ul>
-
-    <h3><a name="nm">New Mexico</a></h3>
-
-    <p>The New Mexico Mining and Minerals Division enforces laws and regulations related to mine safety and reclamation of abandoned mines. The division collects production and employment data on active mining operations through its Mine Registration and Reporting Program. It also uses a Geographic Information System (GIS) to locate and track mining activities in the state, available for public use on the division’s website. The Oil Conservation Division regulates oil, gas, and geothermal activity in New Mexico. It gathers well production data, issues permits for new wells, enforces statutes and rules, and ensures abandoned wells are properly plugged and the land is restored.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in New Mexico:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://www.emnrd.state.nm.us/MMD/">New Mexico Mining and Minerals Division</a></li>
-  		<ul>
-  			<li><a href="http://www.emnrd.state.nm.us/MMD/MARP/MARPRulesRegs.html">Mining regulations</a></li>
-  			<li><a href="http://www.emnrd.state.nm.us/MMD/MARP/MARPCommissionReport.html">Annual Reports to the Mining Commission (operators, production, etc.)</a></li>
-  		</ul>
-  		<li><a href="http://www.emnrd.state.nm.us/OCD/">New Mexico Oil Conservation Division</a></li>
-  		<ul>
-  			<li><a href="http://www.emnrd.state.nm.us/OCD/rules.html">Oil and gas regulations</a></li>
-  			<li><a href="http://www.emnrd.state.nm.us/OCD/statistics.html">Oil and gas production data</a></li>
-  		</ul>
-  		<li><a href="http://nmdfa.state.nm.us/New_Mexico_CAFR.aspx">New Mexico Department of Finance and Administration Comprehensive Annual Financial Report Archive</a></li>
-    </ul>
-
-    <h3><a name="nd">North Dakota</a></h3>
-
-    <p>North Dakota’s Department of Mineral Resources Oil and Gas Division regulates the drilling and production of oil and gas in the state. In addition to its regulatory oversight function, the Oil and Gas Division manages permitting and maintains production and well data. Data pertaining to mineral extraction is housed by the state’s Geological Survey.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in North Dakota:</p>
-
-    <ul class="list-nested">
-    	<li><a href="https://www.dmr.nd.gov/oilgas/">North Dakota Department of Mineral Resources Oil and Gas Division</a></li>
-  		<ul>
-  			<li><a href="https://www.dmr.nd.gov/oilgas/rules/rulebook.pdf">Oil and gas regulations</a></li>
-  			<li><a href="https://www.dmr.nd.gov/oilgas/stats/statisticsvw.asp">Oil and gas drilling and production data</a></li>
-  		</ul>
-  		<li><a href="https://www.dmr.nd.gov/ndgs/">North Dakota Geological Survey</a></li>
-  		<li><a href="http://www.nd.gov/treasurer">North Dakota State Treasurer </a></li>
-  		<ul>
-  			<li><a href="http://www.nd.gov/treasurer/revenue-distribution/">Revenue distribution (including Oil and Gas Gross Production, Oil Extraction, Coal Severance, and other taxes associated with resource extraction)</a></li>
-  			<li><a href="http://www.nd.gov/treasurer/how-is-oil-and-gas-tax-revenue-distributed/">Oil and gas revenue distribution</a></li>
-  		</ul>
-    </ul>
-
-    <h3><a name="ok">Oklahoma</a></h3>
-
-    <p>The Oklahoma Commissioners of the Land Office manages state lands, including oil and gas leasing to generate revenue that supports the state’s common schools and higher education institutions. The Oklahoma Department of Mines regulates the coal and nonfuel mineral production, enforcing a variety of federal and state programs for safety, health, and land reclamation. The department also issues permits for all mining operations.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Oklahoma:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://www.clo.state.ok.us/">Oklahoma Commissioners of the Land Office</a></li>
-  		<ul>
-  			<li><a href="https://clo.ok.gov/policy/rules-regulations/">Rules and regulations</a></li>
-  			<li><a href="https://clo.ok.gov/services/auction-information/minerals/">Oil and gas lease auction information</a></li>
-  		</ul>
-  		<li><a href="http://www.ok.gov/mines/index.html">Oklahoma Department of Mines</a></li>
-  		<ul>
-  			<li><a href="http://www.ok.gov/mines/Coal_Program/index.html">Coal program and related data</a></li>
-  			<li><a href="http://www.ok.gov/mines/Annual_Reports/">Department of Mines Annual Reports</a></li>
-  		</ul>
-  		<li><a href="http://www.ok.gov/OSF/documents/cafr14.pdf">Oklahoma Office of Management and Enterprise Services Comprehensive Annual Financial Report</a></li>
-    </ul>
-
-    <h3><a name="pa">Pennsylvania</a></h3>
-
-    <p>The Department of Environmental Protection, including the Bureau of Mining Programs and the Office of Oil and Gas Management, manages programs that ensure the safe and responsible exploration, development, and recovery of extractive resources. These programs include permitting and inspection, regulatory oversight, and training.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Pennsylvania:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/office_of_oil_and_gas_management/20291">Pennsylvania Department of Environmental Protection Office of Oil and Gas Management</a></li>
-  		<ul>
-  			<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/public_resources/20303/oil_and_gas_surface_regulations/1587188">Oil and gas surface regulations</a></li>
-  			<li><a href="https://www.paoilandgasreporting.state.pa.us/publicreports/Modules/Welcome/Welcome.aspx">Oil and gas production data</a></li>
-  		</ul>
-  	  	<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/mining/6002">Pennsylvania Department of Environmental Protection Office of Active and Abandoned Mine Operations</a></li>
-  		<ul>
-  			<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/bureau_of_mining_programs/20865/regulations/1150023">Coal regulations</a></li>
-  		</ul>
-  	  	<li><a href="http://dcnr.state.pa.us/topogeo/index.aspx">State Bureau of Topographic and Geologic Survey</a></li>
-  		<ul>
-  			<li><a href="http://dcnr.state.pa.us/topogeo/econresource/oilandgas/index.htm">Oil and gas resources</a></li>
-  			<li><a href="http://dcnr.state.pa.us/topogeo/econresource/mineral_industries/index.htm">Mineral resources</a></li>
-  			<li><a href="http://dcnr.state.pa.us/topogeo/econresource/coal/index.htm">Coal resources</a></li>
-  		</ul>
-    </ul>
-
-    <h3><a name="tx">Texas</a></h3>
-
-    <p>The Railroad Commission of Texas is statutorily responsible for regulating the exploration and production of the state’s natural resources: oil, natural gas, minerals (particularly lignite and coal), and alternative fuels. The commission oversees natural resource extraction along with land reclamation and environmental protection. The commission also oversees safety and compliance related to the state’s extensive oil and gas pipeline infrastructure.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Texas:</p>
-
-    <ul class="list-nested">
-    	<li><a href="http://www.rrc.state.tx.us/">Railroad Commission of Texas</a></li>
-  		<ul>
-  			<li><a href="http://www.rrc.state.tx.us/oil-gas/research-and-statistics/production-data/texas-monthly-oil-gas-production/">Monthly oil and gas production data</a></li>
-  			<li><a href="http://www.rrc.state.tx.us/legal/rules/current-rules/">Regulations for commodity extraction</a></li>
-  		</ul>
-  		<li><a href="http://www.texastransparency.org/State_Finance/Budget_Finance/Reports/Revenue_by_Source/revenue_hist.php">Historical state net tax revenue by source</a></li>
-    </ul>
-
-    <h3><a name="ut">Utah</a></h3>
-
-    <p>The Division of Oil, Gas, and Mining within Utah’s Department of Natural Resources is responsible for developing natural resources for the economic benefit of the public while preserving the state’s natural environment. The division maintains four core programs, each with specific oversight functions: the Coal Program, the Mineral Mining Program, the Oil and Gas Program, and the Abandoned Mine Reclamation Program.</p>
-
-    <p>Learn more about natural resource regulation, production, and revenue in Utah:</p>
-
-    <ul class="list-nested">
-  	  <li><a href="http://naturalresources.utah.gov/divisions/ogm.html">Utah Department of Natural Resources Division of Oil, Gas, and Mining</a></li>
-  	  <li><a href="http://linux3.ogm.utah.gov/WebStuff/wwwroot/coal/default.html">Coal program</a></li>
-  	  <li><a href="http://linux3.ogm.utah.gov/WebStuff/wwwroot/minerals/default.html">Minerals program</a></li>
-  	  <li><a href="http://oilgas.ogm.utah.gov/">Oil and gas program</a></li>
-  	  <ul>
-  		  <li><a href="http://oilgas.ogm.utah.gov/Rules/Rules_Page.htm">Oil and gas regulations</a></li>
-  		  <li><a href="http://oilgas.ogm.utah.gov/Data_Center/DataCenter.cfm">Permitting, drilling, and production data</a></li>
-  	  </ul>
-  	  <li><a href="http://linux3.ogm.utah.gov/WebStuff/wwwroot/coal/rulesregs.html">Statutes and rules</a></li>
-  	  <li><a href="http://tax.utah.gov/utah-taxes">Utah State Tax Commission description of all taxes and fees</a></li>
-  	  <li><a href="http://geology.utah.gov/">Utah Geological Survey</a></li>
-  	  <li><a href="http://finance.utah.gov/cafr.html">Utah Department of Administrative Services Division of Finance Comprehensive Annual Financial Report Archive</a></li>
-    </ul>
-
-    <h3><a name="wv">West Virginia</a></h3>
-
-    <p>The West Virginia Department of Environmental Protection oversees natural resource extraction in West Virginia. The department’s Office of Oil and Gas is responsible for monitoring and regulating all actions related to the exploration, drilling, storage, and production of oil and natural gas. The Division of Mining and Reclamation manages compliance, reclamation, permitting, and communications between the public and industry.</p>
-
-    <p>Learn more about natural resource revenue, regulation, and production in West Virginia:</p>
-
-    <ul class="list-nested">
-  	  <li><a href="http://www.dep.wv.gov/Pages/default.aspx">West Virginia Department of Environmental Protection</a></li>
-  	  <ul>
-  		  <li><a href="http://www.dep.wv.gov/dmr/codes/Pages/default.aspx">Mining codes and regulations</a></li>
-  		  <li><a href="http://www.dep.wv.gov/oil-and-gas/Pages/default.aspx">Oil and gas rules and regulations</a></li>
-  	  </ul>
-  	  <li><a href="http://www.wvminesafety.org/default.htm">West Virginia Office of Miners’ Health, Safety, and Training</a></li>
-  	  <ul>
-  		  <li><a href="http://www.wvminesafety.org/STATS.HTM">Surface and subsurface coal production and employment data</a></li>
-  	  </ul>
-  	  <li><a href="http://www.wvcommerce.org/business/businessassistance/expandingorrelocating/businesstaxes.aspx ">Business taxes overview</a></li>
-  	  <li><a href="http://www.wvcommerce.org/business/businessassistance/expandingorrelocating/businesstaxes.aspx">West Virginia Geological and Economic Survey</a></li>
-  	  <li><a href="http://www.finance.wv.gov/FARS/CAFR/Pages/default.aspx">West Virginia Department of Administration, Division of Finance Comprehensive Annual Financial Report Archive</a></li>
+
+<h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
+<h1>State Legal and Fiscal Information</h1>
+
+<nav class="hash_selector">
+  {% include hash_selector.html %}
+</nav>
+
+<h3><a name="ak">Alaska</a></h3>
+
+<p>The Division of Oil and Gas within the Alaska Department of Natural Resources is responsible for leasing state lands for oil, gas, and geothermal extraction. Its major functions include evaluating oil and gas resources, fielding and issuing exploration permits, conducting royalty audits, and negotiating contracts. The website for the Alaska Department of Natural Resources has significant information regarding statutes and regulations, leasing on state lands, and historical revenue collection and distribution information, as well as production data, for oil and gas. Additional information about statutes and regulations and leasing on state lands is available for mining from the Division of Land and Water. The Alaska Department of Revenue’s Tax Division collects state taxes, including the Oil and Gas Production Tax and Oil and Gas Property Tax, and administers tax laws. The website contains information about taxes collected and revenue sources and forecasts.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Alaska:</p>
+
+<ul class="list-nested">
+	<li><a href="http://dog.dnr.alaska.gov/index.htm">Alaska Department of Natural Resources Division of Oil and Gas</a></li>
+	<ul>
+		<li><a href="http://dog.dnr.alaska.gov/AboutUs/OGStatutes.htm">Oil and gas statutes and regulations</a></li>
+		<li><a href="http://dog.dnr.alaska.gov/AboutUs/GeothermalStatutes.htm">Geothermal statutes and regulations</a></li>
+		<li><a href="http://dog.dnr.alaska.gov/Royalty/Funds.htm#received">Oil and gas funds received and distributed</a></li>
+	</ul>
+	<li><a href="http://dnr.alaska.gov/mlw/index.htm">Alaska Department of Natural Resources Division of Land and Water</a></li>
+	<ul>
+		<li><a href="http://dnr.alaska.gov/mlw/mining/sb175.pdf">Mining regulations</a></li>
+		<li><a href="http://dnr.alaska.gov/mlw/mining/AK_MineralPolicy.pdf">State of Alaska mineral development policies</a></li>
+	</ul>
+	<li><a href="http://www.tax.alaska.gov/">Alaska Department of Revenue Tax Division</a></li>
+	<ul>
+		<li><a href="http://www.tax.alaska.gov/programs/reports.aspx">Tax Division reports</a></li>
+		<li><a href="http://www.tax.alaska.gov/programs/sourcebook/index.aspx">Revenue sources and forecast information</a></li>
+	</ul>
+</ul>
+
+<h3><a name="az">Arizona</a></h3>
+
+<p>The Minerals Section within the Arizona State Land Department oversees mining activities on state-trust lands by issuing permits and leases. The Minerals Section’s website contains information about the energy, mineral, and other management programs. The Arizona Department of Mines and Mineral Resources’ information is now available on the Geological Survey Mineral Resources’ webpage, where information on mineral rights, production levels, and laws and regulations can be found. The Office of the Arizona State Treasurer’s website allows visitors to create customized reports on revenue distribution.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Arizona:</p>
+
+<ul class="list-nested">
+	<li><a href="https://land.az.gov/divisions/natural-resources/minerals">Arizona State Land Department Minerals Section</a></li>
+	<li><a href="http://www.azgs.az.gov/minerals.shtml">Arizona Geological Survey, Mineral Resources</a></li>
+	<ul>
+		<li><a href="http://repository.azgs.az.gov/sites/default/files/dlio/files/nid1639/lawregs9thed5thprintverforprintingaugust2014.pdf">Laws and Regulations: Mineral Rights in Arizona</a>, 9th edition</li>
+	</ul>
+	<li><a href="http://www.aztreasury.gov/local-govt/revenue-distributions/">Arizona State Treasurer revenue distribution reports</a></li>
+</ul>
+
+<h3><a name="ca">California</a></h3>
+
+<p>The California Department of Conservation includes both the State Mining and Geology Board and the Division of Oil, Gas, and Geothermal Resources. The board oversees mineral resource extraction, reclaiming mine lands, and preparing geologic hazard information. The division regulates the drilling, operation, maintenance, plugging, and abandonment of oil, natural gas, and geothermal wells. Department of Conservation websites provide information on regulation, production, and programs for oil, gas, geothermal, and mining. The California Natural Resources Agency’s website has information regarding California’s renewable energy programs and goals.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in California:</p>
+
+<ul class="list-nested">
+	<li><a href="http://www.conservation.ca.gov/">California Department of Conservation</a></li>
+	<ul>
+		<li><a href="http://www.conservation.ca.gov/smgb/Pages/Index.aspx">State Mining and Geology Board</a></li>
+		<li><a href="http://www.conservation.ca.gov/smgb/Regulations/Pages/regulations.aspx">Mining regulations</a></li>
+		<li><a href="http://www.conservation.ca.gov/dog/Pages/Index.aspx">Division of Oil, Gas, and Geothermal Resources</a></li>
+		<li><a href="http://www.conservation.ca.gov/dog/pubs_stats/Pages/law_regulations.aspx">Oil, gas, and geothermal laws and regulations</a></li>
+		<li><a href="http://www.conservation.ca.gov/dog/pubs_stats/Pages/stats_prod.aspx">Oil and gas production reports</a></li>
+		<li><a href="http://www.conservation.ca.gov/cgs/Pages/Index.aspx">California Geological Survey</a></li>
+	</ul>
+	<li><a href="http://resources.ca.gov/developing_renewable_energy_sources/">California Natural Resources Agency, information on renewable energy programs</a></li>
+</ul>
+
+<h3><a name="co">Colorado</a></h3>
+
+<p>The Oil and Gas Conservation Commission of the state’s Department of Natural Resources oversees the development of Colorado’s oil and gas natural resources. Its website provides relevant regulatory information, monthly resource production data, quarterly levy data, and information on drilling permits. The Colorado State Land Board manages assets held in public trust for Colorado public schools and institutions, including state lands used for natural resource extraction. The Division of Reclamation Mining and Safety protects miners, the public, and the environment from current and past mining operations. The Colorado Department of Revenue collects and disburses revenue for the state; annual reports provide details on these activities.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Colorado:</p>
+
+<ul class="list-nested">
+	<li><a href="http://dnr.state.co.us/Pages/DNRDefault.aspx">Colorado Department of Natural Resources</a></li>
+	<ul>
+		<li><a href="http://cogcc.state.co.us/#/home">Oil and Gas Conservation Commission</a></li>
+		<li><a href="http://cogcc.state.co.us/reg.html#/overview">Policies and rules</a></li>
+		<li><a href="http://cogcc.state.co.us/data.html#/cogis">Production and levy data</a></li>
+	</ul>
+	<li><a href="http://trustlands.state.co.us/Pages/SLB.aspx">Colorado State Land Board</a></li>
+	<ul>
+		<li><a href="http://trustlands.state.co.us/Sections/Minerals/Pages/Minerals.aspx">Resource Extraction Group</a></li>
+		<li><a href="http://trustlands.state.co.us/Projects/Pages/RenewableEnergy.aspx">Renewable energy</a></li>
+	</ul>
+	<li><a href="http://mining.state.co.us/Pages/Home.aspx">Division of Reclamation Mining and Safety</a></li>
+	<ul>
+		<li><a href="http://mining.state.co.us/Rules/Pages/home.aspx">Rules and regulations</a></li>
+	</ul>
+	<li><a href="https://www.colorado.gov/pacific/revenue/annual-report">Colorado Department of Revenue Annual Report</a></li>
+	<li><a href="https://www.colorado.gov/pacific/dola/energymineral-impact-assistance-fund-eiaf">Energy / Mineral Impact Assistance Fund supported by state severance taxes</a></li>
+</ul>
+
+<h3><a name="il">Illinois</a></h3>
+
+<p>The Department of Natural Resources Office of Mines and Minerals regulates natural resource exploration and development throughout the state. The Office is comprised of four divisions: Land Reclamation; Abandoned Mine Lands; Blasting, Explosives, and Aggregates; and Mine Safety and Training. The Office of Oil and Gas Resource Management is the regulatory authority responsible for permitting, drilling, operating, and plugging oil and gas production wells.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Illinois:</p>
+
+<ul class="list-nested">
+	<li><a href="http://www.dnr.illinois.gov/Pages/default.aspx">Illinois Department of Natural Resources</a></li>
+	<ul>
+		<li><a href="http://www.dnr.illinois.gov/mines/Pages/RegulationsandPublications.aspx">Mining regulations</a></li>
+		<li><a href="http://www.dnr.illinois.gov/OilandGas/Pages/ProgramsandRegulations.aspx">Oil and gas regulations</a></li>
+	</ul>
+	<li><a href="http://isgs.illinois.edu/">Illinois State Geological Survey</a></li>
+	<ul>
+		<li><a href="http://isgs.illinois.edu/research/coal/maps">Coal production maps and data</a></li>
+	</ul>
+	<li><a href="http://www.ioc.state.il.us/index.cfm/resources/reports/cafr/">State of Illinois Comprehensive Annual Financial Report Archive</a></li>
+</ul>
+
+<h3><a name="ky">Kentucky</a></h3>
+
+<p>The Department for Natural Resources Division of Oil and Gas regulates the oil and gas industry in the state to protect mineral owners’ rights and the sustainability of the environment. The department’s divisions of Mine Permits, Mine Reclamation and Enforcement, and Mine Safety each execute different statutory responsibilities for mineral extraction oversight. Kentucky’s Energy and Environment Cabinet established the Department for Energy Development and Independence to develop and employ sustainable energy strategies for the state.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Kentucky:</p>
+
+<ul class="list-nested">
+	<li><a href="http://dnr.ky.gov/Pages/default.aspx">Energy and Environment Cabinet, Department for Natural Resources</a></li>
+	<ul>
+		<li><a href="http://oilandgas.ky.gov/Pages/Welcome.aspx">Division of Oil and Gas</a></li>
+		<li><a href="http://minemaps.ky.gov/">Mine Mapping Information System</a></li>
+	</ul>
+	<li><a href="http://energy.ky.gov/Pages/default.aspx">Energy and Environment Cabinet, State Department for Energy Development and Independence</a></li>
+	<ul>
+		<li><a href="http://energy.ky.gov/Programs/Pages/data.aspx">Resource data and production totals</a></li>
+	</ul>
+	<li><a href="http://www.lrc.ky.gov/kar/frntpage.htm">Kentucky Legislature administrative regulations</a></li>
+	<ul>
+		<li><a href="http://www.lrc.ky.gov/kar/title805.htm">Energy and Environment Cabinet regulations</a></li>
+	</ul>
+	<li><a href="http://www.uky.edu/KGS/">Kentucky Geological Survey</a></li>
+	<ul>
+		<li><a href="http://kgs.uky.edu/kgsmap/OGProdPlot/OGProduction.asp">Oil and gas production</a></li>
+		<li><a href="http://kgs.uky.edu/kgsweb/DataSearching/Coal/Production/prodsearch.asp">Coal production</a></li>
+	</ul>
+	<li><a href="http://finance.ky.gov/services/statewideacct/Pages/ReportsandPublications.aspx">Kentucky Finance and Administration Cabinet Comprehensive Annual Financial Report Archive</a></li>
+</ul>
+
+<h3><a name="la">Louisiana</a></h3>
+
+<p>The Office of Mineral Resources within the Department of Natural Resources manages natural resource extraction throughout the state and receives revenue from royalties, bonuses, rents, interest, and fees for leases for state-owned lands. The Office of Conservation and Office of Coastal Management within the department also oversee Louisiana’s oil and gas resources. The State Energy Office helps maximize Louisiana's energy potential by exploring all energy sources.</p>
+
+<p>Learn more about natural resource production, revenue, and regulation in Louisiana:</p>
+
+<ul class="list-nested">
+	<li><a href="http://dnr.louisiana.gov/">Louisiana Department of Natural Resources</a></li>
+	<ul>
+		<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=208">Oil production</a></li>
+		<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=209">Natural gas production</a></li>
+		<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=213">Oil and natural gas reserves</a></li>
+		<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=212">Royalties, rents, bonuses, and severance tax revenue</a></li>
+	</ul>
+	<li><a href="http://www.doa.la.gov/Pages/osr/lac/LAC-43.aspx">Office of State Register Administrative Code for natural resources</a></li>
+</ul>
+
+<h3><a name="mn">Minnesota</a></h3>
+
+<p>The Division of Lands and Minerals within Minnesota’s Department of Natural Resources manages the state's mineral resources and mine development on state-owned lands to generate revenue for the state's School and University Trust Funds, local communities, and General Fund. The division ensures full reclamation of extractive sites and maintains comprehensive mineral land records.</p>
+
+<p>Learn more about natural resource production and revenue in Minnesota:</p>
+
+<ul class="list-nested">
+	<li><a href="http://www.dnr.state.mn.us/index.html">Minnesota Department of Natural Resources</a></li>
+	<ul>
+		<li><a href="http://www.dnr.state.mn.us/lands_minerals/index.html">Division of Lands and Minerals</a></li>
+		<li><a href="http://minarchive.dnr.state.mn.us/">Minerals data</a></li>
+	</ul>
+	<li><a href="http://mn.gov/mmb/accounting/reports/comprehensive-annual.jsp">Minnesota Comprehensive Annual Financial Report Archive</a></li>
+</ul>
+
+<h3><a name="mt">Montana</a></h3>
+
+<p>Within Montana’s Department of Resources and Natural Conservation, the Trust Lands Management Division oversees 5.2 million acres of state land and manages all energy resource leasing. The Minerals Management Bureau manages and issues leases and permits for oil, gas, coal, and other natural resources on state lands. The Montana Board of Oil and Gas protects citizens and the environment from the negative effects of oil and gas extraction by issuing permits, inspecting wells, and conducting environmental remediation programs.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Montana:</p>
+
+<ul class="list-nested">
+	<li><a href="http://dnrc.mt.gov/">Montana Department of Natural Resources and Conservation</a></li>
+	<ul>
+		<li><a href="http://dnrc.mt.gov/divisions/trust/minerals-management">Minerals Management Bureau</a></li>
+		<li><a href="http://bogc.dnrc.mt.gov/BoardSummaries.asp">Montana Board of Oil and Gas Conservation</a></li>
+		<li><a href="http://bogc.dnrc.mt.gov/rulesregs.asp">Rules and regulations</a></li>
+		<li><a href="http://bogc.dnrc.mt.gov/WebApps/DataMiner/">Wells, production, and leases data</a></li>
+	</ul>
+	<li><a href="https://revenue.mt.gov/home/publications">Montana Department of Revenue Tax Related Reports</a></li>
+</ul>
+
+<h3><a name="nv">Nevada</a></h3>
+
+<p>The Bureau of Mining Regulation and Reclamation within the Department of Conservation and Natural Resources oversees all mining activities in the state of Nevada. The division focuses on regulation (ensuring statutory compliance), closure (confirming stabilization of all applicable mine components), and reclamation (issuing reclamation permits to all large-scale operators).</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Nevada:</p>
+
+<ul class="list-nested">
+	<li><a href="http://dcnr.nv.gov/">Nevada Department of Conservation and Natural Resources</a></li>
+	<ul>
+		<li><a href="http://ndep.nv.gov/BMRR/index.htm">Division of Environmental Protection, Bureau of Mining Regulation and Reclamation</a></li>
+		<li><a href="http://ndep.nv.gov/BMRR/regs.htm">Statutes and regulations</a></li>
+	</ul>
+	<li><a href="http://www.nbmg.unr.edu/index.html">Nevada State Geological Survey</a></li>
+	<ul>
+		<li><a href="http://www.nbmg.unr.edu/Minerals&Energy/index.html">Minerals and energy data</a></li>
+	</ul>
+	<li><a href="http://controller.nv.gov/FinancialReports/CAFR_Download_Page.html">Nevada State Controller Comprehensive Annual Financial Report Archive</a></li>
+</ul>
+
+<h3><a name="nm">New Mexico</a></h3>
+
+<p>The New Mexico Mining and Minerals Division enforces laws and regulations related to mine safety and reclamation of abandoned mines. The division collects production and employment data on active mining operations through its Mine Registration and Reporting Program. It also uses a Geographic Information System (GIS) to locate and track mining activities in the state, available for public use on the division’s website. The Oil Conservation Division regulates oil, gas, and geothermal activity in New Mexico. It gathers well production data, issues permits for new wells, enforces statutes and rules, and ensures abandoned wells are properly plugged and the land is restored.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in New Mexico:</p>
+
+<ul class="list-nested">
+	<li><a href="http://www.emnrd.state.nm.us/MMD/">New Mexico Mining and Minerals Division</a></li>
+	<ul>
+		<li><a href="http://www.emnrd.state.nm.us/MMD/MARP/MARPRulesRegs.html">Mining regulations</a></li>
+		<li><a href="http://www.emnrd.state.nm.us/MMD/MARP/MARPCommissionReport.html">Annual Reports to the Mining Commission (operators, production, etc.)</a></li>
+	</ul>
+	<li><a href="http://www.emnrd.state.nm.us/OCD/">New Mexico Oil Conservation Division</a></li>
+	<ul>
+		<li><a href="http://www.emnrd.state.nm.us/OCD/rules.html">Oil and gas regulations</a></li>
+		<li><a href="http://www.emnrd.state.nm.us/OCD/statistics.html">Oil and gas production data</a></li>
+	</ul>
+	<li><a href="http://nmdfa.state.nm.us/New_Mexico_CAFR.aspx">New Mexico Department of Finance and Administration Comprehensive Annual Financial Report Archive</a></li>
+</ul>
+
+<h3><a name="nd">North Dakota</a></h3>
+
+<p>North Dakota’s Department of Mineral Resources Oil and Gas Division regulates the drilling and production of oil and gas in the state. In addition to its regulatory oversight function, the Oil and Gas Division manages permitting and maintains production and well data. Data pertaining to mineral extraction is housed by the state’s Geological Survey.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in North Dakota:</p>
+
+<ul class="list-nested">
+	<li><a href="https://www.dmr.nd.gov/oilgas/">North Dakota Department of Mineral Resources Oil and Gas Division</a></li>
+	<ul>
+		<li><a href="https://www.dmr.nd.gov/oilgas/rules/rulebook.pdf">Oil and gas regulations</a></li>
+		<li><a href="https://www.dmr.nd.gov/oilgas/stats/statisticsvw.asp">Oil and gas drilling and production data</a></li>
+	</ul>
+	<li><a href="https://www.dmr.nd.gov/ndgs/">North Dakota Geological Survey</a></li>
+	<li><a href="http://www.nd.gov/treasurer">North Dakota State Treasurer </a></li>
+	<ul>
+		<li><a href="http://www.nd.gov/treasurer/revenue-distribution/">Revenue distribution (including Oil and Gas Gross Production, Oil Extraction, Coal Severance, and other taxes associated with resource extraction)</a></li>
+		<li><a href="http://www.nd.gov/treasurer/how-is-oil-and-gas-tax-revenue-distributed/">Oil and gas revenue distribution</a></li>
+	</ul>
+</ul>
+
+<h3><a name="ok">Oklahoma</a></h3>
+
+<p>The Oklahoma Commissioners of the Land Office manages state lands, including oil and gas leasing to generate revenue that supports the state’s common schools and higher education institutions. The Oklahoma Department of Mines regulates the coal and nonfuel mineral production, enforcing a variety of federal and state programs for safety, health, and land reclamation. The department also issues permits for all mining operations.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Oklahoma:</p>
+
+<ul class="list-nested">
+	<li><a href="http://www.clo.state.ok.us/">Oklahoma Commissioners of the Land Office</a></li>
+	<ul>
+		<li><a href="https://clo.ok.gov/policy/rules-regulations/">Rules and regulations</a></li>
+		<li><a href="https://clo.ok.gov/services/auction-information/minerals/">Oil and gas lease auction information</a></li>
+	</ul>
+	<li><a href="http://www.ok.gov/mines/index.html">Oklahoma Department of Mines</a></li>
+	<ul>
+		<li><a href="http://www.ok.gov/mines/Coal_Program/index.html">Coal program and related data</a></li>
+		<li><a href="http://www.ok.gov/mines/Annual_Reports/">Department of Mines Annual Reports</a></li>
+	</ul>
+	<li><a href="http://www.ok.gov/OSF/documents/cafr14.pdf">Oklahoma Office of Management and Enterprise Services Comprehensive Annual Financial Report</a></li>
+</ul>
+
+<h3><a name="pa">Pennsylvania</a></h3>
+
+<p>The Department of Environmental Protection, including the Bureau of Mining Programs and the Office of Oil and Gas Management, manages programs that ensure the safe and responsible exploration, development, and recovery of extractive resources. These programs include permitting and inspection, regulatory oversight, and training.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Pennsylvania:</p>
+
+<ul class="list-nested">
+	<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/office_of_oil_and_gas_management/20291">Pennsylvania Department of Environmental Protection Office of Oil and Gas Management</a></li>
+	<ul>
+		<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/public_resources/20303/oil_and_gas_surface_regulations/1587188">Oil and gas surface regulations</a></li>
+		<li><a href="https://www.paoilandgasreporting.state.pa.us/publicreports/Modules/Welcome/Welcome.aspx">Oil and gas production data</a></li>
+	</ul>
+  	<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/mining/6002">Pennsylvania Department of Environmental Protection Office of Active and Abandoned Mine Operations</a></li>
+	<ul>
+		<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/bureau_of_mining_programs/20865/regulations/1150023">Coal regulations</a></li>
+	</ul>
+  	<li><a href="http://dcnr.state.pa.us/topogeo/index.aspx">State Bureau of Topographic and Geologic Survey</a></li>
+	<ul>
+		<li><a href="http://dcnr.state.pa.us/topogeo/econresource/oilandgas/index.htm">Oil and gas resources</a></li>
+		<li><a href="http://dcnr.state.pa.us/topogeo/econresource/mineral_industries/index.htm">Mineral resources</a></li>
+		<li><a href="http://dcnr.state.pa.us/topogeo/econresource/coal/index.htm">Coal resources</a></li>
+	</ul>
+</ul>
+
+<h3><a name="tx">Texas</a></h3>
+
+<p>The Railroad Commission of Texas is statutorily responsible for regulating the exploration and production of the state’s natural resources: oil, natural gas, minerals (particularly lignite and coal), and alternative fuels. The commission oversees natural resource extraction along with land reclamation and environmental protection. The commission also oversees safety and compliance related to the state’s extensive oil and gas pipeline infrastructure.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Texas:</p>
+
+<ul class="list-nested">
+	<li><a href="http://www.rrc.state.tx.us/">Railroad Commission of Texas</a></li>
+	<ul>
+		<li><a href="http://www.rrc.state.tx.us/oil-gas/research-and-statistics/production-data/texas-monthly-oil-gas-production/">Monthly oil and gas production data</a></li>
+		<li><a href="http://www.rrc.state.tx.us/legal/rules/current-rules/">Regulations for commodity extraction</a></li>
+	</ul>
+	<li><a href="http://www.texastransparency.org/State_Finance/Budget_Finance/Reports/Revenue_by_Source/revenue_hist.php">Historical state net tax revenue by source</a></li>
+</ul>
+
+<h3><a name="ut">Utah</a></h3>
+
+<p>The Division of Oil, Gas, and Mining within Utah’s Department of Natural Resources is responsible for developing natural resources for the economic benefit of the public while preserving the state’s natural environment. The division maintains four core programs, each with specific oversight functions: the Coal Program, the Mineral Mining Program, the Oil and Gas Program, and the Abandoned Mine Reclamation Program.</p>
+
+<p>Learn more about natural resource regulation, production, and revenue in Utah:</p>
+
+<ul class="list-nested">
+  <li><a href="http://naturalresources.utah.gov/divisions/ogm.html">Utah Department of Natural Resources Division of Oil, Gas, and Mining</a></li>
+  <li><a href="http://linux3.ogm.utah.gov/WebStuff/wwwroot/coal/default.html">Coal program</a></li>
+  <li><a href="http://linux3.ogm.utah.gov/WebStuff/wwwroot/minerals/default.html">Minerals program</a></li>
+  <li><a href="http://oilgas.ogm.utah.gov/">Oil and gas program</a></li>
+  <ul>
+	  <li><a href="http://oilgas.ogm.utah.gov/Rules/Rules_Page.htm">Oil and gas regulations</a></li>
+	  <li><a href="http://oilgas.ogm.utah.gov/Data_Center/DataCenter.cfm">Permitting, drilling, and production data</a></li>
   </ul>
+  <li><a href="http://linux3.ogm.utah.gov/WebStuff/wwwroot/coal/rulesregs.html">Statutes and rules</a></li>
+  <li><a href="http://tax.utah.gov/utah-taxes">Utah State Tax Commission description of all taxes and fees</a></li>
+  <li><a href="http://geology.utah.gov/">Utah Geological Survey</a></li>
+  <li><a href="http://finance.utah.gov/cafr.html">Utah Department of Administrative Services Division of Finance Comprehensive Annual Financial Report Archive</a></li>
+</ul>
 
-    <h3><a name="wy">Wyoming</a></h3>
+<h3><a name="wv">West Virginia</a></h3>
 
-    <p>The Wyoming Office of State Lands and Investments manages resource extraction on state land held in public trust. The revenue from energy and mineral resource leasing helps fund public education and essential institutions in the state.</p>
+<p>The West Virginia Department of Environmental Protection oversees natural resource extraction in West Virginia. The department’s Office of Oil and Gas is responsible for monitoring and regulating all actions related to the exploration, drilling, storage, and production of oil and natural gas. The Division of Mining and Reclamation manages compliance, reclamation, permitting, and communications between the public and industry.</p>
 
-    <p>Learn more about natural resource revenue, regulation, and production in Wyoming:</p>
+<p>Learn more about natural resource revenue, regulation, and production in West Virginia:</p>
 
-    <ul class="list-nested">
-  	  <li><a href="https://sites.google.com/a/wyo.gov/osli/home">Wyoming Office of State Lands and Investments</a></li>
-  	  <ul>
-  		  <li><a href="https://sites.google.com/a/wyo.gov/osli/minerals/royalty">Mining and oil and gas leasing and royalties information</a></li>
-  	  </ul>
-  	  <li><a href="http://soswy.state.wy.us/Rules/default.aspx">Wyoming rules and regulations search</a></li>
-  	  <li><a href="http://www.wsgs.wyo.gov/">Wyoming State Geological Survey</a></li>
-  	  <li><a href="http://revenue.wyo.gov/tax-distribution-reports/mineral-tax-distributions">Wyoming Department of Revenue Mineral Tax Distribution reports</a></li>
-    </ul>
-  </article>
-</div>
+<ul class="list-nested">
+  <li><a href="http://www.dep.wv.gov/Pages/default.aspx">West Virginia Department of Environmental Protection</a></li>
+  <ul>
+	  <li><a href="http://www.dep.wv.gov/dmr/codes/Pages/default.aspx">Mining codes and regulations</a></li>
+	  <li><a href="http://www.dep.wv.gov/oil-and-gas/Pages/default.aspx">Oil and gas rules and regulations</a></li>
+  </ul>
+  <li><a href="http://www.wvminesafety.org/default.htm">West Virginia Office of Miners’ Health, Safety, and Training</a></li>
+  <ul>
+	  <li><a href="http://www.wvminesafety.org/STATS.HTM">Surface and subsurface coal production and employment data</a></li>
+  </ul>
+  <li><a href="http://www.wvcommerce.org/business/businessassistance/expandingorrelocating/businesstaxes.aspx ">Business taxes overview</a></li>
+  <li><a href="http://www.wvcommerce.org/business/businessassistance/expandingorrelocating/businesstaxes.aspx">West Virginia Geological and Economic Survey</a></li>
+  <li><a href="http://www.finance.wv.gov/FARS/CAFR/Pages/default.aspx">West Virginia Department of Administration, Division of Finance Comprehensive Annual Financial Report Archive</a></li>
+</ul>
+
+<h3><a name="wy">Wyoming</a></h3>
+
+<p>The Wyoming Office of State Lands and Investments manages resource extraction on state land held in public trust. The revenue from energy and mineral resource leasing helps fund public education and essential institutions in the state.</p>
+
+<p>Learn more about natural resource revenue, regulation, and production in Wyoming:</p>
+
+<ul class="list-nested">
+  <li><a href="https://sites.google.com/a/wyo.gov/osli/home">Wyoming Office of State Lands and Investments</a></li>
+  <ul>
+	  <li><a href="https://sites.google.com/a/wyo.gov/osli/minerals/royalty">Mining and oil and gas leasing and royalties information</a></li>
+  </ul>
+  <li><a href="http://soswy.state.wy.us/Rules/default.aspx">Wyoming rules and regulations search</a></li>
+  <li><a href="http://www.wsgs.wyo.gov/">Wyoming State Geological Survey</a></li>
+  <li><a href="http://revenue.wyo.gov/tax-distribution-reports/mineral-tax-distributions">Wyoming Department of Revenue Mineral Tax Distribution reports</a></li>
+</ul>

--- a/_includes/hash_selector.html
+++ b/_includes/hash_selector.html
@@ -2,11 +2,7 @@
 <select onchange="window.location = '{{site.baseurl}}{{ page.permalink }}#' + this.value">
   {% if page.nav_items %}
   	{% for item in page.nav_items %}
-      {% if item.name == page.nav_items[0].name %}
-        <option selected value="{{item.name}}">{{item.title}}</option>
-      {% else %}
         <option value="{{item.name}}">{{item.title}}</option>
-      {% endif %}
     {% endfor %}
   {% endif %}
 </select>

--- a/_includes/hash_selector.html
+++ b/_includes/hash_selector.html
@@ -1,0 +1,12 @@
+<label>{{page.nav_description}}</label>
+<select onchange="window.location = '{{site.baseurl}}{{ page.permalink }}#' + this.value">
+  {% if page.nav_items %}
+  	{% for item in page.nav_items %}
+      {% if item.name == page.nav_items[0].name %}
+        <option selected value="{{item.name}}">{{item.title}}</option>
+      {% else %}
+        <option value="{{item.name}}">{{item.title}}</option>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+</select>

--- a/_includes/hash_selector.html
+++ b/_includes/hash_selector.html
@@ -1,8 +1,8 @@
 <label>{{page.nav_description}}</label>
 <select onchange="window.location = '{{site.baseurl}}{{ page.permalink }}#' + this.value">
   {% if page.nav_items %}
-  	{% for item in page.nav_items %}
-        <option value="{{item.name}}">{{item.title}}</option>
+    {% for item in page.nav_items %}
+       <option value="{{item.name}}">{{item.title}}</option>
     {% endfor %}
   {% endif %}
 </select>

--- a/_layouts/narrative.html
+++ b/_layouts/narrative.html
@@ -22,4 +22,3 @@ layout: default
 </section>
 
 <script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
-<!-- <script src="{{ site.baseurl }}/js/pages/case-studies.js"></script> -->

--- a/_layouts/narrative.html
+++ b/_layouts/narrative.html
@@ -5,32 +5,21 @@ layout: default
 <section class="container-outer container-padded">
 
 	<article class="container-left-7">
-
 		  {{content | markdownify}}
 
 	</article>
 
-	<div class="container-right-5 sticky_nav">
+	<div class="container-right-5">
 
+	<div class="sticky_nav" data-sticky-offset="50">
 	  <nav class="sticky_nav-nav">
-
-	    <ul>
-	      {% if page.nav_items %}
-	      	{% for item in page.nav_items %}
-		        {% if item.name == page.nav_items[0].name %}
-		          <li class="sticky_nav-nav_item js-cs_nav_item active {{item.name}}"><a href="#{{item.name}}">{{item.title}}</a></li>
-		        {% else %}
-		          <li class="sticky_nav-nav_item js-cs_nav_item {{item.name}}"><a href="#{{item.name}}">{{item.title}}</a></li>
-		        {% endif %}
-		      {% endfor %}
-	      {% endif %}
-	    </ul>
-
+		  {% include hash_selector.html %}
 	  </nav>
+  </div>
 
 	</div>
 
 </section>
 
-
-<script src="{{ site.baseurl }}/js/pages/case-studies.js"></script>
+<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
+<!-- <script src="{{ site.baseurl }}/js/pages/case-studies.js"></script> -->

--- a/_sass/components/_all.scss
+++ b/_sass/components/_all.scss
@@ -12,3 +12,4 @@
 @import 'bureau';
 @import 'map';
 @import 'accordions';
+@import 'hash-selector';

--- a/_sass/components/_hash-selector.scss
+++ b/_sass/components/_hash-selector.scss
@@ -1,7 +1,7 @@
 .hash_selector {
-	display: inline-block;
+  display: inline-block;
 
-	@include respond-to(medium-up) {
-		display: none;
-	}
+  @include respond-to(medium-up) {
+    display: none;
+  }
 }

--- a/_sass/components/_hash-selector.scss
+++ b/_sass/components/_hash-selector.scss
@@ -1,0 +1,7 @@
+.hash_selector {
+	display: inline-block;
+
+	@include respond-to(medium-up) {
+		display: none;
+	}
+}

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -21,8 +21,14 @@
       sticky : document.querySelector('.sticky_nav'),
       main: document.querySelector('main')
     };
+
+    var attrStickyOffset = this.elems.sticky.getAttribute('data-sticky-offset');
+    console.log(attrStickyOffset)
+    this.offset = attrStickyOffset
+      ? parseInt(attrStickyOffset)
+      : this.elems.sticky.offsetTop;
     this.height = this.elems.sticky.clientHeight;
-    this.offset = this.elems.sticky.offsetTop;
+
   };
 
   StickyNav.prototype = {
@@ -31,6 +37,7 @@
       this.mainHeight = this.elems.main.clientHeight;
       this.diffTop = scrollTop - this.mainOffset - this.offset;
       this.diffBottom = scrollTop + this.height - this.mainHeight - this.mainOffset;
+
     },
     update: function(){
       if (this.diffTop >= 0){
@@ -54,6 +61,7 @@
   findScrollPositions();
   stickyNav.setPositions();
   stickyNav.update();
+  console.log(stickyNav)
 
   window.addEventListener('scroll', function() {
     findScrollPositions();

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -23,7 +23,6 @@
     };
 
     var attrStickyOffset = this.elems.sticky.getAttribute('data-sticky-offset');
-    console.log(attrStickyOffset)
     this.offset = attrStickyOffset
       ? parseInt(attrStickyOffset)
       : this.elems.sticky.offsetTop;

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -60,7 +60,6 @@
   findScrollPositions();
   stickyNav.setPositions();
   stickyNav.update();
-  console.log(stickyNav)
 
   window.addEventListener('scroll', function() {
     findScrollPositions();


### PR DESCRIPTION
For #861 

Preview: https://federalist.18f.gov/preview/18F/doi-extractives-data/state-fiscal-layout/how-it-works/state-legal-fiscal-info/

This PR:
* Works within the narrative layout to create a state selector that assists in navigation though the wall of text in `how-it-works/state-legal-fiscal-info/`
* Adds selector in mobile view

@meiqimichelle. Ready for review

Still to do: Selector 'active' state should reflect url and place on the page --> #928 