### PR TITLE
Tiny nonenergy fix

### DIFF
--- a/_how-it-works/the-process/minerals.html
+++ b/_how-it-works/the-process/minerals.html
@@ -1,5 +1,5 @@
 ---
-title: Non-Energy Minerals | How it Works
+title: Nonenergy Minerals | How it Works
 layout: default
 permalink: /how-it-works/minerals/
 ---

--- a/_includes/how-it-works/footer.html
+++ b/_includes/how-it-works/footer.html
@@ -8,7 +8,7 @@
   <ul class="container-right-8">
 	  <li><a href="{{ site.baseurl }}/how-it-works/coal/"><i class="icon-coal icon-padded"></i>Coal</a></li>
 	  <li><a href="{{ site.baseurl }}/how-it-works/offshore-oil-gas/"><i class="icon-oil icon-padded"></i>Oil &amp; Gas</a></li>
-	  <li><a href="{{ site.baseurl }}/how-it-works/minerals/"><i class="icon-hardrock icon-padded"></i>Non-Energy Minerals</a></li>
+	  <li><a href="{{ site.baseurl }}/how-it-works/minerals/"><i class="icon-hardrock icon-padded"></i>Nonenergy Minerals</a></li>
 	  <li><a href="{{ site.baseurl }}/how-it-works/offshore-renewables/"><i class="icon-wind icon-padded"></i>Renewables</a></li>
 	</ul>
 </section>


### PR DESCRIPTION
Removed two hyphens. Addresses a note in the discussion on #813.