### PR TITLE
Homepage content

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@ title: Home
   <div class="container-outer">
     <div class="container-left-8 hero">
       <h2 class="hero-title_text">The United States Extractive Industries Transparency Initiative</h2>
-      <h3>USEITI was created to strengthen public accountability and promote trust in how revenues from oil, gas, mineral, and <span class="term" data-term="renewable energy" title="Click to define" tabindex="0">renewable energy<i class="icon-book"></i></span> resources in the U.S. are managed.</h3>
-      <a href="{{ site.baseurl }}/about/">Learn more about USEITI.</a>
+      <h3>As part of an international effort to promote open and accountable management of natural resources, this site provides data about how extractive industries in the U.S. are managed.</h3>
+      <a href="{{ site.baseurl }}/about/">Learn more about the initiative.</a>
     </div>
     <div class="container-right-4 carousel">
       <a href="{{ site.baseurl }}/how-it-works/" class="carousel-button button-primary">See how it works</a>

--- a/index.html
+++ b/index.html
@@ -72,9 +72,25 @@ title: Home
 
       <div class="card-content">
 
-        <a href="{{ site.baseurl }}/how-it-works/production/"><h3 class="card-title">What natural resources are extracted in the U.S.?</h3></a>
+        <a href="{{ site.baseurl }}/how-it-works/production/"><h3 class="card-title">Download the USEITI 2015 Executive Summary</h3></a>
 
-        <p>The U.S. is one of the top producers of gas, oil, coal, renewable energy, and nonenergy minerals.</p>
+        <p>This document includes an overview of the contextual narrative and an account of the reporting and reconciliation process for the EITI Standard in the U.S.</p>
+
+        <a href="{{ site.baseurl }}/how-it-works/production/" class="card-link">Download the Executive Summary <i class="icon-chevron-sm"></i></a>
+
+      </div>
+
+    </article>
+
+    <article class="card" class="card">
+
+      <a class="card-image_link" href="{{ site.baseurl }}/how-it-works/production/"><img class="card-image" src="{{ site.baseurl }}/img/placeholders/placeholder-rectangle.png" alt="U.S. natural resource sectors"></a>
+
+      <div class="card-content">
+
+        <a href="{{ site.baseurl }}/how-it-works/production/"><h3 class="card-title">What natural resources are extracted?</h3></a>
+
+        <p>The U.S. is one of the top producers of oil, gas, and coal as well as nonenergy minerals like gold, iron, and copper.</p>
 
         <!-- <p>[This will be the U.S. natural resources sectors overview from the written report with high-level info on all land types. It will also have interactive charts based on Federal data, such as the pie chart on the current beta site.]</p> -->
 
@@ -100,7 +116,7 @@ title: Home
 
     </article>
 
-    <article class="card">
+<!--     <article class="card">
 
       <a class="card-image_link" href="{{ site.baseurl }}/explore/federal-revenue-by-company/"><img class="card-image" src="{{ site.baseurl }}/img/placeholders/placeholder-rectangle.png" alt="companies"></a>
 
@@ -109,14 +125,12 @@ title: Home
         <a class="card-image_link" href="{{ site.baseurl }}/explore/federal-revenue-by-company/"><h3 class="card-title">What companies work in these industries?</h3></a>
 
         <p>Thousands of companies, large and small, contributed to the $12.64 billion in revenue collected by the Department of the Interior in 2013.</p>
-
-        <!-- <p>[This section will have the current unilateral data report and filter/download data interaction from the beta site. It will also have information on the reconciliation process and link to the 'Download Report' section of the site for all the details on reconciliation.]</p>
- -->
+        
         <a href="{{ site.baseurl }}/explore/federal-revenue-by-company/" class="card-link">Explore data about these companies <i class="icon-chevron-sm"></i></a>
 
       </div>
 
-    </article>
+    </article> -->
 
     <article class="card">
 
@@ -163,8 +177,6 @@ title: Home
         <p>Revenue from natural resources goes to federal, state, and county governments, as well as to a range of funds that work at the local and national levels.</p>
 
         <!-- <p>[This is where information on revenue disbursement will go. The idea will be similar to the current 'bubble graphic' on the beta site, but that interaction tested poorly (people didn't get it) and so we'll be re-working that design in the fall, and adding more data to it, such as disbursements by state and info on the Land and Water Conservation Fund.]</p> -->
-
-        <!-- <p>The answer is: <strong>it depends</strong>. Laws treat revenues from offshore natural resources and onshore natural resources differently. Laws also treat different commodities differently. For example, for oil and gas, Federal and local governments get royalties that are a percentage of sales. For many minerals such as gold, copper and silver, the governments get mining claim fees but no ongoing royalties.</p> -->
 
         <a href="{{ site.baseurl }}/explore/disbursements/" class="card-link">See where the money goes <i class="icon-chevron-sm"></i></a>
 


### PR DESCRIPTION
This PR makes two changes: revised copy for the top banner on the homepage (#951), and a new homepage card to make the Executive Summary a little easier to find (#1003).

For now, I removed the "What companies work in these industries" card; we can bring that back if need be, but it'll need some refinement if so.