### PR TITLE
Changes colorbrewer theme and no data color

### DIFF
--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -1,6 +1,5 @@
 
 .filters-wrapper {
-  margin-bottom: $base-padding;
   padding: $base-padding;
 
   @include respond-to(medium-up) {

--- a/_sass/blocks/explore/_map.scss
+++ b/_sass/blocks/explore/_map.scss
@@ -74,6 +74,7 @@ eiti-slider {
 .map-intro_text {
   @include heading(para-md);
   padding: $base-padding;
+  padding-top: 0;
 
   @include respond-to(medium-up) {
     padding-left: 0;

--- a/js/pages/all-lands-production.js
+++ b/js/pages/all-lands-production.js
@@ -3,7 +3,7 @@
 
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
-  var colorscheme = colorbrewer.Purples;
+  var colorscheme = colorbrewer.GnBu;
 
   // our state is immutable!
   var state = new Immutable.Map();
@@ -18,7 +18,7 @@
 
   var getter = eiti.data.getter;
   var formatNumber = eiti.format.si;
-  var NULL_FILL = '#eee';
+  var NULL_FILL = '#f7f7f7';
 
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');

--- a/js/pages/exports.js
+++ b/js/pages/exports.js
@@ -3,7 +3,7 @@
 
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
-  var colorscheme = colorbrewer.Purples;
+  var colorscheme = colorbrewer.GnBu;
 
   // our state is immutable!
   var state = new Immutable.Map();

--- a/js/pages/federal-production.js
+++ b/js/pages/federal-production.js
@@ -3,7 +3,7 @@
 
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
-  var colorscheme = colorbrewer.Purples;
+  var colorscheme = colorbrewer.GnBu;
 
   // our state is immutable!
   var state = new Immutable.Map();
@@ -18,7 +18,7 @@
 
   var getter = eiti.data.getter;
   var formatNumber = eiti.format.si;
-  var NULL_FILL = '#eee';
+  var NULL_FILL = '#f7f7f7';
 
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');

--- a/js/pages/gdp.js
+++ b/js/pages/gdp.js
@@ -3,7 +3,7 @@
 
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
-  var colorscheme = colorbrewer.Purples;
+  var colorscheme = colorbrewer.GnBu;
 
   // our state is immutable!
   var state = new Immutable.Map();
@@ -20,7 +20,7 @@
   var formatDollars = eiti.format.dollars;
   var formatPercent = d3.format('%.2');
   var formatNumber = formatDollars;
-  var NULL_FILL = '#eee';
+  var NULL_FILL = '#f7f7f7';
 
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');

--- a/js/pages/jobs.js
+++ b/js/pages/jobs.js
@@ -3,7 +3,7 @@
 
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
-  var colorscheme = colorbrewer.Purples;
+  var colorscheme = colorbrewer.GnBu;
 
   // our state is immutable!
   var state = new Immutable.Map();
@@ -18,7 +18,7 @@
 
   var getter = eiti.data.getter;
   var formatNumber = eiti.format.si;
-  var NULL_FILL = '#eee';
+  var NULL_FILL = '#f7f7f7';
 
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');

--- a/js/pages/revenue.js
+++ b/js/pages/revenue.js
@@ -3,7 +3,7 @@
 
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
-  var colorscheme = colorbrewer.Purples;
+  var colorscheme = colorbrewer.GnBu;
 
   // our state is immutable!
   var state = new Immutable.Map();
@@ -18,7 +18,7 @@
 
   var getter = eiti.data.getter;
   var formatNumber = eiti.format.dollarsAndCents;
-  var NULL_FILL = '#eee';
+  var NULL_FILL = '#f7f7f7';
 
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');


### PR DESCRIPTION
This is for #999. It was hard to tell the difference between our `no data` color and the lightest color in our colorbrewer theme. I screen-shared with @ericronne to pick better defaults. If we have time, we would still like to implement a custom color scheme that better matches our 'brand' but this will work for now. Looks like:

This also removes extra padding that was on the intro paragraph in my hack to get the sentence-title in the right place. Brian's fix made that padding OBE.

<img width="1079" alt="screenshot 2015-12-08 14 02 06" src="https://cloud.githubusercontent.com/assets/4827522/11668407/493efc38-9db4-11e5-8615-25e15efc00f5.png">
