### PR TITLE
More cleanup!

### DIFF
--- a/_sass/blocks/_footer.scss
+++ b/_sass/blocks/_footer.scss
@@ -14,6 +14,7 @@ footer,
   @include heading(para-md);
   color: $mid-gray;
   line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
 }
 
 footer,

--- a/_sass/blocks/_header.scss
+++ b/_sass/blocks/_header.scss
@@ -181,7 +181,6 @@ header,
     display: inline-block;
     float: left;
     font-family: $base-font-family;
-    height: 30px;
     margin: 0;
     margin-left: $base-padding;
     padding: 0.42rem;

--- a/_sass/components/_buttons.scss
+++ b/_sass/components/_buttons.scss
@@ -25,6 +25,7 @@ input[type='submit'] {
   color: $white;
   padding-left: 0.7em;
   padding-right: 0.7em;
+  -webkit-font-smoothing: antialiased;
 
   &:hover,
   &:focus {

--- a/_sass/components/_carousel.scss
+++ b/_sass/components/_carousel.scss
@@ -19,11 +19,16 @@
 // Styleguide components.carousel
 
 .carousel {
+  // @include span-columns(4 of 12);
+
   background-color: $pale-blue;
   border-left: 4px solid $white;
   border-right: 4px solid $white;
+  padding-bottom: 0;
   padding-top: $base-padding-extra;
   text-align: center;
+
+
 }
 
 // .carousel-header_text {

--- a/_sass/elements/_elements.scss
+++ b/_sass/elements/_elements.scss
@@ -13,7 +13,6 @@ body {
   color: $base-font-color;
   font-family: $base-font-family;
   font-size: $base-font-size;
-  // -webkit-font-smoothing: antialiased;
   font-weight: $base-font-weight;
   line-height: $base-line-height;
 }

--- a/_sass/elements/_elements.scss
+++ b/_sass/elements/_elements.scss
@@ -13,7 +13,7 @@ body {
   color: $base-font-color;
   font-family: $base-font-family;
   font-size: $base-font-size;
-  -webkit-font-smoothing: antialiased;
+  // -webkit-font-smoothing: antialiased;
   font-weight: $base-font-weight;
   line-height: $base-line-height;
 }

--- a/index.html
+++ b/index.html
@@ -4,12 +4,10 @@ title: Home
 ---
 <section class="slab-delta">
   <div class="container-outer">
-    <div class="container-left-8">
-      <div class="hero">
-        <h2 class="hero-title_text">The United States Extractive Industries Transparency Initiative</h2>
-        <h3>USEITI was created to strengthen public accountability and promote trust in how revenues from oil, gas, mineral, and <span class="term" data-term="renewable energy" title="Click to define" tabindex="0">renewable energy<i class="icon-book"></i></span> resources in the U.S. are managed.</h3>
-        <a href="{{ site.baseurl }}/about/">Learn more about USEITI.</a>
-      </div>
+    <div class="container-left-8 hero">
+      <h2 class="hero-title_text">The United States Extractive Industries Transparency Initiative</h2>
+      <h3>USEITI was created to strengthen public accountability and promote trust in how revenues from oil, gas, mineral, and <span class="term" data-term="renewable energy" title="Click to define" tabindex="0">renewable energy<i class="icon-book"></i></span> resources in the U.S. are managed.</h3>
+      <a href="{{ site.baseurl }}/about/">Learn more about USEITI.</a>
     </div>
     <div class="container-right-4 carousel">
       <a href="{{ site.baseurl }}/how-it-works/" class="carousel-button button-primary">See how it works</a>


### PR DESCRIPTION
- Removes `-webkit-font-smoothing: antialiased;` from website body to address #875. It should not have been there anyways -- oooops, was built into the reset we were using. This should only be used on light-text-dark-background situations, so I've individually added it back to those parts (primary button and the footer). There may be others I missed that we will catch later.

- Starts to address the extra space at the bottom of the oil-dollar illustration on the homepage. Now our problem is much smaller, but still not completely gone. This actually exists on all of the landing pages, but is hidden elsewhere. I think we'll need to refactor how we're doing those to truly solve the problem.

- Fixes misalignment between search box text input height and search box input height.