### PR TITLE
Add selector to other narrative pages

### DIFF
--- a/_how-it-works/laws-and-regulations/federal-laws.md
+++ b/_how-it-works/laws-and-regulations/federal-laws.md
@@ -1,224 +1,228 @@
 ---
 title: Federal Laws | How It Works
-layout: default
+layout: narrative
 permalink: /how-it-works/federal-laws/
+nav_description: Jump to a section
+nav_items:
+  - name: federal-laws-and-regulations
+    title: Top
+  - name: fiscal-regime
+    title: Fiscal regime
+  - name: fees-and-fines
+    title: Fees and fines
+  - name: other-laws
+    title: Other laws
+  - name: regulations
+    title: Regulations
 ---
 
-
-<div class="container-outer container-padded">
-
-  <article class="container-left-7">
-
-    <div>
-      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
-      /
-    </div>
-    <h1>Federal laws and regulations</h1>
-
-    <p class="case_studies_intro-para">The legislative branch of the federal government has passed many laws that govern natural resource extraction on federal lands.</p>
-
-    <h3>Fiscal regime</h3>
-
-    <p>The following table lists the laws that provide the backbone of the fiscal regime for the extractive industries, as well as the relevant lands and natural resources to which they apply.</p>
-
-    <table>
-      <tr>
-        <th>Law name and code</th>
-        <th>Description</th>
-        <th>Relevant lands</th>
-  	  <th>Relevant natural resources</th>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title30/pdf/USCODE-2011-title30-chap2-sec22.pdf">The General Mining Law of 1872 as Amended</a> (30 USC § 29 et seq. and 43 CFR 3860)</td>
-        <td>Provides the right to patent, meaning transfer to private ownership, federal lands and natural resources for mining. Since October 1, 1994, Congress has imposed a budget moratorium on any new mineral patent applications.</td>
-        <td>Federal onshore (public domain)</td>
-  	  <td>Locatable hardrock minerals (e.g., gold, silver, and copper)</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title25/pdf/USCODE-2011-title25-chap12-sec396.pdf">Leasing of Allotted Lands for Mining Purposes Act of 1909</a> (25 USC § 396 et seq. and 25 CFR 212)</td>
-        <td>States that all lands allotted to Indians, except those made to members of the Five Civilized Tribes and Osage, may be leased for mining purposes for any term of years as may be deemed advisable by the Secretary of the Interior.</td>
-        <td>Indian (allotted)</td>
-  	  <td>Not specified</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.blm.gov/pgdata/etc/medialib/blm/wo/Communications_Directorate/legislation.Par.23212.File.dat/mla_1920_amendments1.pdf">Mineral Leasing Act of 1920 as Amended</a> (30 USC 181 et seq.)</td>
-        <td>Creates a system of leasing mineral resources on federal lands for extraction and grants BLM authority to administer mineral leasing.</td>
-        <td>Federal onshore (public domain)</td>
-  	  <td>Coal, oil, gas, oil or gas shale, sodium, potassium, phosphate, sulfur, and gilsonite</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2009-title25/html/USCODE-2009-title25-chap12.htm">Indian Mineral Leasing Act of 1938</a> (25 USC § 396a et seq.)</td>
-        <td>Opens unallotted lands within any Indian reservation for leasing for mining purposes by authority of the tribal council and approval of the Secretary of the Interior.</td>
-        <td>Indian (tribal)</td>
-  	  <td>Not specified</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.blm.gov/pgdata/etc/medialib/blm/wo/Communications_Directorate/legislation.Par.23212.File.dat/mla_1920_amendments1.pdf#page=56">Mineral Leasing Act for Acquired Lands of 1947</a> (30 USC § 351 et seq. and 43 CFR 3420)</td>
-        <td>Extends the Mineral Leasing Act of 1920 and authority of the Secretary of the Interior to govern mineral leasing on federal acquired lands.</td>
-        <td>Federal onshore (acquired)</td>
-  	  <td>Coal, oil, gas, oil or gas shale, sodium, potassium, phosphate, sulfur, and gilsonite</td>
-      </tr>
-      <tr>
-        <td><a href="http://legcounsel.house.gov/Comps/Act%20Of%20July%2031,%201937-(Materials%20Act%20Of%201947).pdf">Mineral Materials Act of 1947</a> (30 USC § 601 et seq.)</td>
-        <td>Also known as the Common Varieties Act, regulates the sale and permitting of the most common hardrock minerals in place of the General Mining Law of 1872.</td>
-        <td>Federal onshore</td>
-  	  <td>Common hardrock minerals (e.g., sand, gravel, stone, pumice, cinders)</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.boem.gov/uploadedFiles/submergedLA.pdf">Submerged Lands Act of 1953</a> (43 USC § 1301 et seq.)</td>
-        <td>Recognizes states’ rights to the submerged navigable lands within their boundaries, as well as the marine waters within their boundaries, often defined as three geographical miles from the coastline.</td>
-        <td>State offshore</td>
-  	  <td>All natural resources</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2010-title43/html/USCODE-2010-title43-chap29-subchapIII.htm">Outer Continental Shelf Lands Act of 1953 as Amended</a> (43 USC § 1331 et seq.)</td>
-        <td>Gives the Secretary of the Interior responsibility for administering mineral and energy resources exploration, development, and production on the Outer Continental Shelf, subject to environmental safeguards. Mandates receipt of fair market value for mineral leasing.</td>
-        <td>Outer Continental Shelf</td>
-  	  <td>Oil, gas, and other minerals</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/STATUTE-84/pdf/STATUTE-84-Pg1566.pdf">Geothermal Steam Act of 1970</a> (30 USC § 1001 et seq.)</td>
-        <td>Allows the leasing of federal lands under BLM’s administration for geothermal resource development, excluding prohibited lands.</td>
-        <td>Federal onshore</td>
-  	  <td>Geothermal</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title30/pdf/USCODE-2011-title30-chap2-sec21a.pdf">Mining and Minerals Policy Act of 1970</a> (30 USC § 21a et seq.)	</td>
-        <td>Amends the Mining Act of 1920. Establishes the national interest to develop a domestic private enterprise mining industry, while addressing adverse environmental impacts.</td>
-        <td>Federal onshore</td>
-  	  <td>All natural resources</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/STATUTE-90/pdf/STATUTE-90-Pg1083.pdf">Federal Coal Leasing Amendments Act (FCLAA) of 1976</a> (90 STAT 1083)</td>
-        <td>Amends Section 2 of the Mineral Leasing Act of 1920. Requires all public lands available for coal leasing to be leased competitively, the government to only accept lease bids equal to or greater than fair market value, the consolidation of leasing into logical mining units, lease holders to continually operate, and other measures.</td>
-        <td>Federal onshore</td>
-  	  <td>Coal</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/STATUTE-91/pdf/STATUTE-91-Pg445.pdf">Surface Mining Control and Reclamation Act (SMCRA) of 1977</a> (30 USC § 1201 et seq.)</td>
-        <td>Creates the Office of Surface Mining, Reclamation, and Enforcement (OSMRE) to establish a nationwide program to protect society and the environment from the adverse effects of surface coal mining operations, under which OSMRE is charged with balancing the nation’s need for continued domestic coal production with protection of the environment; requires coal mine owners to post bonds as insurance for reclaiming the land after current mining operations, and requires them to pay into the Abandoned Mine Reclamation Fund, a fund intended to address mines abandoned prior to 1977.</td>
-        <td>Federal onshore</td>
-  	  <td>Coal</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.boem.gov/uploadedFiles/BOEM/Oil_and_Gas_Energy_Program/Leasing/Outer_Continental_Shelf/Lands_Act_History/federal%2520og%2520royalty%2520mgmt.pdf">Federal Oil and Gas Royalty Management Act (FOGRMA) of 1982</a> (30 USC § 1701 et seq.)</td>
-        <td>Grants the Secretary of the Interior authority for managing and collecting oil and gas royalties from leases on federal and Indian lands.</td>
-        <td>Federal onshore, Indian, and Outer Continental Shelf</td>
-  	  <td>Oil and gas</td>
-      </tr>
-      <tr>
-        <td><a href="www.gpo.gov/fdsys/pkg/STATUTE-96/pdf/STATUTE-96-Pg1938.pdf">Indian Mineral Development Act of 1982</a> (25 USC §§ 2101–2108 et seq.)</td>
-        <td>Provides Indian tribes with flexibility in the development and sale of mineral resources, including opportunities to enter into joint venture agreements with mineral developers.</td>
-        <td>Indian (tribal)</td>
-  	  <td>Oil and gas, coal, geothermal, and other mineral resources</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title30/pdf/USCODE-2011-title30.pdf">Federal Onshore Oil and Gas Leasing Reform Act (FOOGLRA) of 1987</a> (30 USC § 181 et seq.)</td>
-        <td>Amendment to the Mineral Leasing Act of 1920. Gives the US Forest Service the authority to proactively offer leases for oil and gas on National Forest System lands provided environmental and other land-use regulations are met. BLM largely administers leasing on these lands.</td>
-        <td>Federal onshore</td>
-  	  <td>Oil and gas</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.onrr.gov/laws_r_d/PubLaws/PDFDocs/rsfa.pdf">Federal Oil and Gas Royalty Simplification and Fairness Act (RSFA) of 1996</a> (30 USC § 1701 et seq.)</td>
-        <td>Improves royalty management from federal and Outer Continental Shelf oil and gas leases.</td>
-        <td>Federal onshore and Outer Continental Shelf</td>
-  	  <td>Oil and gas</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/BILLS-109hr6enr/pdf/BILLS-109hr6enr.pdf">Energy Policy Act (EPAct) of 2005 (42 USC § 13201 et seq.)</a></td>
-        <td>Addresses energy production in the United States, including the production, transportation, and transmission of energy on the Outer Continental Shelf from sources other than oil and gas (e.g., wind energy); incentives for oil and gas development; and provisions to access oil and gas resources on federal lands.</td>
-        <td>Federal onshore and Outer Continental Shelf</td>
-  	  <td>Oil, gas, coal, wind, solar, hydropower, and geothermal</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.boem.gov/Oil-and-Gas-Energy-Program/Energy-Economics/econ/GOMESA-pdf.aspx">Gulf of Mexico Energy Security Act (GOMESA) of 2006 (120 Stat. 2922)</a></td>
-        <td>Opens 8.3 million acres in the Gulf of Mexico for oil and gas leasing, shares leasing revenue with gulf producing states and the Land and Water Conservation Fund, and bans oil and gas leasing within 125 miles off the Florida coastline in the Eastern Planning Area and a portion of the Central Planning Area until 2022.</td>
-        <td>Outer Continental Shelf</td>
-  	  <td>Oil and gas</td>
-      </tr>
-    </table>
-
-    <h3>Fees and fines for extractive industries companies</h3>
-
-    <p>There are other laws governing natural resources and extractive companies’ operations. Some of these laws require companies to pay fees. Violating some of these laws can also result in companies paying fines.</p>
-
-    <table>
-      <tr>
-        <th>Law name and code</th>
-        <th>Description</th>
-        <th>Relevant lands</th>
-  	  <th>Relevant natural resources</th>
-      </tr>
-      <tr>
-        <td><a href="http://www.blm.gov/flpma/FLPMA.pdf">Federal Land Policy and Management Act (FLPMA) of 1976 as Amended</a> (43 USC § 1701 et seq.)</td>
-        <td>Requires BLM to administer federal lands using a land use planning framework that includes no unnecessary or undue degradation; multiple-use, sustained yield considerations for present and future generations; and public planning. Requires receipt of fair market value for use of federal lands and resources.</td>
-        <td>Federal onshore and Indian</td>
-  	  <td>All natural resources</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2008-title42/pdf/USCODE-2008-title42-chap85.pdf">Clean Air Act (CAA) of 1970</a> (42 USC § 7401 et seq.)</td>
-        <td>Outlines steps that federal agencies, state and local governments, and industry must take to decrease air pollution. Oil and gas wells are exempt from legal aggregation, whereby the emissions from small sites that are connected, in close proximity or under shared ownership, are added together and regulated as “stationary sources” if they emit or could emit 100 tons per year of a pollutant.</td>
-        <td>All lands</td>
-  	  <td>All natural resources, except when oil and gas are exempted</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2010-title33/pdf/USCODE-2010-title33-chap26.pdf">Clean Water Act (CWA) of 1977</a> (33 USC § 1251 et seq.)</td>
-        <td>Establishes a regulatory framework to protect water quality and monitor discharges of pollutants into waters in the United States. The US Environmental Protection Agency (EPA) does not require National Pollutant Discharge Elimination System (NPDES) permits for uncontaminated storm water discharges from oil and gas exploration, production, processing or treatment operations; transmission; or drill site preparation.</td>
-        <td>All lands</td>
-  	  <td>All natural resources, except when oil and gas are exempted</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2008-title42/pdf/USCODE-2008-title42-chap85.pdf">Safe Drinking Water Act (SDWA) of 1974 (42 USC §§ 300f–300j et seq.)</a></td>
-        <td>Protects public health by regulating the nation’s public drinking water supply and its sources. As of the 2005 Energy Policy Act, hydraulic fracturing fluids are exempt from underground injection control permits unless diesel fuel is used in the extraction process.</td>
-        <td>All lands</td>
-  	  <td>All natural resources, except when oil and gas are exempted</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.epw.senate.gov/sdwa.pdf">Comprehensive Environmental Response, Compensation, and Liability Act (CERCLA) of 1980</a> (42 USC §§ 9601–9675 et seq.)</td>
-        <td>Provides a federal ‘superfund’ to clean up uncontrolled or abandoned hazardous-waste sites, as well as accidents, spills, and other emergency releases of pollutants and contaminants into the environment, and gives EPA the power to seek out those parties responsible for any release and assure their cooperation in the cleanup.</td>
-        <td>All lands</td>
-  	  <td>All natural resources, except when oil and gas are exempted</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.nmfs.noaa.gov/pr/pdfs/laws/esa.pdf">Endangered Species Act (ESA) of 1973</a> (16 USC § 1531 et seq.)</td>
-        <td>Protects and recovers imperiled species and the ecosystems upon which they depend.</td>
-        <td>All lands</td>
-  	  <td>All natural resources</td>
-      </tr>
-      <tr>
-        <td><a href="http://www.nmfs.noaa.gov/pr/pdfs/laws/mmpa.pdf">Marine Mammal Protection Act of 1972 as Amended</a> (16 USC § 1361 et seq.)</td>
-        <td>Prohibits, with certain exceptions, the "take" of marine mammals in US waters and by US citizens on the high seas, and the importation of marine mammals and marine mammal products into the United States.</td>
-        <td>All lands</td>
-  	  <td>All natural resources, except when oil and gas are exempted</td>
-      </tr>
-    </table>
-
-    <h3>Other laws</h3>
-
-    <p>There are many other laws with which extractive industries companies must comply. DOI, EPA, the National Oceanic and Atmospheric Administration (NOAA), and other federal agencies’ websites contain more comprehensive lists of laws they enforce:</p>
-
-    <ul class="list-bullet">
-    	<li><a href="http://www.boem.gov/Regulations/BOEM-Governing-Statutes.aspx">DOI BOEM</a></li>
-  	<li><a href="http://www.bsee.gov/Regulations-and-Guidance/BSEE-Governing-Statutes/">DOI Bureau of Safety and Environmental Enforcement</a> (BSEE)</li>
-  	<li><a href="http://www.blm.gov/wo/st/en/info/regulations.html">DOI BLM</a></li>
-  	<li><a href="http://www2.epa.gov/laws-regulations/laws-and-executive-orders#majorlaws">EPA</a></li>
-  	<li><a href="http://www.osmre.gov/lrg.shtm">OSMRE</a></li>
-  	<li><a href="http://www.nmfs.noaa.gov/ole/about/what_we_do/laws.html">NOAA</a></li>
-    </ul>
-
-    <h3>Regulations</h3>
-
-    <p>Federal agencies, such as DOI and relevant bureaus, implement these laws by developing and enforcing regulations and rules. These key regulations relate to natural resource extraction, particularly on federal and Indian lands:</p>
-
-    <ul class="list-bullet">
-  	  <li><a href="http://www.gpo.gov/fdsys/search/pagedetails.action?collectionCode=CFR&searchPath=Title+25%2FChapter+I%2FSubchapter+I&granuleId=&packageId=CFR-2008-title25-vol1&oldPath=Title+25%2FChapter+I%2FSubchapter+A&fromPageDetails=true&collapse=true&ycord=435">Title 25</a> in the Code of Federal Regulations relates to sovereign Indian nations. Subchapter I deals with energy and minerals (Parts 200–227).</li>
-  	  <li><a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=784ea268c892a669424da1512740a933&mc=true&tpl=/ecfrbrowse/Title30/30tab_02.tpl">Title 30</a> governs mineral resources. <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=050aa7804f2ee861c64ba348d17a79c1&mc=true&tpl=/ecfrbrowse/Title30/30cfrv2_02.tpl#0">Chapter II</a> deals with the BSEE; <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=050aa7804f2ee861c64ba348d17a79c1&mc=true&tpl=/ecfrbrowse/Title30/30cfrv2_02.tpl#500">Chapter V</a> deals with BOEM; <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=050aa7804f2ee861c64ba348d17a79c1&mc=true&tpl=/ecfrbrowse/Title30/30cfrv3_02.tpl#0">Chapter VII</a> deals with OSMRE; <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=050aa7804f2ee861c64ba348d17a79c1&mc=true&tpl=/ecfrbrowse/Title30/30cfrv3_02.tpl#1200">Chapter XII</a> deals with ONRR.</li>
-  	  <li><a href="http://www.ecfr.gov/cgi-bin/text-idx?tpl=/ecfrbrowse/Title43/43tab_02.tpl">Title 43</a> in the Code of Federal Regulations governs public lands. Subchapter C focuses on minerals management (Parts 3000–3870).</li>
-    </ul>
-
-    <p>Implementing laws includes complying with the <a href="http://www.gpo.gov/fdsys/pkg/USCODE-2010-title42/pdf/USCODE-2010-title42-chap55-sec4321.pdf">National Environmental Policy Act (NEPA) of 1969</a> (42 USC § 4321 et seq.). NEPA is intended to ensure that decision makers and the public have information about the potential impacts to the environment of proposed federal actions and alternatives to those actions. When taking any major action, such as leasing natural resources on federal lands for extraction, federal agencies must prepare Environmental Assessments (EAs) and/or EISs to document environmental impacts of agency actions and alternatives to those actions. The public has legally mandated opportunities to comment on these impact statements.
-    </p>
-
-  </article>
-
+<div>
+  <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+  /
 </div>
+<h1 id="federal-laws-and-regulations" data-nav-header="federal-laws-and-regulations">Federal laws and regulations</h1>
+
+<p class="case_studies_intro-para">The legislative branch of the federal government has passed many laws that govern natural resource extraction on federal lands.</p>
+
+<h3 id="fiscal-regime" data-nav-header="fiscal-regime">Fiscal regime</h3>
+
+<p>The following table lists the laws that provide the backbone of the fiscal regime for the extractive industries, as well as the relevant lands and natural resources to which they apply.</p>
+
+<table>
+  <tr>
+    <th>Law name and code</th>
+    <th>Description</th>
+    <th>Relevant lands</th>
+  <th>Relevant natural resources</th>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title30/pdf/USCODE-2011-title30-chap2-sec22.pdf">The General Mining Law of 1872 as Amended</a> (30 USC § 29 et seq. and 43 CFR 3860)</td>
+    <td>Provides the right to patent, meaning transfer to private ownership, federal lands and natural resources for mining. Since October 1, 1994, Congress has imposed a budget moratorium on any new mineral patent applications.</td>
+    <td>Federal onshore (public domain)</td>
+  <td>Locatable hardrock minerals (e.g., gold, silver, and copper)</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title25/pdf/USCODE-2011-title25-chap12-sec396.pdf">Leasing of Allotted Lands for Mining Purposes Act of 1909</a> (25 USC § 396 et seq. and 25 CFR 212)</td>
+    <td>States that all lands allotted to Indians, except those made to members of the Five Civilized Tribes and Osage, may be leased for mining purposes for any term of years as may be deemed advisable by the Secretary of the Interior.</td>
+    <td>Indian (allotted)</td>
+  <td>Not specified</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.blm.gov/pgdata/etc/medialib/blm/wo/Communications_Directorate/legislation.Par.23212.File.dat/mla_1920_amendments1.pdf">Mineral Leasing Act of 1920 as Amended</a> (30 USC 181 et seq.)</td>
+    <td>Creates a system of leasing mineral resources on federal lands for extraction and grants BLM authority to administer mineral leasing.</td>
+    <td>Federal onshore (public domain)</td>
+  <td>Coal, oil, gas, oil or gas shale, sodium, potassium, phosphate, sulfur, and gilsonite</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2009-title25/html/USCODE-2009-title25-chap12.htm">Indian Mineral Leasing Act of 1938</a> (25 USC § 396a et seq.)</td>
+    <td>Opens unallotted lands within any Indian reservation for leasing for mining purposes by authority of the tribal council and approval of the Secretary of the Interior.</td>
+    <td>Indian (tribal)</td>
+  <td>Not specified</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.blm.gov/pgdata/etc/medialib/blm/wo/Communications_Directorate/legislation.Par.23212.File.dat/mla_1920_amendments1.pdf#page=56">Mineral Leasing Act for Acquired Lands of 1947</a> (30 USC § 351 et seq. and 43 CFR 3420)</td>
+    <td>Extends the Mineral Leasing Act of 1920 and authority of the Secretary of the Interior to govern mineral leasing on federal acquired lands.</td>
+    <td>Federal onshore (acquired)</td>
+  <td>Coal, oil, gas, oil or gas shale, sodium, potassium, phosphate, sulfur, and gilsonite</td>
+  </tr>
+  <tr>
+    <td><a href="http://legcounsel.house.gov/Comps/Act%20Of%20July%2031,%201937-(Materials%20Act%20Of%201947).pdf">Mineral Materials Act of 1947</a> (30 USC § 601 et seq.)</td>
+    <td>Also known as the Common Varieties Act, regulates the sale and permitting of the most common hardrock minerals in place of the General Mining Law of 1872.</td>
+    <td>Federal onshore</td>
+  <td>Common hardrock minerals (e.g., sand, gravel, stone, pumice, cinders)</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.boem.gov/uploadedFiles/submergedLA.pdf">Submerged Lands Act of 1953</a> (43 USC § 1301 et seq.)</td>
+    <td>Recognizes states’ rights to the submerged navigable lands within their boundaries, as well as the marine waters within their boundaries, often defined as three geographical miles from the coastline.</td>
+    <td>State offshore</td>
+  <td>All natural resources</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2010-title43/html/USCODE-2010-title43-chap29-subchapIII.htm">Outer Continental Shelf Lands Act of 1953 as Amended</a> (43 USC § 1331 et seq.)</td>
+    <td>Gives the Secretary of the Interior responsibility for administering mineral and energy resources exploration, development, and production on the Outer Continental Shelf, subject to environmental safeguards. Mandates receipt of fair market value for mineral leasing.</td>
+    <td>Outer Continental Shelf</td>
+  <td>Oil, gas, and other minerals</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/STATUTE-84/pdf/STATUTE-84-Pg1566.pdf">Geothermal Steam Act of 1970</a> (30 USC § 1001 et seq.)</td>
+    <td>Allows the leasing of federal lands under BLM’s administration for geothermal resource development, excluding prohibited lands.</td>
+    <td>Federal onshore</td>
+  <td>Geothermal</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title30/pdf/USCODE-2011-title30-chap2-sec21a.pdf">Mining and Minerals Policy Act of 1970</a> (30 USC § 21a et seq.)	</td>
+    <td>Amends the Mining Act of 1920. Establishes the national interest to develop a domestic private enterprise mining industry, while addressing adverse environmental impacts.</td>
+    <td>Federal onshore</td>
+  <td>All natural resources</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/STATUTE-90/pdf/STATUTE-90-Pg1083.pdf">Federal Coal Leasing Amendments Act (FCLAA) of 1976</a> (90 STAT 1083)</td>
+    <td>Amends Section 2 of the Mineral Leasing Act of 1920. Requires all public lands available for coal leasing to be leased competitively, the government to only accept lease bids equal to or greater than fair market value, the consolidation of leasing into logical mining units, lease holders to continually operate, and other measures.</td>
+    <td>Federal onshore</td>
+  <td>Coal</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/STATUTE-91/pdf/STATUTE-91-Pg445.pdf">Surface Mining Control and Reclamation Act (SMCRA) of 1977</a> (30 USC § 1201 et seq.)</td>
+    <td>Creates the Office of Surface Mining, Reclamation, and Enforcement (OSMRE) to establish a nationwide program to protect society and the environment from the adverse effects of surface coal mining operations, under which OSMRE is charged with balancing the nation’s need for continued domestic coal production with protection of the environment; requires coal mine owners to post bonds as insurance for reclaiming the land after current mining operations, and requires them to pay into the Abandoned Mine Reclamation Fund, a fund intended to address mines abandoned prior to 1977.</td>
+    <td>Federal onshore</td>
+  <td>Coal</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.boem.gov/uploadedFiles/BOEM/Oil_and_Gas_Energy_Program/Leasing/Outer_Continental_Shelf/Lands_Act_History/federal%2520og%2520royalty%2520mgmt.pdf">Federal Oil and Gas Royalty Management Act (FOGRMA) of 1982</a> (30 USC § 1701 et seq.)</td>
+    <td>Grants the Secretary of the Interior authority for managing and collecting oil and gas royalties from leases on federal and Indian lands.</td>
+    <td>Federal onshore, Indian, and Outer Continental Shelf</td>
+  <td>Oil and gas</td>
+  </tr>
+  <tr>
+    <td><a href="www.gpo.gov/fdsys/pkg/STATUTE-96/pdf/STATUTE-96-Pg1938.pdf">Indian Mineral Development Act of 1982</a> (25 USC §§ 2101–2108 et seq.)</td>
+    <td>Provides Indian tribes with flexibility in the development and sale of mineral resources, including opportunities to enter into joint venture agreements with mineral developers.</td>
+    <td>Indian (tribal)</td>
+  <td>Oil and gas, coal, geothermal, and other mineral resources</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2011-title30/pdf/USCODE-2011-title30.pdf">Federal Onshore Oil and Gas Leasing Reform Act (FOOGLRA) of 1987</a> (30 USC § 181 et seq.)</td>
+    <td>Amendment to the Mineral Leasing Act of 1920. Gives the US Forest Service the authority to proactively offer leases for oil and gas on National Forest System lands provided environmental and other land-use regulations are met. BLM largely administers leasing on these lands.</td>
+    <td>Federal onshore</td>
+  <td>Oil and gas</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.onrr.gov/laws_r_d/PubLaws/PDFDocs/rsfa.pdf">Federal Oil and Gas Royalty Simplification and Fairness Act (RSFA) of 1996</a> (30 USC § 1701 et seq.)</td>
+    <td>Improves royalty management from federal and Outer Continental Shelf oil and gas leases.</td>
+    <td>Federal onshore and Outer Continental Shelf</td>
+  <td>Oil and gas</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/BILLS-109hr6enr/pdf/BILLS-109hr6enr.pdf">Energy Policy Act (EPAct) of 2005 (42 USC § 13201 et seq.)</a></td>
+    <td>Addresses energy production in the United States, including the production, transportation, and transmission of energy on the Outer Continental Shelf from sources other than oil and gas (e.g., wind energy); incentives for oil and gas development; and provisions to access oil and gas resources on federal lands.</td>
+    <td>Federal onshore and Outer Continental Shelf</td>
+  <td>Oil, gas, coal, wind, solar, hydropower, and geothermal</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.boem.gov/Oil-and-Gas-Energy-Program/Energy-Economics/econ/GOMESA-pdf.aspx">Gulf of Mexico Energy Security Act (GOMESA) of 2006 (120 Stat. 2922)</a></td>
+    <td>Opens 8.3 million acres in the Gulf of Mexico for oil and gas leasing, shares leasing revenue with gulf producing states and the Land and Water Conservation Fund, and bans oil and gas leasing within 125 miles off the Florida coastline in the Eastern Planning Area and a portion of the Central Planning Area until 2022.</td>
+    <td>Outer Continental Shelf</td>
+  <td>Oil and gas</td>
+  </tr>
+</table>
+
+<h3 id="fees-and-fines" data-nav-header="fees-and-fines">Fees and fines for extractive industries companies</h3>
+
+<p>There are other laws governing natural resources and extractive companies’ operations. Some of these laws require companies to pay fees. Violating some of these laws can also result in companies paying fines.</p>
+
+<table>
+  <tr>
+    <th>Law name and code</th>
+    <th>Description</th>
+    <th>Relevant lands</th>
+  <th>Relevant natural resources</th>
+  </tr>
+  <tr>
+    <td><a href="http://www.blm.gov/flpma/FLPMA.pdf">Federal Land Policy and Management Act (FLPMA) of 1976 as Amended</a> (43 USC § 1701 et seq.)</td>
+    <td>Requires BLM to administer federal lands using a land use planning framework that includes no unnecessary or undue degradation; multiple-use, sustained yield considerations for present and future generations; and public planning. Requires receipt of fair market value for use of federal lands and resources.</td>
+    <td>Federal onshore and Indian</td>
+  <td>All natural resources</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2008-title42/pdf/USCODE-2008-title42-chap85.pdf">Clean Air Act (CAA) of 1970</a> (42 USC § 7401 et seq.)</td>
+    <td>Outlines steps that federal agencies, state and local governments, and industry must take to decrease air pollution. Oil and gas wells are exempt from legal aggregation, whereby the emissions from small sites that are connected, in close proximity or under shared ownership, are added together and regulated as “stationary sources” if they emit or could emit 100 tons per year of a pollutant.</td>
+    <td>All lands</td>
+  <td>All natural resources, except when oil and gas are exempted</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2010-title33/pdf/USCODE-2010-title33-chap26.pdf">Clean Water Act (CWA) of 1977</a> (33 USC § 1251 et seq.)</td>
+    <td>Establishes a regulatory framework to protect water quality and monitor discharges of pollutants into waters in the United States. The US Environmental Protection Agency (EPA) does not require National Pollutant Discharge Elimination System (NPDES) permits for uncontaminated storm water discharges from oil and gas exploration, production, processing or treatment operations; transmission; or drill site preparation.</td>
+    <td>All lands</td>
+  <td>All natural resources, except when oil and gas are exempted</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.gpo.gov/fdsys/pkg/USCODE-2008-title42/pdf/USCODE-2008-title42-chap85.pdf">Safe Drinking Water Act (SDWA) of 1974 (42 USC §§ 300f–300j et seq.)</a></td>
+    <td>Protects public health by regulating the nation’s public drinking water supply and its sources. As of the 2005 Energy Policy Act, hydraulic fracturing fluids are exempt from underground injection control permits unless diesel fuel is used in the extraction process.</td>
+    <td>All lands</td>
+  <td>All natural resources, except when oil and gas are exempted</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.epw.senate.gov/sdwa.pdf">Comprehensive Environmental Response, Compensation, and Liability Act (CERCLA) of 1980</a> (42 USC §§ 9601–9675 et seq.)</td>
+    <td>Provides a federal ‘superfund’ to clean up uncontrolled or abandoned hazardous-waste sites, as well as accidents, spills, and other emergency releases of pollutants and contaminants into the environment, and gives EPA the power to seek out those parties responsible for any release and assure their cooperation in the cleanup.</td>
+    <td>All lands</td>
+  <td>All natural resources, except when oil and gas are exempted</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.nmfs.noaa.gov/pr/pdfs/laws/esa.pdf">Endangered Species Act (ESA) of 1973</a> (16 USC § 1531 et seq.)</td>
+    <td>Protects and recovers imperiled species and the ecosystems upon which they depend.</td>
+    <td>All lands</td>
+  <td>All natural resources</td>
+  </tr>
+  <tr>
+    <td><a href="http://www.nmfs.noaa.gov/pr/pdfs/laws/mmpa.pdf">Marine Mammal Protection Act of 1972 as Amended</a> (16 USC § 1361 et seq.)</td>
+    <td>Prohibits, with certain exceptions, the "take" of marine mammals in US waters and by US citizens on the high seas, and the importation of marine mammals and marine mammal products into the United States.</td>
+    <td>All lands</td>
+  <td>All natural resources, except when oil and gas are exempted</td>
+  </tr>
+</table>
+
+<h3 id="other-laws" data-nav-header="other-laws">Other laws</h3>
+
+<p>There are many other laws with which extractive industries companies must comply. DOI, EPA, the National Oceanic and Atmospheric Administration (NOAA), and other federal agencies’ websites contain more comprehensive lists of laws they enforce:</p>
+
+<ul class="list-bullet">
+	<li><a href="http://www.boem.gov/Regulations/BOEM-Governing-Statutes.aspx">DOI BOEM</a></li>
+<li><a href="http://www.bsee.gov/Regulations-and-Guidance/BSEE-Governing-Statutes/">DOI Bureau of Safety and Environmental Enforcement</a> (BSEE)</li>
+<li><a href="http://www.blm.gov/wo/st/en/info/regulations.html">DOI BLM</a></li>
+<li><a href="http://www2.epa.gov/laws-regulations/laws-and-executive-orders#majorlaws">EPA</a></li>
+<li><a href="http://www.osmre.gov/lrg.shtm">OSMRE</a></li>
+<li><a href="http://www.nmfs.noaa.gov/ole/about/what_we_do/laws.html">NOAA</a></li>
+</ul>
+
+<h3 id="regulations" data-nav-header="regulations">Regulations</h3>
+
+<p>Federal agencies, such as DOI and relevant bureaus, implement these laws by developing and enforcing regulations and rules. These key regulations relate to natural resource extraction, particularly on federal and Indian lands:</p>
+
+<ul class="list-bullet">
+  <li><a href="http://www.gpo.gov/fdsys/search/pagedetails.action?collectionCode=CFR&searchPath=Title+25%2FChapter+I%2FSubchapter+I&granuleId=&packageId=CFR-2008-title25-vol1&oldPath=Title+25%2FChapter+I%2FSubchapter+A&fromPageDetails=true&collapse=true&ycord=435">Title 25</a> in the Code of Federal Regulations relates to sovereign Indian nations. Subchapter I deals with energy and minerals (Parts 200–227).</li>
+  <li><a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=784ea268c892a669424da1512740a933&mc=true&tpl=/ecfrbrowse/Title30/30tab_02.tpl">Title 30</a> governs mineral resources. <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=050aa7804f2ee861c64ba348d17a79c1&mc=true&tpl=/ecfrbrowse/Title30/30cfrv2_02.tpl#0">Chapter II</a> deals with the BSEE; <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=050aa7804f2ee861c64ba348d17a79c1&mc=true&tpl=/ecfrbrowse/Title30/30cfrv2_02.tpl#500">Chapter V</a> deals with BOEM; <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=050aa7804f2ee861c64ba348d17a79c1&mc=true&tpl=/ecfrbrowse/Title30/30cfrv3_02.tpl#0">Chapter VII</a> deals with OSMRE; <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=050aa7804f2ee861c64ba348d17a79c1&mc=true&tpl=/ecfrbrowse/Title30/30cfrv3_02.tpl#1200">Chapter XII</a> deals with ONRR.</li>
+  <li><a href="http://www.ecfr.gov/cgi-bin/text-idx?tpl=/ecfrbrowse/Title43/43tab_02.tpl">Title 43</a> in the Code of Federal Regulations governs public lands. Subchapter C focuses on minerals management (Parts 3000–3870).</li>
+</ul>
+
+<p>Implementing laws includes complying with the <a href="http://www.gpo.gov/fdsys/pkg/USCODE-2010-title42/pdf/USCODE-2010-title42-chap55-sec4321.pdf">National Environmental Policy Act (NEPA) of 1969</a> (42 USC § 4321 et seq.). NEPA is intended to ensure that decision makers and the public have information about the potential impacts to the environment of proposed federal actions and alternatives to those actions. When taking any major action, such as leasing natural resources on federal lands for extraction, federal agencies must prepare Environmental Assessments (EAs) and/or EISs to document environmental impacts of agency actions and alternatives to those actions. The public has legally mandated opportunities to comment on these impact statements.
+</p>
+

--- a/_how-it-works/laws-and-regulations/federal-laws.md
+++ b/_how-it-works/laws-and-regulations/federal-laws.md
@@ -4,7 +4,7 @@ layout: narrative
 permalink: /how-it-works/federal-laws/
 nav_description: Jump to a section
 nav_items:
-  - name: federal-laws-and-regulations
+  - name: introduction
     title: Top
   - name: fiscal-regime
     title: Fiscal regime
@@ -20,7 +20,7 @@ nav_items:
   <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
   /
 </div>
-<h1 id="federal-laws-and-regulations" data-nav-header="federal-laws-and-regulations">Federal laws and regulations</h1>
+<h1 id="introduction" data-nav-header="introduction">Federal laws and regulations</h1>
 
 <p class="case_studies_intro-para">The legislative branch of the federal government has passed many laws that govern natural resource extraction on federal lands.</p>
 

--- a/_how-it-works/laws-and-regulations/federal-reforms.md
+++ b/_how-it-works/laws-and-regulations/federal-reforms.md
@@ -4,7 +4,7 @@ layout: narrative
 permalink: /how-it-works/federal-reforms/
 nav_description: Jump to a section
 nav_items:
-  - name: federal-reforms
+  - name: introduction
     title: Top
   - name: deepwater-horizon-oil-spill
     title: Deepwater Horizon oil spill
@@ -22,7 +22,7 @@ nav_items:
   <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
   /
 </div>
-<h1 id="federal-reforms" data-nav-header="federal-reforms">Federal reforms</h1>
+<h1 id="introduction" data-nav-header="introduction">Federal reforms</h1>
 
 <p class="case_studies_intro-para">The federal government reforms laws and regulations by enacting new legislation and proposing new rules to implement the legislation. Reforms can stem from government oversight organizations’ recommendations, including from both DOI’s Office of Inspector General and the Government Accountability Office. Below are reforms following the Deep Water Horizon oil spill, recent findings from government oversight organizations, and proposed rules.</p>
 

--- a/_how-it-works/laws-and-regulations/federal-reforms.md
+++ b/_how-it-works/laws-and-regulations/federal-reforms.md
@@ -1,76 +1,82 @@
 ---
 title: Federal Reforms | How It Works
-layout: default
+layout: narrative
 permalink: /how-it-works/federal-reforms/
+nav_description: Jump to a section
+nav_items:
+  - name: federal-reforms
+    title: Top
+  - name: deepwater-horizon-oil-spill
+    title: Deepwater Horizon oil spill
+  - name: oig-reports
+    title: OIG reports
+  - name: gao-reports
+    title: GAO reports
+  - name: proposed-rules
+    title: Proposed rules
+  - name: dodd-frank
+    title: 2010 Dodd–Frank Act
 ---
 
-<div class="container-outer container-padded">
-
-  <article class="container-left-7">
-
-    <div>
-      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
-      /
-    </div>
-    <h1>Federal reforms</h1>
-
-    <p class="case_studies_intro-para">The federal government reforms laws and regulations by enacting new legislation and proposing new rules to implement the legislation. Reforms can stem from government oversight organizations’ recommendations, including from both DOI’s Office of Inspector General and the Government Accountability Office. Below are reforms following the Deep Water Horizon oil spill, recent findings from government oversight organizations, and proposed rules.</p>
-
-    <h3>Reforms following the Deepwater Horizon oil spill</h3>
-
-    <p>In the aftermath of the <a href="http://www.gpo.gov/fdsys/pkg/GPO-OILCOMMISSION/pdf/GPO-OILCOMMISSION.pdf">Deep Water Horizon oil spill</a> in the Gulf of Mexico in 2010, the federal government overhauled the oversight of DOI’s leasing, regulation, and collection of revenue for oil and gas extraction on the Outer Continental Shelf. DOI’s post Deepwater Horizon reorganization separated and established <a href="http://www.boem.gov/Reforms-since-the-Deepwater-Horizon-Tragedy/">independent oversight for offshore leasing</a> (i.e., BOEM), offshore safety and environmental enforcement (i.e., BSEE), and the collection and accountability of the revenue generated from natural resource development on federal and Indian lands through the creation of the Office of Natural Resources Revenue (i.e., ONRR).</p>
-
-    <p>When the Secretary of the Interior announced the creation of ONRR in May 2010 and the elimination of the former Minerals Management Service in June 2010, the goal was to fundamentally restructure the government’s mineral leasing, regulatory, and revenue collection agencies. The Secretary wanted to:</p>
-
-    <ul class="list-bullet">
-  	<li>Separate the three responsibilities of leasing, regulation, and revenue collection</li>
-  	<li>Provide each office and bureau with the independence and resources necessary to fulfill their missions</li>
-  	<li>Eliminate real and perceived conflicts associated with the previous organizations</li>
-    </ul>
-
-    <p>While the federal government made regulatory reforms following the spill, Congress did not change any laws related to offshore fossil fuel management in response to the accident.</p>
-
-    <h3>Office of Inspector General (OIG) reports</h3>
-
-    <p><a href="https://www.doioig.gov/sites/doioig.gov/files/99-I-387.pdf">DOI’s OIG</a> is responsible for the independent oversight and promotion of excellence, integrity, and accountability within the programs, operations, and management of DOI. OIG also identifies and prevents fraud, waste, and mismanagement within the agency. In recent years, OIG has published numerous reports related to DOI revenue from natural resource extraction, including:</p>
-
-    <ul class="list-bullet">
-  	  <li>October 2014: <a href="https://www.doioig.gov/sites/doioig.gov/files/CR-EV-BIA-0002-2013Public1.pdf">BIA Needs Sweeping Changes to Manage the Osage Nation’s Energy Resources</a>. This report states that the Bureau of Indian Affairs (BIA) Osage Agency has a flawed oil and gas management program, including the policies and procedures that guide royalty payment activities, accounting, and leasing activities. The report provides 33 recommendations to improve the program.</li>
-  	  <li>March 2014: <a href="https://www.doioig.gov/sites/doioig.gov/files/C-IN-BLM-0002-2012Public.pdf">Bureau of Land Management’s Mineral Materials Program</a>. This report states that, among other challenges, the BLM Mineral Materials Program has little assurance that it obtains market value for mineral materials and provides 15 recommendations to enhance the program.</li>
-  	  <li>September 2012: <a href="https://www.doioig.gov/sites/doioig.gov/files/CR-EV-BIA-0001-2011Public.pdf">Oil and Gas Leasing in Indian Country: An Opportunity for Economic Development</a>. This report concludes that Indian oil and gas leasing is not reaching its full economic potential, largely due to a lack of a dedicated and coordinated management focus at the federal level for the more than 17,000 leases on Indian lands.</li>
-  	  <li>May 2010: <a href="https://www.doioig.gov/sites/doioig.gov/files/2010-I-0021.pdf">Minerals Management Service: Royalty-In-Kind Program’s Oil Volume Verification Process</a>. OIG found several areas where the Royalty-In-Kind Program could be improved to ensure proper accounting of royalties that are paid in oil and gas volumes to the federal government, rather than in dollars.</li>
-    </ul>
-
-    <h3>Government Accountability Office (GAO) reports</h3>
-
-    <p>The GAO is an independent, nonpartisan agency that investigates how the federal government spends taxpayer funds, including those for natural resource management on federal and Indian lands. GAO publishes its reports on the <a href="http://www.gao.gov/key_issues/oil_and_natural_gas/issue_summary">GAO Summary Page</a>. Some recent GAO findings related to natural resource extraction include:</p>
-
-    <ul class="list-bullet">
-  	  <li>December 2013: <a href="http://gao.gov/assets/660/659515.pdf">Oil and Gas Resources: Actions Needed for Interior to Better Ensure a Fair Return</a>. This report examines steps DOI has taken to ensure that the public receives a fair return on oil and gas resources extracted from federal lands, as well as recommends improvements to the fiscal system.</li>
-  	  <li>September 2008: <a href="http://www.gao.gov/new.items/d08691.pdf">Oil and Gas Royalties: The Federal System for Collecting Oil and Gas Revenues Needs Comprehensive Reassessment</a>. This report evaluates the government take from federal oil and gas resources and assesses DOI’s work in monitoring the performance and appropriateness of the current fiscal system.</li>
-  	  <li>March 1989: <a href="http://archive.gao.gov/d15t6/138159.pdf">The Mining Law of 1872 Needs Revision</a>. This report critiques the foundational mining law on three major points: that the law’s annual work requirements need to be replaced, that the law forces the federal government to sell valuable land at nominal prices, and that the patent provision runs counter to other natural resource policies.</li>
-    </ul>
-
-    <h3>Proposed rules</h3>
-
-    <p>Per the Administrative Procedures Act, agencies propose rules to implement federal laws. The public has an opportunity to comment on all proposed rules before an agency finalizes any regulations. Recently, DOI bureaus and offices proposed new rules intended to go into effect in 2015, including:</p>
-
-    <ul class="list-bullet">
-  	  <li>Proposed BLM rule on hydraulic fracturing available in the Federal Register publication of <a href="http://www.gpo.gov/fdsys/pkg/FR-2015-03-26/pdf/2015-06658.pdf">Oil and Gas; Hydraulic Fracturing on Federal and Indian Lands</a></li>
-  	  <li>Proposed BLM rule on wind and solar competitive leasing available in the <a href="http://blmsolar.anl.gov/documents/docs/FR_Competitive_Leasing_Sep_30_2014.pdf">Federal Register</a></li>
-  	  <li>Proposed ONRR rule on consolidated federal oil and gas and federal and Indian coal valuation reform available in the <a href="http://www.gpo.gov/fdsys/pkg/FR-2015-01-06/pdf/2014-30033.pdf">Federal Register</a></li>
-    </ul>
-
-    <p>For more details, search the <a href="https://www.federalregister.gov/articles/search?conditions%5Bpublication_date%5D%5Bis%5D=11%2F04%2F2015&conditions%5Bterm%5D=Department+of+the+Interior&conditions%5Btype%5D%5B%5D=PRORULE">Federal Registrar for DOI proposed rules</a>.</p>
-
-    <h3 id="dodd-frank">The 2010 Dodd-Frank Act</h3>
-
-    <p>In 2010, the U.S. enacted the <a href="http://www.gpo.gov/fdsys/pkg/PLAW-111publ203/pdf/PLAW-111publ203.pdf">Dodd-Frank Wall Street Reform and Consumer Protection Act</a> (124 Stat. 1376) to improve transparency and accountability across the financial system. Section 1504 of the act requires extractive industries companies registered with the Securities and Exchange Commission (SEC) to separately disclose information about payments to governments around the world in an interactive data format.</p>
-
-    <p>Section 1504 mandates disclosure of “the type and total amount of (such) payments made for each project of the resource extraction issuer relating to the commercial development of oil, natural gas, or minerals,” including “taxes, royalties, fees (including license fees), production entitlements, bonuses, and other material benefits, that the Commission, consistent with the guidelines of the Extractive Industries Transparency Initiative (to the extent practicable), determines are part of the commonly recognized revenue stream for the commercial development of oil, natural gas, or minerals.”</p>
-
-    <p>SEC is rewriting the rule to implement this law. SEC has stated that the revised rule will be proposed by the end of 2015. Section 5.2e of the EITI Standard states: “Reporting at project level is required, provided that it is consistent with the United States Securities and Exchange Commission rules and the forthcoming (now implemented) European Union requirements.” According to SEC scheduling, it will issue final implementation rules by June 2016.</p>
-
-  </article>
-
+<div>
+  <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+  /
 </div>
+<h1 id="federal-reforms" data-nav-header="federal-reforms">Federal reforms</h1>
+
+<p class="case_studies_intro-para">The federal government reforms laws and regulations by enacting new legislation and proposing new rules to implement the legislation. Reforms can stem from government oversight organizations’ recommendations, including from both DOI’s Office of Inspector General and the Government Accountability Office. Below are reforms following the Deep Water Horizon oil spill, recent findings from government oversight organizations, and proposed rules.</p>
+
+<h3 id="deepwater-horizon-oil-spill" data-nav-header="deepwater-horizon-oil-spill">Reforms following the Deepwater Horizon oil spill</h3>
+
+<p>In the aftermath of the <a href="http://www.gpo.gov/fdsys/pkg/GPO-OILCOMMISSION/pdf/GPO-OILCOMMISSION.pdf">Deep Water Horizon oil spill</a> in the Gulf of Mexico in 2010, the federal government overhauled the oversight of DOI’s leasing, regulation, and collection of revenue for oil and gas extraction on the Outer Continental Shelf. DOI’s post Deepwater Horizon reorganization separated and established <a href="http://www.boem.gov/Reforms-since-the-Deepwater-Horizon-Tragedy/">independent oversight for offshore leasing</a> (i.e., BOEM), offshore safety and environmental enforcement (i.e., BSEE), and the collection and accountability of the revenue generated from natural resource development on federal and Indian lands through the creation of the Office of Natural Resources Revenue (i.e., ONRR).</p>
+
+<p>When the Secretary of the Interior announced the creation of ONRR in May 2010 and the elimination of the former Minerals Management Service in June 2010, the goal was to fundamentally restructure the government’s mineral leasing, regulatory, and revenue collection agencies. The Secretary wanted to:</p>
+
+<ul class="list-bullet">
+<li>Separate the three responsibilities of leasing, regulation, and revenue collection</li>
+<li>Provide each office and bureau with the independence and resources necessary to fulfill their missions</li>
+<li>Eliminate real and perceived conflicts associated with the previous organizations</li>
+</ul>
+
+<p>While the federal government made regulatory reforms following the spill, Congress did not change any laws related to offshore fossil fuel management in response to the accident.</p>
+
+<h3 id="oig-reports" data-nav-header="oig-reports">Office of Inspector General (OIG) reports</h3>
+
+<p><a href="https://www.doioig.gov/sites/doioig.gov/files/99-I-387.pdf">DOI’s OIG</a> is responsible for the independent oversight and promotion of excellence, integrity, and accountability within the programs, operations, and management of DOI. OIG also identifies and prevents fraud, waste, and mismanagement within the agency. In recent years, OIG has published numerous reports related to DOI revenue from natural resource extraction, including:</p>
+
+<ul class="list-bullet">
+  <li>October 2014: <a href="https://www.doioig.gov/sites/doioig.gov/files/CR-EV-BIA-0002-2013Public1.pdf">BIA Needs Sweeping Changes to Manage the Osage Nation’s Energy Resources</a>. This report states that the Bureau of Indian Affairs (BIA) Osage Agency has a flawed oil and gas management program, including the policies and procedures that guide royalty payment activities, accounting, and leasing activities. The report provides 33 recommendations to improve the program.</li>
+  <li>March 2014: <a href="https://www.doioig.gov/sites/doioig.gov/files/C-IN-BLM-0002-2012Public.pdf">Bureau of Land Management’s Mineral Materials Program</a>. This report states that, among other challenges, the BLM Mineral Materials Program has little assurance that it obtains market value for mineral materials and provides 15 recommendations to enhance the program.</li>
+  <li>September 2012: <a href="https://www.doioig.gov/sites/doioig.gov/files/CR-EV-BIA-0001-2011Public.pdf">Oil and Gas Leasing in Indian Country: An Opportunity for Economic Development</a>. This report concludes that Indian oil and gas leasing is not reaching its full economic potential, largely due to a lack of a dedicated and coordinated management focus at the federal level for the more than 17,000 leases on Indian lands.</li>
+  <li>May 2010: <a href="https://www.doioig.gov/sites/doioig.gov/files/2010-I-0021.pdf">Minerals Management Service: Royalty-In-Kind Program’s Oil Volume Verification Process</a>. OIG found several areas where the Royalty-In-Kind Program could be improved to ensure proper accounting of royalties that are paid in oil and gas volumes to the federal government, rather than in dollars.</li>
+</ul>
+
+<h3 id="gao-reports" data-nav-header="gao-reports">Government Accountability Office (GAO) reports</h3>
+
+<p>The GAO is an independent, nonpartisan agency that investigates how the federal government spends taxpayer funds, including those for natural resource management on federal and Indian lands. GAO publishes its reports on the <a href="http://www.gao.gov/key_issues/oil_and_natural_gas/issue_summary">GAO Summary Page</a>. Some recent GAO findings related to natural resource extraction include:</p>
+
+<ul class="list-bullet">
+  <li>December 2013: <a href="http://gao.gov/assets/660/659515.pdf">Oil and Gas Resources: Actions Needed for Interior to Better Ensure a Fair Return</a>. This report examines steps DOI has taken to ensure that the public receives a fair return on oil and gas resources extracted from federal lands, as well as recommends improvements to the fiscal system.</li>
+  <li>September 2008: <a href="http://www.gao.gov/new.items/d08691.pdf">Oil and Gas Royalties: The Federal System for Collecting Oil and Gas Revenues Needs Comprehensive Reassessment</a>. This report evaluates the government take from federal oil and gas resources and assesses DOI’s work in monitoring the performance and appropriateness of the current fiscal system.</li>
+  <li>March 1989: <a href="http://archive.gao.gov/d15t6/138159.pdf">The Mining Law of 1872 Needs Revision</a>. This report critiques the foundational mining law on three major points: that the law’s annual work requirements need to be replaced, that the law forces the federal government to sell valuable land at nominal prices, and that the patent provision runs counter to other natural resource policies.</li>
+</ul>
+
+<h3 id="proposed-rules" data-nav-header="proposed-rules">Proposed rules</h3>
+
+<p>Per the Administrative Procedures Act, agencies propose rules to implement federal laws. The public has an opportunity to comment on all proposed rules before an agency finalizes any regulations. Recently, DOI bureaus and offices proposed new rules intended to go into effect in 2015, including:</p>
+
+<ul class="list-bullet">
+  <li>Proposed BLM rule on hydraulic fracturing available in the Federal Register publication of <a href="http://www.gpo.gov/fdsys/pkg/FR-2015-03-26/pdf/2015-06658.pdf">Oil and Gas; Hydraulic Fracturing on Federal and Indian Lands</a></li>
+  <li>Proposed BLM rule on wind and solar competitive leasing available in the <a href="http://blmsolar.anl.gov/documents/docs/FR_Competitive_Leasing_Sep_30_2014.pdf">Federal Register</a></li>
+  <li>Proposed ONRR rule on consolidated federal oil and gas and federal and Indian coal valuation reform available in the <a href="http://www.gpo.gov/fdsys/pkg/FR-2015-01-06/pdf/2014-30033.pdf">Federal Register</a></li>
+</ul>
+
+<p>For more details, search the <a href="https://www.federalregister.gov/articles/search?conditions%5Bpublication_date%5D%5Bis%5D=11%2F04%2F2015&conditions%5Bterm%5D=Department+of+the+Interior&conditions%5Btype%5D%5B%5D=PRORULE">Federal Registrar for DOI proposed rules</a>.</p>
+
+<h3 id="dodd-frank" data-nav-header="dodd-frank">The 2010 Dodd-Frank Act</h3>
+
+<p>In 2010, the U.S. enacted the <a href="http://www.gpo.gov/fdsys/pkg/PLAW-111publ203/pdf/PLAW-111publ203.pdf">Dodd-Frank Wall Street Reform and Consumer Protection Act</a> (124 Stat. 1376) to improve transparency and accountability across the financial system. Section 1504 of the act requires extractive industries companies registered with the Securities and Exchange Commission (SEC) to separately disclose information about payments to governments around the world in an interactive data format.</p>
+
+<p>Section 1504 mandates disclosure of “the type and total amount of (such) payments made for each project of the resource extraction issuer relating to the commercial development of oil, natural gas, or minerals,” including “taxes, royalties, fees (including license fees), production entitlements, bonuses, and other material benefits, that the Commission, consistent with the guidelines of the Extractive Industries Transparency Initiative (to the extent practicable), determines are part of the commonly recognized revenue stream for the commercial development of oil, natural gas, or minerals.”</p>
+
+<p>SEC is rewriting the rule to implement this law. SEC has stated that the revised rule will be proposed by the end of 2015. Section 5.2e of the EITI Standard states: “Reporting at project level is required, provided that it is consistent with the United States Securities and Exchange Commission rules and the forthcoming (now implemented) European Union requirements.” According to SEC scheduling, it will issue final implementation rules by June 2016.</p>

--- a/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
@@ -1,172 +1,179 @@
 ---
 title: State Laws and Regulations | How It Works
-layout: default
+layout: narrative
 permalink: /how-it-works/state-laws-and-regulations/
+nav_description: Jump to a section
+nav_items:
+  - name: state-laws-and-regulations
+    title: Top
+  - name: role-of-state-government-agencies
+    title: Role of state government
+  - name: state-leasing-programs
+    title: State leasing programs
+  - name: state-extractive-industries-revenue
+    title: Extractive industries revenue
+  - name: revenue-disbursements
+    title: Revenue disbursements
+  - name: natural-resource-trust-funds
+    title: Natural resource trust funds
 ---
 
-<div class="container-outer container-padded">
-
-  <article class="container-left-7">
-
-    <div>
-      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
-      /
-    </div>
-    <h1>State Laws and Regulations</h1>
-
-    <p class="case_studies_intro-para">States maintain ownership of some lands and natural resources; develop their own taxation and royalty systems applicable to oil, gas, nonenergy minerals, and renewable energy; and collect extractive revenue directly. Each state has a unique revenue system.</p>
-
-    <p>While all 50 states have some natural resource extraction activity, the 2015 USEITI Report focuses on 18 states that led the country in oil, gas, coal, and nonenergy mineral production in 2013; had the most DOI revenue or state production taxes; or had the most significant tribal natural resource interests. These 18 states are highlighted on the map below:</p>
-
-    <img src="{{site.baseurl}}/img/placeholders/map.png">
-
-    <p>See <a href="{{site.baseurl}}/how-it-works/state-legal-fiscal-info/">State Legal and Fiscal Information</a> for more details about the individual states’ laws and statutes.</p>
-
-    <h3>Role of state government agencies</h3>
-
-    <p>State government agencies create regulations and rules related to natural resource extraction based on applicable state laws and statutes (federal laws and regulations apply to all states and localities). Specifically, state government agencies manage state-owned land and natural resources, including leasing natural resources for extraction; enforce regulations and rules related to natural resource extraction; and collect, manage, and disburse revenue from natural resource extraction.</p>
-
-    <p>Each state has unique agencies that fulfill these functions. For example:</p>
-
-    <ul class="list-bullet">
-  	  <li><strong>Manage state-owned land and natural resources:</strong> In Louisiana, the Department of Natural Resources oversees natural resource extraction on state-owned lands. In Arizona, the State Land Department fulfills this function. Both agencies administer natural resource leasing programs that transfer rights to natural resources on state-owned lands to companies for extraction.</li>
-  	  <li><strong>Enforce regulations and rules:</strong> States with surface mining operations have agencies devoted to mitigating the environmental impact of such activities and ensuring that companies restore surface mine lands after mining operations are complete: for example, the West Virginia Department of Environmental Protection’s Division of Mining and Reclamation. DOI’s OSMRE oversees this office, as well as others like it.</li>
-  	  <li><strong>Collect, manage, and disburse revenue:</strong> In many states, the department of revenue collects, manages, and disburses revenue collected from natural resource extraction on state and private lands within the state, and transfer payments from the federal government for natural resource extraction on federal lands located within the state. For example, the Montana Department of Revenue collects and distributes revenue in Montana.</li>
-    </ul>
-
-    <p>Local government agencies also play a role in natural resource extraction. In particular, county departments of revenue collect, manage, and disburse local revenue from extractive industries activities.</p>
-
-    <h3>State leasing programs</h3>
-
-    <p>State ownership of land constitutes <a href="http://www.nrcm.org/documents/publiclandownership.pdf">almost 9% of total land area</a> in the U.S. Each state has its own process for leasing natural resources on state-owned lands, and different oversight procedures for when companies explore for, develop, and produce natural resources and when companies decommission projects and reclaim sites. For example, in the State of Alaska, the director of the Division of Oil and Gas at the Department of Natural Resources must establish in writing that the state’s interests will be optimized before any leasing action can occur. Known as a “best-interest finding,” the director weighs the costs and benefits of the leasing action, including potential effects on natural, historical, and cultural resources, as well as on local communities and fish and wildlife populations. The director also considers public comments.</p>
-
-    <h3>State extractive industries revenue</h3>
-
-    <p>The revenue a state receives from extractive activities varies by the local legal and fiscal framework, and by the types of resources and land owners involved. At a high level, many states receive the following revenue:</p>
-
-    <ul class="list-bullet">
-  	  <li>Bonuses, rents, and royalties for natural resources produced from state lands</li>
-  	  <li>Severance taxes, sometimes called gross production taxes or royalties, on the amount or value of natural resources produced in a state whether on federal, state, or privately owned lands</li>
-  	  <li><a href="http://www.onrr.gov/about/pdfdocs/20131119.pdf">Transfer payments</a> from the federal government for natural resource production on federal lands within a state’s borders or off its coast</li>
-    </ul>
-
-    <h4><a href="http://revenue.wyo.gov/mineral-tax-division/severance-tax-filing-information">Wyoming severance tax rates</a></h4>
-
-    <p>As an example, Wyoming applies the following severance taxes on the value of extracted resources before processing and transportation:</p>
-
-    <table>
-      <tr>
-        <th>Natural resource</th>
-        <th>Severance tax rate</th>
-      </tr>
-      <tr>
-        <td>Natural gas</td>
-        <td>6%</td>
-      </tr>
-      <tr>
-        <td>Oil</td>
-        <td>6%</td>
-      </tr>
-      <tr>
-        <td>Surface coal</td>
-        <td>7%</td>
-      </tr>
-      <tr>
-        <td>Subsurface coal</td>
-        <td>3.75%</td>
-      </tr>
-      <tr>
-        <td>Gold</td>
-        <td>2%</td>
-      </tr>
-      <tr>
-        <td>Shale</td>
-        <td>2%</td>
-      </tr>
-    </table>
-
-    <p>State royalty rates vary. <a href="http://app1.lla.state.la.us/PublicReports.nsf/DB918AD8E33411F286257B490074B82A/$FILE/00031C97.pdf">Louisiana royalty rates</a> average 21.9%, and can reach as high as 61.6%. California has a <a href="http://www.leginfo.ca.gov/cgi-bin/displaycode?section=prc&group=06001-07000&file=6826-6836">minimum royalty rate</a> of 16 and 2/3% that can rise up to a maximum percentage outlined in the invitation to bid for a lease, and paid on the average production of oil per well, per day under the lease.</p>
-
-    <h3>State revenue disbursements</h3>
-
-    <p>Each individual state determines how to disburse revenue from extractive industries’ activities. To illustrate, North Dakota, one of the leading oil and gas producing states in the country, levies an Oil and Gas Production Tax at close to 1 cent per Mcf of gas, and at 5% of the gross production value of oil. 20% of the money collected from this tax is distributed to various state funds, while 80% flows to counties, cities, schools, and townships.</p>
-
-    <p>North Dakota also sets an <a href="http://www.nd.gov/tax/misc/faq/oilgas/">Oil Extraction Tax</a> at 6.5% of the gross production value of oil, which is distributed as follows:</p>
-
-    <ul class="list-bullet">
-  	  <li>20% to the Common Schools Trust Fund and Foundation Aid Stabilization Fund to support public institutions of learning and offset foundation aid reductions</li>
-  	  <li>20% to the Sinking Fund and Resources Trust Fund, which allocates resources for energy conservation programs</li>
-  	  <li>30% to the Legacy Fund, which provides a perpetual source of state revenue from finite oil and natural gas resources</li>
-  	  <li>30% to the General Fund, which is the primary cash account for the state to cover <a href="http://www.ncsl.org/research/energy/state-revenues-and-the-natural-gas-boom.aspx">administrative and operating expenses</a></li>
-    </ul>
-
-    <p>In comparison, Alaska, another leading oil and gas producer, levies its own Oil and Gas Production Tax at 35% of the net value. Most of the revenue derived from the Oil and Gas Production Tax is deposited in the state’s General Fund for government operations and basic services. Payments resulting from an assessment or litigation are deposited into the <a href="http://www.tax.alaska.gov/programs/documentviewer/viewer.aspx?1139r">Constitutional Budget Reserve Fund</a>, which covers the state’s short-term deficits.</p>
-
-    <h3>Natural resource trust funds</h3>
-
-    <p>Many states choose to establish permanent mineral trust funds through legislation. These funds allow states to invest and hold revenue from natural resource extraction over time. Permanent mineral trust funds can help governments dependent on revenue from natural resources smooth revenue and investments across boom and bust cycles.</p>
-
-    <h4>Select states with permanent natural resource trust funds</h4>
-
-    <table>
-      <tr>
-        <th>State</th>
-        <th>Natural resources</th>
-        <th>Fund</th>
-        <th>Revenue design</th>
-        <th>Revenue uses</th>
-      </tr>
-      <tr>
-        <td>Alabama</td>
-        <td>Oil and gas</td>
-        <td>Alabama Trust Fund</td>
-        <td>99% of oil and gas capital payments paid to the state</td>
-  	  <td>General Fund, Forever Wild Land Trust Fund</td>
-      </tr>
-      <tr>
-        <td>Alaska</td>
-        <td>Primarily oil</td>
-        <td>Alaska Permanent Fund</td>
-        <td>25% of mineral-related (oil) income and legislative appropriations</td>
-  	  <td>Citizen dividends, inflation proofing, and General Fund</td>
-      </tr>
-      <tr>
-        <td>Montana</td>
-        <td>Coal</td>
-        <td>Coal Severance Tax Trust Fund</td>
-        <td>25% of mineral-related (oil) income and legislative appropriations</td>
-  	  <td>Citizen dividends, inflation proofing, and General Fund</td>
-      </tr>
-      <tr>
-        <td>New Mexico</td>
-        <td>Oil, gas, and coal</td>
-        <td>Severance Tax Permanent Fund</td>
-        <td>50% of coal severance tax collections</td>
-  	  <td>General Fund, education, infrastructure, reclamation, and economic development</td>
-      </tr>
-      <tr>
-        <td>North Dakota</td>
-        <td>Oil</td>
-        <td>Legacy Fund</td>
-        <td>30% of oil production tax revenue</td>
-  	  <td>General Fund</td>
-      </tr>
-      <tr>
-        <td>Utah</td>
-        <td>Coal, oil, and gas</td>
-        <td>State Endowment Fund</td>
-        <td>Severance tax revenue in excess of $71 million from oil and gas tax; revenue in excess of $27.6 million from coal mining</td>
-  	  <td>Economic diversification, capital, and infrastructure</td>
-      </tr>
-      <tr>
-        <td>Wyoming</td>
-        <td>Coal, oil, and gas</td>
-        <td>Wyoming Permanent Mineral Trust Fund</td>
-        <td>A 1.5%–2.5% severance tax on natural gas, oil, and coal (30%–40% of mineral revenue)</td>
-  	  <td>General Fund</td>
-      </tr>
-  </table>
-
-  </article>
-
+<div>
+  <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+  /
 </div>
+<h1 id="state-laws-and-regulations" data-nav-header="state-laws-and-regulations">State Laws and Regulations</h1>
+
+<p class="case_studies_intro-para">States maintain ownership of some lands and natural resources; develop their own taxation and royalty systems applicable to oil, gas, nonenergy minerals, and renewable energy; and collect extractive revenue directly. Each state has a unique revenue system.</p>
+
+<p>While all 50 states have some natural resource extraction activity, the 2015 USEITI Report focuses on 18 states that led the country in oil, gas, coal, and nonenergy mineral production in 2013; had the most DOI revenue or state production taxes; or had the most significant tribal natural resource interests. These 18 states are highlighted on the map below:</p>
+
+<img src="{{site.baseurl}}/img/placeholders/map.png">
+
+<p>See <a href="{{site.baseurl}}/how-it-works/state-legal-fiscal-info/">State Legal and Fiscal Information</a> for more details about the individual states’ laws and statutes.</p>
+
+<h3 id="role-of-state-government-agencies" data-nav-header="role-of-state-government-agencies">Role of state government agencies</h3>
+
+<p>State government agencies create regulations and rules related to natural resource extraction based on applicable state laws and statutes (federal laws and regulations apply to all states and localities). Specifically, state government agencies manage state-owned land and natural resources, including leasing natural resources for extraction; enforce regulations and rules related to natural resource extraction; and collect, manage, and disburse revenue from natural resource extraction.</p>
+
+<p>Each state has unique agencies that fulfill these functions. For example:</p>
+
+<ul class="list-bullet">
+  <li><strong>Manage state-owned land and natural resources:</strong> In Louisiana, the Department of Natural Resources oversees natural resource extraction on state-owned lands. In Arizona, the State Land Department fulfills this function. Both agencies administer natural resource leasing programs that transfer rights to natural resources on state-owned lands to companies for extraction.</li>
+  <li><strong>Enforce regulations and rules:</strong> States with surface mining operations have agencies devoted to mitigating the environmental impact of such activities and ensuring that companies restore surface mine lands after mining operations are complete: for example, the West Virginia Department of Environmental Protection’s Division of Mining and Reclamation. DOI’s OSMRE oversees this office, as well as others like it.</li>
+  <li><strong>Collect, manage, and disburse revenue:</strong> In many states, the department of revenue collects, manages, and disburses revenue collected from natural resource extraction on state and private lands within the state, and transfer payments from the federal government for natural resource extraction on federal lands located within the state. For example, the Montana Department of Revenue collects and distributes revenue in Montana.</li>
+</ul>
+
+<p>Local government agencies also play a role in natural resource extraction. In particular, county departments of revenue collect, manage, and disburse local revenue from extractive industries activities.</p>
+
+<h3 id="state-leasing-programs" data-nav-header="state-leasing-programs">State leasing programs</h3>
+
+<p>State ownership of land constitutes <a href="http://www.nrcm.org/documents/publiclandownership.pdf">almost 9% of total land area</a> in the U.S. Each state has its own process for leasing natural resources on state-owned lands, and different oversight procedures for when companies explore for, develop, and produce natural resources and when companies decommission projects and reclaim sites. For example, in the State of Alaska, the director of the Division of Oil and Gas at the Department of Natural Resources must establish in writing that the state’s interests will be optimized before any leasing action can occur. Known as a “best-interest finding,” the director weighs the costs and benefits of the leasing action, including potential effects on natural, historical, and cultural resources, as well as on local communities and fish and wildlife populations. The director also considers public comments.</p>
+
+<h3 id="state-extractive-industries-revenue" data-nav-header="state-extractive-industries-revenue">State extractive industries revenue</h3>
+
+<p>The revenue a state receives from extractive activities varies by the local legal and fiscal framework, and by the types of resources and land owners involved. At a high level, many states receive the following revenue:</p>
+
+<ul class="list-bullet">
+  <li>Bonuses, rents, and royalties for natural resources produced from state lands</li>
+  <li>Severance taxes, sometimes called gross production taxes or royalties, on the amount or value of natural resources produced in a state whether on federal, state, or privately owned lands</li>
+  <li><a href="http://www.onrr.gov/about/pdfdocs/20131119.pdf">Transfer payments</a> from the federal government for natural resource production on federal lands within a state’s borders or off its coast</li>
+</ul>
+
+<h4><a href="http://revenue.wyo.gov/mineral-tax-division/severance-tax-filing-information">Wyoming severance tax rates</a></h4>
+
+<p>As an example, Wyoming applies the following severance taxes on the value of extracted resources before processing and transportation:</p>
+
+<table>
+  <tr>
+    <th>Natural resource</th>
+    <th>Severance tax rate</th>
+  </tr>
+  <tr>
+    <td>Natural gas</td>
+    <td>6%</td>
+  </tr>
+  <tr>
+    <td>Oil</td>
+    <td>6%</td>
+  </tr>
+  <tr>
+    <td>Surface coal</td>
+    <td>7%</td>
+  </tr>
+  <tr>
+    <td>Subsurface coal</td>
+    <td>3.75%</td>
+  </tr>
+  <tr>
+    <td>Gold</td>
+    <td>2%</td>
+  </tr>
+  <tr>
+    <td>Shale</td>
+    <td>2%</td>
+  </tr>
+</table>
+
+<p>State royalty rates vary. <a href="http://app1.lla.state.la.us/PublicReports.nsf/DB918AD8E33411F286257B490074B82A/$FILE/00031C97.pdf">Louisiana royalty rates</a> average 21.9%, and can reach as high as 61.6%. California has a <a href="http://www.leginfo.ca.gov/cgi-bin/displaycode?section=prc&group=06001-07000&file=6826-6836">minimum royalty rate</a> of 16 and 2/3% that can rise up to a maximum percentage outlined in the invitation to bid for a lease, and paid on the average production of oil per well, per day under the lease.</p>
+
+<h3 id="revenue-disbursements" data-nav-header="revenue-disbursements">State revenue disbursements</h3>
+
+<p>Each individual state determines how to disburse revenue from extractive industries’ activities. To illustrate, North Dakota, one of the leading oil and gas producing states in the country, levies an Oil and Gas Production Tax at close to 1 cent per Mcf of gas, and at 5% of the gross production value of oil. 20% of the money collected from this tax is distributed to various state funds, while 80% flows to counties, cities, schools, and townships.</p>
+
+<p>North Dakota also sets an <a href="http://www.nd.gov/tax/misc/faq/oilgas/">Oil Extraction Tax</a> at 6.5% of the gross production value of oil, which is distributed as follows:</p>
+
+<ul class="list-bullet">
+  <li>20% to the Common Schools Trust Fund and Foundation Aid Stabilization Fund to support public institutions of learning and offset foundation aid reductions</li>
+  <li>20% to the Sinking Fund and Resources Trust Fund, which allocates resources for energy conservation programs</li>
+  <li>30% to the Legacy Fund, which provides a perpetual source of state revenue from finite oil and natural gas resources</li>
+  <li>30% to the General Fund, which is the primary cash account for the state to cover <a href="http://www.ncsl.org/research/energy/state-revenues-and-the-natural-gas-boom.aspx">administrative and operating expenses</a></li>
+</ul>
+
+<p>In comparison, Alaska, another leading oil and gas producer, levies its own Oil and Gas Production Tax at 35% of the net value. Most of the revenue derived from the Oil and Gas Production Tax is deposited in the state’s General Fund for government operations and basic services. Payments resulting from an assessment or litigation are deposited into the <a href="http://www.tax.alaska.gov/programs/documentviewer/viewer.aspx?1139r">Constitutional Budget Reserve Fund</a>, which covers the state’s short-term deficits.</p>
+
+<h3 id="natural-resource-trust-funds" data-nav-header="natural-resource-trust-funds">Natural resource trust funds</h3>
+
+<p>Many states choose to establish permanent mineral trust funds through legislation. These funds allow states to invest and hold revenue from natural resource extraction over time. Permanent mineral trust funds can help governments dependent on revenue from natural resources smooth revenue and investments across boom and bust cycles.</p>
+
+<h4>Select states with permanent natural resource trust funds</h4>
+
+<table>
+  <tr>
+    <th>State</th>
+    <th>Natural resources</th>
+    <th>Fund</th>
+    <th>Revenue design</th>
+    <th>Revenue uses</th>
+  </tr>
+  <tr>
+    <td>Alabama</td>
+    <td>Oil and gas</td>
+    <td>Alabama Trust Fund</td>
+    <td>99% of oil and gas capital payments paid to the state</td>
+  <td>General Fund, Forever Wild Land Trust Fund</td>
+  </tr>
+  <tr>
+    <td>Alaska</td>
+    <td>Primarily oil</td>
+    <td>Alaska Permanent Fund</td>
+    <td>25% of mineral-related (oil) income and legislative appropriations</td>
+  <td>Citizen dividends, inflation proofing, and General Fund</td>
+  </tr>
+  <tr>
+    <td>Montana</td>
+    <td>Coal</td>
+    <td>Coal Severance Tax Trust Fund</td>
+    <td>25% of mineral-related (oil) income and legislative appropriations</td>
+  <td>Citizen dividends, inflation proofing, and General Fund</td>
+  </tr>
+  <tr>
+    <td>New Mexico</td>
+    <td>Oil, gas, and coal</td>
+    <td>Severance Tax Permanent Fund</td>
+    <td>50% of coal severance tax collections</td>
+  <td>General Fund, education, infrastructure, reclamation, and economic development</td>
+  </tr>
+  <tr>
+    <td>North Dakota</td>
+    <td>Oil</td>
+    <td>Legacy Fund</td>
+    <td>30% of oil production tax revenue</td>
+  <td>General Fund</td>
+  </tr>
+  <tr>
+    <td>Utah</td>
+    <td>Coal, oil, and gas</td>
+    <td>State Endowment Fund</td>
+    <td>Severance tax revenue in excess of $71 million from oil and gas tax; revenue in excess of $27.6 million from coal mining</td>
+  <td>Economic diversification, capital, and infrastructure</td>
+  </tr>
+  <tr>
+    <td>Wyoming</td>
+    <td>Coal, oil, and gas</td>
+    <td>Wyoming Permanent Mineral Trust Fund</td>
+    <td>A 1.5%–2.5% severance tax on natural gas, oil, and coal (30%–40% of mineral revenue)</td>
+  <td>General Fund</td>
+  </tr>
+</table>
+

--- a/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
@@ -4,7 +4,7 @@ layout: narrative
 permalink: /how-it-works/state-laws-and-regulations/
 nav_description: Jump to a section
 nav_items:
-  - name: state-laws-and-regulations
+  - name: introduction
     title: Top
   - name: role-of-state-government-agencies
     title: Role of state government
@@ -22,7 +22,7 @@ nav_items:
   <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
   /
 </div>
-<h1 id="state-laws-and-regulations" data-nav-header="state-laws-and-regulations">State Laws and Regulations</h1>
+<h1 id="introduction" data-nav-header="introduction">State Laws and Regulations</h1>
 
 <p class="case_studies_intro-para">States maintain ownership of some lands and natural resources; develop their own taxation and royalty systems applicable to oil, gas, nonenergy minerals, and renewable energy; and collect extractive revenue directly. Each state has a unique revenue system.</p>
 

--- a/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
+++ b/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
@@ -4,7 +4,7 @@ layout: narrative
 permalink: /how-it-works/state-legal-fiscal-info/
 nav_description: Jump to a state
 nav_items:
-	- name: state-legal-fiscal-information
+	- name: introduction
 		title: Top
   - name: ak
     title: Alaska
@@ -49,7 +49,7 @@ nav_items:
   <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
   /
 </div>
-<h1 id="state-legal-fiscal-information" data-nav-header="state-legal-fiscal-information">State Legal and Fiscal Information</h1>
+<h1 id="introduction" data-nav-header="introduction">State Legal and Fiscal Information</h1>
 
 <nav class="hash_selector">
   {% include hash_selector.html %}

--- a/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
+++ b/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
@@ -4,6 +4,8 @@ layout: narrative
 permalink: /how-it-works/state-legal-fiscal-info/
 nav_description: Jump to a state
 nav_items:
+	- name: state-legal-fiscal-information
+		title: Top
   - name: ak
     title: Alaska
   - name: az
@@ -47,13 +49,13 @@ nav_items:
   <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
   /
 </div>
-<h1>State Legal and Fiscal Information</h1>
+<h1 id="state-legal-fiscal-information" data-nav-header="state-legal-fiscal-information">State Legal and Fiscal Information</h1>
 
 <nav class="hash_selector">
   {% include hash_selector.html %}
 </nav>
 
-<h3><a name="ak" data-nav-header="ak">Alaska</a></h3>
+<h3 id="ak" data-nav-header="ak">Alaska</h3>
 
 <p>The Division of Oil and Gas within the Alaska Department of Natural Resources is responsible for leasing state lands for oil, gas, and geothermal extraction. Its major functions include evaluating oil and gas resources, fielding and issuing exploration permits, conducting royalty audits, and negotiating contracts. The website for the Alaska Department of Natural Resources has significant information regarding statutes and regulations, leasing on state lands, and historical revenue collection and distribution information, as well as production data, for oil and gas. Additional information about statutes and regulations and leasing on state lands is available for mining from the Division of Land and Water. The Alaska Department of Revenue’s Tax Division collects state taxes, including the Oil and Gas Production Tax and Oil and Gas Property Tax, and administers tax laws. The website contains information about taxes collected and revenue sources and forecasts.</p>
 
@@ -78,7 +80,7 @@ nav_items:
 	</ul>
 </ul>
 
-<h3><a name="az" data-nav-header="az">Arizona</a></h3>
+<h3 id="az" data-nav-header="az">Arizona</h3>
 
 <p>The Minerals Section within the Arizona State Land Department oversees mining activities on state-trust lands by issuing permits and leases. The Minerals Section’s website contains information about the energy, mineral, and other management programs. The Arizona Department of Mines and Mineral Resources’ information is now available on the Geological Survey Mineral Resources’ webpage, where information on mineral rights, production levels, and laws and regulations can be found. The Office of the Arizona State Treasurer’s website allows visitors to create customized reports on revenue distribution.</p>
 
@@ -93,7 +95,7 @@ nav_items:
 	<li><a href="http://www.aztreasury.gov/local-govt/revenue-distributions/">Arizona State Treasurer revenue distribution reports</a></li>
 </ul>
 
-<h3><a name="ca" data-nav-header="ca">California</a></h3>
+<h3 id="ca" data-nav-header="ca">California</h3>
 
 <p>The California Department of Conservation includes both the State Mining and Geology Board and the Division of Oil, Gas, and Geothermal Resources. The board oversees mineral resource extraction, reclaiming mine lands, and preparing geologic hazard information. The division regulates the drilling, operation, maintenance, plugging, and abandonment of oil, natural gas, and geothermal wells. Department of Conservation websites provide information on regulation, production, and programs for oil, gas, geothermal, and mining. The California Natural Resources Agency’s website has information regarding California’s renewable energy programs and goals.</p>
 
@@ -112,7 +114,7 @@ nav_items:
 	<li><a href="http://resources.ca.gov/developing_renewable_energy_sources/">California Natural Resources Agency, information on renewable energy programs</a></li>
 </ul>
 
-<h3><a name="co" data-nav-header="co">Colorado</a></h3>
+<h3 id="co" data-nav-header="co">Colorado</h3>
 
 <p>The Oil and Gas Conservation Commission of the state’s Department of Natural Resources oversees the development of Colorado’s oil and gas natural resources. Its website provides relevant regulatory information, monthly resource production data, quarterly levy data, and information on drilling permits. The Colorado State Land Board manages assets held in public trust for Colorado public schools and institutions, including state lands used for natural resource extraction. The Division of Reclamation Mining and Safety protects miners, the public, and the environment from current and past mining operations. The Colorado Department of Revenue collects and disburses revenue for the state; annual reports provide details on these activities.</p>
 
@@ -138,7 +140,7 @@ nav_items:
 	<li><a href="https://www.colorado.gov/pacific/dola/energymineral-impact-assistance-fund-eiaf">Energy / Mineral Impact Assistance Fund supported by state severance taxes</a></li>
 </ul>
 
-<h3><a name="il" data-nav-header="il">Illinois</a></h3>
+<h3 id="il" data-nav-header="il">Illinois</h3>
 
 <p>The Department of Natural Resources Office of Mines and Minerals regulates natural resource exploration and development throughout the state. The Office is comprised of four divisions: Land Reclamation; Abandoned Mine Lands; Blasting, Explosives, and Aggregates; and Mine Safety and Training. The Office of Oil and Gas Resource Management is the regulatory authority responsible for permitting, drilling, operating, and plugging oil and gas production wells.</p>
 
@@ -157,7 +159,7 @@ nav_items:
 	<li><a href="http://www.ioc.state.il.us/index.cfm/resources/reports/cafr/">State of Illinois Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3><a name="ky" data-nav-header="ky">Kentucky</a></h3>
+<h3 id="ky" data-nav-header="ky">Kentucky</h3>
 
 <p>The Department for Natural Resources Division of Oil and Gas regulates the oil and gas industry in the state to protect mineral owners’ rights and the sustainability of the environment. The department’s divisions of Mine Permits, Mine Reclamation and Enforcement, and Mine Safety each execute different statutory responsibilities for mineral extraction oversight. Kentucky’s Energy and Environment Cabinet established the Department for Energy Development and Independence to develop and employ sustainable energy strategies for the state.</p>
 
@@ -185,7 +187,7 @@ nav_items:
 	<li><a href="http://finance.ky.gov/services/statewideacct/Pages/ReportsandPublications.aspx">Kentucky Finance and Administration Cabinet Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3><a name="la" data-nav-header="la">Louisiana</a></h3>
+<h3 id="la" data-nav-header="la">Louisiana</h3>
 
 <p>The Office of Mineral Resources within the Department of Natural Resources manages natural resource extraction throughout the state and receives revenue from royalties, bonuses, rents, interest, and fees for leases for state-owned lands. The Office of Conservation and Office of Coastal Management within the department also oversee Louisiana’s oil and gas resources. The State Energy Office helps maximize Louisiana's energy potential by exploring all energy sources.</p>
 
@@ -202,7 +204,7 @@ nav_items:
 	<li><a href="http://www.doa.la.gov/Pages/osr/lac/LAC-43.aspx">Office of State Register Administrative Code for natural resources</a></li>
 </ul>
 
-<h3><a name="mn" data-nav-header="mn">Minnesota</a></h3>
+<h3 id="mn" data-nav-header="mn">Minnesota</h3>
 
 <p>The Division of Lands and Minerals within Minnesota’s Department of Natural Resources manages the state's mineral resources and mine development on state-owned lands to generate revenue for the state's School and University Trust Funds, local communities, and General Fund. The division ensures full reclamation of extractive sites and maintains comprehensive mineral land records.</p>
 
@@ -217,7 +219,7 @@ nav_items:
 	<li><a href="http://mn.gov/mmb/accounting/reports/comprehensive-annual.jsp">Minnesota Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3><a name="mt" data-nav-header="mt">Montana</a></h3>
+<h3 id="mt" data-nav-header="mt">Montana</h3>
 
 <p>Within Montana’s Department of Resources and Natural Conservation, the Trust Lands Management Division oversees 5.2 million acres of state land and manages all energy resource leasing. The Minerals Management Bureau manages and issues leases and permits for oil, gas, coal, and other natural resources on state lands. The Montana Board of Oil and Gas protects citizens and the environment from the negative effects of oil and gas extraction by issuing permits, inspecting wells, and conducting environmental remediation programs.</p>
 
@@ -234,7 +236,7 @@ nav_items:
 	<li><a href="https://revenue.mt.gov/home/publications">Montana Department of Revenue Tax Related Reports</a></li>
 </ul>
 
-<h3><a name="nv" data-nav-header="nv">Nevada</a></h3>
+<h3 id="nv" data-nav-header="nv">Nevada</h3>
 
 <p>The Bureau of Mining Regulation and Reclamation within the Department of Conservation and Natural Resources oversees all mining activities in the state of Nevada. The division focuses on regulation (ensuring statutory compliance), closure (confirming stabilization of all applicable mine components), and reclamation (issuing reclamation permits to all large-scale operators).</p>
 
@@ -253,7 +255,7 @@ nav_items:
 	<li><a href="http://controller.nv.gov/FinancialReports/CAFR_Download_Page.html">Nevada State Controller Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3><a name="nm" data-nav-header="nm">New Mexico</a></h3>
+<h3 id="nm" data-nav-header="nm">New Mexico</h3>
 
 <p>The New Mexico Mining and Minerals Division enforces laws and regulations related to mine safety and reclamation of abandoned mines. The division collects production and employment data on active mining operations through its Mine Registration and Reporting Program. It also uses a Geographic Information System (GIS) to locate and track mining activities in the state, available for public use on the division’s website. The Oil Conservation Division regulates oil, gas, and geothermal activity in New Mexico. It gathers well production data, issues permits for new wells, enforces statutes and rules, and ensures abandoned wells are properly plugged and the land is restored.</p>
 
@@ -273,7 +275,7 @@ nav_items:
 	<li><a href="http://nmdfa.state.nm.us/New_Mexico_CAFR.aspx">New Mexico Department of Finance and Administration Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3><a name="nd" data-nav-header="nd">North Dakota</a></h3>
+<h3 id="nd" data-nav-header="nd">North Dakota</h3>
 
 <p>North Dakota’s Department of Mineral Resources Oil and Gas Division regulates the drilling and production of oil and gas in the state. In addition to its regulatory oversight function, the Oil and Gas Division manages permitting and maintains production and well data. Data pertaining to mineral extraction is housed by the state’s Geological Survey.</p>
 
@@ -293,7 +295,7 @@ nav_items:
 	</ul>
 </ul>
 
-<h3><a name="ok" data-nav-header="ok">Oklahoma</a></h3>
+<h3 id="ok" data-nav-header="ok">Oklahoma</h3>
 
 <p>The Oklahoma Commissioners of the Land Office manages state lands, including oil and gas leasing to generate revenue that supports the state’s common schools and higher education institutions. The Oklahoma Department of Mines regulates the coal and nonfuel mineral production, enforcing a variety of federal and state programs for safety, health, and land reclamation. The department also issues permits for all mining operations.</p>
 
@@ -313,7 +315,7 @@ nav_items:
 	<li><a href="http://www.ok.gov/OSF/documents/cafr14.pdf">Oklahoma Office of Management and Enterprise Services Comprehensive Annual Financial Report</a></li>
 </ul>
 
-<h3><a name="pa" data-nav-header="pa">Pennsylvania</a></h3>
+<h3 id="pa" data-nav-header="pa">Pennsylvania</h3>
 
 <p>The Department of Environmental Protection, including the Bureau of Mining Programs and the Office of Oil and Gas Management, manages programs that ensure the safe and responsible exploration, development, and recovery of extractive resources. These programs include permitting and inspection, regulatory oversight, and training.</p>
 
@@ -337,7 +339,7 @@ nav_items:
 	</ul>
 </ul>
 
-<h3><a name="tx" data-nav-header="tx">Texas</a></h3>
+<h3 id="tx" data-nav-header="tx">Texas</h3>
 
 <p>The Railroad Commission of Texas is statutorily responsible for regulating the exploration and production of the state’s natural resources: oil, natural gas, minerals (particularly lignite and coal), and alternative fuels. The commission oversees natural resource extraction along with land reclamation and environmental protection. The commission also oversees safety and compliance related to the state’s extensive oil and gas pipeline infrastructure.</p>
 
@@ -352,7 +354,7 @@ nav_items:
 	<li><a href="http://www.texastransparency.org/State_Finance/Budget_Finance/Reports/Revenue_by_Source/revenue_hist.php">Historical state net tax revenue by source</a></li>
 </ul>
 
-<h3><a name="ut" data-nav-header="ut">Utah</a></h3>
+<h3 id="ut" data-nav-header="ut">Utah</h3>
 
 <p>The Division of Oil, Gas, and Mining within Utah’s Department of Natural Resources is responsible for developing natural resources for the economic benefit of the public while preserving the state’s natural environment. The division maintains four core programs, each with specific oversight functions: the Coal Program, the Mineral Mining Program, the Oil and Gas Program, and the Abandoned Mine Reclamation Program.</p>
 
@@ -373,7 +375,7 @@ nav_items:
   <li><a href="http://finance.utah.gov/cafr.html">Utah Department of Administrative Services Division of Finance Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3><a name="wv" data-nav-header="wv">West Virginia</a></h3>
+<h3 id="wv" data-nav-header="wv">West Virginia</h3>
 
 <p>The West Virginia Department of Environmental Protection oversees natural resource extraction in West Virginia. The department’s Office of Oil and Gas is responsible for monitoring and regulating all actions related to the exploration, drilling, storage, and production of oil and natural gas. The Division of Mining and Reclamation manages compliance, reclamation, permitting, and communications between the public and industry.</p>
 
@@ -394,7 +396,7 @@ nav_items:
   <li><a href="http://www.finance.wv.gov/FARS/CAFR/Pages/default.aspx">West Virginia Department of Administration, Division of Finance Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3><a name="wy" data-nav-header="wy">Wyoming</a></h3>
+<h3 id="wy" data-nav-header="wy">Wyoming</h3>
 
 <p>The Wyoming Office of State Lands and Investments manages resource extraction on state land held in public trust. The revenue from energy and mineral resource leasing helps fund public education and essential institutions in the state.</p>
 

--- a/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
+++ b/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
@@ -4,8 +4,8 @@ layout: narrative
 permalink: /how-it-works/state-legal-fiscal-info/
 nav_description: Jump to a state
 nav_items:
-	- name: introduction
-		title: Top
+  - name: introduction
+    title: Top
   - name: ak
     title: Alaska
   - name: az
@@ -62,22 +62,22 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Alaska:</p>
 
 <ul class="list-nested">
-	<li><a href="http://dog.dnr.alaska.gov/index.htm">Alaska Department of Natural Resources Division of Oil and Gas</a></li>
-	<ul>
-		<li><a href="http://dog.dnr.alaska.gov/AboutUs/OGStatutes.htm">Oil and gas statutes and regulations</a></li>
-		<li><a href="http://dog.dnr.alaska.gov/AboutUs/GeothermalStatutes.htm">Geothermal statutes and regulations</a></li>
-		<li><a href="http://dog.dnr.alaska.gov/Royalty/Funds.htm#received">Oil and gas funds received and distributed</a></li>
-	</ul>
-	<li><a href="http://dnr.alaska.gov/mlw/index.htm">Alaska Department of Natural Resources Division of Land and Water</a></li>
-	<ul>
-		<li><a href="http://dnr.alaska.gov/mlw/mining/sb175.pdf">Mining regulations</a></li>
-		<li><a href="http://dnr.alaska.gov/mlw/mining/AK_MineralPolicy.pdf">State of Alaska mineral development policies</a></li>
-	</ul>
-	<li><a href="http://www.tax.alaska.gov/">Alaska Department of Revenue Tax Division</a></li>
-	<ul>
-		<li><a href="http://www.tax.alaska.gov/programs/reports.aspx">Tax Division reports</a></li>
-		<li><a href="http://www.tax.alaska.gov/programs/sourcebook/index.aspx">Revenue sources and forecast information</a></li>
-	</ul>
+  <li><a href="http://dog.dnr.alaska.gov/index.htm">Alaska Department of Natural Resources Division of Oil and Gas</a></li>
+  <ul>
+    <li><a href="http://dog.dnr.alaska.gov/AboutUs/OGStatutes.htm">Oil and gas statutes and regulations</a></li>
+    <li><a href="http://dog.dnr.alaska.gov/AboutUs/GeothermalStatutes.htm">Geothermal statutes and regulations</a></li>
+    <li><a href="http://dog.dnr.alaska.gov/Royalty/Funds.htm#received">Oil and gas funds received and distributed</a></li>
+  </ul>
+  <li><a href="http://dnr.alaska.gov/mlw/index.htm">Alaska Department of Natural Resources Division of Land and Water</a></li>
+  <ul>
+    <li><a href="http://dnr.alaska.gov/mlw/mining/sb175.pdf">Mining regulations</a></li>
+    <li><a href="http://dnr.alaska.gov/mlw/mining/AK_MineralPolicy.pdf">State of Alaska mineral development policies</a></li>
+  </ul>
+  <li><a href="http://www.tax.alaska.gov/">Alaska Department of Revenue Tax Division</a></li>
+  <ul>
+    <li><a href="http://www.tax.alaska.gov/programs/reports.aspx">Tax Division reports</a></li>
+    <li><a href="http://www.tax.alaska.gov/programs/sourcebook/index.aspx">Revenue sources and forecast information</a></li>
+  </ul>
 </ul>
 
 <h3 id="az" data-nav-header="az">Arizona</h3>
@@ -87,12 +87,12 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Arizona:</p>
 
 <ul class="list-nested">
-	<li><a href="https://land.az.gov/divisions/natural-resources/minerals">Arizona State Land Department Minerals Section</a></li>
-	<li><a href="http://www.azgs.az.gov/minerals.shtml">Arizona Geological Survey, Mineral Resources</a></li>
-	<ul>
-		<li><a href="http://repository.azgs.az.gov/sites/default/files/dlio/files/nid1639/lawregs9thed5thprintverforprintingaugust2014.pdf">Laws and Regulations: Mineral Rights in Arizona</a>, 9th edition</li>
-	</ul>
-	<li><a href="http://www.aztreasury.gov/local-govt/revenue-distributions/">Arizona State Treasurer revenue distribution reports</a></li>
+  <li><a href="https://land.az.gov/divisions/natural-resources/minerals">Arizona State Land Department Minerals Section</a></li>
+  <li><a href="http://www.azgs.az.gov/minerals.shtml">Arizona Geological Survey, Mineral Resources</a></li>
+  <ul>
+    <li><a href="http://repository.azgs.az.gov/sites/default/files/dlio/files/nid1639/lawregs9thed5thprintverforprintingaugust2014.pdf">Laws and Regulations: Mineral Rights in Arizona</a>, 9th edition</li>
+  </ul>
+  <li><a href="http://www.aztreasury.gov/local-govt/revenue-distributions/">Arizona State Treasurer revenue distribution reports</a></li>
 </ul>
 
 <h3 id="ca" data-nav-header="ca">California</h3>
@@ -102,16 +102,16 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in California:</p>
 
 <ul class="list-nested">
-	<li><a href="http://www.conservation.ca.gov/">California Department of Conservation</a></li>
-	<ul>
-		<li><a href="http://www.conservation.ca.gov/smgb/Pages/Index.aspx">State Mining and Geology Board</a></li>
-		<li><a href="http://www.conservation.ca.gov/smgb/Regulations/Pages/regulations.aspx">Mining regulations</a></li>
-		<li><a href="http://www.conservation.ca.gov/dog/Pages/Index.aspx">Division of Oil, Gas, and Geothermal Resources</a></li>
-		<li><a href="http://www.conservation.ca.gov/dog/pubs_stats/Pages/law_regulations.aspx">Oil, gas, and geothermal laws and regulations</a></li>
-		<li><a href="http://www.conservation.ca.gov/dog/pubs_stats/Pages/stats_prod.aspx">Oil and gas production reports</a></li>
-		<li><a href="http://www.conservation.ca.gov/cgs/Pages/Index.aspx">California Geological Survey</a></li>
-	</ul>
-	<li><a href="http://resources.ca.gov/developing_renewable_energy_sources/">California Natural Resources Agency, information on renewable energy programs</a></li>
+  <li><a href="http://www.conservation.ca.gov/">California Department of Conservation</a></li>
+  <ul>
+    <li><a href="http://www.conservation.ca.gov/smgb/Pages/Index.aspx">State Mining and Geology Board</a></li>
+    <li><a href="http://www.conservation.ca.gov/smgb/Regulations/Pages/regulations.aspx">Mining regulations</a></li>
+    <li><a href="http://www.conservation.ca.gov/dog/Pages/Index.aspx">Division of Oil, Gas, and Geothermal Resources</a></li>
+    <li><a href="http://www.conservation.ca.gov/dog/pubs_stats/Pages/law_regulations.aspx">Oil, gas, and geothermal laws and regulations</a></li>
+    <li><a href="http://www.conservation.ca.gov/dog/pubs_stats/Pages/stats_prod.aspx">Oil and gas production reports</a></li>
+    <li><a href="http://www.conservation.ca.gov/cgs/Pages/Index.aspx">California Geological Survey</a></li>
+  </ul>
+  <li><a href="http://resources.ca.gov/developing_renewable_energy_sources/">California Natural Resources Agency, information on renewable energy programs</a></li>
 </ul>
 
 <h3 id="co" data-nav-header="co">Colorado</h3>
@@ -121,23 +121,23 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Colorado:</p>
 
 <ul class="list-nested">
-	<li><a href="http://dnr.state.co.us/Pages/DNRDefault.aspx">Colorado Department of Natural Resources</a></li>
-	<ul>
-		<li><a href="http://cogcc.state.co.us/#/home">Oil and Gas Conservation Commission</a></li>
-		<li><a href="http://cogcc.state.co.us/reg.html#/overview">Policies and rules</a></li>
-		<li><a href="http://cogcc.state.co.us/data.html#/cogis">Production and levy data</a></li>
-	</ul>
-	<li><a href="http://trustlands.state.co.us/Pages/SLB.aspx">Colorado State Land Board</a></li>
-	<ul>
-		<li><a href="http://trustlands.state.co.us/Sections/Minerals/Pages/Minerals.aspx">Resource Extraction Group</a></li>
-		<li><a href="http://trustlands.state.co.us/Projects/Pages/RenewableEnergy.aspx">Renewable energy</a></li>
-	</ul>
-	<li><a href="http://mining.state.co.us/Pages/Home.aspx">Division of Reclamation Mining and Safety</a></li>
-	<ul>
-		<li><a href="http://mining.state.co.us/Rules/Pages/home.aspx">Rules and regulations</a></li>
-	</ul>
-	<li><a href="https://www.colorado.gov/pacific/revenue/annual-report">Colorado Department of Revenue Annual Report</a></li>
-	<li><a href="https://www.colorado.gov/pacific/dola/energymineral-impact-assistance-fund-eiaf">Energy / Mineral Impact Assistance Fund supported by state severance taxes</a></li>
+  <li><a href="http://dnr.state.co.us/Pages/DNRDefault.aspx">Colorado Department of Natural Resources</a></li>
+  <ul>
+    <li><a href="http://cogcc.state.co.us/#/home">Oil and Gas Conservation Commission</a></li>
+    <li><a href="http://cogcc.state.co.us/reg.html#/overview">Policies and rules</a></li>
+    <li><a href="http://cogcc.state.co.us/data.html#/cogis">Production and levy data</a></li>
+  </ul>
+  <li><a href="http://trustlands.state.co.us/Pages/SLB.aspx">Colorado State Land Board</a></li>
+  <ul>
+    <li><a href="http://trustlands.state.co.us/Sections/Minerals/Pages/Minerals.aspx">Resource Extraction Group</a></li>
+    <li><a href="http://trustlands.state.co.us/Projects/Pages/RenewableEnergy.aspx">Renewable energy</a></li>
+  </ul>
+  <li><a href="http://mining.state.co.us/Pages/Home.aspx">Division of Reclamation Mining and Safety</a></li>
+  <ul>
+    <li><a href="http://mining.state.co.us/Rules/Pages/home.aspx">Rules and regulations</a></li>
+  </ul>
+  <li><a href="https://www.colorado.gov/pacific/revenue/annual-report">Colorado Department of Revenue Annual Report</a></li>
+  <li><a href="https://www.colorado.gov/pacific/dola/energymineral-impact-assistance-fund-eiaf">Energy / Mineral Impact Assistance Fund supported by state severance taxes</a></li>
 </ul>
 
 <h3 id="il" data-nav-header="il">Illinois</h3>
@@ -147,16 +147,16 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Illinois:</p>
 
 <ul class="list-nested">
-	<li><a href="http://www.dnr.illinois.gov/Pages/default.aspx">Illinois Department of Natural Resources</a></li>
-	<ul>
-		<li><a href="http://www.dnr.illinois.gov/mines/Pages/RegulationsandPublications.aspx">Mining regulations</a></li>
-		<li><a href="http://www.dnr.illinois.gov/OilandGas/Pages/ProgramsandRegulations.aspx">Oil and gas regulations</a></li>
-	</ul>
-	<li><a href="http://isgs.illinois.edu/">Illinois State Geological Survey</a></li>
-	<ul>
-		<li><a href="http://isgs.illinois.edu/research/coal/maps">Coal production maps and data</a></li>
-	</ul>
-	<li><a href="http://www.ioc.state.il.us/index.cfm/resources/reports/cafr/">State of Illinois Comprehensive Annual Financial Report Archive</a></li>
+  <li><a href="http://www.dnr.illinois.gov/Pages/default.aspx">Illinois Department of Natural Resources</a></li>
+  <ul>
+    <li><a href="http://www.dnr.illinois.gov/mines/Pages/RegulationsandPublications.aspx">Mining regulations</a></li>
+    <li><a href="http://www.dnr.illinois.gov/OilandGas/Pages/ProgramsandRegulations.aspx">Oil and gas regulations</a></li>
+  </ul>
+  <li><a href="http://isgs.illinois.edu/">Illinois State Geological Survey</a></li>
+  <ul>
+    <li><a href="http://isgs.illinois.edu/research/coal/maps">Coal production maps and data</a></li>
+  </ul>
+  <li><a href="http://www.ioc.state.il.us/index.cfm/resources/reports/cafr/">State of Illinois Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
 <h3 id="ky" data-nav-header="ky">Kentucky</h3>
@@ -166,25 +166,25 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Kentucky:</p>
 
 <ul class="list-nested">
-	<li><a href="http://dnr.ky.gov/Pages/default.aspx">Energy and Environment Cabinet, Department for Natural Resources</a></li>
-	<ul>
-		<li><a href="http://oilandgas.ky.gov/Pages/Welcome.aspx">Division of Oil and Gas</a></li>
-		<li><a href="http://minemaps.ky.gov/">Mine Mapping Information System</a></li>
-	</ul>
-	<li><a href="http://energy.ky.gov/Pages/default.aspx">Energy and Environment Cabinet, State Department for Energy Development and Independence</a></li>
-	<ul>
-		<li><a href="http://energy.ky.gov/Programs/Pages/data.aspx">Resource data and production totals</a></li>
-	</ul>
-	<li><a href="http://www.lrc.ky.gov/kar/frntpage.htm">Kentucky Legislature administrative regulations</a></li>
-	<ul>
-		<li><a href="http://www.lrc.ky.gov/kar/title805.htm">Energy and Environment Cabinet regulations</a></li>
-	</ul>
-	<li><a href="http://www.uky.edu/KGS/">Kentucky Geological Survey</a></li>
-	<ul>
-		<li><a href="http://kgs.uky.edu/kgsmap/OGProdPlot/OGProduction.asp">Oil and gas production</a></li>
-		<li><a href="http://kgs.uky.edu/kgsweb/DataSearching/Coal/Production/prodsearch.asp">Coal production</a></li>
-	</ul>
-	<li><a href="http://finance.ky.gov/services/statewideacct/Pages/ReportsandPublications.aspx">Kentucky Finance and Administration Cabinet Comprehensive Annual Financial Report Archive</a></li>
+  <li><a href="http://dnr.ky.gov/Pages/default.aspx">Energy and Environment Cabinet, Department for Natural Resources</a></li>
+  <ul>
+    <li><a href="http://oilandgas.ky.gov/Pages/Welcome.aspx">Division of Oil and Gas</a></li>
+    <li><a href="http://minemaps.ky.gov/">Mine Mapping Information System</a></li>
+  </ul>
+  <li><a href="http://energy.ky.gov/Pages/default.aspx">Energy and Environment Cabinet, State Department for Energy Development and Independence</a></li>
+  <ul>
+    <li><a href="http://energy.ky.gov/Programs/Pages/data.aspx">Resource data and production totals</a></li>
+  </ul>
+  <li><a href="http://www.lrc.ky.gov/kar/frntpage.htm">Kentucky Legislature administrative regulations</a></li>
+  <ul>
+    <li><a href="http://www.lrc.ky.gov/kar/title805.htm">Energy and Environment Cabinet regulations</a></li>
+  </ul>
+  <li><a href="http://www.uky.edu/KGS/">Kentucky Geological Survey</a></li>
+  <ul>
+    <li><a href="http://kgs.uky.edu/kgsmap/OGProdPlot/OGProduction.asp">Oil and gas production</a></li>
+    <li><a href="http://kgs.uky.edu/kgsweb/DataSearching/Coal/Production/prodsearch.asp">Coal production</a></li>
+  </ul>
+  <li><a href="http://finance.ky.gov/services/statewideacct/Pages/ReportsandPublications.aspx">Kentucky Finance and Administration Cabinet Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
 <h3 id="la" data-nav-header="la">Louisiana</h3>
@@ -194,14 +194,14 @@ nav_items:
 <p>Learn more about natural resource production, revenue, and regulation in Louisiana:</p>
 
 <ul class="list-nested">
-	<li><a href="http://dnr.louisiana.gov/">Louisiana Department of Natural Resources</a></li>
-	<ul>
-		<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=208">Oil production</a></li>
-		<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=209">Natural gas production</a></li>
-		<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=213">Oil and natural gas reserves</a></li>
-		<li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=212">Royalties, rents, bonuses, and severance tax revenue</a></li>
-	</ul>
-	<li><a href="http://www.doa.la.gov/Pages/osr/lac/LAC-43.aspx">Office of State Register Administrative Code for natural resources</a></li>
+  <li><a href="http://dnr.louisiana.gov/">Louisiana Department of Natural Resources</a></li>
+  <ul>
+    <li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=208">Oil production</a></li>
+    <li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=209">Natural gas production</a></li>
+    <li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=213">Oil and natural gas reserves</a></li>
+    <li><a href="http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=212">Royalties, rents, bonuses, and severance tax revenue</a></li>
+  </ul>
+  <li><a href="http://www.doa.la.gov/Pages/osr/lac/LAC-43.aspx">Office of State Register Administrative Code for natural resources</a></li>
 </ul>
 
 <h3 id="mn" data-nav-header="mn">Minnesota</h3>
@@ -211,12 +211,12 @@ nav_items:
 <p>Learn more about natural resource production and revenue in Minnesota:</p>
 
 <ul class="list-nested">
-	<li><a href="http://www.dnr.state.mn.us/index.html">Minnesota Department of Natural Resources</a></li>
-	<ul>
-		<li><a href="http://www.dnr.state.mn.us/lands_minerals/index.html">Division of Lands and Minerals</a></li>
-		<li><a href="http://minarchive.dnr.state.mn.us/">Minerals data</a></li>
-	</ul>
-	<li><a href="http://mn.gov/mmb/accounting/reports/comprehensive-annual.jsp">Minnesota Comprehensive Annual Financial Report Archive</a></li>
+  <li><a href="http://www.dnr.state.mn.us/index.html">Minnesota Department of Natural Resources</a></li>
+  <ul>
+    <li><a href="http://www.dnr.state.mn.us/lands_minerals/index.html">Division of Lands and Minerals</a></li>
+    <li><a href="http://minarchive.dnr.state.mn.us/">Minerals data</a></li>
+  </ul>
+  <li><a href="http://mn.gov/mmb/accounting/reports/comprehensive-annual.jsp">Minnesota Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
 <h3 id="mt" data-nav-header="mt">Montana</h3>
@@ -226,14 +226,14 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Montana:</p>
 
 <ul class="list-nested">
-	<li><a href="http://dnrc.mt.gov/">Montana Department of Natural Resources and Conservation</a></li>
-	<ul>
-		<li><a href="http://dnrc.mt.gov/divisions/trust/minerals-management">Minerals Management Bureau</a></li>
-		<li><a href="http://bogc.dnrc.mt.gov/BoardSummaries.asp">Montana Board of Oil and Gas Conservation</a></li>
-		<li><a href="http://bogc.dnrc.mt.gov/rulesregs.asp">Rules and regulations</a></li>
-		<li><a href="http://bogc.dnrc.mt.gov/WebApps/DataMiner/">Wells, production, and leases data</a></li>
-	</ul>
-	<li><a href="https://revenue.mt.gov/home/publications">Montana Department of Revenue Tax Related Reports</a></li>
+  <li><a href="http://dnrc.mt.gov/">Montana Department of Natural Resources and Conservation</a></li>
+  <ul>
+    <li><a href="http://dnrc.mt.gov/divisions/trust/minerals-management">Minerals Management Bureau</a></li>
+    <li><a href="http://bogc.dnrc.mt.gov/BoardSummaries.asp">Montana Board of Oil and Gas Conservation</a></li>
+    <li><a href="http://bogc.dnrc.mt.gov/rulesregs.asp">Rules and regulations</a></li>
+    <li><a href="http://bogc.dnrc.mt.gov/WebApps/DataMiner/">Wells, production, and leases data</a></li>
+  </ul>
+  <li><a href="https://revenue.mt.gov/home/publications">Montana Department of Revenue Tax Related Reports</a></li>
 </ul>
 
 <h3 id="nv" data-nav-header="nv">Nevada</h3>
@@ -243,16 +243,16 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Nevada:</p>
 
 <ul class="list-nested">
-	<li><a href="http://dcnr.nv.gov/">Nevada Department of Conservation and Natural Resources</a></li>
-	<ul>
-		<li><a href="http://ndep.nv.gov/BMRR/index.htm">Division of Environmental Protection, Bureau of Mining Regulation and Reclamation</a></li>
-		<li><a href="http://ndep.nv.gov/BMRR/regs.htm">Statutes and regulations</a></li>
-	</ul>
-	<li><a href="http://www.nbmg.unr.edu/index.html">Nevada State Geological Survey</a></li>
-	<ul>
-		<li><a href="http://www.nbmg.unr.edu/Minerals&Energy/index.html">Minerals and energy data</a></li>
-	</ul>
-	<li><a href="http://controller.nv.gov/FinancialReports/CAFR_Download_Page.html">Nevada State Controller Comprehensive Annual Financial Report Archive</a></li>
+  <li><a href="http://dcnr.nv.gov/">Nevada Department of Conservation and Natural Resources</a></li>
+  <ul>
+    <li><a href="http://ndep.nv.gov/BMRR/index.htm">Division of Environmental Protection, Bureau of Mining Regulation and Reclamation</a></li>
+    <li><a href="http://ndep.nv.gov/BMRR/regs.htm">Statutes and regulations</a></li>
+  </ul>
+  <li><a href="http://www.nbmg.unr.edu/index.html">Nevada State Geological Survey</a></li>
+  <ul>
+    <li><a href="http://www.nbmg.unr.edu/Minerals&Energy/index.html">Minerals and energy data</a></li>
+  </ul>
+  <li><a href="http://controller.nv.gov/FinancialReports/CAFR_Download_Page.html">Nevada State Controller Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
 <h3 id="nm" data-nav-header="nm">New Mexico</h3>
@@ -262,17 +262,17 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in New Mexico:</p>
 
 <ul class="list-nested">
-	<li><a href="http://www.emnrd.state.nm.us/MMD/">New Mexico Mining and Minerals Division</a></li>
-	<ul>
-		<li><a href="http://www.emnrd.state.nm.us/MMD/MARP/MARPRulesRegs.html">Mining regulations</a></li>
-		<li><a href="http://www.emnrd.state.nm.us/MMD/MARP/MARPCommissionReport.html">Annual Reports to the Mining Commission (operators, production, etc.)</a></li>
-	</ul>
-	<li><a href="http://www.emnrd.state.nm.us/OCD/">New Mexico Oil Conservation Division</a></li>
-	<ul>
-		<li><a href="http://www.emnrd.state.nm.us/OCD/rules.html">Oil and gas regulations</a></li>
-		<li><a href="http://www.emnrd.state.nm.us/OCD/statistics.html">Oil and gas production data</a></li>
-	</ul>
-	<li><a href="http://nmdfa.state.nm.us/New_Mexico_CAFR.aspx">New Mexico Department of Finance and Administration Comprehensive Annual Financial Report Archive</a></li>
+  <li><a href="http://www.emnrd.state.nm.us/MMD/">New Mexico Mining and Minerals Division</a></li>
+  <ul>
+    <li><a href="http://www.emnrd.state.nm.us/MMD/MARP/MARPRulesRegs.html">Mining regulations</a></li>
+    <li><a href="http://www.emnrd.state.nm.us/MMD/MARP/MARPCommissionReport.html">Annual Reports to the Mining Commission (operators, production, etc.)</a></li>
+  </ul>
+  <li><a href="http://www.emnrd.state.nm.us/OCD/">New Mexico Oil Conservation Division</a></li>
+  <ul>
+    <li><a href="http://www.emnrd.state.nm.us/OCD/rules.html">Oil and gas regulations</a></li>
+    <li><a href="http://www.emnrd.state.nm.us/OCD/statistics.html">Oil and gas production data</a></li>
+  </ul>
+  <li><a href="http://nmdfa.state.nm.us/New_Mexico_CAFR.aspx">New Mexico Department of Finance and Administration Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
 <h3 id="nd" data-nav-header="nd">North Dakota</h3>
@@ -282,17 +282,17 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in North Dakota:</p>
 
 <ul class="list-nested">
-	<li><a href="https://www.dmr.nd.gov/oilgas/">North Dakota Department of Mineral Resources Oil and Gas Division</a></li>
-	<ul>
-		<li><a href="https://www.dmr.nd.gov/oilgas/rules/rulebook.pdf">Oil and gas regulations</a></li>
-		<li><a href="https://www.dmr.nd.gov/oilgas/stats/statisticsvw.asp">Oil and gas drilling and production data</a></li>
-	</ul>
-	<li><a href="https://www.dmr.nd.gov/ndgs/">North Dakota Geological Survey</a></li>
-	<li><a href="http://www.nd.gov/treasurer">North Dakota State Treasurer </a></li>
-	<ul>
-		<li><a href="http://www.nd.gov/treasurer/revenue-distribution/">Revenue distribution (including Oil and Gas Gross Production, Oil Extraction, Coal Severance, and other taxes associated with resource extraction)</a></li>
-		<li><a href="http://www.nd.gov/treasurer/how-is-oil-and-gas-tax-revenue-distributed/">Oil and gas revenue distribution</a></li>
-	</ul>
+  <li><a href="https://www.dmr.nd.gov/oilgas/">North Dakota Department of Mineral Resources Oil and Gas Division</a></li>
+  <ul>
+    <li><a href="https://www.dmr.nd.gov/oilgas/rules/rulebook.pdf">Oil and gas regulations</a></li>
+    <li><a href="https://www.dmr.nd.gov/oilgas/stats/statisticsvw.asp">Oil and gas drilling and production data</a></li>
+  </ul>
+  <li><a href="https://www.dmr.nd.gov/ndgs/">North Dakota Geological Survey</a></li>
+  <li><a href="http://www.nd.gov/treasurer">North Dakota State Treasurer </a></li>
+  <ul>
+    <li><a href="http://www.nd.gov/treasurer/revenue-distribution/">Revenue distribution (including Oil and Gas Gross Production, Oil Extraction, Coal Severance, and other taxes associated with resource extraction)</a></li>
+    <li><a href="http://www.nd.gov/treasurer/how-is-oil-and-gas-tax-revenue-distributed/">Oil and gas revenue distribution</a></li>
+  </ul>
 </ul>
 
 <h3 id="ok" data-nav-header="ok">Oklahoma</h3>
@@ -302,17 +302,17 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Oklahoma:</p>
 
 <ul class="list-nested">
-	<li><a href="http://www.clo.state.ok.us/">Oklahoma Commissioners of the Land Office</a></li>
-	<ul>
-		<li><a href="https://clo.ok.gov/policy/rules-regulations/">Rules and regulations</a></li>
-		<li><a href="https://clo.ok.gov/services/auction-information/minerals/">Oil and gas lease auction information</a></li>
-	</ul>
-	<li><a href="http://www.ok.gov/mines/index.html">Oklahoma Department of Mines</a></li>
-	<ul>
-		<li><a href="http://www.ok.gov/mines/Coal_Program/index.html">Coal program and related data</a></li>
-		<li><a href="http://www.ok.gov/mines/Annual_Reports/">Department of Mines Annual Reports</a></li>
-	</ul>
-	<li><a href="http://www.ok.gov/OSF/documents/cafr14.pdf">Oklahoma Office of Management and Enterprise Services Comprehensive Annual Financial Report</a></li>
+  <li><a href="http://www.clo.state.ok.us/">Oklahoma Commissioners of the Land Office</a></li>
+  <ul>
+    <li><a href="https://clo.ok.gov/policy/rules-regulations/">Rules and regulations</a></li>
+    <li><a href="https://clo.ok.gov/services/auction-information/minerals/">Oil and gas lease auction information</a></li>
+  </ul>
+  <li><a href="http://www.ok.gov/mines/index.html">Oklahoma Department of Mines</a></li>
+  <ul>
+    <li><a href="http://www.ok.gov/mines/Coal_Program/index.html">Coal program and related data</a></li>
+    <li><a href="http://www.ok.gov/mines/Annual_Reports/">Department of Mines Annual Reports</a></li>
+  </ul>
+  <li><a href="http://www.ok.gov/OSF/documents/cafr14.pdf">Oklahoma Office of Management and Enterprise Services Comprehensive Annual Financial Report</a></li>
 </ul>
 
 <h3 id="pa" data-nav-header="pa">Pennsylvania</h3>
@@ -322,21 +322,21 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Pennsylvania:</p>
 
 <ul class="list-nested">
-	<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/office_of_oil_and_gas_management/20291">Pennsylvania Department of Environmental Protection Office of Oil and Gas Management</a></li>
-	<ul>
-		<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/public_resources/20303/oil_and_gas_surface_regulations/1587188">Oil and gas surface regulations</a></li>
-		<li><a href="https://www.paoilandgasreporting.state.pa.us/publicreports/Modules/Welcome/Welcome.aspx">Oil and gas production data</a></li>
-	</ul>
-  	<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/mining/6002">Pennsylvania Department of Environmental Protection Office of Active and Abandoned Mine Operations</a></li>
-	<ul>
-		<li><a href="http://www.portal.state.pa.us/portal/server.pt/community/bureau_of_mining_programs/20865/regulations/1150023">Coal regulations</a></li>
-	</ul>
-  	<li><a href="http://dcnr.state.pa.us/topogeo/index.aspx">State Bureau of Topographic and Geologic Survey</a></li>
-	<ul>
-		<li><a href="http://dcnr.state.pa.us/topogeo/econresource/oilandgas/index.htm">Oil and gas resources</a></li>
-		<li><a href="http://dcnr.state.pa.us/topogeo/econresource/mineral_industries/index.htm">Mineral resources</a></li>
-		<li><a href="http://dcnr.state.pa.us/topogeo/econresource/coal/index.htm">Coal resources</a></li>
-	</ul>
+  <li><a href="http://www.portal.state.pa.us/portal/server.pt/community/office_of_oil_and_gas_management/20291">Pennsylvania Department of Environmental Protection Office of Oil and Gas Management</a></li>
+  <ul>
+    <li><a href="http://www.portal.state.pa.us/portal/server.pt/community/public_resources/20303/oil_and_gas_surface_regulations/1587188">Oil and gas surface regulations</a></li>
+    <li><a href="https://www.paoilandgasreporting.state.pa.us/publicreports/Modules/Welcome/Welcome.aspx">Oil and gas production data</a></li>
+  </ul>
+    <li><a href="http://www.portal.state.pa.us/portal/server.pt/community/mining/6002">Pennsylvania Department of Environmental Protection Office of Active and Abandoned Mine Operations</a></li>
+  <ul>
+    <li><a href="http://www.portal.state.pa.us/portal/server.pt/community/bureau_of_mining_programs/20865/regulations/1150023">Coal regulations</a></li>
+  </ul>
+    <li><a href="http://dcnr.state.pa.us/topogeo/index.aspx">State Bureau of Topographic and Geologic Survey</a></li>
+  <ul>
+    <li><a href="http://dcnr.state.pa.us/topogeo/econresource/oilandgas/index.htm">Oil and gas resources</a></li>
+    <li><a href="http://dcnr.state.pa.us/topogeo/econresource/mineral_industries/index.htm">Mineral resources</a></li>
+    <li><a href="http://dcnr.state.pa.us/topogeo/econresource/coal/index.htm">Coal resources</a></li>
+  </ul>
 </ul>
 
 <h3 id="tx" data-nav-header="tx">Texas</h3>
@@ -346,12 +346,12 @@ nav_items:
 <p>Learn more about natural resource regulation, production, and revenue in Texas:</p>
 
 <ul class="list-nested">
-	<li><a href="http://www.rrc.state.tx.us/">Railroad Commission of Texas</a></li>
-	<ul>
-		<li><a href="http://www.rrc.state.tx.us/oil-gas/research-and-statistics/production-data/texas-monthly-oil-gas-production/">Monthly oil and gas production data</a></li>
-		<li><a href="http://www.rrc.state.tx.us/legal/rules/current-rules/">Regulations for commodity extraction</a></li>
-	</ul>
-	<li><a href="http://www.texastransparency.org/State_Finance/Budget_Finance/Reports/Revenue_by_Source/revenue_hist.php">Historical state net tax revenue by source</a></li>
+  <li><a href="http://www.rrc.state.tx.us/">Railroad Commission of Texas</a></li>
+  <ul>
+    <li><a href="http://www.rrc.state.tx.us/oil-gas/research-and-statistics/production-data/texas-monthly-oil-gas-production/">Monthly oil and gas production data</a></li>
+    <li><a href="http://www.rrc.state.tx.us/legal/rules/current-rules/">Regulations for commodity extraction</a></li>
+  </ul>
+  <li><a href="http://www.texastransparency.org/State_Finance/Budget_Finance/Reports/Revenue_by_Source/revenue_hist.php">Historical state net tax revenue by source</a></li>
 </ul>
 
 <h3 id="ut" data-nav-header="ut">Utah</h3>
@@ -366,8 +366,8 @@ nav_items:
   <li><a href="http://linux3.ogm.utah.gov/WebStuff/wwwroot/minerals/default.html">Minerals program</a></li>
   <li><a href="http://oilgas.ogm.utah.gov/">Oil and gas program</a></li>
   <ul>
-	  <li><a href="http://oilgas.ogm.utah.gov/Rules/Rules_Page.htm">Oil and gas regulations</a></li>
-	  <li><a href="http://oilgas.ogm.utah.gov/Data_Center/DataCenter.cfm">Permitting, drilling, and production data</a></li>
+    <li><a href="http://oilgas.ogm.utah.gov/Rules/Rules_Page.htm">Oil and gas regulations</a></li>
+    <li><a href="http://oilgas.ogm.utah.gov/Data_Center/DataCenter.cfm">Permitting, drilling, and production data</a></li>
   </ul>
   <li><a href="http://linux3.ogm.utah.gov/WebStuff/wwwroot/coal/rulesregs.html">Statutes and rules</a></li>
   <li><a href="http://tax.utah.gov/utah-taxes">Utah State Tax Commission description of all taxes and fees</a></li>
@@ -384,12 +384,12 @@ nav_items:
 <ul class="list-nested">
   <li><a href="http://www.dep.wv.gov/Pages/default.aspx">West Virginia Department of Environmental Protection</a></li>
   <ul>
-	  <li><a href="http://www.dep.wv.gov/dmr/codes/Pages/default.aspx">Mining codes and regulations</a></li>
-	  <li><a href="http://www.dep.wv.gov/oil-and-gas/Pages/default.aspx">Oil and gas rules and regulations</a></li>
+    <li><a href="http://www.dep.wv.gov/dmr/codes/Pages/default.aspx">Mining codes and regulations</a></li>
+    <li><a href="http://www.dep.wv.gov/oil-and-gas/Pages/default.aspx">Oil and gas rules and regulations</a></li>
   </ul>
   <li><a href="http://www.wvminesafety.org/default.htm">West Virginia Office of Miners’ Health, Safety, and Training</a></li>
   <ul>
-	  <li><a href="http://www.wvminesafety.org/STATS.HTM">Surface and subsurface coal production and employment data</a></li>
+    <li><a href="http://www.wvminesafety.org/STATS.HTM">Surface and subsurface coal production and employment data</a></li>
   </ul>
   <li><a href="http://www.wvcommerce.org/business/businessassistance/expandingorrelocating/businesstaxes.aspx ">Business taxes overview</a></li>
   <li><a href="http://www.wvcommerce.org/business/businessassistance/expandingorrelocating/businesstaxes.aspx">West Virginia Geological and Economic Survey</a></li>
@@ -405,7 +405,7 @@ nav_items:
 <ul class="list-nested">
   <li><a href="https://sites.google.com/a/wyo.gov/osli/home">Wyoming Office of State Lands and Investments</a></li>
   <ul>
-	  <li><a href="https://sites.google.com/a/wyo.gov/osli/minerals/royalty">Mining and oil and gas leasing and royalties information</a></li>
+    <li><a href="https://sites.google.com/a/wyo.gov/osli/minerals/royalty">Mining and oil and gas leasing and royalties information</a></li>
   </ul>
   <li><a href="http://soswy.state.wy.us/Rules/default.aspx">Wyoming rules and regulations search</a></li>
   <li><a href="http://www.wsgs.wyo.gov/">Wyoming State Geological Survey</a></li>

--- a/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
@@ -1,96 +1,99 @@
 ---
 title: Tribal Laws and Regulations | How It Works
-subpage:
-layout: default
+layout: narrative
 permalink: /how-it-works/tribal-laws-and-regulations/
+nav_description: Jump to a section
+nav_items:
+  - name: introduction
+    title: Top
+  - name: federal-obligations
+    title: Federal Obligations
+  - name: leasing-process
+    title: Leasing Process
+  - name: production-and-revenue
+    title: Production and revenue
+  - name: fy-2013-production-and-revenue
+    title: FY 2013 production and revenue
 ---
 
-<div class="container-outer container-padded">
-
-  <article class="container-left-7">
-
-    <div>
-      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
-      /
-    </div>
-    <h1>Tribal laws and regulations</h1>
-
-    <p class="case_studies_intro-para">According to the 2011 American Community Survey conducted by the U.S. Census, there were 5.1 million American Indians and Alaska Natives living in the United States, accounting for approximately <a href="https://www.census.gov/newsroom/releases/archives/facts_for_features_special_editions/cb12-ff22.html">1.6% of the population</a>.</p>
-
-    <p>The federal government formally recognizes 566 Indian tribes and 325 Indian reservations that cover <a href="http://www.blm.gov/public_land_statistics/pls13/pls2013.pdf">56 million acres of land</a>. This land is held in trust by DOI and has <a href="http://www.resourcegovernance.org/sites/default/files/RWI_Native_American_Lands_2011.pdf">significant natural resource extraction potential</a>, containing up to 30% of U.S. coal reserves west of the Mississippi, 50% of potential uranium reserves, and 20% of known oil and gas reserves. Extracting natural resources on Indian land and distributing the associated revenue involves a unique set of processes and stakeholders.</p>
-
-    <h2>Federal obligations</h2>
-
-    <p>The basis of the regulatory relationship between Indian tribes and the federal government was established in the Commerce Clause of the U.S. Constitution (Article 1, Section 8, Clause 3). This relationship, as it pertains to land use and ownership, was clarified in the 1830s. In a series of Supreme Court decisions known as the Marshall Trilogy, former Supreme Court Justice John Marshall established several important principles of Indian law.</p>
-
-    <p>One was the federal Indian trust responsibility, whereby the government charged itself with “<a href="http://www.bia.gov/FAQs/index.htm">moral obligations of the highest responsibility and trust</a>” toward Indian tribes. In this capacity, the U.S. Government maintains fiduciary responsibility to protect tribal assets and resources and serves as a trustee for Indian lands. Another was the principle that tribes are sovereign, which is inherent to them as the original governing bodies of what is now the United States, and that sovereignty can only be diminished by Congress.</p>
-
-    <h2>Leasing process</h2>
-
-    <p>Today, there are <a href="http://teeic.indianaffairs.gov/triballand/">two major types of Indian-owned land</a>:</p>
-
-    <ul class="list-bullet">
-  	  <li>Trust land, in which the federal government holds legal title, but the beneficial interest remains with individual or tribe. Trust lands held on behalf of individuals are known as allotments.</li>
-  	  <li>Fee land purchased by tribes, in which the tribe acquires legal title under specific statutory authority</li>
-    </ul>
-
-    <p>These lands yield natural resources through a process governed primarily by the tribes themselves and four agencies within DOI. When a tribe initiates the leasing process, BIA or the tribe itself negotiates the lease sale, sets royalty rates and rental amounts, and issues the lease. If the tribe negotiates the lease, the BIA will approve the final negotiated deal. For an allotment owned by an individual, the BIA holds a bidding process to ensure the best return for the allottee. Once a contract is signed, BLM inspects the lease and helps prepare production and mining plans.</p>
-
-    <p>ONRR collects royalties from extractive companies and reviews monthly revenue and production reports to ensure accuracy. ONRR also performs lease audits to ensure royalties are correctly paid.</p>
-
-    <p>The Office of the Special Trustee for American Indians (OST) receives the payments and information from ONRR and <a href="http://www.onrr.gov/IndianServices/pdfdocs/FrequentlyAskedQuestion.pdf">disburses 100% of the funds to the owner of the land</a>, whether that is an individual or a tribe.</p>
-
-    <h2>Indian land production and revenue</h2>
-
-    <p>Natural resources are increasingly a key source of income for many American Indian tribes. In FY 2013, ONRR and OST disbursed <a href="http://statistics.onrr.gov/ReportTool.aspx">$933 million to American Indian tribes and allottees</a>, an increase of more than 171% from 10 years prior.</p>
-
-    <h3>FY 2013 production and revenue</h3>
-
-    <table>
-      <tr>
-        <th>Resource</th>
-        <th>Production</th>
-        <th>Royalties</th>
-  	  <th>Rents</th>
-  	  <th>Bonuses</th>
-      </tr>
-      <tr>
-        <td>Coal</td>
-        <td>19,145,716 tons</td>
-        <td>$78,225,311</td>
-  	  <td>$106,325</td>
-  	  <td>$12,561,353</td>
-      </tr>
-      <tr>
-        <td>Oil</td>
-        <td>46,421,857 bbl</td>
-        <td>$729,744,651</td>
-  	  <td rowspan="3">$4,231,254</td>
-  	  <td>-</td>
-      </tr>
-      <tr>
-        <td>Natural gas</td>
-        <td>240,552,694 Mcf</td>
-        <td>$126,043,575</td>
-  	  <td>-</td>
-      </tr>
-      <tr>
-        <td>Natural gas liquids</td>
-        <td>154,923,429 gal</td>
-        <td>$15,317,988</td>
-  	  <td>-</td>
-      </tr>
-      <tr>
-        <td>Copper</td>
-        <td>3,967 tons</td>
-        <td>$1,034,988</td>
-  	  <td>$6,174</td>
-  	  <td>-</td>
-      </tr>
-    </table>
-
-    <p>The federal government may only release information about natural resource extraction and revenue in aggregate across all Indian lands. This is because of confidentiality and proprietary constraints on tribal data. These constraints arise from treaties, laws, and regulations that the government consistently and uniformly applies.</p>
-
-  </article>
-
+<div>
+  <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+  /
 </div>
+<h1 id="introduction" data-nav-header="introduction">Tribal laws and regulations</h1>
+
+<p class="case_studies_intro-para">According to the 2011 American Community Survey conducted by the U.S. Census, there were 5.1 million American Indians and Alaska Natives living in the United States, accounting for approximately <a href="https://www.census.gov/newsroom/releases/archives/facts_for_features_special_editions/cb12-ff22.html">1.6% of the population</a>.</p>
+
+<p>The federal government formally recognizes 566 Indian tribes and 325 Indian reservations that cover <a href="http://www.blm.gov/public_land_statistics/pls13/pls2013.pdf">56 million acres of land</a>. This land is held in trust by DOI and has <a href="http://www.resourcegovernance.org/sites/default/files/RWI_Native_American_Lands_2011.pdf">significant natural resource extraction potential</a>, containing up to 30% of U.S. coal reserves west of the Mississippi, 50% of potential uranium reserves, and 20% of known oil and gas reserves. Extracting natural resources on Indian land and distributing the associated revenue involves a unique set of processes and stakeholders.</p>
+
+<h2 id="federal-obligations" data-nav-header="federal-obligations">Federal obligations</h2>
+
+<p>The basis of the regulatory relationship between Indian tribes and the federal government was established in the Commerce Clause of the U.S. Constitution (Article 1, Section 8, Clause 3). This relationship, as it pertains to land use and ownership, was clarified in the 1830s. In a series of Supreme Court decisions known as the Marshall Trilogy, former Supreme Court Justice John Marshall established several important principles of Indian law.</p>
+
+<p>One was the federal Indian trust responsibility, whereby the government charged itself with “<a href="http://www.bia.gov/FAQs/index.htm">moral obligations of the highest responsibility and trust</a>” toward Indian tribes. In this capacity, the U.S. Government maintains fiduciary responsibility to protect tribal assets and resources and serves as a trustee for Indian lands. Another was the principle that tribes are sovereign, which is inherent to them as the original governing bodies of what is now the United States, and that sovereignty can only be diminished by Congress.</p>
+
+<h2 id="leasing-process" data-nav-header="leasing-process">Leasing process</h2>
+
+<p>Today, there are <a href="http://teeic.indianaffairs.gov/triballand/">two major types of Indian-owned land</a>:</p>
+
+<ul class="list-bullet">
+  <li>Trust land, in which the federal government holds legal title, but the beneficial interest remains with individual or tribe. Trust lands held on behalf of individuals are known as allotments.</li>
+  <li>Fee land purchased by tribes, in which the tribe acquires legal title under specific statutory authority</li>
+</ul>
+
+<p>These lands yield natural resources through a process governed primarily by the tribes themselves and four agencies within DOI. When a tribe initiates the leasing process, BIA or the tribe itself negotiates the lease sale, sets royalty rates and rental amounts, and issues the lease. If the tribe negotiates the lease, the BIA will approve the final negotiated deal. For an allotment owned by an individual, the BIA holds a bidding process to ensure the best return for the allottee. Once a contract is signed, BLM inspects the lease and helps prepare production and mining plans.</p>
+
+<p>ONRR collects royalties from extractive companies and reviews monthly revenue and production reports to ensure accuracy. ONRR also performs lease audits to ensure royalties are correctly paid.</p>
+
+<p>The Office of the Special Trustee for American Indians (OST) receives the payments and information from ONRR and <a href="http://www.onrr.gov/IndianServices/pdfdocs/FrequentlyAskedQuestion.pdf">disburses 100% of the funds to the owner of the land</a>, whether that is an individual or a tribe.</p>
+
+<h2 id="production-and-revenue" data-nav-header="production-and-revenue">Indian land production and revenue</h2>
+
+<p>Natural resources are increasingly a key source of income for many American Indian tribes. In FY 2013, ONRR and OST disbursed <a href="http://statistics.onrr.gov/ReportTool.aspx">$933 million to American Indian tribes and allottees</a>, an increase of more than 171% from 10 years prior.</p>
+
+<h3 id="fy-2013-production-and-revenue" data-nav-header="fy-2013-production-and-revenue">FY 2013 production and revenue</h3>
+
+<table>
+  <tr>
+    <th>Resource</th>
+    <th>Production</th>
+    <th>Royalties</th>
+  <th>Rents</th>
+  <th>Bonuses</th>
+  </tr>
+  <tr>
+    <td>Coal</td>
+    <td>19,145,716 tons</td>
+    <td>$78,225,311</td>
+  <td>$106,325</td>
+  <td>$12,561,353</td>
+  </tr>
+  <tr>
+    <td>Oil</td>
+    <td>46,421,857 bbl</td>
+    <td>$729,744,651</td>
+  <td rowspan="3">$4,231,254</td>
+  <td>-</td>
+  </tr>
+  <tr>
+    <td>Natural gas</td>
+    <td>240,552,694 Mcf</td>
+    <td>$126,043,575</td>
+  <td>-</td>
+  </tr>
+  <tr>
+    <td>Natural gas liquids</td>
+    <td>154,923,429 gal</td>
+    <td>$15,317,988</td>
+  <td>-</td>
+  </tr>
+  <tr>
+    <td>Copper</td>
+    <td>3,967 tons</td>
+    <td>$1,034,988</td>
+  <td>$6,174</td>
+  <td>-</td>
+  </tr>
+</table>
+
+<p>The federal government may only release information about natural resource extraction and revenue in aggregate across all Indian lands. This is because of confidentiality and proprietary constraints on tribal data. These constraints arise from treaties, laws, and regulations that the government consistently and uniformly applies.</p>

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -16,11 +16,6 @@
   margin-bottom: 0;
   padding: $base-padding-lite;
 
-  // &.active a {
-  //   color: $dark-gray;
-  //   font-weight: $weight-book;
-  // }
-
   &[data-active=true] {
     color: $dark-gray;
     font-weight: $weight-book;

--- a/_sass/elements/_forms.scss
+++ b/_sass/elements/_forms.scss
@@ -113,7 +113,7 @@ select {
   font-weight: $weight-light;
   margin-bottom: 1em;
   overflow: hidden;
-  padding: 0.5em 7rem 0.5em 0.8rem;
+  padding: 0.5em 2.2rem 0.5em 0.8rem;
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;

--- a/_sass/elements/_links.scss
+++ b/_sass/elements/_links.scss
@@ -16,6 +16,7 @@
 
 
 p a,
+ul a,
 .link-alpha {
   @extend %link;
   color: $blue;

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -63,7 +63,7 @@
 
     OpenListNav.prototype.updateSelectField = function(newValue) {
       if (newValue){
-        return this.navSelect.val(newValue);
+        this.navSelect.val(newValue);
       }
     };
 
@@ -103,16 +103,16 @@
       // initialize nav status as not updated
       var updated = false;
 
-      Array.prototype.forEach.call(this.navHeaders, function(header){
-
-        var inViewPort = isElementInViewport(header);
-        if (inViewPort && !self.navIsSelect && !updated) {
-          self.update(null, header.name);
-          updated = true;
-        } else if(inViewPort && self.navIsSelect && !updated) {
-          self.updateSelectField(header.name);
-          updated = true;
-        }
+       Array.prototype.forEach.call(this.navHeaders, function(header){
+         var inViewPort = isElementInViewport(header);
+         if (inViewPort && !self.navIsSelect && !updated) {
+           self.update(null, header.name);
+           updated = true;
+         } else if(inViewPort && self.navIsSelect && !updated) {
+           var newName = header.name || header.id;
+          self.updateSelectField(newName);
+           updated = true;
+         }
       });
     };
 


### PR DESCRIPTION
For #995
The diffs make it look like this is a massive PR, but it doesn't change all that much.

It modifies all of the pages in [state laws and governance](at https://federalist.18f.gov/preview/18F/doi-extractives-data/dev/how-it-works/#laws-governance) and...
* updates the jekyll front matter to generate the nav selector. 
* changes the page layout to `narrative` (this is where most of the diffs come from)
* adds `id` and `data-nav-header` that sync with the nav selector
* made a minor change to the nav selector to allow the selector to reference `name`s _and_ `id`s 

ready for review! @meiqimichelle @coreycaitlin please modify any navigation language that you don't like :)