### PR TITLE
Much cleaning, wow

### DIFF
--- a/_case-studies/boone-logan-and-mingo.md
+++ b/_case-studies/boone-logan-and-mingo.md
@@ -8,7 +8,7 @@ nav_items:
     title: Top
   - name: geology
     title: Geology and history
-  - name: produduction
+  - name: production
     title: Production
   - name: employment
     title: Employment
@@ -17,20 +17,20 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h1 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h1>
 
 The U.S. possesses the largest estimated recoverable coal reserves in the world. This resource abundance allowed coal to serve as the single largest source of domestic electricity generation for more than six decades.[^1] However, coal production has declined since 2007 due to increased competition from natural gas, as well as the effects of recent federal regulations.
 
 One of the most productive coal deposits in the country is the Central Appalachian Coal Basin, which supplies the numerous surface and underground mines of West Virginia. The counties in the southern half of the state maintain estimated recoverable coal reserves of 1.2 billion tons.[^2] In particular, the contiguous Boone, Logan, and Mingo counties have long been a center of coal exploration and extraction.
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
 
 Coal has driven economic development across Boone, Logan, and Mingo counties for many decades. In 1742, Explorer John Peter Salley first discovered bituminous coal in what would later become Boone County. Although forest extraction was the first major industry in the region, large-scale coal mining began in Boone County in the 1880s. The arrival of the Norfolk & Western Railroad in the 1890s and the Chesapeake & Ohio Railroad soon thereafter launched a coal extraction boom in all three counties. The early decades of the twentieth century marked a period of frenzied development in these counties. In the decades that followed, coal continued to drive the counties’ economies, but population numbers declined as mechanization and a shift to greater surface mining reduced the need for labor.[^3]
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 In 2013, 37 underground mines and 31 surface mines were operating across the three counties.[^4] In all three counties, the top ten landowners own at least 50% of private land.[^5] Notable operations include Boone County’s Twilight Mountaintop Removal Surface Mine (2.5 million tons in 2013) and Hobet 21 Surface Mine (2.3 million tons in 2013).[^6] [^7]
 
@@ -38,25 +38,25 @@ Cumulatively, mines in Boone, Logan, and Mingo counties produced 32.7 million to
 
 <img src="{{ site.baseurl }}/img/counties/wv-production.png" alt="Coal Production: Boone, Logan, and Mingo Counties from 2004-2013" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 Coal extraction has provided employment in these communities for the past century, but employment is declining in tandem with the region’s dropping production levels and the industry’s increased mechanization. In 2013, the combined population of the three counties was 88,211.[^10] That year, 3,427 people were employed at underground mines and 1,601 people were employed at surface mines across the three counties.[^11] This translates to 19% of the total employed population, or 6% of the total population. These numbers marked a 20% drop in the sector’s employment since 2007.[^12] The following graph illustrates changes in mining employment across these three counties from 2004 through 2013, compared with employment in all other industries.[^13] [^14]
 
 <img src="{{ site.baseurl }}/img/counties/wv-wage.png" alt="Boone, Logan, and Mingo Counties Mining Industry vs. All Other Industries Wage and Salary Employment from 2004–2013" class="case_studies_content-graph">
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 West Virginia levies three primary state tax mechanisms to collect coal revenue and distribute it to counties. The most significant of these mechanisms is the Coal Severance Tax, which amounts to 5% of the sale price of mined coal. 75% of net proceeds from this tax are distributed to coal-producing counties, while the remaining 25% is divided amongst all counties and municipalities in the state.[^15] In 2013, Boone, Logan, and Mingo counties received $7.7 million out of a total $32.5 million collected by the state from this tax.[^16]
 
 Boone, Logan, and Mingo also benefit from the Coal County Reallocation Severance Tax (an additional coal severance tax specifically for the counties in which the coal was located at the time it was extracted) and the Waste Coal Tax (a severance tax on coal produced from refuse, gob piles, and slurry ponds). Boone, Logan, and Mingo counties received more than $1.2 million out of a total $4.5 million disbursed across all counties from the Coal County Reallocation Severance Tax in 2013.[^17] Logan and Mingo counties received additional revenue in the tens of thousands of dollars from the Waste Coal Tax.[^18]
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 The West Virginia Department of Transportation (DOT) consists of three operating sections, including the Coal Resource Transportation System (CRTS). The CRTS manages, among other items, the permit system for coal haulers that would like to use designated CRTS roads. As of 2003, coal haulers must purchase a permit that allows for a gross vehicle weight of up to 120,000 pounds depending on their truck configuration.[^19] Fees collected through that permitting process are used by the Commission of Highways to match funds provided by coal companies and other parties for repairs and improvements to CRTS roads and bridges. Exact information on how much money the state collects and spends on industry-related transportation maintenance and repairs was not found in publicly available government sources.
 
 The West Virginia Office of Miners’ Health, Safety, and Training (WVOMHST) is the lead state agency for incidents involving coal mine emergencies. In 2013, the state agency’s expenditures totaled $15,346,893.[^20] Of that total, $12.8 million came from a general revenue fund, $2.2 million from industry fees, and the remainder from consolidated federal funds.[^21] The West Virginia Emergency Operations Plan sheds light on various WVOMHST tasks, including coordinating all rescue-related activities, maintaining the Mine and Industrial Accident Emergency Operations Center, and keeping the coal mine emergency contact list current.[^22] Publicly available government documents do not clarify how much Boone, Logan, and Mingo counties spend on coal mine-related emergency services.
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/campbell.md
+++ b/_case-studies/campbell.md
@@ -8,7 +8,7 @@ nav_items:
     title: Top
   - name: geology
     title: Geology and history
-  - name: produduction
+  - name: production
     title: Production
   - name: employment
     title: Employment
@@ -17,20 +17,20 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 Most of the coal consumed in the U.S. fuels the country’s electricity needs, and coal constitutes 39% of all electricity generated in the U.S.[^1] Wyoming leads domestic coal production, accounting for two-fifths of the nation’s output.[^2] More coal is extracted in Wyoming than in the next four largest-producing states combined, with nine of the nation’s ten largest mines located in the state.[^3] Campbell County, in the northeast corner of the state, supplies more coal for generating electricity than any other county in the nation.
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 Campbell County’s geographic position atop the Powder River Basin came with such plentiful coal deposits that early cattle ranchers in the area could dig their own coal.[^4] Significant mining operations in the region began in the early twentieth century with the Peerless and Wyodak Mines near the city of Gillette. Further coal development and the discovery of oil spurred population growth in the county throughout the decades that followed.
 
 Most Campbell County coal is sub-bituminous, meaning it contains 35% to 45% carbon. Although sub-bituminous coal has the second lowest energy content of the four main types of coal, it is often found in thick deposits near the surface, which results in lower mining costs.[^5] The low sulfur content of the coal in Campbell County deposits became an advantage in the market after the 1990 revision of the Clean Air Act, which required reduced sulfur emissions from coal-fired power plants.[^6] Today, the Powder River Basin is estimated to have 25 billion tons of economically recoverable coal resources.[^7]
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 In 2013, Campbell County produced 343 million tons of coal, accounting for 88% of the state’s total production.[^8] Wyoming coal mines operate largely on federal lands managed by the Bureau of Land Management under the U.S. Department of the Interior.[^9] In fact, Wyoming is the site of more coal mining on federal and Indian lands than any other state in the country, constituting 80% of the total coal production on federal and Indian lands in the fiscal year ending in 2014.[^10] [^11]
 
@@ -38,13 +38,13 @@ Production levels fluctuated between 2004 and 2013. For instance, 2013’s level
 
 <img src="{{ site.baseurl }}/img/counties/wy-production.png" alt="Campbell County Coal Production 2004–2013" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 The coal mining industry provides employment for 5,195 workers in Campbell County (out of a total population of 48,176), representing approximately 11% of county residents and 24% of total employment.[^13] The chart below shows the county employment trend in the broader mining industry from 2004 through 2013, including mining and mining-support activities.[^14]
 
 <img src="{{ site.baseurl }}/img/counties/wy-wage.png" alt="Campbell County Mining Industry vs. All Other Industries Wage and Salary Employment 2004–2013" class="case_studies_content-graph">
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 With $120 million in total government revenue for 2014, Campbell County is the most revenue rich county in Wyoming.[^15] [^16] [^17] Its wealth is largely due to the revenue brought in from coal extraction. In 2013, Campbell County valued its own coal production at $3.5 billion.[^18] The State of Wyoming applies a 7% severance tax on the value of extracted surface coal.[^19] Between 2011 and 2012, Wyoming collected $587 million in severance tax revenue from coal production.[^20]
 
@@ -54,13 +54,13 @@ Campbell County further generates coal-related revenue through a gross products 
 
 Local communities in Wyoming also benefit from federal mineral royalties and coal lease bonuses. Between 2011 and 2012, the state received $850 million in coal-related royalties and bonuses.[^25] This revenue helped fund public programs such as the state’s school foundation, highway fund, city budgets, and the University of Wyoming. The exact distribution formulas for these funds among the various public programs is outlined in the state’s Mineral Revenue Report.[^26]
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 Campbell County and the Wyoming Department of Transportation (DOT) published the Campbell County Coal Belt Transportation Study in 2010.[^27] The report documents recommendations for roadway network improvements in the near and long term, discusses coal industry impacts to the system, and identifies funding options. While Campbell County is expected to be the primary funding source for new transportation improvements, the study includes a wide variety of collaborative funding efforts, including the Bureau of Land Management’s Abandoned Mine Lands program funds, road impact fees, a sinking fund account, and direct state and federal appropriations.[^28] The study estimates that it would require $43.9 million in investment in county roads between 2010 and 2015 to support coal extraction.[^29]
 
 No publicly available government data discussing the emergency services, reclamation, or water-infrastructure costs of coal mining in Campbell County was found.
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/default.md
+++ b/_case-studies/default.md
@@ -19,13 +19,13 @@ nav_items:
 
 <p class="case_studies_intro-para">In some communities, extractive industries play a much larger role than in others. These narratives provide  snapshots into twelve communities that, over the last decade, have led in production of one of six resources: iron, copper, gold, coal, oil, and natural gas.</p>
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">Overview</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">Overview</a></h2>
 
 While extractive industries made up 2.6% of the U.S. GDP in 2013, they play a much larger role in some local communities. For example, extractive industries make up more than a third of Wyoming’s GDP.[^1] At the county level, certain communities and local economies may be even more dependent on extractive industries.
 
 This section includes 12 case studies that provide a snapshot of communities that have led the U.S. in producing oil, gas, coal, gold, iron, or copper over the last decade. These case studies shed light on the economic and fiscal effects of oil, gas, and mineral extraction on local communities, including revenue sustainability.
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue sustainability</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue sustainability</a></h2>
 
 Local governments and communities must consider the many ways natural resource management and extraction can affect their fiscal health. One of the most significant considerations is the sustainability of the revenues local governments receive due to natural resource extraction. Multiple EITI guiding principles reference revenue sustainability as a critical factor in making natural resource wealth &ldquo;an engine for sustainable economic growth.&rdquo;[^2] However, when it comes to managing this critical factor, there are two challenges localities need to address:
 
@@ -37,7 +37,7 @@ Local governments and communities must consider the many ways natural resource m
 
 These revenue sustainability considerations are magnified at the local level: A significant influx or loss of natural resource revenue can have a material impact, both positive and negative, on the quality and variety of services that a local government can provide its residents. Therefore, to achieve sustainable economic prosperity, local governments must consider how they can best use natural resource revenue to promote long-term growth and investment in their communities, and how to ensure that the financial benefits of extraction outweigh the costs in the short- and long-term.
 
-<h3 ><a name="county-revenue" class="case_studies_content-heading" data-nav-header="county-revenue">Revenue</a></h3>
+<h2 class="h3"><a name="county-revenue" class="case_studies_content-heading" data-nav-header="county-revenue">Revenue</a></h2>
 
 At the county level, revenue received from extractive activities takes many forms. For example, some payments originate from taxes on land ownership, while others are based on ownership of the natural resource itself. There are also different methods of valuation ranging from payments at the point-of-sale, to annual taxes, to those based on an estimated value of the natural resource. The four most common types of revenue examined include: property taxes, sales and use taxes, state transfer payments, and additional production taxes.
 
@@ -46,7 +46,7 @@ At the county level, revenue received from extractive activities takes many form
 * **State transfer payments.** Revenue transferred to the county by the state that comes from sources such as **severance taxes** paid by extractive industries to the state based on the volume or value of the resources extracted, and **lease payments**, such as bonuses, rents, and royalties, paid by extractive industries to a public land and mineral owner (either the federal government or the state).
 * **County production taxes.** Severance taxes or other payments paid by extractive industries to the county based on the volume or value of resources extracted, or per lease terms if the county is the landowner.
 
-<h3><a name="county-costs" class="case_studies_content-heading" data-nav-header="county-costs">Costs</a></h3>
+<h2 class="h3"><a name="county-costs" class="case_studies_content-heading" data-nav-header="county-costs">Costs</a></h2>
 
 More often than not, local governments must also make financial investments in their communities to support extractive industries. Costs vary based on the size of the community, the state of its current infrastructure, and the type of natural resources extracted. In some circumstances, these costs are outweighed by the influx of revenue, while in other cases costs can result in net negative fiscal effects on local governments.[^3] Given these possibilities and considerations, these case studies focus on four types of fiscal costs at the local level:
 
@@ -57,7 +57,7 @@ More often than not, local governments must also make financial investments in t
 
 There are additional fiscal benefits and burdens associated with extractive activities beyond those addressed here. For example, a local government may receive in-kind revenue from extractive industries, such as payment for a new public road that company employees will use to access work sites. Another fiscal cost might be additional government staff for managing public services that support extractive activities. While all are worthy of careful consideration by local communities and governments, these case studies focus on the revenue and costs defined above.
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data</a></h2>
 
 We used a range of information publicly available online to compile the case studies, including government databases, documents, and reports, as well as information produced by councils of governments. The case studies integrate data and analysis already reported elsewhere by government bodies. Local data sources were prioritized, and data was collected and presented at the most granular level available. We used state information when county information was not available.
 

--- a/_case-studies/default.md
+++ b/_case-studies/default.md
@@ -15,16 +15,6 @@ nav_items:
     title: Data
 ---
 
-<!-- <h3 class="case_studies_content-icon">
-  <i class="icon-oil"></i>
-  <i class="icon-gas"></i>
-  <i class="icon-coal"></i>
-  <i class="icon-gold"></i>
-  <i class="icon-copper"></i>
-  <i class="icon-iron"></i>
-  <a name="intro" class="case_studies_content-heading js-cs_section">Six commodities</a>
-</h3> -->
-
 <h1 class="case_studies_intro-heading">How do extractive industries impact communities like mine?</h1>
 
 <p class="case_studies_intro-para">In some communities, extractive industries play a much larger role than in others. These narratives provide  snapshots into twelve communities that, over the last decade, have led in production of one of six resources: iron, copper, gold, coal, oil, and natural gas.</p>

--- a/_case-studies/desoto.md
+++ b/_case-studies/desoto.md
@@ -17,18 +17,18 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 For years, natural gas production in the Haynesville Shale in the southern U.S. was too difficult and costly. However, in the mid- to late-2000s, advances in hydraulic fracturing and horizontal drilling techniques, as well as rising natural gas prices, made extracting natural gas in the region both technically feasible and profitable for the extractive industries.
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 The Haynesville sedimentary rock formation rests 10,000 feet to 13,000 feet below the surface of northwestern Louisiana, eastern Texas, and southwestern Arkansas. DeSoto Parish, home to 27,112 residents, sits at the center of the Haynesville Shale. In the early 2000s, DeSoto Parish’s economy consisted primarily of cattle and dairy farming, and forest extraction. However, DeSoto’s economy transformed when the Chesapeake Energy Corporation drilled the first exploratory well in the Haynesville Shale in 2007, setting off a natural gas boom in the parish in 2008.[^1]
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 From 2007 to 2011, natural gas production quadrupled in northern Louisiana, where DeSoto Parish is located.[^2] More recently, declining natural gas prices have resulted in lower production numbers. In 2013, northern Louisiana produced a total of 1,858,222,187 thousand cubic feet (or Mcf) of natural gas.[^3]
 
@@ -36,13 +36,13 @@ In 2013, the U.S. Energy Information Administration estimated that there were 16
 
 <img src="{{ site.baseurl }}/img/counties/la-production.png" alt="Northern Louisiana Natural Gas Production" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 Out of DeSoto’s nearly 28,000 residents, 548 people (about 2%) are employed in mining-support activities, which include oil and gas extraction.[^5] [^6] Of this group, 271 people are employed specifically in support activities for oil and gas extraction.[^7] Employment data for the complete oil and gas industry in the parish is unavailable. The chart below shows the increase in employment in broader extractive industries — specifically mining, quarrying, and oil and gas extraction — in DeSoto Parish between 2004 and 2013.[^8]
 
 <img src="{{ site.baseurl }}/img/counties/la-wage.png" alt="DeSoto Parish Mining, Quarrying, and Oil and Gas Extraction Industries vs. All Other Industries Wage and Salary Employment 2004–2013" class="case_studies_content-graph">
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 The Haynesville Shale natural gas boom has increased revenue for the State of Louisiana and DeSoto Parish through state severance taxes and royalties, parish property taxes, and sales and use taxes.
 
@@ -56,7 +56,7 @@ The DeSoto Parish School Board reports receiving the largest percentage of its a
 
 Property taxes also contribute substantially to the school board’s revenue, funding employee salaries, operations, and debt service payments on capital bonds for the local education system.[^20] The DeSoto Parish School Board estimated that 26.8% of the school budget would come from property taxes, and 49.1% would come from sales and use taxes in FY 2012–2013.[^21] State tax documents do not specify what percentage of property taxes comes from the gas industry.
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 Since 2008, Louisiana has invested $1.1 billion in transportation projects in the seven parishes located in the northwest region of the state, including DeSoto Parish.[^22] While Louisiana’s latest comprehensive state transportation plan acknowledges that the state must pay adequate attention to the transportation needs of the rapidly expanding oil and gas industry, it does not specify the types or costs of projects supported.[^23]
 
@@ -64,7 +64,7 @@ Louisiana completed a Hydraulic Fracturing State Review in March 2011, which exp
 
 The DeSoto Parish Emergency Medical Services (EMS) Department formed in 2001, funded by a four percent millage tax.[^25] Since then, the DeSoto EMS Department has worked closely with gas companies on safety measures, including answering numerous calls related to gas-well site incidents. The parish is not bearing the full burden of these incidents; the parish has received donations from private companies to offset equipment costs. The frequency and value of the donations is not published.
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/elko-and-eureka.md
+++ b/_case-studies/elko-and-eureka.md
@@ -17,20 +17,20 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 Gold is a precious mineral highly valued for its durability and beauty. Used to make jewelry and art, it also has technological uses, such as memory chip conductors and reflective satellite coverings. In 2013, the U.S. was the third-largest producer of gold, extracting 227 tons valued at $10.2 billion.[^1] The U.S. gold reserves, with an estimated size of 3,000 tons, are the fifth largest in the world.[^2] Nevada accounts for 74% of total U.S. gold production.[^3]
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 Mineral mining in Nevada began shortly after the onset of the California Gold Rush in 1849. The 1859 discovery of the Comstock Lode silver deposit in the Virginia Range of western Nevada was the first major discovery of silver ore in the country.[^4] All told, the Great Basin geological region, which covers most of Nevada and crosses into Oregon, Utah, and California, has a total resource potential that exceeds 3,200 metric tons (100,000,000 ounces) of gold.[^5]
 
 In 1962, Newmont Mining Corporation discovered large deposits of gold ore along the Carlin Trend, a mineral-rich belt stretching 40 miles across Elko and Eureka counties that soon became one of the largest gold-producing regions in the world. This discovery marked the beginning of a robust gold-mining industry in the region: As of 2012, 87% of Nevada’s total historical gold output had been generated since the Carlin Trend discovery.[^6]
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 Nevada is in the midst of the biggest gold boom in U.S. history, which began in 1981 and has produced over 240 million ounces, often from public lands. This surge in production is largely the result of discovering sediment-hosted deposits that contain microscopic gold particles.[^7] These deposits occur when gold is deposited quickly and disseminated into the surrounding rock.
 
@@ -38,15 +38,15 @@ The two major gold-mining companies driving this development are Newmont Mining 
 
 <img src="{{ site.baseurl }}/img/counties/nv-production.png" alt="Elko and Eureka Counties Gold Production 2008–2012" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 In these two counties, gold-mining operations employed approximately 10% of the total population in 2012, or 5,196 workers and 1,121 contractors within a two-county population of 52,957. Gold-mining employment represented 26% of total employment in the counties in 2012.[^10]
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 Gold mining is a key driver of funding for local governments across the state. In addition to various property and sales taxes, counties receive annual revenue from the gold industry, largely from the state’s Net Proceeds of Minerals Tax. This tax is considered to be an ad valorem property tax assessed on minerals produced in the state, applied at a rate of 5% on royalties and all other net proceeds exceeding $4 million. In 2012, Nevada counties received $117 million in revenue from the Net Proceeds of Minerals Tax.[^11] Of that, Elko and Eureka received $31 million to spend on public services and infrastructure.[^12]
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 A number of state-level resources shed light on Elko and Eureka counties’ transportation systems, reclamation procedures, and emergency services. While these government publications discuss costs to the state government, they do not specify the fiscal costs of gold extraction to Elko and Eureka county governments.
 
@@ -55,7 +55,7 @@ A number of state-level resources shed light on Elko and Eureka counties’ tran
 	<li><a href="http://ndep.nv.gov/bmrr/cost.htm">Nevada Bureau of Mining Regulation & Reclamation Cost Estimator</a></li>
 </ul>
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/greenlee.md
+++ b/_case-studies/greenlee.md
@@ -17,28 +17,28 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 Copper is a major industrial metal used in construction, electronics, transportation, industrial machinery, and consumer products. In 2012, the U.S. was the world’s fourth-largest copper producer, mining 1.15 million tons of copper worth a total value of approximately $9 billion.[^1] Of the five major copper-producing states (Arizona, Utah, New Mexico, Nevada, and Montana), Arizona was the most productive in 2011, with copper output totalling 751,000 metric tons, or 68% of the national total.[^2] Greenlee and Pima counties generated the majority of that production.
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 Greenlee County has a long history of copper mining dating back to the mineral’s discovery in the area during the 1870s. Initial recovery operations drew prospectors to the towns of Clifton, Morenci, and Metcalf, where underground mining methods targeted high-grade copper ores. In the 1920s, the Phelps Dodge Corporation (now Freeport-McMoRan Inc.) became the single owner of mining operations in the jurisdiction and discovered huge reserves of low-grade ores in the area. However, when the price of copper collapsed during the Great Depression, mining in the region temporarily halted between 1932 and 1937, until Phelps Dodge Corporation converted its underground mining operations to open-pit methods that could profitably harvest lower-grade ores.[^3] The modern Morenci Mine was thus established and has been a significant economic driver in the county ever since.
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 The largest-producing copper mine in North America is the privately owned Morenci Mine, located in Greenlee County. In 2012, the Morenci Mine produced 537 million pounds of recoverable copper.[^4] This amount reflects a 22% decrease in production from its output five years prior as a result of the 2008 global recession and associated price drop.[^5] [^6] However, production increased 19% between 2010 and 2011, reflecting a healthy rebound in production in conjunction with rising copper prices. Moreover, in 2012 the Morenci Mine maintained a total output capacity of 420,000 metric tons of copper-molybdenum ore — an amount greater than the combined output capacity of the next three largest copper mines in the state.[^7]
 
 <img src="{{ site.baseurl }}/img/counties/az-production.png" alt="Morencini Copper Production vs. Average Price from 2007-2012" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 Copper production employed 10,637 workers in Arizona in 2011, comprising less than 1% of statewide private-sector employment (out of 1,992,727 total workers).[^8] [^9] In Greenlee County, the ebbs and flows of employment mirror trends in the copper industry. County unemployment reached 18% in 2009 at the height of the recession before falling to around 7% in 2013, as global demand and prices stabilized.[^10] Freeport-McMoRan Inc. owns and operates Greenlee County’s Morenci Mine, after merging with Phelps Dodge Corporation in 2007, and serves as the key copper-mining employer. In 2011, mining activities in the county employed approximately 2,296 workers out of a population of 8,594.[^11]
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 State revenue from copper extraction is directed back to Greenlee County primarily through the state’s severance tax. Arizona levies this tax on metal minerals (including copper) set at 2.5% on 50% of the difference between the gross value of production and the production costs. While 47.6% of this revenue goes to the state’s General Fund, the other 52.4% is distributed to cities and counties.[^12]
 
@@ -46,11 +46,11 @@ Arizona also collects a Transaction Privilege Tax for the right to do business i
 
 In 2012, Greenlee County received $4,376,829 in transaction privilege and severance tax disbursements.[^14] In publicly available documents, the Arizona Department of Revenue reports this revenue as one sum, and does not specify what percentage of the tax stems from copper mining. Greenlee County also collected $2,763,245 in local property taxes levied for general purposes, public health services, and flood control (out of a total $17.1 million in county revenue) in 2012.[^15] While some portion of property taxes stems from copper mining, the percentage is not specified in publicly available data.
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 Copper mining activity is a key consideration in Greenlee County road planning.[^16] No additional publicly available government sources delineating specific fiscal costs of copper mining in Greenlee County were found.
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/humbolt-and-lander.md
+++ b/_case-studies/humbolt-and-lander.md
@@ -17,20 +17,20 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 Gold is a precious mineral highly valued for its durability and beauty. Used to make jewelry and art, it also has technological uses such as memory chip conductors and reflective satellite coverings. In 2013, the U.S. was the third largest producer of gold, extracting 227 tons valued at $10.2 billion.[^1] The U.S. gold reserves, with an estimated size of 3,000 tons, are the fifth largest in the world.[^2] The Great Basin, located primarily in Nevada, accounts for 74% of total U.S. gold production.[^3]
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 Mineral mining in Nevada began shortly after the onset of the California Gold Rush in 1849. The 1859 discovery of the Comstock Lode silver deposit in the Virginia Range of western Nevada was the first major discovery of silver ore in the country.[^4] All told, the Great Basin geological region, which covers most of Nevada and crosses into Oregon, Utah, and California, has a total resource potential that exceeds 3,200 metric tons (100,000,000 ounces) of gold.[^5]
 
 The major gold mines in Humboldt and Lander counties represent more recent production operations. The counties’ two largest mines, the Twin Creeks Mine in Humboldt and the Pipeline/Cortez Hills Mine in Lander, did not start producing gold until the early 1990s. These mines are now two of the largest gold producers in the state.
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 Nevada is currently experiencing the biggest gold boom in U.S. history, which began in 1981 and has produced over 240 million ounces, often from public lands.[^6] This surge in production is largely the result of discovering deposits that contain microscopic gold particles.[^7] These deposits occur when gold is deposited quickly and disseminated into the surrounding rock.
 
@@ -38,15 +38,15 @@ The two major gold-mining companies behind this development are Newmont Mining C
 
 <img src="{{ site.baseurl }}/img/counties/nv-humboldt-production.png" alt="Humboldt and Lander Counties Gold Production from 2008–2012" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 In 2012, gold extraction provided jobs for 3,704 workers and 2,156 contractors, which represented 25% of the entire county population of 22,981, and 58% of total employment in the two counties.[^10] [^11]
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 Gold-mining serves as a key driver of funding for local governments across the state. In addition to various property and sales taxes, counties receive annual revenue from the gold industry, largely from the state’s Net Proceeds of Minerals Tax. This tax is considered to be an ad valorem property tax assessed on minerals produced in the state, applied at a rate of 5% on royalties and all other net proceeds exceeding $4 million. In FY 2012, Nevada counties received $117 million in revenue from minerals taxes.[^12] [^13] Of that total, $71 million went to these two counties.[^14]
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 A number of state-level resources, which are listed below, shed light on Humboldt and Lander County transportation systems, reclamation procedures, and emergency services. While these government publications discuss costs to the state government, they do not specify the fiscal costs of gold extraction to Humboldt and Lander county governments.
 
@@ -55,7 +55,7 @@ A number of state-level resources, which are listed below, shed light on Humbold
 	<li><a href="http://ndep.nv.gov/bmrr/cost.htm">Nevada Bureau of Mining Regulation & Reclamation Cost Estimator</a></li>
 </ul>
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/kern.md
+++ b/_case-studies/kern.md
@@ -17,20 +17,20 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 Kern County is situated in the southernmost region of the San Joaquin Valley, in California’s interior. While Kern County has significant deposits of many resources — including natural gas, geothermal steam, wind, gold, and other minerals — oil in particular has shaped Kern County’s local economy for over a century.
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 Companies began extracting oil at a commercial level in California in the 1850s, inspired by the oil rush in Pennsylvania and a growing market for oil-fueled lighting. In the 1860s, production began in Kern County, where extractors dug holes into oil seeps to remove the fuel. Near the turn of the century, extraction in the county shifted toward commercial drilling, in part because of the 1890 discovery of the Midway-Sunset field, which is still the largest-producing oil field in California today.[^1]
 
 During the beginning of the twentieth century, many other large oil discoveries occurred in Kern County, and continued at a lesser pace through the 1970s. As discoveries of new fields ended in the 1970s, refined steam-injection techniques helped producers extract the substantial heavy oil — a more difficult and costly type of oil to extract and transport — from known Kern County fields.[^2]
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 In terms of oil production, Kern County has long been a leader both nationally and within California. Kern County produced 141,040,000 oil barrels (bbls) in 2013.[^3] In 2012, the largest-producing oil fields in the state were privately owned oil fields in Kern County, including the Midway-Sunset field (29.3 m bbls), the Kern River Field (26.2 m bbls), and the Belridge South Field (23.6 m bbls).[^4] As of 2009, the two top oil-producing companies in California, excluding offshore production, were Chevron Corporation and Aera Energy LLC, both of which have operations in Kern County.[^5]
 
@@ -38,13 +38,13 @@ Since peaking in 1985, California’s oil production has trended downward; Kern 
 
 <img src="{{ site.baseurl }}/img/counties/ca-production.png" alt="Kern County Oil Production from 2004–2013" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 In 2013, oil and gas extraction employed over 10,000 of Kern County’s 865,923 residents, or between 1% to 2% of the population and 3.3% of total employment.[^8] [^9] In particular, 3,309 people were employed in oil and gas extraction, and 8,039 in support activities (1,748 in drilling for oil and gas, and 6,289 in support activities for oil and gas operations).[^10] Although oil production in the county has decreased, oil and gas industry employment increased from 2010 to 2013, because of the introduction of hydraulic fracturing methods used to extract natural gas.
 
 <img src="{{ site.baseurl }}/img/counties/ca-wage.png" alt="Kern County Oil and Gas Industry vs. All Other Industries Wage and Salary Employment from 2004–2013" class="case_studies_content-graph">
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 California does not levy a statewide severance tax on oil and gas production, but counties in the state collect ad valorem or property taxes on oil and gas resources and equipment owned in their jurisdictions. The state does levy an annual assessment on oil and gas production to fund the Department of Conservation’s Oil, Gas, and Geothermal Resources Division. The division oversees the drilling, operation, maintenance, and plugging and abandonment of oil, natural gas, and geothermal wells.[^11]
 
@@ -52,7 +52,7 @@ Like other counties in the state, Kern County collects property taxes for oil an
 
 According to the Kern County Treasurer-Tax Collector, the top payer of property taxes in the county in FY 2014–2015 was Chevron Corporation. The company received a bill for more than $90 million in taxes, or 9.39% of the county’s $964 million in total property taxes owed. All of the top ten property tax payers were associated with either the extractive or energy sectors, and they received bills for a combined $323 million, or 33.5% of total property taxes due to the county.[^14]
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 A number of resources shed light on Kern County’s transportation systems, water infrastructure, reclamation procedures, and emergency services. However, these government publications do not explicitly discuss the fiscal costs of oil extraction to the Kern County government.
 
@@ -63,7 +63,7 @@ A number of resources shed light on Kern County’s transportation systems, wate
 	<li><a href="http://www.co.kern.ca.us/CAO/policy/16.pdf">Kern County Policy and Administrative Procedures Manual: Emergency Preparedness (PDF)</a></li>
 </ul>
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/marquette.md
+++ b/_case-studies/marquette.md
@@ -17,20 +17,20 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 Iron ore is the primary mineral substance for the world’s iron and steel industries. Michigan is the second-largest producer of iron ore in the country behind Minnesota. All of Michigan’s iron-production operations are located in the northern reaches of the state, in Marquette County.
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 Marquette County generated 20% of the national iron output in 2012.[^1] This iron ore is located in the Marquette Iron Range, a narrow basin of iron formations running approximately 33 miles through the towns of Negaunee and Ishpeming. Discovered in 1844, this range houses Michigan’s oldest iron-mining operations; the Jackson Mining Company began extraction here in 1848. In the following decades, the development of critical infrastructure — including roads, railroads, and a canal connecting Lake Superior and Lake Huron — spurred additional mining activity. It was iron mining that originally drew settlers to the area.
 
 Although increased production costs and a diversified global supply of iron drove down output in the first half of the twentieth century, the development of new technology in the 1950s made it economically feasible to produce lower-grade taconite, which increased output.[^2]
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 Today’s iron mining along the Marquette Iron Range is centered on the Empire and Tilden Mines, operated by Cliffs Natural Resources Inc. In 2012, these two mines generated a combined 10.8 million metric tons of usable iron ore, which produced a total of 6.6 million metric tons of iron.[^3] Marquette County’s usable iron ore output had remained relatively constant over the preceding ten years, averaging 12 million metric tons out of a total annual capacity of 13 million metric tons.[^4] As shown in the chart below, the 2009 economic crisis drove down iron-ore production, but it rebounded the following year.
 
@@ -38,19 +38,19 @@ Major corporate landowners own a significant portion of the land used for natura
 
 <img src="{{ site.baseurl }}/img/counties/mi-production.png" alt="Marquette County Crude vs. Usable Iron Production from 2003–2012" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 According to the Bureau of Labor Statistics (BLS), total private sector employment in Marquette County stood at 27,195 in 2012.[^6] The iron-mining industry employed 1,500 individuals (6% of total employment). Iron-ore reserve estimates project a thirty-year supply at Tilden Mine, suggesting continued employment opportunities for the near future.[^7] Empire Mine production, on the other hand, was slated to halt in 2014 until a partnership agreement with ArcelorMittal USA Inc. extended the mine’s operations (and employment potential) through 2016.[^8]
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 The State of Michigan assesses mining operations under the same state and local taxes as other commercial ventures in the state (for example, sales, use, and property taxes). However, the state does collect a specific tax on low-grade iron ore at a rate of 1.1% of the value per gross ton produced.[^9] In 2013, Marquette County collected $3,049,250 from that tax, comprising 12.8% of the total $23,834,433 General Fund operating budget for that year.[^10] The low-grade iron ore tax revenue constituted an increase of $767,000 from 2012.[^11] These funds supported public services, such as law enforcement, health care, childcare, aging services, and the county’s international airport.[^12]
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 Public sources specifying the fiscal costs of iron-ore mining in Marquette County were not found.
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/north-slope.md
+++ b/_case-studies/north-slope.md
@@ -17,31 +17,31 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 The U.S. has experienced rapid change in domestic oil production since 2008, when crude oil production reached a low of 3.98 million bbl/day.[^1] Just five years later, the U.S. had nearly doubled its daily production output, with Texas and North Dakota driving much of the growth.[^2] [^3] Alaska did not experience the same production boom, with crude oil output steadily declining over the past decade.[^4] In spite of that downward trend, Alaska remained  the fourth largest state producer of crude oil in 2013, and the nation’s largest oil-producing county is Alaska’s North Slope Borough.[^5]
 
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 The North Slope Borough is the country’s largest organized local jurisdiction, spanning more than 94,000 miles north of the Arctic Circle. Its 9,686 residents, most of whom are Inupiat Alaskan Natives, are spread across eight separate communities.[^6] The northern coast of Alaska was documented as a potential oil-producing region as early as 1900. However, the borough’s government was not formally incorporated until 1972, soon after the discovery of oil at Prudhoe Bay, the largest single oil field in North America.[^7]
 
 Oil production increased dramatically in 1977 with the opening of the Alaska Pipeline, which provided an economically viable way to transport large amounts of crude oil from the North Slope to market. In 1994, ARCO identified another significant deposit at the Alpine Field, located on state land east of the Colville River and extending into the federally administered National Petroleum Reserve of Alaska. The North Slope’s Prudhoe Bay, Alpine Field, and Kuparuk River constitute the majority of the state of Alaska’s oil production. Today, the borough’s oil reserve base is extensive, with approximately six billion barrels of proved oil.[^8]
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 In 2013, the North Slope Borough produced 182.5 million bbl of oil on both state-owned and federal land.[^9] Since production at Prudhoe Bay commenced, all of the North Slope’s extraction has taken place in the northern portion of the Colville-Canning province, administered by either the Alaska Department of Natural Resources or the Bureau of Land Management. While three major companies account for most production, North Slope exploration and extraction has diversified, with 63 current lease holders from seven countries.[^10] Annual oil production in the borough peaked in 1988 (at 722 million bbl) and has steadily declined since.[^11]
 
 <img src="{{ site.baseurl }}/img/counties/ak-production.png" alt="Oil Production in North Slope" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 The oil industry is a key driver of jobs throughout the borough. In 2013, oil and gas extraction provided 1,768 jobs on the North Slope, accounting for 12.5% of total employment (14,199).[^12] [^13] The North Slope Borough’s population is less than 10,000, so many private jobs are filled by nonresidents. In 2013, nonresidents accounted for 33.6% of oil industry workers in Alaska, up from 31.6% in 2012.[^14] The North Slope Borough government itself remains the largest employer of local residents, along with the Arctic Slope Regional Corporation, school district, and local Native corporations.[^15]
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenues</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenues</a></h3>
 
 Given the North Slope’s relative geographic isolation, oil revenue is critical for supporting local schools, health centers, fire stations, water and sanitation facilities, and infrastructure. In 2013, the North Slope government received $470 million in revenue. Of that revenue, the borough received $332 million from local property taxes, 98% of which was levied on oil- and gas-related properties.[^16]
 
@@ -54,7 +54,7 @@ At the state level, the Alaska government collects oil-related revenue for the b
 
 Alaskan residents also receive annual dividend payments from the state’s Permanent Fund, based on a five-year average of the fund’s performance. The state established the Permanent Fund in 1976, as construction of the Alaska Pipeline concluded. Twenty-five percent of revenue from mineral leases on state-owned lands and from federal mineral revenue-sharing payments go into the Permanent Fund for investment. In 2013 each Alaskan resident received $900 as a result of this payout.[^19]
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 Oil extraction also incurs certain fiscal costs. Oil exploration and development on the North Slope require infrastructure, including airports, docks, pads and roads, ports, production-related facilities, pipelines, and gravel islands.[^20] The North Slope Borough is responsible for maintaining approximately 100 miles of roads, as well as boat ramps, boat landings, port facilities, nine public airports, and thousands of miles of winter trails and roads.[^21]
 
@@ -66,7 +66,7 @@ The state also spends public dollars on reclamation services, including managing
 
 The North Slope Borough often responds to, and pays for, emergency services on oilfield roads, such as Kuparuk Oilfield roads.[^27] The Alaska state government also invests a significant amount of tax dollars to prevent and respond to oil and hazardous substance emergencies in the state. For example, the Office of Management and Budget appropriated $750,000 toward oil and hazardous substance first-responder equipment and preparedness in 2013.[^28]
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publically available data.
 

--- a/_case-studies/pima.md
+++ b/_case-studies/pima.md
@@ -17,28 +17,28 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 Copper is a major industrial metal used in construction, electronics, transportation, industrial machinery, and consumer products. In 2012, the U.S. was the world’s fourth-largest copper producer, mining 1.15 million tons of copper worth approximately $9 billion.[^1] Of the five major copper-producing states (Arizona, Utah, New Mexico, Nevada, and Montana), Arizona was the most productive in 2011; its copper output totaled 751,000 metric tons, representing 68% of the national total.[^2] Greenlee and Pima counties generated the majority of that production.
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 In Pima County, much like nearby Greenlee County, copper mining began in the 1870s. Mining activity in Pima County flourished in the late nineteeth century, particularly as the arrival of the Southern Pacific Railroad brought increased commerce and traffic to the region. The copper-mining industry followed a series of boom-and-bust cycles throughout the following decades, with particular spikes during the two world wars, when demand soared. Today, copper output in Pima County is driven by operations at three open-pit mines: Sierrita, Mission Complex, and Silver Bell.
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 In 2012, the combined copper production from Pima County’s three major mines totaled 152,700 metric tons.[^3] [^4] [^5] This output constituted 13% of national production for that year.[^6] Freeport-McMoRan Inc. manages the Sierrita mine, the top-producing operation in the county, while ASARCO LLC owns both the Mission Complex and Silver Bell mines.[^7]
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 Copper mining makes up a relatively small portion of Pima County’s overall employment, largely as a result of the Tucson metropolitan area’s more diversified economy and workforce. Of Pima County’s total 2012 employment of 346,828, copper mining and related activities account for less than 1% (1,745 workers).[^8] The county cites a 58% growth in employment in this sector compared to 2004 levels.[^9] Data for mining and support activities for the entire mining industry shows an overall increase in employment in Pima County from 2004 through 2013.[^10] [^11]
 
 <img src="{{ site.baseurl }}/img/counties/az-wage.png" alt="Mining Industry vs. All Other Industries Wage and Salary Pima County Employment from 2004–2013" class="case_studies_content-graph">
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 State revenue from copper extraction is directed back to Pima County primarily through the state’s severance tax. Arizona levies this tax on metal minerals (including copper) set at 2.5% on 50% of the difference between the gross value of production and the production costs. While 47.6% of this revenue goes to the state’s General Fund, the other 52.4% is distributed to cities and counties.[^12] In 2013, $21 million was distributed to all cities and counties in Arizona from the severance tax on metals.[^13] Arizona also collects a Transaction Privilege Tax, although this tax does not apply to copper revenue.[^14]
 
@@ -46,11 +46,11 @@ Pima County derives revenue from copper mining within its borders. However, in o
 
 ASARCO LLC also pays royalties to both the State of Arizona and the Tohono O’odham Nation as part of the leasing agreement to operate the Mission Mine, which is located on both state-owned and Indian land.
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 Publically available government sources specifying the fiscal costs of copper mining in Pima County were not found.
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/st-louis.md
+++ b/_case-studies/st-louis.md
@@ -17,18 +17,18 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 Iron ore is the primary mineral substance for the world's iron and steel industries. The U.S. is estimated to possess iron ore reserves of 110 billion tons, which can produce approximately 27 billion tons of metallic iron. In 2013, the U.S. was the world’s eighth-largest producer of iron ore, generating an output of 53 million metric tons. More than three-fourths of that output came from iron mines located in a single area of Minnesota: St. Louis County.[^1]
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 All iron mining in St. Louis County takes place along the Mesabi Iron Range. The Mesabi Range is a narrow, 120-mile-long iron deposit stretching from Babbitt to Grand Rapids that has shaped the economic development of the region throughout the past century. Iron ore was first discovered in the Mesabi Range in 1866; extractive operations began in the 1890s, and focused on exploiting the rich reserves of high-grade natural ore that could be easily processed into steel. After extracting approximately 2.5 billion tons of this natural ore, the industry had largely exhausted the supply by the 1950s, and companies began mining a lower-grade iron ore alternative: taconite. Taconite mining targets chert-magnetite ores that are processed and upgraded into higher-grade iron pellets to feed steel mill blast furnaces. To date, the industry has produced approximately 1.6 billion tons of these iron pellets from Mesabi Range ore.[^2]
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 In 2012, St. Louis County's eight iron mines produced 41.7 million metric tons of ore. Production rates were relatively constant throughout the preceding ten years, averaging 37.8 million metric tons with a compound annual growth rate of 2%.[^3] [^4] As shown in the chart, iron production in St. Louis County drives the majority of national iron production. The abnormally low production rate in 2009 was broadly the result of the global economic recession and weak demand from Chinese steel mills.
 
@@ -36,11 +36,11 @@ In Minnesota, the state government is the largest owner of mineral rights. It ow
 
 <img src="{{ site.baseurl }}/img/counties/mn-production.png" alt="Iron Ore Production from 2003 - 2012" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 The iron industry employs thousands of people in St. Louis County. The three major companies that operate the county’s iron mines and processing facilities are Cliffs Natural Resources, ArcelorMittal USA Inc., and the United States Steel Corporation. The eight mines in St. Louis County operated by these and other companies provided 3,970 jobs in 2012, comprising 4% of the county’s total 93,615 employment.[^7] [^8]
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 Annually, the iron ore industry in Minnesota takes in more than $3 billion in sales revenue.[^9] Various state and county tax mechanisms funnel a portion of these dollars back into the counties. The Taconite Production Tax, which is levied on concentrates or pellets produced by taconite companies, is the largest tax paid by the mining industry in Minnesota. Counties receive 26.05 cents per ton of iron ore from the Taconite Production Tax; in 2012, this amounted to $11.6 million for St. Louis County out of the $102 million collected from this tax across the state.[^10]
 
@@ -48,7 +48,7 @@ The production tax is distributed to a variety of recipients for public use, inc
 
 St. Louis County also collects revenue from various ad valorem and property taxes, including the tax on unmined taconite ($265,107 in 2013) and the ad valorem tax on taconite railroads ($2,981 in 2013).[^12] Taken together with the Taconite Production Tax, this revenue is important for the county’s schools, infrastructure, and public services.
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 Mining operations in Minnesota rely heavily on the state’s multimodal transportation system, which includes trucks, trains, ports, and barges: for instance, taconite makes up more than half the tonnage moved by rail across the state. However, keeping the railroads running requires significant financial investment. The Minnesota Department of Transportation (DOT) projects that it will need between $125 million and $433 million from Minnesota state and local governments throughout the next 20 years to fulfill the freight-rail-improvement component of its State Rail Plan.[^14] The state does not itemize how much of that money, if any, is specified for rail improvements that support the mining industry.
 
@@ -56,7 +56,7 @@ The Port of Duluth/Superior is the busiest port on the Great Lakes, and handles 
 
 In Minnesota, the Department of Natural Resources (DNR) has the authority to regulate the reclamation of lands subject to metallic mining operations. The finances for any publicly funded reclamation activities come from a variety of sources, including the General Fund, annual fees directly from the permit holders, application and supplemental fees for permits, and industry and other governmental agencies.[^17] In FY 2012–2013, the Minnesota DNR Resources Land and Minerals Program spent $4.4 million, or 6% of its budget, on mine land reclamation.[^18] Generally, the mining-operation permit holder bears the cost of reclamation, except in cases in which the mine is abandoned and there is no party under legal obligation to reclaim the site, or the mine operator is fiscally insolvent.
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/tarrant-and-johnson.md
+++ b/_case-studies/tarrant-and-johnson.md
@@ -17,32 +17,32 @@ nav_items:
   - name: costs
     title: Costs
   - name: data
-    title: Data availablity
+    title: Data
 ---
 
-<h3><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
+<h2 class="h3"><a name="intro" class="case_studies_content-heading" data-nav-header="intro">{{ page.title }}</a></h3>
 
 Texas leads the country in natural gas production, generating more gas annually than the next three highest-producing states combined (Louisiana, Oklahoma, and Wyoming).[^1] Tarrant and Johnson counties contribute significantly to Texas’s natural gas production due to their geographic positioning atop the rich reserves of the Barnett Shale field in the Bend Arch-Fort Worth Basin.
 
-<h3><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
+<h2 class="h3"><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h3>
 
 The Barnett Shale reserve spans approximately 5,000 square miles of sedimentary clay and quartz rock, with much of the productive portion of the rock located beneath Tarrant and Johnson counties. With an estimated 43 trillion cubic feet of proved reserves of natural gas, the Barnett Shale is one of the largest onshore natural gas formations in the country.[^2]
 
 For many years, the Barnett Shale acted as an important sealing cap rock for conventional oil and gas development, but was not regarded as a legitimate source for economically viable drilling. However, technological advances in the 1980s allowed Mitchell Energy to drill its first well, and drilling activity increased with rising gas prices in the 1990s. Specifically, horizontal drilling and hydraulic fracturing techniques allowed producers to access more natural gas from relatively thin shale deposits. The number of horizontal wells in the Barnett Shale grew from approximately 400 in 2004 to 10,860 in 2011.[^3] [^4]
 
-<h3><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h3>
+<h2 class="h3"><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
 
 In 2013, Tarrant and Johnson counties produced a combined 1.16 trillion cubic feet of natural gas from state-owned lands, constituting a significant portion of Texas’s total 7.73 trillion cubic feet output.[^5] [^6] [^7] Almost all other drilling in the state occurs on private lands, as only 1.8% of the acreage in Texas is federal land.[^8] The 2013 output was particularly remarkable given that only ten years prior, the two counties were producing just 7% of this amount.[^9] [^10] However, production began to drop in 2013 with falling natural gas prices and strong global supplies.
 
 <img src="{{ site.baseurl }}/img/counties/tx-production.png" alt="Tarrant and Johnson Counties Natural Gas Production on State-Owned Lands 2004 – 2013" class="case_studies_content-graph">
 
-<h3><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h3>
+<h2 class="h3"><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
 
 The boom in natural gas production in the Barnett Shale over the past decade increased employment in this sector. Based on data from the U.S. Census Bureau, the number of residents employed in the oil and gas industries has more than quadrupled in the past decade.[^11] In 2013, the oil and gas industry (including extraction, drilling, and support services) employed an estimated 7,371 residents, or less than 1% of the two counties’ total employment of 849,624 and less than 0.01% of the two counties’ total population of 2.07 million.[^12]
 
 <img src="{{ site.baseurl }}/img/counties/tx-employment.png" alt="Tarrant and Johnson Counties Oil and Gas Industry Employment Trend 2004 - 2013" class="case_studies_content-graph">
 
-<h3><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h3>
+<h2 class="h3"><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
 
 The State of Texas levies a Natural Gas Production Tax at 7.5% of the market value of the gas, but with the various allowable exemptions and reductions, the effective tax rate hovers below 2%.[^13] In 2013, the state government collected $1.5 billion from this tax, earmarking 25% for investment in the Permanent School Fund (PSF), and directing the rest to the state’s Economic Stabilization Fund.[^14] The interest earned on the PSF investments is distributed by the State Board of Education to every school district on a per-pupil basis.[^15]
 
@@ -50,7 +50,7 @@ The state also collects royalties from the natural gas produced on state-owned l
 
 Tarrant and Johnson counties derive additional revenue from extractive industries through local property and mineral taxes. In Tarrant County, thousands of homeowners own very small interests in gas units located under large residential developments.[^17] The value of all real property in a given county is assessed by the County Appraisal District, and property taxes are levied based on applicable mill rates for the locality. Property tax revenue for Tarrant and Johnson counties from all sources, not just natural gas property, totaled $367 million in 2013, which constituted a 48% increase from 2004. In its 2012 annual report, the Tarrant County Auditor’s Office cited the development of Barnett Shale gas resources as a factor in providing significant employment and business opportunities, which helped to offset the reduction in other property values and provided additional taxable value.[^18] [^19]
 
-<h3><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h3>
+<h2 class="h3"><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
 
 Texas leaves the siting and permitting for natural gas development to its municipalities, and while benefits accrue to these communities, extraction does come with costs. During well construction and drilling, heavy truck traffic causes wear on roads and bridges that can significantly reduce their service life. This problem is particularly pronounced on roadways that were not originally designed to support industrial traffic. According to the Texas Department of Transportation (DOT), the volume of truck traffic required to bring one gas well into production is equivalent to the impact of approximately eight million cars; truck traffic required to maintain that well is equivalent to another two million cars. Constructing such a well reduces highway service life by as much as 53%.[^20]
 
@@ -58,7 +58,7 @@ In its 2012 State Water Report, the Texas Water Development Board recommended $4
 
 The Texas Railroad Commission requires operators to remove water from extraction pits and refill them with sediment within set time frames, as well as completing the appropriate paperwork for any dry or inactive wells that will remain offline for more than a year.[^23] However, in cases where operators do not comply, Texas relies on its Oil and Gas Regulation Cleanup Fund to reclaim oil and gas wells.[^24] In FY 2013, the fund paid $54,263,532 for well plugging, site reclamation, monitoring and inspections, oil and gas permitting, and administration, and set aside an additional $22,277,506 in encumbrances for these activities.[^25] [^26] A combination of industry permitting fees, production taxes, enforcement penalties, reimbursements, proceeds from the sale of salvaged equipment and hydrocarbons, and federal money from the Coastal Impact Assistance Program finance the fund.[^27]
 
-<h3><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h3>
+<h2 class="h3"><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_downloads/default.md
+++ b/_downloads/default.md
@@ -30,9 +30,9 @@ permalink: /downloads/
         </a>
         <a href="{{site.baseurl}}/downloads/federal_revenue_onshore_acct-year_FY04-14_2015-11-20.xlsx" class="button-tertiary">
           <icon class="icon-cloud icon-padded"></icon>Download onshore dataset, FY (xlsx, 1.1 MB)
-        </a>
-        <a href="#" class="button-tertiary">
-          <i class="fa fa-file-text-o u-padding-right"></i>Documentation coming soon
+        </a><br>
+        <a href="/downloads/federal-revenue-by-location/" class="button-tertiary">
+          <i class="fa fa-file-text-o u-padding-right"></i>Documentation
         </a>
       </li>
 
@@ -54,7 +54,7 @@ permalink: /downloads/
           <icon class="icon-cloud icon-padded"></icon>Download full dataset, docs included (xlsx, 39 KB)
         </a>
         <a href="{{site.baseurl}}/downloads/reconciliation/" class="button-tertiary">
-          <icon class="icon-cloud icon-padded"></icon>Documentation
+          <icon class="fa fa-file-text-o u-padding-right"></icon>Documentation
         </a>
       </li>
 

--- a/_downloads/default.md
+++ b/_downloads/default.md
@@ -7,39 +7,17 @@ permalink: /downloads/
 
 <div class="container-outer container-padded">
 
-  <article class="container-left-7">
+  <article class="container-left-7 downloads">
 
     <h1>Download Data & Documentation</h1>
 
-    <p class="case_studies_intro-para">We use many government datasets on this site to power our <a href="{{ site.baseurl }}/explore/">interactive visualizations</a>. Some of these were created through the USEITI process, and are available here for download. Others come from other government sources. For those, we provide links direct to the source here so you can find fresh data whenever you need it. You can also read the USEITI web team’s <a href="https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#federal-revenue">data notes</a>. We can’t wait to see what you do with the data!</p>
+    <p class="case_studies_intro-para">We use many government datasets on this site to power our <a href="{{ site.baseurl }}/explore/">interactive visualizations</a>. Some of these were created through the USEITI process, and are available here for download. Others come from other government sources. For those, we provide links direct to the source here so you can find fresh data whenever you need it. You can also read the USEITI web team’s <a href="https://github.com/18F/doi-extractives-data/wiki/Data-Catalog#federal-revenue">data notes</a>.</p>
 
-    <h3>Production</h3>
+    <h2 class="h3 downloads-section_heading">Revenue</h2>
+
     <ul class="list-sections">
     	<li>
-        <a id="production-all" class="link-no_under"><h4>All lands and waters</h4></a>
-        <p>This data is from the <a href="http://www.eia.gov/">Energy Information Agency</a>. The specific data we used for the interactions is a subset of the huge amount of data available on their website. <em>Tip: to find data on the EIA site, click 'Sources & Uses' in the navigation near the top of the site.</em></p>
-        <a href="http://www.eia.gov/" class="button-tertiary">
-          Go to EIA &#8594;
-        </a>
-      </li>
-
-      <li>
-        <a id="production-fed" class="link-no_under"><h4>Federal lands and waters</h4></a>
-        <p>Commodity volumes of natural resources extracted from federal land and waters. This dataset is from the <a href="http://www.onrr.gov/">Office of Natural Resources Revenue</a> (ONRR), which is part of the Department of the Interior. This is the first year ONRR has produced this dataset.</p>
-        <a href="{{site.baseurl}}/downloads/production_federal_lands_waters_CY2013_oil_gas_solids-2015-11-25.xlsx" class="button-tertiary">
-          <icon class="icon-cloud icon-padded"></icon>Download full dataset (xlsx, 517 KB)
-        </a>
-        <a href="{{site.baseurl}}/downloads/federal-production/" class="button-tertiary">
-          <i class="fa fa-file-text-o u-padding-right"></i>Documentation
-        </a>
-      </li>
-
-    </ul>
-
-    <h3>Revenue</h3>
-    <ul class="list-sections">
-    	<li>
-        <a id="revenue-fed-location" class="link-no_under"><h4>Federal revenue by location</h4></a>
+        <a id="revenue-fed-location" class="link-no_under"><h3>Federal revenue by location</h3></a>
         <p>Federal revenue from natural resources extracted from federal land and waters by location. This dataset is from the <a href="http://www.onrr.gov/">Office of Natural Resources Revenue</a>, which is part of the Department of the Interior. It is separated into onshore and offshore data, and is available by calendar year (CY) and fiscal year (FY).</p>
         <a href="{{site.baseurl}}/downloads/federal_revenue_offshore_acct-year_CY04-13_2015-11-20.xlsx" class="button-tertiary">
           <icon class="icon-cloud icon-padded"></icon>Download offshore dataset, CY (xlsx, 321 KB)
@@ -59,7 +37,7 @@ permalink: /downloads/
       </li>
 
       <li>
-        <a id="revenue-fed-company" class="link-no_under"><h4>Federal revenue by company</h4></a>
+        <a id="revenue-fed-company" class="link-no_under"><h3>Federal revenue by company</h3></a>
         <p>Federal revenue from natural resources extracted from federal land and waters by company. This dataset is from the <a href="http://www.onrr.gov/">Office of Natural Resources Revenue</a>, which is part of the Department of the Interior.</p>
         <a href="{{site.baseurl}}/downloads/federal_revenue_by_company_CY2013_2015-11-10.xlsx" class="button-tertiary">
           <icon class="icon-cloud icon-padded"></icon>Download full dataset (xlsx, 132 KB)
@@ -70,7 +48,7 @@ permalink: /downloads/
       </li>
 
       <li>
-        <a id="reconciliation" class="link-no_under"><h4> Reconciliation</h4></a>
+        <a id="reconciliation" class="link-no_under"><h3> Reconciliation</h3></a>
         <p>Countries implementing the EITI Standard publish reports that disclose the revenues and other information from extraction of the country’s natural resources. Companies report payments to the government (e.g., rents, taxes, royalties) and the government reports what it received. These figures are compiled and reconciled by an independent administrator and published. The 2015 USEITI reconciliation is below.</p>
         <a href="{{site.baseurl}}/downloads/reconciliation_2015-11-20.xlsx" class="button-tertiary">
           <icon class="icon-cloud icon-padded"></icon>Download full dataset, docs included (xlsx, 39 KB)
@@ -81,7 +59,7 @@ permalink: /downloads/
       </li>
 
       <li>
-        <a id="tax" class="link-no_under"><h4>Corporate income tax</h4></a>
+        <a id="tax" class="link-no_under"><h3>Corporate income tax</h3></a>
         <p>The IRS Statistics of Income program publishes data on the <a href="https://www.irs.gov/uac/Tax-Stats-2">Tax Statistics</a> website. Information on corporate income tax liability is located under <a href="https://www.irs.gov/uac/SOI-Tax-Stats-Corporation-Tax-Statistics">Corporation Tax Statistics</a>. Tax data for <a href="https://www.irs.gov/uac/SOI-Tax-Stats-S-Corporation-Statistics">S-corporations</a> is aggregated separately.</p>
         <a href="https://www.irs.gov/uac/Tax-Stats-2" class="button-tertiary">
           Go to IRS &#8594;
@@ -89,7 +67,7 @@ permalink: /downloads/
       </li>
 
       <li>
-        <a id="disbursements" class="link-no_under"><h4>Disbursements</h4></a>
+        <a id="disbursements" class="link-no_under"><h3>Disbursements</h3></a>
         <p>The amount of money earned from extraction of natural resources on federal lands that is disbursed to various legislated funds. This dataset is from the <a href="http://www.onrr.gov/">Office of Natural Resources Revenue</a>, which is part of the Department of the Interior. In addition, we have more detailed datasets on two of the funds: <a href="https://www.doi.gov/lwcf">Land and Water Conservation Fund</a> (LWCF) and <a href="http://www.nps.gov/subjects/historicpreservation/NHPA-50.htm">National Historic Preservation Act</a> (NHPA).</p>
         <a href="{{site.baseurl}}/downloads/disbursements_2012-2013_2015-11-20.xlsx" class="button-tertiary">
           <icon class="icon-cloud icon-padded"></icon>Download disbursement dataset (xlsx, 14 KB)
@@ -107,10 +85,33 @@ permalink: /downloads/
 
     </ul>
 
-    <h3>Economic impact</h3>
+    <h2 class="h3 downloads-section_heading">Production</h2>
     <ul class="list-sections">
     	<li>
-        <a id="gdp" class="link-no_under"><h4>Gross Domestic Product</h4></a>
+        <a id="production-all" class="link-no_under"><h3>All lands and waters</h3></a>
+        <p>This data is from the <a href="http://www.eia.gov/">Energy Information Agency</a>. The specific data we used for the interactions is a subset of the huge amount of data available on their website. <em>Tip: to find data on the EIA site, click 'Sources & Uses' in the navigation near the top of the site.</em></p>
+        <a href="http://www.eia.gov/" class="button-tertiary">
+          Go to EIA &#8594;
+        </a>
+      </li>
+
+      <li>
+        <a id="production-fed" class="link-no_under"><h3>Federal lands and waters</h3></a>
+        <p>Commodity volumes of natural resources extracted from federal land and waters. This dataset is from the <a href="http://www.onrr.gov/">Office of Natural Resources Revenue</a> (ONRR), which is part of the Department of the Interior. This is the first year ONRR has produced this dataset.</p>
+        <a href="{{site.baseurl}}/downloads/production_federal_lands_waters_CY2013_oil_gas_solids-2015-11-25.xlsx" class="button-tertiary">
+          <icon class="icon-cloud icon-padded"></icon>Download full dataset (xlsx, 517 KB)
+        </a>
+        <a href="{{site.baseurl}}/downloads/federal-production/" class="button-tertiary">
+          <i class="fa fa-file-text-o u-padding-right"></i>Documentation
+        </a>
+      </li>
+
+    </ul>
+
+    <h2 class="h3 downloads-section_heading">Economic impact</h2>
+    <ul class="list-sections">
+    	<li>
+        <a id="gdp" class="link-no_under"><h3>Gross Domestic Product</h3></a>
         <p>This data is from the <a href="http://www.bea.gov/">Bureau of Economic Analysis</a>. The data we used for the interactions is a subset of the data on their website. We access this data live via an Application Programming Interface (API).</p>
         <a href="http://www.bea.gov/" class="button-tertiary">
           Go to BEA &#8594;
@@ -121,7 +122,7 @@ permalink: /downloads/
       </li>
 
       <li>
-        <a id="exports" class="link-no_under"><h4>Exports</h4></a>
+        <a id="exports" class="link-no_under"><h3>Exports</h3></a>
         <p>This data is from the <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html">U.S. Census Bureau</a>. It arrives in Excel format, and lists the top 25 exports for each state from 2011-2014 by <a href="http://unstats.un.org/unsd/tradekb/Knowledgebase/Harmonized-Commodity-Description-and-Coding-Systems-HS">HS6 code</a>.</p>
         <a href="https://www.census.gov/foreign-trade/statistics/state/data/index.html" class="button-tertiary">
           Go to U.S. Census exports data page &#8594;
@@ -129,7 +130,7 @@ permalink: /downloads/
       </li>
 
       <li>
-        <a id="jobs" class="link-no_under"><h4>Jobs</h4></a>
+        <a id="jobs" class="link-no_under"><h3>Jobs</h3></a>
         <p>We use two types of jobs data on this site. One is <em>Wage and Salary</em> data, which describes the number of people (full-time and part-time) employed in natural resource extraction that receive wages or salaries from companies. This data is from the <a href="http://www.bls.gov/">Bureau of Labor Statistics</a>, specifically the Quarterly Census of Employment and Wages. The best way to get this data is from <a href="http://www.bls.gov/cew/datatoc.htm">this page</a> and to download CSVs single files annual averages (you will need to load titles).</p>
         <a href="http://www.bls.gov/cew/datatoc.htm" class="button-tertiary">
           Go to BLS quarterly census &#8594;

--- a/_downloads/disbursements.md
+++ b/_downloads/disbursements.md
@@ -14,55 +14,55 @@ permalink: /downloads/disbursements/
     </div>
     <h1>Disbursements</h1>
 
-    <a href="{{site.baseurl}}/downloads/disbursements_2012-2013_2015-11-20.xlsx" class="button-tertiary">
-      <icon class="icon-cloud icon-padded"></icon>Download disbursement dataset (xlsx, 14 KB)
-    </a>
+    <p class="case_studies_intro-para">This dataset contains disbursement information for fiscal years 2012-2013. Disbursements of revenue due to extractive activities on U.S. Federal lands occur monthly; this data set is a sum of those disbursements by fiscal year.</p>
 
+    <p class="downloads-download_links-intro">Download fiscal year data:
+      <ul class="downloads-download_links">
+        <li><a href="{{site.baseurl}}/downloads/disbursements_2012-2013_2015-11-20.xlsx"><icon class="icon-cloud icon-padded"></icon>
+        Full dataset (xlsx, 14 KB)</a></li>
+       </ul>
+     </p>
 
-    <h2>Documentation</h2>
+    <h2 class="h3">Scope</h2>
 
-    <p>The datasets contains disbursement information for fiscal years 2012-2013. Disbursements of revenue due to extractive activities on U.S. Federal lands occur monthly; this data set is a sum of those disbursements by fiscal year.</p>
-    
-    <h3>Scope</h3>
-    
-    <p>These datasets include natural resource disbursements for U.S. federal lands and offshore areas, and Indian Lands. It does not include privately-owned lands, or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. </p>
-    
-    <h3>Data Publication</h3>
-    
-    <p>The Disbursement dataset is updated in December after the end of the federal government fiscal year.  </p>
-    
-    <h3>Data Dictionary</h3>
-    
-    <h4>Onshore Descriptions:</h4>
-    
+    <p>This dataset includes natural resource disbursements for U.S. federal lands and offshore areas, and Indian Lands. It does not include privately-owned lands, or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. </p>
+
+    <h2 class="h3">Data Publication</h2>
+
+    <p>The disbursement dataset is updated in December after the end of the federal government fiscal year.  </p>
+
+    <h2>Data Dictionary</h2>
+
+    <p>Laws treat revenues from offshore natural resources and onshore natural resources differently. There are set percentages and amounts from each that go certain places every year.</p>
+
+    <h3>Onshore</h3>
+
     <p><strong>U.S. Treasury.</strong> Funds disbursed to the Treasury go to the General Fund, which is the federal government’s basic operating fund. The General Fund pays for roughly two-thirds of all federal expenditures, including the US military, national parks, and schools.</p>
-    
+
     <p><strong>States.</strong> Funds disbursed to states fall under the jurisdiction of each state, and each state determines how the funds will be used.</p>
-    
+
     <p><strong>Reclamation.</strong> Established by Congress in 1902 to pay for Bureau of Reclamation projects, this fund supports the establishment of critical infrastructure projects like dams and power plants.</p>
-    
+
     <p><strong>American Indian Tribes.</strong> ONRR disburses 100% of revenue collected from resource extraction on American Indian lands back to the Indian tribes and individual Indian landowners.</p>
-    
+
     <p><strong>Other.</strong> Certain onshore funds are directed back to the federal agencies that administer these lands (e.g., BLM, US Fish and Wildlife Service, and US Forest Service) to help cover the agencies’ operational costs. The Ultra-Deepwater Research Program and the Mescal Settlement Agreement also receive $50 million each.</p>
-    
-    <h4>Offshore Descriptions:</h4>
-    
+
+    <h3>Offshore</h3>
+
     <p><strong>U.S. Treasury.</strong> The majority of offshore revenue is disbursed to the Treasury, which enters it into the General Fund, the federal government’s basic operating fund. The General Fund pays for roughly two-thirds of all federal expenditures, including the US military, national parks, and schools.</p>
-    
+
     <p><strong>Land and Water Conservation Fund.</strong> This fund provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states.</p>
-    
+
     <p><strong>Historic Preservation Fund.</strong> This fund helps preserve US historical and archaeological sites and cultural heritage through grants to state and tribal historic preservation offices.</p>
-    
+
     <p><strong>States.</strong> States receive federal Outer Continental Shelf revenue in two ways:
-        <ol>
+        <ol class="list-decimal">
             <li>27% of revenue from leases in the 8(g) Zone (the first three nautical miles of the Outer Continental Shelf) are shared with states; and</li>
             <li>37.5% of revenue from certain leases in the Gulf of Mexico are shared with Alabama, Louisiana, Mississippi, and Texas.</li>
         </ol>
     </p>
-    
+
     <p><strong>Other.</strong> Certain offshore funds are directed back to the federal agencies that administer these lands (e.g., BOEM and BSEE) to help cover the agencies’ operational costs.</p>
-
-
 
   </article>
 

--- a/_downloads/federal-production.md
+++ b/_downloads/federal-production.md
@@ -14,47 +14,48 @@ permalink: /downloads/federal-production/
     </div>
     <h1>Federal Production by Location</h1>
 
-    <a href="{{site.baseurl}}/downloads/production_federal_lands_waters_CY2013_oil_gas_solids-2015-11-25.xlsx" class="button-tertiary">
-      <icon class="icon-cloud icon-padded"></icon>Download full dataset (xlsx, 517 KB)
-    </a>
+    <p class="case_studies_intro-para">This dataset contains information on production on federal lands and waters for calendar years 2005-2014. The data is current as of July 11, 2015 for coal and hardrock production and August 25, 2015 for Oil and Gas production. If you are looking for datasets organized by the U.S. government’s fiscal year, please visit <a href="http://statistics.onrr.gov/">statistics.onrr.gov</a>.</p>
 
+    <p class="downloads-download_links-intro">Download calendar year data:
+      <ul class="downloads-download_links">
+        <li><a href="{{site.baseurl}}/downloads/production_federal_lands_waters_CY2013_oil_gas_solids-2015-11-25.xlsx"><icon class="icon-cloud icon-padded"></icon>
+        Full dataset (xlsx, 517 KB)
+       </a></li>
+     </ul>
+   </p>
 
-    <h2>Documentation</h2>
+    <h2 class="h3">Scope</h2>
+    <p>This dataset includes natural resource production for U.S. federal lands and offshore areas. It does not include Indian lands, privately-owned lands, or U.S. state lands. The dataset currently include data tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue (ONRR). The production data for Oil and Gas is collected on Form ONRR-4054 (Oil and Gas Operations Report). Coal and hardrock production is collected on Form ONRR-4430 (Solid Minerals Production and Royalty Report).</p>
 
-    <p>The datasets contains production information for calendar years 2005-2014 as of July 11, 2015 for coal and hardrock production and August 25, 2015 for Oil and Gas production. If you are looking for datasets organized by the U.S. government’s fiscal year, please visit <a href="http://statistics.onrr.gov/">statistics.onrr.gov</a>.</p>
-    
-    <h3>Scope</h3>
-    <p>These datasets include natural resource production for U.S. federal lands and offshore areas. It does not include Indian lands, privately-owned lands, or U.S. state lands. The datasets currently include data tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue (ONRR). The production data for Oil and Gas is collected on Form ONRR-4054 (Oil and Gas Operations Report), Coal and hardrock production is collected on Form ONRR-4430 (Solid Minerals Production and Royalty Report).</p>
-    
-    <h3>Data Publication</h3>
-    
-    <p>The production data set is updated six months after the end of the year. Fiscal year 2015 data will be published in March 2016 and calendar year 2015 data will be published in June 2016. </p>
+    <h2 class="h3">Data Publication</h2>
 
-    <p><strong>Why was some solids data withheld?</strong></p>
-    
+    <p>This dataset is updated six months after the end of the year. Fiscal year 2015 data will be published in March 2016 and calendar year 2015 data will be published in June 2016. </p>
+
+    <h2 class="h3">Why was some solids data withheld?</strong></h2>
+
     <p>ONRR withheld some solids production information out of an abundance of caution to ensure that there were no violations of the Trade Secrets Act. </p>
-    
+
     <ul class="list-bullet">
         <li>"W" is displayed in the Production Volume column for those products that reveal proprietary data at the county level </li>
         <li>All "W" volumes are accounted for in separate line totals where state and county have been "Withheld" (columns C, D and E)</li>
     </ul>
 
-    <h3>Offshore data dictionary</h3>
-    
+    <h2>Offshore data dictionary</h2>
+
     <p>The offshore dataset is organized by offshore planning areas. There are more offshore planning areas than are represented in our data. Those not represented had no production during the time period. For more information on offshore planning areas, including spatial boundaries, see the Bureau of Ocean Energy Management's (BOEM) <a href="http://www.boem.gov/Maps-and-GIS-Data/">maps and GIS data</a>.</p>
-    
+
     <h3>FIPS Code</h3>
-    
+
     <p>Federal Information Processing Standard (FIPS) code is a five-digit code which uniquely identifies counties and county equivalents in the U.S., certain U.S. possessions, and certain freely associated states. The first two digits are the FIPS state code and the last three are the county code within the state or possession.</p>
 
     <h3>Region</h3>
-    
+
     <p>BOEM separates offshore area into four regions: Gulf of Mexico, Atlantic, Pacific, and Alaska. For more information on offshore regions, including spatial boundaries, see BOEM's <a href="http://www.boem.gov/Maps-and-GIS-Data/">maps and GIS data</a>.</p>
-    
+
     <h3>Planning Area</h3>
-    
+
     <p>Offshore regions are broken out into planning areas. For more information on offshore planning areas, including spatial boundaries, see BOEM's <a href="http://www.boem.gov/Maps-and-GIS-Data/">maps and GIS data</a>.</p>
-    
+
     <h3>Product Groupings</h3>
 
     <ul class="list-bullet">

--- a/_downloads/federal-revenue-by-company.md
+++ b/_downloads/federal-revenue-by-company.md
@@ -19,10 +19,9 @@ permalink: /downloads/federal-revenue-by-company/
     <p class="downloads-download_links-intro">Download calendar year data:
       <ul class="downloads-download_links">
         <li><a href="{{site.baseurl}}/downloads/federal_revenue_by_company_CY2013_2015-11-10.xlsx"><icon class="icon-cloud icon-padded"></icon>
-        Full dataset (xlsx, 132 KB)
-       </a></li>
-     </ul>
-   </p>
+        Full dataset (xlsx, 132 KB)</a></li>
+       </ul>
+     </p>
 
     <h2 class="h3">Scope</h2>
 

--- a/_downloads/federal-revenue-by-company.md
+++ b/_downloads/federal-revenue-by-company.md
@@ -14,35 +14,39 @@ permalink: /downloads/federal-revenue-by-company/
     </div>
     <h1>Federal Revenue by Company</h1>
 
-    <a href="{{site.baseurl}}/downloads/federal_revenue_by_company_CY2013_2015-11-10.xlsx" class="button-tertiary">
-      <icon class="icon-cloud icon-padded"></icon>Download full dataset (xlsx, 132 KB)
-    </a>
+    <p class="case_studies_intro-para">This dataset provides calendar year 2013 natural resource revenues data by company. This new dataset is a product of USEITI and represents cooperation between government, industry, and civil society to create and confirm this information, and provide it in a way that adds to the national dialogue on natural resource extraction. This data set will be updated in the first quarter of the calendar year.</p>
 
-    <h2>Documentation</h2>
+    <p class="downloads-download_links-intro">Download calendar year data:
+      <ul class="downloads-download_links">
+        <li><a href="{{site.baseurl}}/downloads/federal_revenue_by_company_CY2013_2015-11-10.xlsx"><icon class="icon-cloud icon-padded"></icon>
+        Full dataset (xlsx, 132 KB)
+       </a></li>
+     </ul>
+   </p>
 
-    <p>The &ldquo;total revenues by company&rdquo; dataset on this site provides calendar year 2013 natural resource revenues data by company. This new dataset is a product of USEITI and represents cooperation between government, industry, and civil society to create and confirm this information, and provide it in a way that adds to the national dialogue on natural resource extraction. This data set will be updated in the first quarter of the calendar year.</p>
+    <h2 class="h3">Scope</h2>
 
-    <h3>Scope</h3>
+    <p>This dataset includes revenues for U.S. federal lands and offshore areas. It does not include Indian lands, privately-owned lands, or U.S. state lands. The datasets currently include data tracked and managed by the Department of the Interior’s (DOI) Office of Natural Resources Revenue (ONRR), Bureau of Land Management (BLM), and Office of Surface Mining, Reclamation, and Enforcement.</p>
 
-    <p>These datasets include revenues for U.S. federal lands and offshore areas. It does not include Indian lands, privately-owned lands, or U.S. state lands. The datasets currently include data tracked and managed by the Department of the Interior’s (DOI) Office of Natural Resources Revenue (ONRR), Bureau of Land Management (BLM), and Office of Surface Mining, Reclamation, and Enforcement.</p>
-
-    <h3>Companies below threshold</h3>
+    <h2 class="h3">Why is there a line in the data called 'companies below threshold'?</h2>
 
     <p>The USEITI Multi-Stakeholder Group agreed to an annual reporting threshold of $100,000 because these aggregated payments make up less than one quarter of one percent of total payments. Many of the companies that fall below this threshold are small companies, individuals, and family trusts. Payments made by entities that reported less than $100,000 are aggregated (rolled-up) into this category.</p>
 
-    <h3>One mine one product</h3>
+    <h2 class="h3">Why is there a line in the data called 'one mine one product'?</h2>
 
-    <p>Disclosing payments of solid mineral companies who only produce and sell only one product from one mine can reveal proprietary sales price and contracting information and cause competitive harm to these small companies. The DOI is legally obligated through the Trades Secrets Act to safeguard this data, so payments from these companies are aggregated (rolled-up) in this category. These aggregated payments make up less than three thousandths of one percent of all payments.</p>
+    <p>Disclosing payments of solid mineral companies who only produce and sell only one product from one mine can reveal proprietary sales price and contracting information and cause competitive harm to these small companies. The Department of the Interior is legally obligated through the Trades Secrets Act to safeguard this data, so payments from these companies are aggregated (rolled-up) in this category. These aggregated payments make up less than three thousandths of one percent of all payments.</p>
 
-    <h3>Why are some values negative?</h3>
+    <h2 class="h3">Why are some values negative?</h2>
 
     <p>Companies can adjust and correct their payments for up to seven years after a transaction takes place. If a company overpays their royalty, rent, or bonus, they are entitled to recoup their overpayment. If the overpayment and recoupment happen in different years, the recoupment will appear as a negative amount in ONRR’s revenue summaries.</p>
 
-    <h3>Why is there a Gas value, an Oil value and an Oil & Gas value?</p></h3>
+    <h2 class="h3">Why is there a Gas value, an Oil value and an Oil & Gas value?</p></h2>
 
     <p>“Oil & Gas” is the commodity category used for offshore oil and gas rents and bonuses. At the time of lease sale, it isn’t known whether a lease will produce oil, gas, or both oil and gas. After a lease starts producing a commodity (or commodities), the lease owner starts paying royalties, and these royalties can then be associated with either oil or gas. Hence, rent and bonus lines of data will be associated with an “Oil & Gas” commodity type, while royalty lines of data will be associated with either “Oil” or “Gas” commodity types.</p>
 
-    <h3>Data dictionary: fields and definitions</h3>
+    <h2>Data dictionary</h2>
+
+    <h3>Fields and definitions</h3>
 
     <p><strong>Company Name.</strong> Name of company.</p>
 

--- a/_downloads/federal-revenue-by-location.md
+++ b/_downloads/federal-revenue-by-location.md
@@ -6,13 +6,105 @@ permalink: /downloads/federal-revenue-by-location/
 
 <div class="container-outer container-padded">
 
-  <article class="container-left-7">
+  <article class="container-left-7 downloads-docs">
 
     <div>
       <a class="breadcrumb" href="{{ site.baseurl }}/downloads/">Downloads</a>
       /
     </div>
     <h1>Federal Revenue by Location</h1>
+
+    <p class="case_studies_intro-para">There are two types of federal-revenue-by-location datasets available on this site. One includes offshore data, and the other includes onshore data. We have versions of these datasets available for both calendar year and fiscal year 2013, and they are both accounting year data. </p>
+
+    <p class="downloads-download_links-intro">Download calendar year data:
+      <ul class="downloads-download_links">
+        <li><a href="{{site.baseurl}}/downloads/federal_revenue_offshore_acct-year_CY04-13_2015-11-20.xlsx"><icon class="icon-cloud icon-padded"></icon>
+         Offshore dataset (xlsx, 321 KB)
+       </a></li>
+       <li><a href="{{site.baseurl}}/downloads/federal_revenue_onshore_acct-year_CY04-13_2015-11-20.xlsx"><icon class="icon-cloud icon-padded"></icon>
+         Onshore dataset (xlsx, 1.1 MB)
+       </a></li>
+      </ul>
+    </p>
+
+    <p class="downloads-download_links-intro">Download fiscal year data:
+      <ul class="downloads-download_links">
+        <li><a href="{{site.baseurl}}/downloads/federal_revenue_offshore_acct-year_FY04-14_2015-11-20.xlsx"><icon class="icon-cloud icon-padded"></icon>
+          Offshore dataset (xlsx, 348 KB)
+        </a></li>
+       <li><a href="{{site.baseurl}}/downloads/federal_revenue_onshore_acct-year_FY04-14_2015-11-20.xlsx"><icon class="icon-cloud icon-padded"></icon>
+         Onshore dataset (xlsx, 1.1 MB)
+       </a></li>
+      </ul>
+    </p>
+
+    <h2 class="h3">Scope</h2>
+
+    <p>These datasets include natural resource revenues for U.S. Federal lands and offshore areas. It does not include Indian lands, privately-owned lands or U.S. state lands. The datasets currently include data tracked and managed by the Department of the Interior’s Office of Natural Resource Revenues.</p>
+
+    <h2 class="h3">Why are some values negative?</h2>
+
+    <p>Companies can adjust and correct their payments for up to seven years after a transaction takes place. If a company overpays their royalty, rent, or bonus, they are entitled to recoup their overpayment. If the overpayment and recoupment happen in different years, the recoupment will appear as a negative amount in the Office of Natural Resource Revenue's revenue summaries.</p>
+
+    <h2 class="h3">Why is there a Gas value, an Oil value and an Oil & Gas value?</h2>
+
+    <p>“Oil & Gas” is the commodity category used for offshore oil and gas rents and bonuses. At the time of lease sale, it isn’t known whether a lease will produce oil, gas or both oil and gas. After a lease starts producing a commodity (or commodities), the lease owner starts paying royalties. These can then be associated with either oil or gas. Hence, rent and bonus lines of data will be associated with an “Oil & Gas” commodity type, while royalty lines of data will be associated with either “Oil” or “Gas” commodity types.</p>
+
+
+    <h2>Offshore data dictionary</h2>
+
+    <p>The offshore dataset is organized by offshore planning areas. There are more offshore planning areas than are represented in our data. Those not represented had no revenues for calendar year 2013. For a more information on offshore planning areas, including spatial boundaries, see the Bureau of Ocean Energy Management's <a href="http://www.boem.gov/Maps-and-GIS-Data/">maps and GIS data</a>.</p>
+
+    <h3>Fields and definitions</h3>
+
+    <p><span>Revenue Type.</span> Revenues from U.S. natural resources fall into one of several types:
+      <ul class="list-bullet">
+        <li><span>Royalties. </span>
+          A natural resource lease owner pays royalties after the lease starts producing a commodity in paying quantities. The amount is based on a percentage of the revenue from the commodity sold. The exact percentage is set in the original lease document that went along with the lease sale.</li>
+        <li><span>Bonus. </span>
+          The amount paid by the highest successful bidder for a natural resource lease. The winning bid.</li>
+        <li><span>Other revenues. </span>
+          This category includes revenues that are not included in the royalty, rent, or bonus categories, such as minimum royalties, estimated royalties, settlement agreements, and interest.</li>
+        <li><span>Rents. </span>
+          A natural resource lease might not produce anything in paying quantities for some time after it is sold. Until it does, periodic payments are made for the right to continue exploration and development of the land for future natural resource production. These payments are called rent.</li>
+      </ul>
+    </p>
+
+    <p><span>Commodity Type. </span>The Department of the Interior collects revenues on over 60 different products. The majority of revenues come from Oil & Gas, Coal and Renewables (Geothermal and Wind), but you will find many other product categories in these datasets.
+    </p>
+
+    <p><span>Region. </span>The Bureau of Ocean Energy Management separates offshore area into four regions: Gulf of Mexico, Atlantic, Pacific and Alaska. For a more information on offshore regions, including spatial boundaries, see the Bureau of Ocean Energy Management's <a href="http://www.boem.gov/Maps-and-GIS-Data/">maps and GIS data</a>.</p>
+
+    <p><span>Planning Area. </span>Offshore regions are broken out into planning areas. For a more information on offshore planning areas, including spatial boundaries, see the Bureau of Ocean Energy Management's <a href="http://www.boem.gov/Maps-and-GIS-Data/">maps and GIS data</a>.</p>
+
+    <p><span>Revenue. </span>Total revenue.</p>
+
+
+    <h2>Onshore data dictionary</h2>
+
+    <p>The onshore dataset is organized by state. There are more states than are listed in this dataset. Those states without natural resource revenues in calendar year 2013 are not included.</p>
+
+    <h3>Fields and definitions</h3>
+
+    <p><span>Row Labels. </span>This field contains either a state name, or a commodity name. The state name always comes first with its commodity breakdowns below it.</p>
+
+    <p><span>Sum of Royalty/Revenue. </span>This field provides the total royalty or revenue for the listed state (total) or commodity in that state.</p>
+
+    <h2>Advanced offshore and onshore information</h2>
+
+    <p>Commodities can be further broken down into products. These are the products that could fall into the commodity categories found in these datasets.</p>
+
+    <p><span>Coal.</span> Coal (ton), Coal-Bituminous-Raw (ton).</p>
+
+    <p><span>Gas.</span> Coal Bed Methane (mcf), Flash Gas (mcf), Fuel Gas (mcf), Gas Hydrate (mcf), Gas Lost - Flared or Vented (mcf), Nitrogen (mcf), Processed (Residue) Gas (mcf), Unprocessed (Wet) Gas (mcf), NGL (Gas Plant Products).</p>
+
+    <p><span>Oil.</span> Asphaltic Crude (bbl), Black Wax Crude (bbl), Condensate (bbl), Drip or Scrubber Condensate (bbl),  Drip or Scrubber Condensate (bbl), Fuel Oil (bbl), Inlet Scrubber (bbl), Oil (bbl), Oil Lost (bbl), Other Liquid Hydrocarbons (bbl), Sour Crude (bbl), Sweet Crude (bbl), Yellow Wax Crude (bbl).</p>
+
+    <p><span>Geothermal.</span> Geothermal - Direct Utilization, Hundreds of Gallons (cgal), Geothermal - Direct Utilization, Millions of BTUs (mmbtu), Geothermal - Electrical Generation, Kilowatt Hours (kwh), Geothermal - Electrical Generation, Thousands of Pounds (klb), Geothermal - sulfur (lton).</p>
+
+    <p><span>Wind.</span> Wind.</p>
+
+    <p><span>Other Commodities.</span> Anhydrous Sodium Sulfate (ton), Borax-Decahydrate (ton), Borax-Pentahydrate (ton), Boric Acid (ton), Carbon Dioxide Gas (CO2) (mcf), Cinders (ton), Clay (ton), Copper Concentrate (ton), Gilsonite (ton), Gold (ton), Gypsum (ton), Helium (bbl), Langbeinite (ton), Lead Concentrate (ton), Leonardite (ton), Limestone (ton), Magnesium Chloride Brine (ton), Manure Salts (ton), Muriate Of Potash-Granular (ton), Muriate Of Potash-Standard (ton), Other (ton), Phosphate Raw Ore (ton), Potash (ton), Purge Liquor (ton), Quartz Crystal (lb), Salt (ton), Sand/Gravel (ton), Sand/Gravel-Cubic Yards (cyd), Silver (oz), Soda Ash (ton), Sodium Bi-Carbonate (ton), Sodium Bisulfite (ton), Sodium Sesquicarbonate (ton), Sulfide (ton), Sulfur (lton), Sylvite-Raw Ore (ton), Trona Ore (ton), Zinc Concentrate (ton).</p>
 
   </article>
 

--- a/_downloads/reconciliation.md
+++ b/_downloads/reconciliation.md
@@ -12,32 +12,34 @@ permalink: /downloads/reconciliation/
       <a class="breadcrumb" href="{{ site.baseurl }}/downloads/">Downloads</a>
       /
     </div>
-    <h1>Reconciliation Data</h1>
+    <h1>Reconciliation</h1>
 
-    <a href="{{site.baseurl}}/downloads/reconciliation_2015-11-20.xlsx" class="button-tertiary">
-      <icon class="icon-cloud icon-padded"></icon>Download full dataset, docs included (xlsx, 39 KB)
-    </a>
-
-    <h2>Documentation</h2>
-    <p>To implement the EITI Standard, government, industry, and civil society collaborate in a disclosure process called reconciliation. The three sectors in a participating country develop a framework for reconciliation. Government and industry share with the Independent Administrator (IA) the total amount of revenue the government received and industry paid in the year under review. The IA reconciles reported revenue and investigates any discrepancies. The public can see the results for their respective country in an annual EITI report.</p>
+    <p class="case_studies_intro-para">To implement the EITI Standard, government, industry, and civil society collaborate in a disclosure process called reconciliation. The three sectors in a participating country develop a framework for reconciliation. Government and industry share with the Independent Administrator (IA) the total amount of revenue the government received and industry paid in the year under review. The IA reconciles reported revenue and investigates any discrepancies. The public can see the results for their respective country in an annual EITI report.</p>
 
     <p>Through a unilateral disclosure, the Department of the Interior (DOI) published online all in-scope revenue from extraction on federal lands by revenue stream and company for CY 2013. DOI reported a total of $12.64 billion in revenue, disclosing to the public 100% of in-scope DOI revenue from extraction on federal lands during CY 2013. In addition to DOI’s unilateral disclosure, the Multi-stakeholder Group (MSG) asked companies to report to the IA that same nontax information, revenue payments to DOI, as well as federal corporate income tax payments and refunds from the Internal Revenue Service (IRS).</p>
 
-    <h3>What is the scope of the revenue payment data reconciliation?</h3>
+    <p class="downloads-download_links-intro">Download calendar year data:
+      <ul class="downloads-download_links">
+        <li><a href="{{site.baseurl}}/downloads/reconciliation_2015-11-20.xlsx"><icon class="icon-cloud icon-padded"></icon>
+        Full dataset (xlsx, 39 KB)</a></li>
+       </ul>
+     </p>
+
+    <h2>Scope</h2>
 
     <p>Requirement 4 of the EITI Standard outlines the responsibility of the MSG to determine the scope of EITI reporting in the United States. In carrying out this responsibility, the MSG considered information from a variety of sources before coming to a consensus on the scope for the 2015 USEITI Report.</p>
 
     <p>The MSG publishes meeting minutes and materials for all subcommittee and full MSG meetings on the <a href="https://www.doi.gov/eiti/FACA/meetings">MSG website</a>. These minutes and materials document the MSG’s historical considerations and decisions around scoping. Please refer to <em>Appendix A: Revenue Reporting Considerations</em> within the <a href="{{site.baseurl}}/downloads/USEITI_extractive-revenue-appendix_2015-12-02.pdf">Extractive Revenue Appendix (PDF)</a> for additional background on the scoping process for USEITI.</p>
 
-    <h4>In-scope government entities and revenue streams</h4>
+    <h3>In-scope government entities and revenue streams</h3>
 
     <p></p>
 
-    <h4>In-scope reporting entities</h4>
+    <h3>In-scope reporting entities</h3>
 
     <p>The MSG identified that ONRR collects a majority of DOI’s extractive industries-related revenue. The MSG decided to use ONRR’s reported revenue as a proxy for DOI revenue to establish the materiality threshold for reporting. The MSG decided on a materiality threshold for the 2015 USEITI Report of $50 million total annual revenue reported to ONRR by a parent company, including its subsidiaries, which was presented and approved as part of the <a href="http://www.cbuilding.org/sites/default/files/USEITI_Candidacy_Application_Approved_0.pdf">USEITI candidacy application (PDF)</a>. The MSG agreed on this threshold because it would allow at least 80% of ONRR’s revenue to be in-scope for the reconciliation. A more detailed analysis of ONRR revenue data revealed that the $50 million threshold resulted in 84% of ONRR revenue being in-scope for the reconciliation. DOI’s unilateral disclosure covers 100% of revenue from all companies operating within the U.S.</p>
 
-    <h5>In-scope companies</h5>
+    <h3>In-scope companies</h3>
 
     <ul class="list-bullet">
         <li>Alpha Natural Resources, Inc.</li>
@@ -90,15 +92,15 @@ permalink: /downloads/reconciliation/
         <li>WPX Energy, Inc.</li>
     </ul>
 
-    <h4>Basis and period of reporting</h4>
+    <h2>Basis and period of reporting</h2>
 
     <p>The period of the reconciliation was CY 2013 (January 1, 2013 through December 31, 2013). Reporting companies and government entities reported data for payments made or reported in CY 2013. The reporting currency for the 2015 USEITI Report was US dollars (USD). Companies reported data at the consolidated entity level, including data for all identified subsidiary entities.</p>
 
-    <h3>How did the Independent Administrator perform the reconciliation?</h3>
+    <h2>How did the Independent Administrator perform the reconciliation?</h2>
 
     <p>Based upon Requirement 5.1 of the EITI Standard, the IA performed the reconciliation of company payments and government revenue as follows:</p>
 
-    <h4>Data collection</h4>
+    <h3>Data collection</h3>
 
     <p>The IA distributed the 2015 USEITI reporting and reconciliation package to reporting companies on March 4, 2015. The package included a cover letter summarizing the USEITI process, a <a href="https://www.doi.gov/sites/doi.gov/files/migrated/eiti/upload/USEITI-Reporting-Template-03042015-1.pdf">Data Reporting Template (PDF)</a>, a <a href="https://www.doi.gov/sites/doi.gov/files/migrated/eiti/upload/USEITI-Reporting-Template-Guidelines-030415-1.pdf">reporting template guidelines document (PDF)</a> with detailed reporting instructions, and <a href="https://www.doi.gov/sites/doi.gov/files/migrated/eiti/upload/Form-8821-IRS-USEITI.pdf">IRS Form 8821 (PDF)</a>, which is required to authorize the IRS to disclose tax data to the IA for the reporting companies participating in reconciliation of taxes.</p>
 
@@ -110,11 +112,11 @@ permalink: /downloads/reconciliation/
         <li>For reporting companies that made the decision to allow for tax reconciliation, the IRS provided the data directly to the IA for reconciliation. Due to federal tax confidentiality laws, these reporting companies have to authorize the IRS to release corporate tax payment data to the IA through the use of IRS Form 8821.</li>
     </ul>
 
-    <h4>Data reconciliation</h4>
+    <h3>Data reconciliation</h3>
 
     <p>The IA reconciled the data by comparing the reported amounts from reporting companies to the reported amounts from government entities and identifying any variance amounts. The IA then compared any variance amounts to an investigation threshold known as the Margin of Variance.</p>
 
-    <h4>Margin of variance</h4>
+    <h3>Margin of variance</h3>
 
     <p>The MSG considered and approved a Margin of Variance for the IA to apply during the reconciliation. The purpose of the Margin of Variance was to establish a threshold above which variances in reported payments required further evaluation. The MSG determined that variances below the Margin of Variance did not require further evaluation. Variances that were below the respective threshold were presented as-is, with no further consideration. Variances that exceeded the respective threshold were subject to further evaluation and explanation.</p>
 

--- a/_how-it-works/laws-and-regulations/federal-laws.md
+++ b/_how-it-works/laws-and-regulations/federal-laws.md
@@ -24,7 +24,7 @@ nav_items:
 
 <p class="case_studies_intro-para">The legislative branch of the federal government has passed many laws that govern natural resource extraction on federal lands.</p>
 
-<h3 id="fiscal-regime" data-nav-header="fiscal-regime">Fiscal regime</h3>
+<h2 class="h3" id="fiscal-regime" data-nav-header="fiscal-regime">Fiscal regime</h2>
 
 <p>The following table lists the laws that provide the backbone of the fiscal regime for the extractive industries, as well as the relevant lands and natural resources to which they apply.</p>
 
@@ -145,7 +145,7 @@ nav_items:
   </tr>
 </table>
 
-<h3 id="fees-and-fines" data-nav-header="fees-and-fines">Fees and fines for extractive industries companies</h3>
+<h2 class="h3" id="fees-and-fines" data-nav-header="fees-and-fines">Fees and fines for extractive industries companies</h2>
 
 <p>There are other laws governing natural resources and extractive companies’ operations. Some of these laws require companies to pay fees. Violating some of these laws can also result in companies paying fines.</p>
 
@@ -200,7 +200,7 @@ nav_items:
   </tr>
 </table>
 
-<h3 id="other-laws" data-nav-header="other-laws">Other laws</h3>
+<h2 class="h3" id="other-laws" data-nav-header="other-laws">Other laws</h2>
 
 <p>There are many other laws with which extractive industries companies must comply. DOI, EPA, the National Oceanic and Atmospheric Administration (NOAA), and other federal agencies’ websites contain more comprehensive lists of laws they enforce:</p>
 
@@ -213,7 +213,7 @@ nav_items:
 <li><a href="http://www.nmfs.noaa.gov/ole/about/what_we_do/laws.html">NOAA</a></li>
 </ul>
 
-<h3 id="regulations" data-nav-header="regulations">Regulations</h3>
+<h2 class="h3" id="regulations" data-nav-header="regulations">Regulations</h2>
 
 <p>Federal agencies, such as DOI and relevant bureaus, implement these laws by developing and enforcing regulations and rules. These key regulations relate to natural resource extraction, particularly on federal and Indian lands:</p>
 
@@ -225,4 +225,3 @@ nav_items:
 
 <p>Implementing laws includes complying with the <a href="http://www.gpo.gov/fdsys/pkg/USCODE-2010-title42/pdf/USCODE-2010-title42-chap55-sec4321.pdf">National Environmental Policy Act (NEPA) of 1969</a> (42 USC § 4321 et seq.). NEPA is intended to ensure that decision makers and the public have information about the potential impacts to the environment of proposed federal actions and alternatives to those actions. When taking any major action, such as leasing natural resources on federal lands for extraction, federal agencies must prepare Environmental Assessments (EAs) and/or EISs to document environmental impacts of agency actions and alternatives to those actions. The public has legally mandated opportunities to comment on these impact statements.
 </p>
-

--- a/_how-it-works/laws-and-regulations/federal-reforms.md
+++ b/_how-it-works/laws-and-regulations/federal-reforms.md
@@ -26,7 +26,7 @@ nav_items:
 
 <p class="case_studies_intro-para">The federal government reforms laws and regulations by enacting new legislation and proposing new rules to implement the legislation. Reforms can stem from government oversight organizations’ recommendations, including from both DOI’s Office of Inspector General and the Government Accountability Office. Below are reforms following the Deep Water Horizon oil spill, recent findings from government oversight organizations, and proposed rules.</p>
 
-<h3 id="deepwater-horizon-oil-spill" data-nav-header="deepwater-horizon-oil-spill">Reforms following the Deepwater Horizon oil spill</h3>
+<h2 class="h3" id="deepwater-horizon-oil-spill" data-nav-header="deepwater-horizon-oil-spill">Reforms following the Deepwater Horizon oil spill</h2>
 
 <p>In the aftermath of the <a href="http://www.gpo.gov/fdsys/pkg/GPO-OILCOMMISSION/pdf/GPO-OILCOMMISSION.pdf">Deep Water Horizon oil spill</a> in the Gulf of Mexico in 2010, the federal government overhauled the oversight of DOI’s leasing, regulation, and collection of revenue for oil and gas extraction on the Outer Continental Shelf. DOI’s post Deepwater Horizon reorganization separated and established <a href="http://www.boem.gov/Reforms-since-the-Deepwater-Horizon-Tragedy/">independent oversight for offshore leasing</a> (i.e., BOEM), offshore safety and environmental enforcement (i.e., BSEE), and the collection and accountability of the revenue generated from natural resource development on federal and Indian lands through the creation of the Office of Natural Resources Revenue (i.e., ONRR).</p>
 
@@ -40,7 +40,7 @@ nav_items:
 
 <p>While the federal government made regulatory reforms following the spill, Congress did not change any laws related to offshore fossil fuel management in response to the accident.</p>
 
-<h3 id="oig-reports" data-nav-header="oig-reports">Office of Inspector General (OIG) reports</h3>
+<h2 class="h3" id="oig-reports" data-nav-header="oig-reports">Office of Inspector General (OIG) reports</h2>
 
 <p><a href="https://www.doioig.gov/sites/doioig.gov/files/99-I-387.pdf">DOI’s OIG</a> is responsible for the independent oversight and promotion of excellence, integrity, and accountability within the programs, operations, and management of DOI. OIG also identifies and prevents fraud, waste, and mismanagement within the agency. In recent years, OIG has published numerous reports related to DOI revenue from natural resource extraction, including:</p>
 
@@ -51,7 +51,7 @@ nav_items:
   <li>May 2010: <a href="https://www.doioig.gov/sites/doioig.gov/files/2010-I-0021.pdf">Minerals Management Service: Royalty-In-Kind Program’s Oil Volume Verification Process</a>. OIG found several areas where the Royalty-In-Kind Program could be improved to ensure proper accounting of royalties that are paid in oil and gas volumes to the federal government, rather than in dollars.</li>
 </ul>
 
-<h3 id="gao-reports" data-nav-header="gao-reports">Government Accountability Office (GAO) reports</h3>
+<h2 class="h3" id="gao-reports" data-nav-header="gao-reports">Government Accountability Office (GAO) reports</h2>
 
 <p>The GAO is an independent, nonpartisan agency that investigates how the federal government spends taxpayer funds, including those for natural resource management on federal and Indian lands. GAO publishes its reports on the <a href="http://www.gao.gov/key_issues/oil_and_natural_gas/issue_summary">GAO Summary Page</a>. Some recent GAO findings related to natural resource extraction include:</p>
 
@@ -61,7 +61,7 @@ nav_items:
   <li>March 1989: <a href="http://archive.gao.gov/d15t6/138159.pdf">The Mining Law of 1872 Needs Revision</a>. This report critiques the foundational mining law on three major points: that the law’s annual work requirements need to be replaced, that the law forces the federal government to sell valuable land at nominal prices, and that the patent provision runs counter to other natural resource policies.</li>
 </ul>
 
-<h3 id="proposed-rules" data-nav-header="proposed-rules">Proposed rules</h3>
+<h2 class="h3" id="proposed-rules" data-nav-header="proposed-rules">Proposed rules</h2>
 
 <p>Per the Administrative Procedures Act, agencies propose rules to implement federal laws. The public has an opportunity to comment on all proposed rules before an agency finalizes any regulations. Recently, DOI bureaus and offices proposed new rules intended to go into effect in 2015, including:</p>
 
@@ -73,7 +73,7 @@ nav_items:
 
 <p>For more details, search the <a href="https://www.federalregister.gov/articles/search?conditions%5Bpublication_date%5D%5Bis%5D=11%2F04%2F2015&conditions%5Bterm%5D=Department+of+the+Interior&conditions%5Btype%5D%5B%5D=PRORULE">Federal Registrar for DOI proposed rules</a>.</p>
 
-<h3 id="dodd-frank" data-nav-header="dodd-frank">The 2010 Dodd-Frank Act</h3>
+<h2 class="h3" id="dodd-frank" data-nav-header="dodd-frank">The 2010 Dodd-Frank Act</h2>
 
 <p>In 2010, the U.S. enacted the <a href="http://www.gpo.gov/fdsys/pkg/PLAW-111publ203/pdf/PLAW-111publ203.pdf">Dodd-Frank Wall Street Reform and Consumer Protection Act</a> (124 Stat. 1376) to improve transparency and accountability across the financial system. Section 1504 of the act requires extractive industries companies registered with the Securities and Exchange Commission (SEC) to separately disclose information about payments to governments around the world in an interactive data format.</p>
 

--- a/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
@@ -32,7 +32,7 @@ nav_items:
 
 <p>See <a href="{{site.baseurl}}/how-it-works/state-legal-fiscal-info/">State Legal and Fiscal Information</a> for more details about the individual states’ laws and statutes.</p>
 
-<h3 id="role-of-state-government-agencies" data-nav-header="role-of-state-government-agencies">Role of state government agencies</h3>
+<h2 class="h3" id="role-of-state-government-agencies" data-nav-header="role-of-state-government-agencies">Role of state government agencies</h2>
 
 <p>State government agencies create regulations and rules related to natural resource extraction based on applicable state laws and statutes (federal laws and regulations apply to all states and localities). Specifically, state government agencies manage state-owned land and natural resources, including leasing natural resources for extraction; enforce regulations and rules related to natural resource extraction; and collect, manage, and disburse revenue from natural resource extraction.</p>
 
@@ -46,11 +46,11 @@ nav_items:
 
 <p>Local government agencies also play a role in natural resource extraction. In particular, county departments of revenue collect, manage, and disburse local revenue from extractive industries activities.</p>
 
-<h3 id="state-leasing-programs" data-nav-header="state-leasing-programs">State leasing programs</h3>
+<h2 class="h3" id="state-leasing-programs" data-nav-header="state-leasing-programs">State leasing programs</h2>
 
 <p>State ownership of land constitutes <a href="http://www.nrcm.org/documents/publiclandownership.pdf">almost 9% of total land area</a> in the U.S. Each state has its own process for leasing natural resources on state-owned lands, and different oversight procedures for when companies explore for, develop, and produce natural resources and when companies decommission projects and reclaim sites. For example, in the State of Alaska, the director of the Division of Oil and Gas at the Department of Natural Resources must establish in writing that the state’s interests will be optimized before any leasing action can occur. Known as a “best-interest finding,” the director weighs the costs and benefits of the leasing action, including potential effects on natural, historical, and cultural resources, as well as on local communities and fish and wildlife populations. The director also considers public comments.</p>
 
-<h3 id="state-extractive-industries-revenue" data-nav-header="state-extractive-industries-revenue">State extractive industries revenue</h3>
+<h2 class="h3" id="state-extractive-industries-revenue" data-nav-header="state-extractive-industries-revenue">State extractive industries revenue</h2>
 
 <p>The revenue a state receives from extractive activities varies by the local legal and fiscal framework, and by the types of resources and land owners involved. At a high level, many states receive the following revenue:</p>
 
@@ -60,9 +60,9 @@ nav_items:
   <li><a href="http://www.onrr.gov/about/pdfdocs/20131119.pdf">Transfer payments</a> from the federal government for natural resource production on federal lands within a state’s borders or off its coast</li>
 </ul>
 
-<h4><a href="http://revenue.wyo.gov/mineral-tax-division/severance-tax-filing-information">Wyoming severance tax rates</a></h4>
+<h3 class="h5">Wyoming severance tax rates</h3>
 
-<p>As an example, Wyoming applies the following severance taxes on the value of extracted resources before processing and transportation:</p>
+<p>As an example, <a href="http://revenue.wyo.gov/mineral-tax-division/severance-tax-filing-information">Wyoming applies the following severance taxes</a> on the value of extracted resources before processing and transportation:</p>
 
 <table>
   <tr>
@@ -97,7 +97,7 @@ nav_items:
 
 <p>State royalty rates vary. <a href="http://app1.lla.state.la.us/PublicReports.nsf/DB918AD8E33411F286257B490074B82A/$FILE/00031C97.pdf">Louisiana royalty rates</a> average 21.9%, and can reach as high as 61.6%. California has a <a href="http://www.leginfo.ca.gov/cgi-bin/displaycode?section=prc&group=06001-07000&file=6826-6836">minimum royalty rate</a> of 16 and 2/3% that can rise up to a maximum percentage outlined in the invitation to bid for a lease, and paid on the average production of oil per well, per day under the lease.</p>
 
-<h3 id="revenue-disbursements" data-nav-header="revenue-disbursements">State revenue disbursements</h3>
+<h2 class="h3" id="revenue-disbursements" data-nav-header="revenue-disbursements">State revenue disbursements</h2>
 
 <p>Each individual state determines how to disburse revenue from extractive industries’ activities. To illustrate, North Dakota, one of the leading oil and gas producing states in the country, levies an Oil and Gas Production Tax at close to 1 cent per Mcf of gas, and at 5% of the gross production value of oil. 20% of the money collected from this tax is distributed to various state funds, while 80% flows to counties, cities, schools, and townships.</p>
 
@@ -112,11 +112,11 @@ nav_items:
 
 <p>In comparison, Alaska, another leading oil and gas producer, levies its own Oil and Gas Production Tax at 35% of the net value. Most of the revenue derived from the Oil and Gas Production Tax is deposited in the state’s General Fund for government operations and basic services. Payments resulting from an assessment or litigation are deposited into the <a href="http://www.tax.alaska.gov/programs/documentviewer/viewer.aspx?1139r">Constitutional Budget Reserve Fund</a>, which covers the state’s short-term deficits.</p>
 
-<h3 id="natural-resource-trust-funds" data-nav-header="natural-resource-trust-funds">Natural resource trust funds</h3>
+<h2 class="h3" id="natural-resource-trust-funds" data-nav-header="natural-resource-trust-funds">Natural resource trust funds</h2>
 
 <p>Many states choose to establish permanent mineral trust funds through legislation. These funds allow states to invest and hold revenue from natural resource extraction over time. Permanent mineral trust funds can help governments dependent on revenue from natural resources smooth revenue and investments across boom and bust cycles.</p>
 
-<h4>Select states with permanent natural resource trust funds</h4>
+<h4 class="h5">Select states with permanent natural resource trust funds</h4>
 
 <table>
   <tr>
@@ -176,4 +176,3 @@ nav_items:
   <td>General Fund</td>
   </tr>
 </table>
-

--- a/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
+++ b/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
@@ -49,7 +49,9 @@ nav_items:
   <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
   /
 </div>
-<h1 id="introduction" data-nav-header="introduction">State Legal and Fiscal Information</h1>
+<h1 id="introduction" data-nav-header="introduction">Regulations in 18 states</h1>
+
+<p class="case_studies_intro-para">Learn more about natural resource regulation, production, and revenue in the 18 states that, in 2013, led the country in oil, gas, coal, and nonenergy mineral production; had the most DOI revenue and / or state production taxes; or had the most significant tribal natural resource interest.</p>
 
 <nav class="hash_selector">
   {% include hash_selector.html %}

--- a/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
+++ b/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
@@ -57,7 +57,7 @@ nav_items:
   {% include hash_selector.html %}
 </nav>
 
-<h3 id="ak" data-nav-header="ak">Alaska</h3>
+<h2 class="h3" id="ak" data-nav-header="ak">Alaska</h2>
 
 <p>The Division of Oil and Gas within the Alaska Department of Natural Resources is responsible for leasing state lands for oil, gas, and geothermal extraction. Its major functions include evaluating oil and gas resources, fielding and issuing exploration permits, conducting royalty audits, and negotiating contracts. The website for the Alaska Department of Natural Resources has significant information regarding statutes and regulations, leasing on state lands, and historical revenue collection and distribution information, as well as production data, for oil and gas. Additional information about statutes and regulations and leasing on state lands is available for mining from the Division of Land and Water. The Alaska Department of Revenue’s Tax Division collects state taxes, including the Oil and Gas Production Tax and Oil and Gas Property Tax, and administers tax laws. The website contains information about taxes collected and revenue sources and forecasts.</p>
 
@@ -82,7 +82,7 @@ nav_items:
   </ul>
 </ul>
 
-<h3 id="az" data-nav-header="az">Arizona</h3>
+<h2 class="h3" id="az" data-nav-header="az">Arizona</h2>
 
 <p>The Minerals Section within the Arizona State Land Department oversees mining activities on state-trust lands by issuing permits and leases. The Minerals Section’s website contains information about the energy, mineral, and other management programs. The Arizona Department of Mines and Mineral Resources’ information is now available on the Geological Survey Mineral Resources’ webpage, where information on mineral rights, production levels, and laws and regulations can be found. The Office of the Arizona State Treasurer’s website allows visitors to create customized reports on revenue distribution.</p>
 
@@ -97,7 +97,7 @@ nav_items:
   <li><a href="http://www.aztreasury.gov/local-govt/revenue-distributions/">Arizona State Treasurer revenue distribution reports</a></li>
 </ul>
 
-<h3 id="ca" data-nav-header="ca">California</h3>
+<h2 class="h3" id="ca" data-nav-header="ca">California</h2>
 
 <p>The California Department of Conservation includes both the State Mining and Geology Board and the Division of Oil, Gas, and Geothermal Resources. The board oversees mineral resource extraction, reclaiming mine lands, and preparing geologic hazard information. The division regulates the drilling, operation, maintenance, plugging, and abandonment of oil, natural gas, and geothermal wells. Department of Conservation websites provide information on regulation, production, and programs for oil, gas, geothermal, and mining. The California Natural Resources Agency’s website has information regarding California’s renewable energy programs and goals.</p>
 
@@ -116,7 +116,7 @@ nav_items:
   <li><a href="http://resources.ca.gov/developing_renewable_energy_sources/">California Natural Resources Agency, information on renewable energy programs</a></li>
 </ul>
 
-<h3 id="co" data-nav-header="co">Colorado</h3>
+<h2 class="h3" id="co" data-nav-header="co">Colorado</h2>
 
 <p>The Oil and Gas Conservation Commission of the state’s Department of Natural Resources oversees the development of Colorado’s oil and gas natural resources. Its website provides relevant regulatory information, monthly resource production data, quarterly levy data, and information on drilling permits. The Colorado State Land Board manages assets held in public trust for Colorado public schools and institutions, including state lands used for natural resource extraction. The Division of Reclamation Mining and Safety protects miners, the public, and the environment from current and past mining operations. The Colorado Department of Revenue collects and disburses revenue for the state; annual reports provide details on these activities.</p>
 
@@ -142,7 +142,7 @@ nav_items:
   <li><a href="https://www.colorado.gov/pacific/dola/energymineral-impact-assistance-fund-eiaf">Energy / Mineral Impact Assistance Fund supported by state severance taxes</a></li>
 </ul>
 
-<h3 id="il" data-nav-header="il">Illinois</h3>
+<h2 class="h3" id="il" data-nav-header="il">Illinois</h2>
 
 <p>The Department of Natural Resources Office of Mines and Minerals regulates natural resource exploration and development throughout the state. The Office is comprised of four divisions: Land Reclamation; Abandoned Mine Lands; Blasting, Explosives, and Aggregates; and Mine Safety and Training. The Office of Oil and Gas Resource Management is the regulatory authority responsible for permitting, drilling, operating, and plugging oil and gas production wells.</p>
 
@@ -161,7 +161,7 @@ nav_items:
   <li><a href="http://www.ioc.state.il.us/index.cfm/resources/reports/cafr/">State of Illinois Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3 id="ky" data-nav-header="ky">Kentucky</h3>
+<h2 class="h3" id="ky" data-nav-header="ky">Kentucky</h2>
 
 <p>The Department for Natural Resources Division of Oil and Gas regulates the oil and gas industry in the state to protect mineral owners’ rights and the sustainability of the environment. The department’s divisions of Mine Permits, Mine Reclamation and Enforcement, and Mine Safety each execute different statutory responsibilities for mineral extraction oversight. Kentucky’s Energy and Environment Cabinet established the Department for Energy Development and Independence to develop and employ sustainable energy strategies for the state.</p>
 
@@ -189,7 +189,7 @@ nav_items:
   <li><a href="http://finance.ky.gov/services/statewideacct/Pages/ReportsandPublications.aspx">Kentucky Finance and Administration Cabinet Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3 id="la" data-nav-header="la">Louisiana</h3>
+<h2 class="h3" id="la" data-nav-header="la">Louisiana</h2>
 
 <p>The Office of Mineral Resources within the Department of Natural Resources manages natural resource extraction throughout the state and receives revenue from royalties, bonuses, rents, interest, and fees for leases for state-owned lands. The Office of Conservation and Office of Coastal Management within the department also oversee Louisiana’s oil and gas resources. The State Energy Office helps maximize Louisiana's energy potential by exploring all energy sources.</p>
 
@@ -206,7 +206,7 @@ nav_items:
   <li><a href="http://www.doa.la.gov/Pages/osr/lac/LAC-43.aspx">Office of State Register Administrative Code for natural resources</a></li>
 </ul>
 
-<h3 id="mn" data-nav-header="mn">Minnesota</h3>
+<h2 class="h3" id="mn" data-nav-header="mn">Minnesota</h2>
 
 <p>The Division of Lands and Minerals within Minnesota’s Department of Natural Resources manages the state's mineral resources and mine development on state-owned lands to generate revenue for the state's School and University Trust Funds, local communities, and General Fund. The division ensures full reclamation of extractive sites and maintains comprehensive mineral land records.</p>
 
@@ -221,7 +221,7 @@ nav_items:
   <li><a href="http://mn.gov/mmb/accounting/reports/comprehensive-annual.jsp">Minnesota Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3 id="mt" data-nav-header="mt">Montana</h3>
+<h2 class="h3" id="mt" data-nav-header="mt">Montana</h2>
 
 <p>Within Montana’s Department of Resources and Natural Conservation, the Trust Lands Management Division oversees 5.2 million acres of state land and manages all energy resource leasing. The Minerals Management Bureau manages and issues leases and permits for oil, gas, coal, and other natural resources on state lands. The Montana Board of Oil and Gas protects citizens and the environment from the negative effects of oil and gas extraction by issuing permits, inspecting wells, and conducting environmental remediation programs.</p>
 
@@ -238,7 +238,7 @@ nav_items:
   <li><a href="https://revenue.mt.gov/home/publications">Montana Department of Revenue Tax Related Reports</a></li>
 </ul>
 
-<h3 id="nv" data-nav-header="nv">Nevada</h3>
+<h2 class="h3" id="nv" data-nav-header="nv">Nevada</h2>
 
 <p>The Bureau of Mining Regulation and Reclamation within the Department of Conservation and Natural Resources oversees all mining activities in the state of Nevada. The division focuses on regulation (ensuring statutory compliance), closure (confirming stabilization of all applicable mine components), and reclamation (issuing reclamation permits to all large-scale operators).</p>
 
@@ -257,7 +257,7 @@ nav_items:
   <li><a href="http://controller.nv.gov/FinancialReports/CAFR_Download_Page.html">Nevada State Controller Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3 id="nm" data-nav-header="nm">New Mexico</h3>
+<h2 class="h3" id="nm" data-nav-header="nm">New Mexico</h2>
 
 <p>The New Mexico Mining and Minerals Division enforces laws and regulations related to mine safety and reclamation of abandoned mines. The division collects production and employment data on active mining operations through its Mine Registration and Reporting Program. It also uses a Geographic Information System (GIS) to locate and track mining activities in the state, available for public use on the division’s website. The Oil Conservation Division regulates oil, gas, and geothermal activity in New Mexico. It gathers well production data, issues permits for new wells, enforces statutes and rules, and ensures abandoned wells are properly plugged and the land is restored.</p>
 
@@ -277,7 +277,7 @@ nav_items:
   <li><a href="http://nmdfa.state.nm.us/New_Mexico_CAFR.aspx">New Mexico Department of Finance and Administration Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3 id="nd" data-nav-header="nd">North Dakota</h3>
+<h2 class="h3" id="nd" data-nav-header="nd">North Dakota</h2>
 
 <p>North Dakota’s Department of Mineral Resources Oil and Gas Division regulates the drilling and production of oil and gas in the state. In addition to its regulatory oversight function, the Oil and Gas Division manages permitting and maintains production and well data. Data pertaining to mineral extraction is housed by the state’s Geological Survey.</p>
 
@@ -297,7 +297,7 @@ nav_items:
   </ul>
 </ul>
 
-<h3 id="ok" data-nav-header="ok">Oklahoma</h3>
+<h2 class="h3" id="ok" data-nav-header="ok">Oklahoma</h2>
 
 <p>The Oklahoma Commissioners of the Land Office manages state lands, including oil and gas leasing to generate revenue that supports the state’s common schools and higher education institutions. The Oklahoma Department of Mines regulates the coal and nonfuel mineral production, enforcing a variety of federal and state programs for safety, health, and land reclamation. The department also issues permits for all mining operations.</p>
 
@@ -317,7 +317,7 @@ nav_items:
   <li><a href="http://www.ok.gov/OSF/documents/cafr14.pdf">Oklahoma Office of Management and Enterprise Services Comprehensive Annual Financial Report</a></li>
 </ul>
 
-<h3 id="pa" data-nav-header="pa">Pennsylvania</h3>
+<h2 class="h3" id="pa" data-nav-header="pa">Pennsylvania</h2>
 
 <p>The Department of Environmental Protection, including the Bureau of Mining Programs and the Office of Oil and Gas Management, manages programs that ensure the safe and responsible exploration, development, and recovery of extractive resources. These programs include permitting and inspection, regulatory oversight, and training.</p>
 
@@ -341,7 +341,7 @@ nav_items:
   </ul>
 </ul>
 
-<h3 id="tx" data-nav-header="tx">Texas</h3>
+<h2 class="h3" id="tx" data-nav-header="tx">Texas</h2>
 
 <p>The Railroad Commission of Texas is statutorily responsible for regulating the exploration and production of the state’s natural resources: oil, natural gas, minerals (particularly lignite and coal), and alternative fuels. The commission oversees natural resource extraction along with land reclamation and environmental protection. The commission also oversees safety and compliance related to the state’s extensive oil and gas pipeline infrastructure.</p>
 
@@ -356,7 +356,7 @@ nav_items:
   <li><a href="http://www.texastransparency.org/State_Finance/Budget_Finance/Reports/Revenue_by_Source/revenue_hist.php">Historical state net tax revenue by source</a></li>
 </ul>
 
-<h3 id="ut" data-nav-header="ut">Utah</h3>
+<h2 class="h3" id="ut" data-nav-header="ut">Utah</h2>
 
 <p>The Division of Oil, Gas, and Mining within Utah’s Department of Natural Resources is responsible for developing natural resources for the economic benefit of the public while preserving the state’s natural environment. The division maintains four core programs, each with specific oversight functions: the Coal Program, the Mineral Mining Program, the Oil and Gas Program, and the Abandoned Mine Reclamation Program.</p>
 
@@ -377,7 +377,7 @@ nav_items:
   <li><a href="http://finance.utah.gov/cafr.html">Utah Department of Administrative Services Division of Finance Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3 id="wv" data-nav-header="wv">West Virginia</h3>
+<h2 class="h3" id="wv" data-nav-header="wv">West Virginia</h2>
 
 <p>The West Virginia Department of Environmental Protection oversees natural resource extraction in West Virginia. The department’s Office of Oil and Gas is responsible for monitoring and regulating all actions related to the exploration, drilling, storage, and production of oil and natural gas. The Division of Mining and Reclamation manages compliance, reclamation, permitting, and communications between the public and industry.</p>
 
@@ -398,7 +398,7 @@ nav_items:
   <li><a href="http://www.finance.wv.gov/FARS/CAFR/Pages/default.aspx">West Virginia Department of Administration, Division of Finance Comprehensive Annual Financial Report Archive</a></li>
 </ul>
 
-<h3 id="wy" data-nav-header="wy">Wyoming</h3>
+<h2 class="h3" id="wy" data-nav-header="wy">Wyoming</h2>
 
 <p>The Wyoming Office of State Lands and Investments manages resource extraction on state land held in public trust. The revenue from energy and mineral resource leasing helps fund public education and essential institutions in the state.</p>
 

--- a/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
@@ -26,13 +26,13 @@ nav_items:
 
 <p>The federal government formally recognizes 566 Indian tribes and 325 Indian reservations that cover <a href="http://www.blm.gov/public_land_statistics/pls13/pls2013.pdf">56 million acres of land</a>. This land is held in trust by DOI and has <a href="http://www.resourcegovernance.org/sites/default/files/RWI_Native_American_Lands_2011.pdf">significant natural resource extraction potential</a>, containing up to 30% of U.S. coal reserves west of the Mississippi, 50% of potential uranium reserves, and 20% of known oil and gas reserves. Extracting natural resources on Indian land and distributing the associated revenue involves a unique set of processes and stakeholders.</p>
 
-<h2 id="federal-obligations" data-nav-header="federal-obligations">Federal obligations</h2>
+<h2 class="h3" id="federal-obligations" data-nav-header="federal-obligations">Federal obligations</h2>
 
 <p>The basis of the regulatory relationship between Indian tribes and the federal government was established in the Commerce Clause of the U.S. Constitution (Article 1, Section 8, Clause 3). This relationship, as it pertains to land use and ownership, was clarified in the 1830s. In a series of Supreme Court decisions known as the Marshall Trilogy, former Supreme Court Justice John Marshall established several important principles of Indian law.</p>
 
 <p>One was the federal Indian trust responsibility, whereby the government charged itself with “<a href="http://www.bia.gov/FAQs/index.htm">moral obligations of the highest responsibility and trust</a>” toward Indian tribes. In this capacity, the U.S. Government maintains fiduciary responsibility to protect tribal assets and resources and serves as a trustee for Indian lands. Another was the principle that tribes are sovereign, which is inherent to them as the original governing bodies of what is now the United States, and that sovereignty can only be diminished by Congress.</p>
 
-<h2 id="leasing-process" data-nav-header="leasing-process">Leasing process</h2>
+<h2 class="h3" id="leasing-process" data-nav-header="leasing-process">Leasing process</h2>
 
 <p>Today, there are <a href="http://teeic.indianaffairs.gov/triballand/">two major types of Indian-owned land</a>:</p>
 
@@ -47,11 +47,11 @@ nav_items:
 
 <p>The Office of the Special Trustee for American Indians (OST) receives the payments and information from ONRR and <a href="http://www.onrr.gov/IndianServices/pdfdocs/FrequentlyAskedQuestion.pdf">disburses 100% of the funds to the owner of the land</a>, whether that is an individual or a tribe.</p>
 
-<h2 id="production-and-revenue" data-nav-header="production-and-revenue">Indian land production and revenue</h2>
+<h2 class="h3" id="production-and-revenue" data-nav-header="production-and-revenue">Indian land production and revenue</h2>
 
 <p>Natural resources are increasingly a key source of income for many American Indian tribes. In FY 2013, ONRR and OST disbursed <a href="http://statistics.onrr.gov/ReportTool.aspx">$933 million to American Indian tribes and allottees</a>, an increase of more than 171% from 10 years prior.</p>
 
-<h3 id="fy-2013-production-and-revenue" data-nav-header="fy-2013-production-and-revenue">FY 2013 production and revenue</h3>
+<h3 class="h5" id="fy-2013-production-and-revenue" data-nav-header="fy-2013-production-and-revenue">FY 2013 production and revenue</h3>
 
 <table>
   <tr>

--- a/_how-it-works/natural-resources/ownership.md
+++ b/_how-it-works/natural-resources/ownership.md
@@ -14,13 +14,19 @@ permalink: /how-it-works/ownership/
     </div>
     <h1>Ownership</h1>
 
+    <p class="case_studies_intro-para">Natural resource ownership in the United States is closely tied to land ownership. We'll talk about both these types of ownership here.</p>
+
     <h2>Land ownership</h2>
 
-    <p class="case_studies_intro-para">Natural resource ownership in the United States is closely tied to land ownership. There are four main types of land owners: citizens and corporations; the federal government; state and local governments; and Indian tribes and individuals. There are two types of owners for submerged lands under the ocean: states and the federal government.</p>
+    <p>There are four main types of land owners: citizens and corporations; the federal government; state and local governments; and Indian tribes and individuals. There are two types of owners for submerged lands under the ocean: states and the federal government.</p>
 
-    <p><strong>Private lands</strong> are owned by private citizens or corporations.</p>
+    <h3>Private lands</h3>
 
-    <p><strong><a href="http://fas.org/sgp/crs/misc/R42346.pdf">Federal lands</a></strong> are owned by or under jurisdiction of the federal government, including:</p>
+    <p>Private lands are owned by private citizens or corporations.</p>
+
+    <h3>Federal lands</h3>
+
+    <p><a href="http://fas.org/sgp/crs/misc/R42346.pdf">Federal lands</a> are owned by or under jurisdiction of the federal government, including:</p>
 
     <ul class="list-bullet">
       <li>Public domain lands ceded to the U.S. by treaty, purchase, or conquest</li>
@@ -29,7 +35,9 @@ permalink: /how-it-works/ownership/
   	<li><a href="http://www.boem.gov/OCS-Lands-Act-History/">Outer Continental Shelf</a> submerged lands located farther than three miles off a state’s coastline, or three marine leagues into the Gulf of Mexico off of Texas and Western Florida</li>
     </ul>
 
-    <p><strong>State and local lands</strong> are owned by state or local governments, including:</p>
+    <h3>State and local lands</h3>
+
+    <p>State and local lands are owned by state or local governments, including:</p>
 
     <ul class="list-bullet">
       <li>Lands owned by a particular state</li>
@@ -37,7 +45,9 @@ permalink: /how-it-works/ownership/
   	<li>Lands owned by a local government, such as a county</li>
     </ul>
 
-    <p><strong>Indian lands</strong> are owned by Native Americans, and include:</p>
+    <h3>Indian lands</h3>
+
+    <p>Indian lands are owned by Native Americans, and include:</p>
 
     <ul class="list-bullet">
       <li>Tribal lands held in trust by the federal government for a tribe’s use</li>
@@ -51,7 +61,7 @@ permalink: /how-it-works/ownership/
 
     <p>Natural resource ownership has historical roots in the 19th century, when the federal government passed homestead and development acts to encourage settlement in the West. These acts, along with the General Mining Law of 1872, allowed for federal public domain lands, and the natural resources within them, to pass to private ownership. Starting in the 20th century, the U.S. passed legislation that began to withdraw both specific natural resources and eventually public domain lands from settlement and other development, preserving these lands and natural resources in federal ownership today.</p>
 
-    <h4>Split ownership</h4>
+    <h3>Split ownership</h3>
 
     <p>Sometimes the land’s surface owner is different from the owner of the minerals in the ground below. The party that owns the land’s surface has surface rights, while the party that owns the natural resources in the ground has subsurface rights. When ownership is divided in this way, it is referred to as a <a href="http://www.blm.gov/wo/st/en/prog/energy/oil_and_gas/best_management_practices/split_estate.html">split estate</a>. There are 57 million acres of land in the U.S. where the federal government owns oil, gas, coal, and other minerals below the surface, but another party, mostly citizens or corporations, owns the surface land above. Land and mineral ownership can become quite complicated. Often, a combination of private landholders, the federal government, a state government, or Indian tribes own the span of a single mine or field.</p>
 

--- a/_how-it-works/natural-resources/revenues.md
+++ b/_how-it-works/natural-resources/revenues.md
@@ -12,19 +12,23 @@ permalink: /how-it-works/revenues/
       <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
       /
     </div>
-    <h1>Revenues</h1>
+    <h1>Revenue</h1>
 
-    <h3>DOI revenue</h3>
+    <p class="case_studies_intro-para">Companies pay a wide range of fees, rates and taxes to extract natural resources in the U.S. The amounts differ depending on what the <a href="{{ site.baseurl }}/how-it-works/ownership/">ownership</a> of the natural resource looks like. We'll cover some of the major types of payments companies make here. They are usually called 'revenue' because they represent revenue to the American public.</p>
 
-    <p class="case_studies_intro-para">When companies extract natural resources on federal onshore lands and the Outer Continental Shelf, they pay revenue to the Department of the Interior (DOI). In general, companies pay bonuses, rents, royalties, or fees and penalties (if incurred) to ONRR, and in some cases bonuses and rents to BLM. Royalties, a percentage of the sales value of extracted resources, make up most of the revenue paid to DOI.</p>
+    <h2>Payments to extract natural resources from federal land and waters</h2>
+
+    <p>When companies extract natural resources on federal onshore lands and the Outer Continental Shelf, they pay revenue to the Department of the Interior (DOI). In general, companies pay bonuses, rents, royalties, or fees and penalties (if incurred) to ONRR, and in some cases bonuses and rents to BLM. Royalties, a percentage of the sales value of extracted resources, make up most of the revenue paid to DOI.</p>
 
     <p>Lease holders also pay different fees to BLM, BSEE, and BOEM, often to reimburse the federal government for costs associated with awarding, administering, and enforcing leases. For extracting locatable hardrock minerals on federal lands, companies pay fees, but not royalties under the Mining Law of 1872.</p>
 
     <img src="{{site.baseurl}}/img/landing-placeholders/revenue-type-summary-table.png">
 
+    <h2>Payments to extract natural resources from any land or water in the U.S.</h2>
+
     <h3>Corporate income taxes</h3>
 
-    <p>Corporations operating in the extractive industries also pay taxes to the IRS on their income. These companies pay federal corporate income taxes regardless of whether they extract natural resources from federal, state, or privately held lands, so long as they have a liability. These companies also pay taxes on income from extracting natural resources and processing them into other products and commodities. There are different types of companies operating in these industries, with different ownership structures, and as a result, they are treated as different taxpayers:</p>
+    <p>Corporations operating in the extractive industries pay taxes to the IRS on their income. These companies pay federal corporate income taxes regardless of whether they extract natural resources from federal, state, or privately held lands, so long as they have a liability. These companies also pay taxes on income from extracting natural resources and processing them into other products and commodities. There are different types of companies operating in these industries, with different ownership structures, and as a result, they are treated as different taxpayers:</p>
 
     <ul class="list-bullet">
   	  <li>C-corporations with many shareholders who own the company; these companies pays corporate income taxes to the IRS</li>
@@ -66,11 +70,15 @@ permalink: /how-it-works/revenues/
 
     <p>The federal budget also includes annual estimates of the net revenue effects of eliminating a wider range of fossil fuel related tax expenditures outlined in <a href="https://www.treasury.gov/open/Documents/USA%20FFSR%20progress%20report%20to%20G20%202014%20Final.pdf">United States – Progress Report on Fossil Fuel Subsidies</a>. When added together, eliminating fossil fuel tax expenditures would decrease the U.S. deficit by $4.4 billion a year on average over a 10-year window, per estimates in the White House report, <a href="https://www.whitehouse.gov/sites/default/files/omb/budget/fy2016/assets/16msr.pdf">Fiscal Year 2016 Mid-Session Review: Budget of the U.S. Government</a>. The report did not include estimates of the effects of eliminating renewable and nonenergy mineral tax expenditures.</p>
 
+    <h2>After a payment, what happens to the revenue?</h2>
+
     <h3>Federal budget process</h3>
 
     <p>Once revenue is collected by the federal government, it passes through a series of budgetary gateways before ultimately funding public services and community development. These gateways are described below:</p>
 
     <img src="{{site.baseurl}}/img/landing-placeholders/disbursements.png">
+
+    <p>You can explore disbursement data on our site <a href="{{ site.baseurl }}/explore/disbursements/">here</a>.</p>
 
   </article>
 

--- a/_sass/blocks/_about.scss
+++ b/_sass/blocks/_about.scss
@@ -36,7 +36,7 @@
   text-align: left;
 
   li {
-    line-height: 1.1;
+    line-height: 1.2;
     padding-bottom: $base-padding-lite;
   }
 }

--- a/_sass/blocks/_all.scss
+++ b/_sass/blocks/_all.scss
@@ -40,3 +40,10 @@
 //
 // Styleguide blocks.search
 @import 'search';
+
+// Downloads
+//
+// Styles for the page at /downloads/
+//
+// Styleguide blocks.downloads
+@import 'downloads';

--- a/_sass/blocks/_downloads.scss
+++ b/_sass/blocks/_downloads.scss
@@ -13,3 +13,30 @@
   margin-top: $base-padding-jumbo;
   padding-bottom: $base-padding-lite;
 }
+
+.downloads-download_links-intro {
+  margin-bottom: 0;
+}
+
+.downloads-download_links {
+  a {
+    font-size: 1rem;
+    font-weight: $weight-book;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  li {
+    margin-left: $base-padding-lite;
+  }
+}
+
+.downloads-docs {
+  span {
+    font-weight: $weight-book;
+  }
+}

--- a/_sass/blocks/_downloads.scss
+++ b/_sass/blocks/_downloads.scss
@@ -1,0 +1,15 @@
+// Styleguide blocks.downloads
+
+.downloads {
+  h3 {
+    font-size: 1.2rem;
+    padding-top: $base-padding;
+  }
+}
+
+.downloads-section_heading {
+  border-bottom: 2px solid $mid-gray;
+  margin-bottom: $base-padding;
+  margin-top: $base-padding-jumbo;
+  padding-bottom: $base-padding-lite;
+}

--- a/_sass/blocks/case-studies/_content.scss
+++ b/_sass/blocks/case-studies/_content.scss
@@ -10,7 +10,6 @@
   ul {
     font-weight: $weight-light;
     list-style-type: square;
-    padding-bottom: $base-padding;
     padding-left: $base-padding;
   }
 }
@@ -40,4 +39,8 @@
 
 .case_studies_content-heading {
   color: $dark-gray;
+
+  &:hover {
+    text-decoration: none;
+  }
 }

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -6,6 +6,15 @@
   @include respond-to(medium-down) {
     display: none;
   }
+
+  ul a {
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
 }
 
 .sticky_nav-nav_item {

--- a/_sass/elements/_typography.scss
+++ b/_sass/elements/_typography.scss
@@ -62,9 +62,16 @@ ul,
 }
 
 p + h2,
+p + .h2,
 p + h3,
+p + .h3,
 p + h4,
+p + .h4,
 table + h3,
-ul + h3 {
+table + .h3,
+ul + h2,
+ul + .h2,
+ul + h3,
+ul + .h3 {
   margin-top: $base-padding-large;
 }

--- a/pages/about.md
+++ b/pages/about.md
@@ -15,8 +15,7 @@ permalink: /about/
         <h2 class="about_intro-header">The 2015 USEITI Report is now available, and includes:</h2>
         <ul class="list-bullet about_intro-list">
           <li>Never-before-released federal production data</li>
-          <li>Another important point here that is probably on two lines</li>
-          <li>Even a third thing</li>
+          <li>New narratives explaining how the whole system of leasing federal land works in the U.S.</li>
         </ul>
         <a href="{{ site.baseurl }}/about/whats-new/" class="carousel-button button-primary">See what's new</a>
       </div>

--- a/pages/report.md
+++ b/pages/report.md
@@ -14,19 +14,21 @@ permalink: /about/report/
     </div>
 
     <h1>{{page.title}}</h1>
-    <p class="case_studies_intro-para">As part of fulfilling the international <a href="https://eiti.org/document/standard">EITI Standard</a>, the Independent Administrator worked with the <a href="https://www.doi.gov/eiti/FACA">Multi-stakeholder Group</a> to develop an Executive Summary.</p>
+    <p class="case_studies_intro-para">As part of fulfilling the international <a href="https://eiti.org/document/standard">EITI Standard</a>, the Independent Administrator worked with the <a href="https://www.doi.gov/eiti/FACA">Multi-stakeholder Group</a> to develop an Executive Summary of the USEITI 2015 Report.</p>
 
     <p>This document, which you can download below, includes an overview of the contextual narrative and an account of the reporting and reconciliation process for the EITI Standard in the U.S.</p>
 
     <p>However, many parts of the report are primarily available online. Explore this site to:</p>
 
     <ul class="list-bullet">
-  	  <li><a href="{{ site.baseurl }}/explore/">See maps and charts of extractive industries data.</a></li>
-  	  <li><a href="{{ site.baseurl }}/case-studies/">Read 12 case studies about how extractive industries have affected specific counties.</a></li>
-  	  <li><a href="{{ site.baseurl }}/downloads/">Download data sets and view data documentation.</a></li>
+  	  <li><a href="{{ site.baseurl }}/explore/">See maps and charts</a> of extractive industries data.</li>
+  	  <li>Read <a href="{{ site.baseurl }}/case-studies/">12 case studies</a> about how extractive industries have affected specific counties.</li>
+  	  <li><a href="{{ site.baseurl }}/downloads/">Download data</a> and view data documentation.</li>
     </ul>
 
     <p>In many parts of this site, you'll also find invitations to discuss and participate in USEITI actitivies both online and in person.</p>
+
+    <h2>USEITI 2015 Executive Summary</h2>
 
     <a href="{{site.baseurl}}/downloads/USEITI_executive-summary_2015-12-02.pdf" class="button-tertiary">
       <icon class="icon-cloud icon-padded"></icon>Download Executive Summary (pdf, 4 MB)

--- a/pages/whats_new.md
+++ b/pages/whats_new.md
@@ -36,6 +36,8 @@ permalink: /about/whats-new/
 
     <p><strong>How it works:</strong> Beyond the numbers, we've included new narratives explaining how the whole system of leasing federal land and collecting royalties on extracted materials works in the U.S. <a href="">Learn how it works.</a></p>
 
+    <h2>What's next</h2>
+
     <p>This site is still in progress. Over the coming months, here's what we're looking forward to:</p>
 
     <ul class="list-bullet">

--- a/pages/whats_new.md
+++ b/pages/whats_new.md
@@ -14,7 +14,7 @@ permalink: /about/whats-new/
     </div>
 
     <h1>{{page.title}}</h1>
-    
+
     <p>The ititial USEITI beta site launched in early 2015, offering visualizations that showed how such resources generate revenue across the country, and where the money earned goes.</p>
 
     <p>This site expands and improves on that site in response to user feedback and new data. Here's some of the ways we've made the site more useful:</p>
@@ -41,7 +41,7 @@ permalink: /about/whats-new/
     <ul class="list-bullet">
       <li>USEITI has invited states to opt in to this process, with the goal of making state-level data more navigable for members of the public. In 2016, participating states will begin contributing data.</li>
       <li>In early 2016, we'll be making reconciliation data more interactive and easier to explore.</li>
-      <li>We'll be collecting community feedback to help us make the site clearer and more useful. <a href="">Help us improve the site.</a></li>
+      <li>We'll be collecting community feedback to help us make the site clearer and more useful. <a href="https://ethn.io/38933">Help us improve the site.</a></li>
     </ul>
 
   </div>


### PR DESCRIPTION
- Removes commented-out code from narratives
- Fixes style issue on case studies page introduced when I added link underline styles for `ul` in paragraphs.
- Fixes `<h>` semantic order on case studies, downloads and how-it-works pages for #888 .
- Normalizes styles across documentation and how it works article pages.
- Adds intro paragraphs on a few how it works articles where the article was clearly taken from a larger section.
- Adds intro paragraph and new section names to how-it-works/revenue
- Removes filler text on about page.
- Every-so-slightly cleans up styles on what's new and exec summary.

@coreycaitlin for visibility -- maybe you want to review before merge, or merge it and then see how things look live. I made lots of tiny adjustments to the narrative pages.