### PR TITLE
Added toggle attribute to explore page filter toggle

### DIFF
--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -53,7 +53,7 @@ permalink: /explore/gdp/
   </div>
   <section class="container-right-8">
     <div class="filters-wrapper slab-foxtrot container">
-      <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters">Show Filters</button>
+      <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
 
       <form id="filters" aria-hidden="true" class="filters">
         <div class="filters-heading">
@@ -103,7 +103,7 @@ permalink: /explore/gdp/
       </form>
 
       <div class="container-outer">
-        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters">Show Filters</button>
+        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
       </div>
 
     </div>

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -19,7 +19,7 @@ permalink: /explore/federal-production/
     <div class="filters-wrapper slab-foxtrot">
       <button class="toggle-filters toggle-desktop" is="eiti-toggle"
         aria-controls="filters" aria-expanded="false"
-        data-expanded-text="Hide Filters">Show Filters</button>
+        data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
 
       <form id="filters" aria-hidden="true" class="filters container-outer">
 
@@ -85,7 +85,7 @@ permalink: /explore/federal-production/
       </form>
 
       <div class="container-outer">
-        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters">Show Filters</button>
+        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
       </div>
 
     </div>

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -19,7 +19,7 @@ permalink: /explore/federal-revenue-by-location/
   </div>
   <section class="container-right-8">
     <div class="filters-wrapper slab-foxtrot container">
-      <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters">Show Filters</button>
+      <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
 
       <form id="filters" aria-hidden="true" class="filters">
         <div class="filters-heading">
@@ -79,7 +79,7 @@ permalink: /explore/federal-revenue-by-location/
       </form>
 
       <div class="container-outer">
-        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters">Show Filters</button>
+        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
       </div>
 
     </div>


### PR DESCRIPTION
Fixes #894 

Preview: https://federalist.18f.gov/preview/18F/doi-extractives-data/explore/toggles/gdp/

There are now two buttons on `gdp`, `federal-production`, and `federal-revenue-by-location` that have a shared state, so that toggling with one changes the status of the other.

@shawnbot when you get a chance could you review?