### PR TITLE
Cleans data viz styles

### DIFF
--- a/_explore/default.md
+++ b/_explore/default.md
@@ -72,7 +72,7 @@ permalink: /explore/
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/explore/reconciliation/">Reconciliation</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for reconciliation"></button>
 			<div class="accordion-content">
-				<p class="landing-description">As a part of USEITI, companies report payments to the government (e.g., rents, taxes, royalties) and the government reports what it received. These figures are compiled and reconciled by an independent administrator and published. In the future, this dataset will be interactive. For now, you can <a href="{{site.baseurl}}/explore/reconciliation/">learn about the reconciliation process</a> or <a href="{{site.baseurl}}/downloads/">download the dataset &#8594;</a></p>
+				<p class="landing-description">As a part of USEITI, companies report payments to the government (e.g., rents, taxes, royalties) and the government reports what it received. These figures are compiled and reconciled by an independent administrator and published. In the future, this dataset will be interactive. For now, you can <a href="{{site.baseurl}}/explore/reconciliation/">learn about the reconciliation process</a> or <a href="{{site.baseurl}}/downloads/#reconciliation">download the dataset &#8594;</a></p>
 				<a href="{{site.baseurl}}/explore/reconciliation/">
 					<img class="landing-image" src="{{site.baseurl}}/img/landing-placeholders/placeholder.png">
 				</a>

--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -12,97 +12,13 @@ permalink: /explore/exports/
         /
       </div>
       <h1>Exports</h1>
-      <p>In 2013, the U.S. exported $137,558 million in petroleum end-use goods, 8.6% of all exports totaling $1,592,784 million. The U.S. is now a net exporter of petroleum products and coal, although still a net importer of natural gas and crude oil. Natural resource commodity exports, meaning commodities that underwent minimal processing, made up approximately $22,000 million in goods produced and sold abroad.</p>
-<!--
-  <h3>2013 exports by commodity</h3>
+      <p>In 2013, the U.S. exported $137,558 million in petroleum end-use goods, 8.6% of all exports. The U.S. is now a net exporter of petroleum products and coal, although still a net importer of natural gas and crude oil.</p>
 
-  <table>
-    <tr>
-      <th>Natural resource commodity</th>
-      <th>Exports</th>
-    </tr>
-    <tr>
-      <td>Bituminous coal, not agglomerated</td>
-      <td>$8,949 million</td>
-    </tr>
-    <tr>
-      <td>Natural gas, gaseous</td>
-      <td>$5,560 million</td>
-    </tr>
-    <tr>
-      <td>Crude oil from petroleum and bituminous miner	</td>
-      <td>$4,108 million</td>
-    </tr>
-    <tr>
-      <td>Copper ores and concentrates</td>
-      <td>$2,302 million</td>
-    </tr>
-    <tr>
-      <td>Agglomerated iron ores</td>
-      <td>$922 million</td>
-    </tr>
-    <tr>
-      <td>Coal NESOI, not agglomerated</td>
-      <td>$172 million</td>
-    </tr>
-    <tr>
-      <td>Precious metal ores and concentrates (including gold)</td>
-      <td>$140 million</td>
-    </tr>
-    <tr>
-      <td>Total</td>
-      <td>$22,153 million</td>
-    </tr>
-  </table>
+      <p><em>Explore extractive industries exports by state from 2011 to 2013 as dollar totals, and as percent of all exports.</em></p>
 
-  <h3>2013 exports by commodity volume</h3>
+      <a href="{{site.baseurl}}/downloads/#exports">Data and documentation &#8594;
+      </a>
 
-  <table>
-    <tr>
-      <th>Natural resource commodity</th>
-      <th>Production units</th>
-    </tr>
-    <tr>
-      <td>Crude oil</td>
-      <td>48,968 thousand barrels</td>
-    </tr>
-    <tr>
-      <td>Natural gas plant liquids and liquefied refinery gases</td>
-      <td>170,941 thousand barrels</td>
-    </tr>
-    <tr>
-      <td>Compressed natural gas and liquefied natural gas</td>
-      <td>1,572,413 million cubic feet</td>
-    </tr>
-    <tr>
-      <td>Other liquids (hydrogen / oxygenates / renewables / other hydrocarbons, unfinished oils, motor and aviation gas)</td>
-      <td>130,881 thousand barrels</td>
-    </tr>
-    <tr>
-      <td>Iron ore</td>
-      <td>11 million metric tons</td>
-    </tr>
-    <tr>
-      <td>Copper ores and concentrates</td>
-      <td>348 thousand metric tons</td>
-    </tr>
-    <tr>
-      <td>Refined copper</td>
-      <td>113 thousand metric tons</td>
-    </tr>
-    <tr>
-      <td>Gold (refined bullion, doré, ores, concentrates, precipitates)</td>
-      <td>691 metric tons</td>
-    </tr>
-    <tr>
-      <td>Metallurgical coal</td>
-      <td>65,678,865 short tons</td>
-    </tr>
-    <tr>
-      <td>Steam coal</td>
-      <td>51,980,403 short tons</td>
-    </tr>
-  </table> -->
     </div>
   </div>
   <section class="container-right-8">
@@ -131,10 +47,10 @@ permalink: /explore/exports/
             <label class="unit-selector"><input type="radio" name="units" value="percent">%</label>
           </div>
           -->
-          <label for="unit-selector">Units</label>
+          <label for="unit-selector">Show results as</label>
           <select id="unit-selector" name="units">
-            <option value="dollars" selected>$</option>
-            <option value="percent">%</option>
+            <option value="dollars" selected>Dollars ($)</option>
+            <option value="percent">Percentage (%)</option>
           </select>
         </div>
         <div class="container-left">
@@ -144,7 +60,7 @@ permalink: /explore/exports/
           <svg id="timeline" class="timeline" viewBox="0 0 1024 60"></svg>
         </div>
 
-        <div class="filter container">
+        <div class="filter container filters-last">
           <eiti-slider id="year-selector" name="year"
             min="2011" max="2014" snap="1" value="2014">
           </eiti-slider>
@@ -171,6 +87,8 @@ permalink: /explore/exports/
     </div>
 
     <div class="regions container">
+
+      <p class="map-intro_text">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam.</p>
 
       <section id="US" class="region active">
         <div class="map-wrapper">

--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -54,7 +54,7 @@ permalink: /explore/exports/
           </select>
         </div>
         <div class="container-left">
-          <label for="year-selector">Exports by Year</label>
+          <label for="year-selector">Years</label>
         </div>
         <div class="filter container">
           <svg id="timeline" class="timeline" viewBox="0 0 1024 60"></svg>

--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -49,8 +49,8 @@ permalink: /explore/exports/
           -->
           <label for="unit-selector">Show results as</label>
           <select id="unit-selector" name="units">
-            <option value="dollars" selected>Dollars ($)</option>
-            <option value="percent">Percentage (%)</option>
+            <option value="dollars" selected>Dollars</option>
+            <option value="percent">Percentage</option>
           </select>
         </div>
         <div class="container-left">

--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -7,7 +7,10 @@ permalink: /explore/exports/
 <section id="gdp" class="explore-subpage container">
   <div class="container-left-4">
     <div class="container-outer">
-      <h5 class="subpage-breadcrumb"><a href="{{ site.baseurl }}/explore/">Explore</a> /</h5>
+      <div>
+        <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore</a>
+        /
+      </div>
       <h1>Exports</h1>
       <p>In 2013, the U.S. exported $137,558 million in petroleum end-use goods, 8.6% of all exports totaling $1,592,784 million. The U.S. is now a net exporter of petroleum products and coal, although still a net importer of natural gas and crude oil. Natural resource commodity exports, meaning commodities that underwent minimal processing, made up approximately $22,000 million in goods produced and sold abroad.</p>
 <!--

--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -12,46 +12,13 @@ permalink: /explore/gdp/
       </div>
       <h1>Gross Domestic Product</h1>
 
-      <p>In 2013, our GDP was $16.8 trillion, making the U.S. economy the largest in the world. Overall the extractive industries account for 2.6% of the economy, outpacing utilities, agriculture, and education services in contribution to national GDP. Extractive industries totaled <a href="http://www.bea.gov/iTable/iTable.cfm?ReqID=51&step=1#reqid=51&step=51&isuri=1&5114=a&5102=1">$439 billion in real value added</a>.</p>
+      <p>In 2013, our GDP was $16.8 trillion, making the U.S. economy the largest in the world. Overall the extractive industries account for 2.6% of the economy, outpacing utilities, agriculture, and education services in contribution to national GDP.</p>
 
       <p><em>Explore GDP from 2004 to 2013 by state as a dollar value, or as a percentage of total GDP.</em></p>
 
-      <!-- <h3>2013 extractive industries value-added GDP</h3>
+      <a href="{{site.baseurl}}/downloads/#gdp">Data and documentation &#8594;
+      </a>
 
-      <table>
-        <tr>
-          <th>Industry</th>
-          <th>Real value added</th>
-          <th>Value added as a percentage of total GDP</th>
-        </tr>
-        <tr>
-          <td>All industries</td>
-          <td>$16,768.1 billion</td>
-          <td>100%</td>
-        </tr>
-        <tr>
-          <td>Extractive industries</td>
-          <td>$439.4 billion</td>
-          <td>2.6%</td>
-        </tr>
-        <tr>
-          <td>Oil and gas</td>
-          <td>$291.9 billion</td>
-          <td>1.7%</td>
-        </tr>
-        <tr>
-          <td>Mining except oil and gas</td>
-          <td>$78.8 billion</td>
-          <td>0.5%</td>
-        </tr>
-        <tr>
-          <td>Support activities for mining</td>
-          <td>$68.7 billion</td>
-          <td>0.4%</td>
-        </tr>
-      </table>
-
-      <p>Extractive industries affect the economy in a number of ways, including the quantity and value of the natural resources produced, the revenue collected for public purposes, the jobs held by people working in extractive industries, and the exports that draw in money from abroad. While it can be difficult to quantify an industry’s impact on a country, these measures—production, revenue, employment, and exports—start to highlight the extractive industries’ role in the economy.</p> -->
     </div>
   </div>
   <section class="container-right-8">
@@ -84,20 +51,20 @@ permalink: /explore/gdp/
           -->
           <label for="unit-selector">Units</label>
           <select id="unit-selector" name="units">
-            <option value="dollars" selected>$</option>
-            <option value="percent">%</option>
+            <option value="dollars" selected>Dollars</option>
+            <option value="percent">Percentage</option>
           </select>
         </div>
 
 
         <div class="container-left">
-          <label for="year-selector">GDP by Year</label>
+          <label for="year-selector">Years</label>
         </div>
         <div class="filter container">
           <svg id="timeline" class="timeline" viewBox="0 0 1024 60"></svg>
         </div>
 
-        <div class="filter container">
+        <div class="filter container filters-last">
           <eiti-slider id="year-selector" name="year"
             min="2004" max="2013" snap="1" value="2013">
           </eiti-slider>
@@ -124,6 +91,8 @@ permalink: /explore/gdp/
     </div>
 
     <div class="regions container">
+
+      <p class="map-intro_text">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam.</p>
 
       <section id="US" class="region active">
         <div class="map-wrapper">

--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -6,7 +6,10 @@ permalink: /explore/gdp/
 <section id="gdp" class="explore-subpage container">
   <div class="container-left-4">
     <div class="container-outer">
-      <h5 class="subpage-breadcrumb"><a href="{{ site.baseurl }}/explore/">Explore</a> /</h5>
+      <div>
+        <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore</a>
+        /
+      </div>
       <h1>Gross Domestic Product</h1>
 
       <p>In 2013, our GDP was $16.8 trillion, making the U.S. economy the largest in the world. Overall the extractive industries account for 2.6% of the economy, outpacing utilities, agriculture, and education services in contribution to national GDP. Extractive industries totaled <a href="http://www.bea.gov/iTable/iTable.cfm?ReqID=51&step=1#reqid=51&step=51&isuri=1&5114=a&5102=1">$439 billion in real value added</a>.</p>

--- a/_explore/economic-impact/jobs.html
+++ b/_explore/economic-impact/jobs.html
@@ -6,7 +6,10 @@ permalink: /explore/jobs/
 <section id="jobs" class="explore-subpage container">
   <div class="container-left-4">
     <div class="container-outer">
-      <h5 class="subpage-breadcrumb"><a href="{{ site.baseurl }}/explore/">Explore</a> /</h5>
+      <div>
+        <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore</a>
+        /
+      </div>
       <h1>Jobs</h1>
 
       <p>TKTKTK.</p>

--- a/_explore/economic-impact/jobs.html
+++ b/_explore/economic-impact/jobs.html
@@ -12,13 +12,18 @@ permalink: /explore/jobs/
       </div>
       <h1>Jobs</h1>
 
-      <p>TKTKTK.</p>
+      <p>808,000 people drew wages or salaries from work in the extractive industries in 2013. In addition, there are thousands of self-employed people working across the extractive industries.</p>
+
+      <p><em>Explore extractive industries jobs from 2004 to 2013 by state for both salaried employees and self-employed.</em></p>
+
+      <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation &#8594;
+      </a>
 
     </div>
   </div>
   <section class="container-right-8">
     <div class="filters-wrapper slab-foxtrot container">
-      <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
+      <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-toggler="filters">Show filters</button>
 
       <form id="filters" aria-hidden="true" class="filters">
         <div class="filters-heading">
@@ -45,20 +50,20 @@ permalink: /explore/jobs/
           -->
           <label for="figure-selector">Job type</label>
           <select id="figure-selector" name="figure">
-            <option value="wage" selected>wage and salary</option>
-            <option value="self">self-employment</option>
+            <option value="wage" selected>Wage and salary</option>
+            <option value="self">Self-employed</option>
           </select>
         </div>
 
 
         <div class="container-left">
-          <label for="year-selector">Jobs by Year</label>
+          <label for="year-selector">Years</label>
         </div>
         <div class="filter container">
           <svg id="timeline" class="timeline" viewBox="0 0 1024 60"></svg>
         </div>
 
-        <div class="filter container">
+        <div class="filter container filters-last">
           <eiti-slider id="year-selector" name="year"
             min="2004" max="2013" snap="1" value="2013">
           </eiti-slider>
@@ -67,7 +72,7 @@ permalink: /explore/jobs/
       </form>
 
       <div class="container-outer">
-        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
+        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-toggler="filters">Show filters</button>
       </div>
 
     </div>
@@ -78,13 +83,15 @@ permalink: /explore/jobs/
   <div class="slab-alpha">
     <div class="container-outer">
       <h1 id="filter-description" class="filter-description">
-        Extractives jobs in
+        Extractive industries jobs in
         <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
         (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
       </h1>
     </div>
 
     <div class="regions container">
+
+      <p class="map-intro_text">There are two types of jobs data here. One is <em>Wage and Salary</em> data, which describes the number of people employed in natural resource extraction that receive wages or salaries from companies. The other type is <em>Self-Employed</em>, which describes people work in natural resource extraction, but don’t receive wages or salaries because they own their company. You can select which type of data you'd like to see in the filters above.</p>
 
       <section id="US" class="region active">
         <div class="map-wrapper">

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -16,6 +16,14 @@ permalink: /explore/federal-production/
 
       <p><em>Explore production on federal lands and waters from 2005 to 2014 by state and county for 28 individual products.</em></p>
 
+      <a href="{{site.baseurl}}/downloads/#production-fed">
+        <icon class="icon-cloud icon-padded"></icon>Download full dataset
+      </a><br>
+
+      <a href="#">
+        <i class="fa fa-file-text-o u-padding-right"></i>Documentation
+      </a>
+
     </div>
   </div>
   <section class="container-right-8">
@@ -75,11 +83,11 @@ permalink: /explore/federal-production/
         </div>
 
         <div class="container-left">
-          <label for="year-selector">Production by year <span class="units"></span></label>
+          <label for="year-selector">Years <span class="units"></span></label>
         </div>
         <svg id="timeline" class="timeline" viewBox="0 0 1024 60"></svg>
 
-        <div class="filter">
+        <div class="filter container filters-last">
           <eiti-slider id="year-selector" name="year"
             min="2005" max="2014" snap="1" value="2013">
           </eiti-slider>
@@ -104,6 +112,8 @@ permalink: /explore/federal-production/
       </div>
 
       <div class="regions container">
+
+        <p class="map-intro_text">This map shows whether there is production on federal lands or not. Once you select a specific product in the filters above, it will show production amount for your selected year. Why? We can't sum different products that are measured in different units.</p>
 
         <section id="US" class="region active">
           <div class="map-wrapper">

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -6,7 +6,10 @@ permalink: /explore/federal-production/
 <section id="federal-production" class="explore-subpage container">
   <div class="container-left-4">
     <div class="container-outer">
-      <h5 class="subpage-breadcrumb"><a href="{{ site.baseurl }}/explore/">Explore</a> /</h5>
+      <div>
+        <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore</a>
+        /
+      </div>
       <h1>Federal Production</h1>
 
       <p>Revenue from extractive industries on federal lands totaled approximately $13.4 billion, or 0.4% of total $3,396.9 billion in revenue collected across the federal government.</p>

--- a/_explore/revenue/corporate-income-tax.md
+++ b/_explore/revenue/corporate-income-tax.md
@@ -8,8 +8,10 @@ permalink: /explore/corporate-income-tax/
 
   <article class="container-left-7">
 
-    <h3> <a href="{{ site.baseurl }}/explore/">Explore Data</a> / </h3>
-
+    <div>
+      <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore</a>
+      /
+    </div>
     <h1>Corporate Income Tax</h1>
 
     <p class="case_studies_intro-para">Due to U.S. law, information about companies’ individual income tax payments is confidential. However, there are two key sources of publicly available information about federal income taxes for the extractive industries: the government and the filings of companies that are publicly listed.</p>

--- a/_explore/revenue/disbursements.md
+++ b/_explore/revenue/disbursements.md
@@ -6,7 +6,11 @@ permalink: /explore/disbursements/
 
 <div class="container-outer container-padded">
 
-  <h3> <a href="{{ site.baseurl }}/explore/">Explore Data</a> / Disbursements</h3>
+  <div>
+    <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore</a>
+    /
+  </div>
+  <h1>Disbursements</h1>
 
   <!-- <p>Once collected, the federal government distributes revenue from natural resource extraction for public use in a variety of ways. Federal corporate income taxes go to the General Fund of the Treasury, and Congress determines how to allocate these resources each year through the appropriations process.</p>
 

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -99,6 +99,8 @@ permalink: /explore/federal-revenue-by-location/
 
     <div class="regions container">
 
+      <p class="map-intro_text">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
+
       <section id="US" class="region active">
         <div class="map-wrapper">
           <svg is="eiti-map" id="US-map" class="region-map" simplify="1e-2"

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -92,13 +92,13 @@ permalink: /explore/federal-revenue-by-location/
 
   <div class="slab-alpha">
     <div class="container-outer">
-      <h1 id="filter-description" class="filter-description">
+      <h2 id="filter-description" class="filter-description">
         Revenue from
         <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
         on federal lands in
         <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
         (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-      </h1>
+      </h2>
     </div>
 
     <div class="regions container">

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -6,7 +6,10 @@ permalink: /explore/federal-revenue-by-location/
 <section id="revenue" class="explore-subpage container">
   <div class="container-left-4">
     <div class="container-outer">
-      <h5 class="subpage-breadcrumb"><a href="{{ site.baseurl }}/explore/">Explore</a> /</h5>
+      <div>
+        <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore</a>
+        /
+      </div>
       <h1>Federal Revenue by Location</h1>
 
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -12,12 +12,17 @@ permalink: /explore/federal-revenue-by-location/
       </div>
       <h1>Federal Revenue by Location</h1>
 
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing
-        elit. Praesent eget justo sodales neque fermentum
-        consequat eu sit amet libero. Aliquam eu eleifend leo.
-        Donec sem dolor, volutpat quis tortor pretium,
-        tincidunt pretium massa. Curabitur sed euismod velit.
-        Aenean eu venenatis turpis, mattis tempus orci.</p>
+      <p>Revenue from extractive industries on federal lands totaled approximately $13.4 billion, or 0.4% of total $3,396.9 billion in revenue collected across the federal government.</p>
+
+      <p><em>Explore revenues on federal lands and waters from 2004 to 2013 by state, county and offshore areas.</em></p>
+
+      <a href="{{site.baseurl}}/downloads/#revenue-fed-location">
+        <icon class="icon-cloud icon-padded"></icon>Download full dataset
+      </a><br>
+
+      <a href="#">
+        <i class="fa fa-file-text-o u-padding-right"></i>Documentation
+      </a>
     </div>
   </div>
   <section class="container-right-8">

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -22,19 +22,18 @@ permalink: /explore/federal-revenue-by-location/
   </div>
   <section class="container-right-8">
     <div class="filters-wrapper slab-foxtrot container">
-      <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
+      <button class="toggle-filters toggle-desktop button-primary" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-toggler="filters">Show filters</button>
 
       <form id="filters" aria-hidden="true" class="filters">
         <div class="filters-heading">
           <h3>Filter revenue</h3>
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing
-      elit.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
         </div>
         <div class="container-left-6">
           <div id="commodity-group-filter" class="filter">
             <label for="commodity-group-selector">Commodity Category</label>
             <select id="commodity-group-selector" name="group">
-              <option value="">All commodity categories</option>
+              <option value="">All categories</option>
               {% for group in site.data.commodities.groups %}
               <option value="{{ group[0] }}">{{ group[1].name }}</option>
               {% endfor %}
@@ -67,13 +66,13 @@ permalink: /explore/federal-revenue-by-location/
         </div>
 
         <div class="container-left">
-          <label for="year-selector">Revenue by Year</label>
+          <label for="year-selector">Years</label>
         </div>
         <div class="filter container">
           <svg id="timeline" class="timeline" viewBox="0 0 1024 60"></svg>
         </div>
 
-        <div class="filter container">
+        <div class="filter container filters-last">
           <eiti-slider id="year-selector" name="year"
             min="2004" max="2013" snap="1" value="2013">
           </eiti-slider>
@@ -82,12 +81,9 @@ permalink: /explore/federal-revenue-by-location/
       </form>
 
       <div class="container-outer">
-        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide Filters" data-toggler="filters">Show Filters</button>
+        <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-toggler="filters">Show filters</button>
       </div>
-
     </div>
-
-
   </div>
 
   <div class="slab-alpha">

--- a/_explore/revenue/reconciliation.md
+++ b/_explore/revenue/reconciliation.md
@@ -6,22 +6,30 @@ permalink: /explore/reconciliation/
 
 <div class="container-outer container-padded">
 
-  <h3> <a href="{{ site.baseurl }}/explore/">Explore Data</a> / Reconciliation</h3>
-  
-  <p>As a part of USEITI, companies report payments to the government (e.g., rents, taxes, royalties) and the government reports what it received. These figures are compiled and reconciled by an independent administrator and published. In the future, this dataset will be interactive. For now, you can learn about the reconciliation process or <a href="{{site.baseurl}}/downloads/">download the dataset</a>.</p>
-  
-  <h3>Reconciliation results</h3>
-  
-  <p>When the independent administrator compared company payments to government revenue, 17 discrepancies exceeded the margin of variance. The independent administrator worked with the companies and government entities to investigate these discrepancies, and was able to find explanations for all of them. Explanations included differences in when payments were recorded and how they were classified.</p>
-  
-  <p>Of the 45 companies that were asked to participate, 31 reported DOI revenue and 11 reported federal corporate income taxes.</p>
-  
-  <img src="reporting p. 8" />
-      
-  <img src="reporting p. 8" />
-  
-  <p>Five companies also allowed for corporate income tax reconciliation: BP America; Cimarex Energy Co.; Could Peak Energy Resources, LLC; Shell E&P Company; and W&T Offshore, Inc.</p>
-    
-  <p>After the independent administrator compared and reconciled the government revenue streams with company payments, 17 material variances remained, all of which were explained through the reconciliation process, leaving zero unexplained variances.</p>
-  
+  <div class="container-left-7">
+
+    <div>
+      <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore</a>
+      /
+    </div>
+    <h1>Reconciliation</h1>
+
+    <p>As a part of USEITI, companies report payments to the government (e.g., rents, taxes, royalties) and the government reports what it received. These figures are compiled and reconciled by an independent administrator and published. In the future, this dataset will be interactive. For now, you can learn about the reconciliation process or <a href="{{site.baseurl}}/downloads/">download the dataset</a>.</p>
+
+    <h3>Reconciliation results</h3>
+
+    <p>When the independent administrator compared company payments to government revenue, 17 discrepancies exceeded the margin of variance. The independent administrator worked with the companies and government entities to investigate these discrepancies, and was able to find explanations for all of them. Explanations included differences in when payments were recorded and how they were classified.</p>
+
+    <p>Of the 45 companies that were asked to participate, 31 reported DOI revenue and 11 reported federal corporate income taxes.</p>
+
+    <img src="reporting p. 8" />
+
+    <img src="reporting p. 8" />
+
+    <p>Five companies also allowed for corporate income tax reconciliation: BP America; Cimarex Energy Co.; Could Peak Energy Resources, LLC; Shell E&P Company; and W&T Offshore, Inc.</p>
+
+    <p>After the independent administrator compared and reconciled the government revenue streams with company payments, 17 material variances remained, all of which were explained through the reconciliation process, leaving zero unexplained variances.</p>
+
+  </div>
+
 </div>

--- a/_how-it-works/laws-and-regulations/federal-laws.md
+++ b/_how-it-works/laws-and-regulations/federal-laws.md
@@ -9,7 +9,10 @@ permalink: /how-it-works/federal-laws/
 
   <article class="container-left-7">
 
-    <h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
+    <div>
+      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+      /
+    </div>
     <h1>Federal laws and regulations</h1>
 
     <p class="case_studies_intro-para">The legislative branch of the federal government has passed many laws that govern natural resource extraction on federal lands.</p>

--- a/_how-it-works/laws-and-regulations/federal-reforms.md
+++ b/_how-it-works/laws-and-regulations/federal-reforms.md
@@ -8,7 +8,10 @@ permalink: /how-it-works/federal-reforms/
 
   <article class="container-left-7">
 
-    <h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
+    <div>
+      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+      /
+    </div>
     <h1>Federal reforms</h1>
 
     <p class="case_studies_intro-para">The federal government reforms laws and regulations by enacting new legislation and proposing new rules to implement the legislation. Reforms can stem from government oversight organizations’ recommendations, including from both DOI’s Office of Inspector General and the Government Accountability Office. Below are reforms following the Deep Water Horizon oil spill, recent findings from government oversight organizations, and proposed rules.</p>

--- a/_how-it-works/laws-and-regulations/governance-taxes.md
+++ b/_how-it-works/laws-and-regulations/governance-taxes.md
@@ -6,7 +6,10 @@ permalink: /how-it-works/governance/taxes/
 
 <div class="container-outer container-padded">
 
-	<h5><a href="{{site.baseurl}}{{site.permalink}}">How It Works</a> /</h5>
+	<div>
+		<a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+		/
+	</div>
   <h1>Tax Expenditures</h1>
 
   <p>Tax expenditures are defined in the law as revenue losses attributable to provisions of the federal tax laws which allow a special exclusion, exemption, or deduction from gross income or which provide a special credit, a preferential rate of tax, or a deferral of tax liability. These exceptions may be viewed as alternatives to other policy instruments, such as spending or regulatory programs.</p>
@@ -113,4 +116,3 @@ permalink: /how-it-works/governance/taxes/
   </table>
 
 </div>
-

--- a/_how-it-works/laws-and-regulations/governance.md
+++ b/_how-it-works/laws-and-regulations/governance.md
@@ -6,7 +6,10 @@ permalink: /how-it-works/governance/
 
 <div class="container-outer container-padded">
 
-  <h5><a href="{{site.baseurl}}{{site.permalink}}">How It Works</a> /</h5>
+  <div>
+    <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+    /
+  </div>
   <h1>Governance</h1>
 
   <h4>From <a href="https://github.com/18F/doi-extractives-data/wiki/Information-Architecture">Information Architecture</a>:</h4>
@@ -29,5 +32,3 @@ permalink: /how-it-works/governance/
     <li><a href="{{ site.baseurl }}/how-it-works/governance/taxes/">Tax Expenditures</a></li>
   </ul>
 </div>
-
-

--- a/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
@@ -8,7 +8,10 @@ permalink: /how-it-works/state-laws-and-regulations/
 
   <article class="container-left-7">
 
-    <h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
+    <div>
+      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+      /
+    </div>
     <h1>State Laws and Regulations</h1>
 
     <p class="case_studies_intro-para">States maintain ownership of some lands and natural resources; develop their own taxation and royalty systems applicable to oil, gas, nonenergy minerals, and renewable energy; and collect extractive revenue directly. Each state has a unique revenue system.</p>

--- a/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
+++ b/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
@@ -43,7 +43,10 @@ nav_items:
 ---
 
 
-<h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
+<div>
+  <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+  /
+</div>
 <h1>State Legal and Fiscal Information</h1>
 
 <nav class="hash_selector">

--- a/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
@@ -9,7 +9,10 @@ permalink: /how-it-works/tribal-laws-and-regulations/
 
   <article class="container-left-7">
 
-    <h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
+    <div>
+      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+      /
+    </div>
     <h1>Tribal laws and regulations</h1>
 
     <p class="case_studies_intro-para">According to the 2011 American Community Survey conducted by the U.S. Census, there were 5.1 million American Indians and Alaska Natives living in the United States, accounting for approximately <a href="https://www.census.gov/newsroom/releases/archives/facts_for_features_special_editions/cb12-ff22.html">1.6% of the population</a>.</p>

--- a/_how-it-works/natural-resources/ownership.md
+++ b/_how-it-works/natural-resources/ownership.md
@@ -8,7 +8,10 @@ permalink: /how-it-works/ownership/
 
   <article class="container-left-7">
 
-    <h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
+    <div>
+      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+      /
+    </div>
     <h1>Ownership</h1>
 
     <h2>Land ownership</h2>

--- a/_how-it-works/natural-resources/production.md
+++ b/_how-it-works/natural-resources/production.md
@@ -8,7 +8,10 @@ permalink: /how-it-works/production/
 
   <article class="container-left-7">
 
-    <h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
+    <div>
+      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+      /
+    </div>
     <h1>Production</h1>
 
     <p class="case_studies_intro-para">The United States is home to many different natural resources, including fossil fuel (i.e., oil, gas, and coal), renewable energy (i.e., geothermal, solar, and wind), and nonenergy mineral resources (i.e., gold, copper, and iron). Since the 19th century, natural resource extraction has been a major industry in the U.S., with fluctuations throughout time.</p>

--- a/_how-it-works/natural-resources/revenues.md
+++ b/_how-it-works/natural-resources/revenues.md
@@ -8,7 +8,10 @@ permalink: /how-it-works/revenues/
 
   <article class="container-left-7">
 
-    <h5><a href="{{site.baseurl}}/how-it-works">How It Works</a> /</h5>
+    <<div>
+      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+      /
+    </div>
     <h1>Revenues</h1>
 
     <h3>DOI revenue</h3>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -41,6 +41,7 @@ $z-negative: -1;
 $white: #ffffff;
 $black: #040404;
 $blue: #157bac;
+$blue-alt: darken($blue, 5%); //for constrast, darker
 $light-blue: #e6f9ff;
 $pale-blue: #f2fcff;
 $mid-blue: #c6e9ff;

--- a/_sass/blocks/explore/_all.scss
+++ b/_sass/blocks/explore/_all.scss
@@ -5,7 +5,7 @@
 //
 // Styleguide blocks.explore
 .explore-subpage {
-  $positive-fill: $pale-blue;
+  $positive-fill: $white;
   $negative-fill: #bbb;
 
   @import 'subpage';

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -11,6 +11,14 @@
   @include respond-to(huge-plus-up) {
     margin-right: 0;
   }
+
+  select {
+    height: 50px;
+  }
+}
+
+.filters-last {
+  margin-bottom: 80px;
 }
 
 .filters-heading {
@@ -19,15 +27,30 @@
 
   @include respond-to(medium-up) {
     display: inline-block;
+    width: 65%;
   }
 
   h3 {
     margin-bottom: 0;
   }
+
+  p {
+    @include heading(para-md);
+    color: $blue-alt;
+  }
 }
 
 .filters {
   color: $dark-blue;
+
+  label {
+    @include heading(para-sm);
+    color: $blue-alt;
+    font-weight: $weight-light;
+    letter-spacing: 0.7px;
+    margin-bottom: 3px;
+    text-transform: uppercase;
+  }
 }
 
 #commodity-group-selector,

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -67,12 +67,12 @@
   display: none;
 }
 
-#unit-selector {
-  background: $white;
-  border-radius: $base-border-radius;
-  height: 34px;
-  overflow: hidden;
-}
+// #unit-selector {
+//   background: $white;
+//   border-radius: $base-border-radius;
+//   height: 34px;
+//   overflow: hidden;
+// }
 
 .unit-selector {
   @include user-select(none);

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -18,7 +18,9 @@
 }
 
 .filters-last {
-  margin-bottom: 80px;
+  @include respond-to(medium-up) {
+    margin-bottom: 80px;
+  }
 }
 
 .filters-heading {

--- a/_sass/blocks/explore/_map.scss
+++ b/_sass/blocks/explore/_map.scss
@@ -21,6 +21,9 @@ eiti-slider {
   @include heading(para-xl);
   font-weight: $weight-bold;
   letter-spacing: -0.5px;
+  margin-top: -115px; //TODO: magic number, remove
+  padding-left: $base-padding;
+  width: 65%;
 
   .filter-part {
     border-bottom: 2px dotted $neutral-gray;

--- a/_sass/blocks/explore/_map.scss
+++ b/_sass/blocks/explore/_map.scss
@@ -21,14 +21,17 @@ eiti-slider {
   @include heading(para-xl);
   font-weight: $weight-bold;
   letter-spacing: -0.5px;
-  margin-top: -115px; //TODO: magic number, remove
-  padding-left: $base-padding;
-  width: 65%;
 
   .filter-part {
     border-bottom: 2px dotted $neutral-gray;
     color: inherit;
     text-decoration: none;
+  }
+
+  @include respond-to(medium-up) {
+    margin-top: -115px; //TODO: magic number, remove
+    padding-left: $base-padding;
+    width: 65%;
   }
 }
 
@@ -87,6 +90,9 @@ eiti-slider {
 
 .map-intro_text {
   @include heading(para-md);
-  padding-top: $base-padding;
-  padding-bottom: $base-padding;
+  padding: $base-padding;
+
+  @include respond-to(medium-up) {
+    padding-left: 0;
+  }
 }

--- a/_sass/blocks/explore/_map.scss
+++ b/_sass/blocks/explore/_map.scss
@@ -22,16 +22,16 @@ eiti-slider {
   font-weight: $weight-bold;
   letter-spacing: -0.5px;
 
-  .filter-part {
-    border-bottom: 2px dotted $neutral-gray;
-    color: inherit;
-    text-decoration: none;
-  }
-
   @include respond-to(medium-up) {
     margin-top: -115px; //TODO: magic number, remove
     padding-left: $base-padding;
     width: 65%;
+  }
+
+  .filter-part {
+    border-bottom: 2px dotted $neutral-gray;
+    color: inherit;
+    text-decoration: none;
   }
 }
 

--- a/_sass/blocks/explore/_map.scss
+++ b/_sass/blocks/explore/_map.scss
@@ -12,13 +12,16 @@ eiti-slider {
 
 .region-map {
   display: block;
-  height: 250px;
   margin-bottom: 1em;
-  max-height: 30vh; // 30% of the viewport height
+  max-height: 50vh; // 50% of the viewport height
   width: 100%;
 }
 
 .filter-description {
+  @include heading(para-xl);
+  font-weight: $weight-bold;
+  letter-spacing: -0.5px;
+
   .filter-part {
     border-bottom: 2px dotted $neutral-gray;
     color: inherit;
@@ -78,4 +81,3 @@ eiti-slider {
     }
   }
 }
-

--- a/_sass/blocks/explore/_map.scss
+++ b/_sass/blocks/explore/_map.scss
@@ -34,7 +34,7 @@ eiti-slider {
 
 .map-legend {
   display: flex;
-  margin-bottom: 1em;
+  margin-bottom: $base-padding-large;
 
   .step {
     border-bottom-style: solid;
@@ -83,4 +83,10 @@ eiti-slider {
       stroke-width: 2;
     }
   }
+}
+
+.map-intro_text {
+  @include heading(para-md);
+  padding-top: $base-padding;
+  padding-bottom: $base-padding;
 }

--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -18,11 +18,10 @@
 }
 
 .subregion {
-
-    td {
-      padding-bottom: ($base-padding * 0.7);
-      padding-top: ($base-padding * 0.7);
-    }
+  td {
+    padding-bottom: ($base-padding * 0.7);
+    padding-top: ($base-padding * 0.7);
+  }
 }
 
 .subregion-name {

--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -66,9 +66,11 @@
     }
 
     .subregion-name {
-      @include heading(h3);
+      @include heading(para-lg);
+      font-weight: $weight-bold;
+      min-width: 200px;
       padding: 0;
-      padding-left: $base-padding * 0.9;
+      padding-left: ($base-padding * 0.9);
     }
   }
 

--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -7,27 +7,33 @@
   padding-top: 0;
 
   .subregion-name {
-    @include heading(h3);
     margin: 0;
-
   }
 }
 
 .region-header-category {
+  @include heading(para-md);
   margin-bottom: $base-padding;
-  padding-left: $base-padding * 0.9;
+  padding-left: ($base-padding * 0.9);
+}
+
+.subregion {
+
+    td {
+      padding-bottom: ($base-padding * 0.7);
+      padding-top: ($base-padding * 0.7);
+    }
 }
 
 .subregion-name {
-  @include heading('para-lg');
-  @include font-size(1);
+  @include heading(para-md);
+  font-weight: $weight-book;
   margin: 0;
-  padding: 0 $base-padding;
-  width: 66%;
+  width: 86%;
 
-  @include respond-to(tiny-up) {
-    @include heading('h4');
-  }
+  // @include respond-to(tiny-up) {
+  //   @include heading(para-md);
+  // }
 
   .color-swatch {
     display: inline-block;
@@ -46,7 +52,7 @@
   th,
   tr {
     border: 0;
-    border-bottom: 1px solid $mid-gray;
+    border-bottom: 1px solid $neutral-gray;
     text-align: left;
   }
 
@@ -101,4 +107,3 @@
     width: 100px;
   }
 }
-

--- a/_sass/blocks/explore/_toggle.scss
+++ b/_sass/blocks/explore/_toggle.scss
@@ -2,7 +2,7 @@
 .toggle,
 .toggle-desktop {
   background: transparent;
-  color: $dark-blue;
+  color: $blue;
 
   &:before {
     content: $icon-plus-sm;
@@ -40,9 +40,14 @@
 
 .toggle-desktop {
   display: none;
+  background-color: $blue;
+  color: $white;
   float: right;
+  font-weight: $weight-bold;
   margin-bottom: 0;
-  padding: 0;
+  padding: ($base-padding-lite * 1.5);
+  padding-left: $base-padding;
+  padding-right: $base-padding;
 
   @include respond-to(medium-up){
     display: inline-block;
@@ -52,5 +57,3 @@
     vertical-align: text-top;
   }
 }
-
-

--- a/js/pages/federal-production.js
+++ b/js/pages/federal-production.js
@@ -425,7 +425,7 @@
       });
     } else {
       data = [
-        {color: NULL_FILL, value: 'no production'},
+        {color: NULL_FILL, value: 'no production on federal land'},
         {color: colorscheme[3][2], value: '1 or more products'},
       ];
     }


### PR DESCRIPTION
This PR brings the data visualization code close to Eric's mocks. What this does:
- makes the maps bigger
- gets all typography closer to mocks
- uses an ugly hack to make the summary sentence appear where it's supposed it, but I should work with @gemfarmer or @shawnbot to make this better later. For example, it shouldn't have a blue background when the filters are closed.
- adds links to download/docs
- adds text where applicable
- brings all visualizations that are live on dev to a common point (these edits are on all pages)

## Desktop
![screenshot 2015-12-03 16 28 06](https://cloud.githubusercontent.com/assets/4827522/11577445/f031e9e8-99da-11e5-973c-74232eeabb90.png)

## Desktop, filters open
![screenshot 2015-12-03 16 28 20](https://cloud.githubusercontent.com/assets/4827522/11577448/f3c19554-99da-11e5-8b2c-c23dbced4e40.png)
