### PR TITLE
Add narrative layout to natural resource pages

### DIFF
--- a/_how-it-works/natural-resources/ownership.md
+++ b/_how-it-works/natural-resources/ownership.md
@@ -1,72 +1,80 @@
 ---
 title: Ownership | How it Works
-layout: default
+layout: narrative
 permalink: /how-it-works/ownership/
+nav_description: Jump to a section
+nav_items:
+  - name: introduction
+    title: Top
+  - nav_group: Land ownership
+  - name: private-lands
+    title: Private Lands
+  - name: federal-lands
+    title: Federal Lands
+  - name: state-and-local-lands
+    title: State and Local Lands
+  - name: indian-lands
+    title: Indian Lands
+  - nav_group: Natural resource ownership
+  - name: split-ownership
+    title: Split Ownership
 ---
 
-<div class="container-outer container-padded">
-
-  <article class="container-left-7">
-
-    <div>
-      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
-      /
-    </div>
-    <h1>Ownership</h1>
-
-    <p class="case_studies_intro-para">Natural resource ownership in the United States is closely tied to land ownership. We'll talk about both these types of ownership here.</p>
-
-    <h2>Land ownership</h2>
-
-    <p>There are four main types of land owners: citizens and corporations; the federal government; state and local governments; and Indian tribes and individuals. There are two types of owners for submerged lands under the ocean: states and the federal government.</p>
-
-    <h3>Private lands</h3>
-
-    <p>Private lands are owned by private citizens or corporations.</p>
-
-    <h3>Federal lands</h3>
-
-    <p><a href="http://fas.org/sgp/crs/misc/R42346.pdf">Federal lands</a> are owned by or under jurisdiction of the federal government, including:</p>
-
-    <ul class="list-bullet">
-      <li>Public domain lands ceded to the U.S. by treaty, purchase, or conquest</li>
-      <li>Acquired lands purchased by, given to, exchanged with, or transferred through condemnation proceedings to the federal government</li>
-  	<li>Military acquired lands purchased by the federal government under military acquisition laws</li>
-  	<li><a href="http://www.boem.gov/OCS-Lands-Act-History/">Outer Continental Shelf</a> submerged lands located farther than three miles off a state’s coastline, or three marine leagues into the Gulf of Mexico off of Texas and Western Florida</li>
-    </ul>
-
-    <h3>State and local lands</h3>
-
-    <p>State and local lands are owned by state or local governments, including:</p>
-
-    <ul class="list-bullet">
-      <li>Lands owned by a particular state</li>
-      <li><a href="http://www.boem.gov/uploadedfiles/submergedla.pdf">State submerged lands</a> under the ocean stretching from a state’s coast to three miles out into the ocean, or in the case of Texas and western Florida, from the coast out to three marine leagues into the Gulf of Mexico</li>
-  	<li>Lands owned by a local government, such as a county</li>
-    </ul>
-
-    <h3>Indian lands</h3>
-
-    <p>Indian lands are owned by Native Americans, and include:</p>
-
-    <ul class="list-bullet">
-      <li>Tribal lands held in trust by the federal government for a tribe’s use</li>
-      <li>Allotments held in trust by the federal government for individual Indians’ use</li>
-  	<li><a href="http://www.gao.gov/assets/660/650857.pdf">Alaska Native Corporation</a> lands in Alaska, held by 12 regional Alaska Native Corporations that received rights to some surface lands, as well as rights to natural resources below the surface. Along with these 12 regional Alaska Native Corporations, certain village-level Alaska Native Corporations hold additional surface land rights.</li>
-    </ul>
-
-    <h2>Natural resource ownership</h2>
-
-    <p>Private individuals and corporations, as well as federal, state, local, and tribal governments, can own both land and the oil, gas, coal, and other minerals found below the surface. In fact, widespread private ownership of these resources makes the U.S. different from nearly every other country in which these resources simply belong to the national government.</p>
-
-    <p>Natural resource ownership has historical roots in the 19th century, when the federal government passed homestead and development acts to encourage settlement in the West. These acts, along with the General Mining Law of 1872, allowed for federal public domain lands, and the natural resources within them, to pass to private ownership. Starting in the 20th century, the U.S. passed legislation that began to withdraw both specific natural resources and eventually public domain lands from settlement and other development, preserving these lands and natural resources in federal ownership today.</p>
-
-    <h3>Split ownership</h3>
-
-    <p>Sometimes the land’s surface owner is different from the owner of the minerals in the ground below. The party that owns the land’s surface has surface rights, while the party that owns the natural resources in the ground has subsurface rights. When ownership is divided in this way, it is referred to as a <a href="http://www.blm.gov/wo/st/en/prog/energy/oil_and_gas/best_management_practices/split_estate.html">split estate</a>. There are 57 million acres of land in the U.S. where the federal government owns oil, gas, coal, and other minerals below the surface, but another party, mostly citizens or corporations, owns the surface land above. Land and mineral ownership can become quite complicated. Often, a combination of private landholders, the federal government, a state government, or Indian tribes own the span of a single mine or field.</p>
-
-    <p>When it comes to the natural resources found off the coast, the federal government and state governments split ownership. In general, states have primary authority and natural resource ownership in the three-mile area extending outward from their coasts. The federal government owns oil, gas, and minerals located in the submerged lands on the Outer Continental Shelf, which extend from the states’ offshore boundaries out to at least 200 nautical miles from the shore.</p>
-
-  </article>
-
+<div>
+  <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+  /
 </div>
+<h1 id="introduction" data-nav-header="introduction">Ownership</h1>
+
+<p class="case_studies_intro-para">Natural resource ownership in the United States is closely tied to land ownership. We'll talk about both these types of ownership here.</p>
+
+<h2>Land ownership</h2>
+
+<p>There are four main types of land owners: citizens and corporations; the federal government; state and local governments; and Indian tribes and individuals. There are two types of owners for submerged lands under the ocean: states and the federal government.</p>
+
+<h3 id="private-lands" data-nav-header="private-lands">Private lands</h3>
+
+<p>Private lands are owned by private citizens or corporations.</p>
+
+<h3 id="federal-lands" data-nav-header="federal-lands">Federal lands</h3>
+
+<p><a href="http://fas.org/sgp/crs/misc/R42346.pdf">Federal lands</a> are owned by or under jurisdiction of the federal government, including:</p>
+
+<ul class="list-bullet">
+  <li>Public domain lands ceded to the U.S. by treaty, purchase, or conquest</li>
+  <li>Acquired lands purchased by, given to, exchanged with, or transferred through condemnation proceedings to the federal government</li>
+<li>Military acquired lands purchased by the federal government under military acquisition laws</li>
+<li><a href="http://www.boem.gov/OCS-Lands-Act-History/">Outer Continental Shelf</a> submerged lands located farther than three miles off a state’s coastline, or three marine leagues into the Gulf of Mexico off of Texas and Western Florida</li>
+</ul>
+
+<h3 id="state-and-local-lands" data-nav-header="state-and-local-lands">State and local lands</h3>
+
+<p>State and local lands are owned by state or local governments, including:</p>
+
+<ul class="list-bullet">
+  <li>Lands owned by a particular state</li>
+  <li><a href="http://www.boem.gov/uploadedfiles/submergedla.pdf">State submerged lands</a> under the ocean stretching from a state’s coast to three miles out into the ocean, or in the case of Texas and western Florida, from the coast out to three marine leagues into the Gulf of Mexico</li>
+<li>Lands owned by a local government, such as a county</li>
+</ul>
+
+<h3 id="indian-lands" data-nav-header="indian-lands">Indian lands</h3>
+
+<p>Indian lands are owned by Native Americans, and include:</p>
+
+<ul class="list-bullet">
+  <li>Tribal lands held in trust by the federal government for a tribe’s use</li>
+  <li>Allotments held in trust by the federal government for individual Indians’ use</li>
+<li><a href="http://www.gao.gov/assets/660/650857.pdf">Alaska Native Corporation</a> lands in Alaska, held by 12 regional Alaska Native Corporations that received rights to some surface lands, as well as rights to natural resources below the surface. Along with these 12 regional Alaska Native Corporations, certain village-level Alaska Native Corporations hold additional surface land rights.</li>
+</ul>
+
+<h2>Natural resource ownership</h2>
+
+<p>Private individuals and corporations, as well as federal, state, local, and tribal governments, can own both land and the oil, gas, coal, and other minerals found below the surface. In fact, widespread private ownership of these resources makes the U.S. different from nearly every other country in which these resources simply belong to the national government.</p>
+
+<p>Natural resource ownership has historical roots in the 19th century, when the federal government passed homestead and development acts to encourage settlement in the West. These acts, along with the General Mining Law of 1872, allowed for federal public domain lands, and the natural resources within them, to pass to private ownership. Starting in the 20th century, the U.S. passed legislation that began to withdraw both specific natural resources and eventually public domain lands from settlement and other development, preserving these lands and natural resources in federal ownership today.</p>
+
+<h3 id="split-ownership" data-nav-header="split-ownership">Split ownership</h3>
+
+<p>Sometimes the land’s surface owner is different from the owner of the minerals in the ground below. The party that owns the land’s surface has surface rights, while the party that owns the natural resources in the ground has subsurface rights. When ownership is divided in this way, it is referred to as a <a href="http://www.blm.gov/wo/st/en/prog/energy/oil_and_gas/best_management_practices/split_estate.html">split estate</a>. There are 57 million acres of land in the U.S. where the federal government owns oil, gas, coal, and other minerals below the surface, but another party, mostly citizens or corporations, owns the surface land above. Land and mineral ownership can become quite complicated. Often, a combination of private landholders, the federal government, a state government, or Indian tribes own the span of a single mine or field.</p>
+
+<p>When it comes to the natural resources found off the coast, the federal government and state governments split ownership. In general, states have primary authority and natural resource ownership in the three-mile area extending outward from their coasts. The federal government owns oil, gas, and minerals located in the submerged lands on the Outer Continental Shelf, which extend from the states’ offshore boundaries out to at least 200 nautical miles from the shore.</p>

--- a/_how-it-works/natural-resources/production.md
+++ b/_how-it-works/natural-resources/production.md
@@ -1,124 +1,142 @@
 ---
 title: Production | How It Works
-layout: default
+layout: narrative
 permalink: /how-it-works/production/
+nav_description: Jump to a section
+nav_items:
+  - name: introduction
+    title: Top
+  - nav_group: Fossil fuels
+  - name: oil
+    title: Oil
+  - name: gas
+    title: Gas
+  - name: coal
+    title: Coal
+  - nav_group: Renewable energy
+  - name: geothermal-energy
+    title: Geothermal energy
+  - name: solar-energy
+    title: Solar energy
+  - name: wind-power
+    title: Wind power
+  - nav_group: Nonenergy minerals
+  - name: gold
+    title: Gold
+  - name: copper
+    title: Copper
+  - name: iron
+    title: Iron
 ---
 
-<div class="container-outer container-padded">
-
-  <article class="container-left-7">
-
-    <div>
-      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
-      /
-    </div>
-    <h1>Production</h1>
-
-    <p class="case_studies_intro-para">The United States is home to many different natural resources, including fossil fuel (i.e., oil, gas, and coal), renewable energy (i.e., geothermal, solar, and wind), and nonenergy mineral resources (i.e., gold, copper, and iron). Since the 19th century, natural resource extraction has been a major industry in the U.S., with fluctuations throughout time.</p>
-
-    <p><img src="{{site.baseurl}}/img/landing-placeholders/global-rank-production.png"></p>
-
-    <h2>Fossil fuels</h2>
-
-    <p>Fossil fuels are our main source of electricity, and the primary fuel for powering motor vehicles and heating homes. Fossil fuel resources comprised approximately <a href="http://www.eia.gov/totalenergy/data/monthly/archive/00351405.pdf">82% of total U.S. energy consumption in 2013</a> (nuclear energy comprised 8%, and renewable energy 10%).</p>
-
-    <p>Besides creating energy, these natural resources are also used to make many products. For example, manufacturers use oil to make asphalt and coal to make steel. Through natural processes over hundreds of millions of years, plant and animal matter becomes energy resources in the form of oil, gas, and coal. While fossil fuels are abundant, they are not renewable.</p>
-
-    <h3>Oil</h3>
-
-    <p>Oil forms in underground reservoirs on land and under the ocean. Crude oil occurs naturally, while petroleum products (e.g., jet fuel, diesel fuel, and heating oil) come from refining and otherwise processing crude oil and other liquids. Petroleum is a broad term that can mean both crude oil and petroleum products. In 2013, <a href="http://www.eia.gov/todayinenergy/detail.cfm?id=15631">five states</a>—Texas, North Dakota, California, Alaska, and Oklahoma—and federal submerged lands in the Gulf of Mexico supplied more than 80% of the crude oil produced here.</p>
-
-    <h3>Gas</h3>
-
-    <p>Gas, also called natural gas, forms underground on land and offshore in beds under the ocean. There are two types of natural gas: dry and wet. Dry natural gas is mostly methane. Wet natural gas contains a small amount of methane, as well as other liquid hydrocarbons—such as ethane, propane, and butane—and nonhydrocarbon gases. Wet natural gas is the source of natural gas liquids. Once wet natural gas is extracted from the ground, natural gas liquids are separated from the gas stream close to the well or at a gas processing plant. This leaves both dry gas and natural gas liquids such as ethane, propane, and butane.</p>
-
-    <p>The U.S. produces more gas than any other country in the world. In 2013, <a href="http://www.eia.gov/dnav/ng/ng_prod_sum_a_epg0_vgm_mmcf_a.htm">five states</a> produced 67% of the total dry natural gas: Texas, Pennsylvania, Louisiana, Wyoming, and Oklahoma.</p>
-
-    <p>In conventional extraction, companies extract oil and gas by drilling a vertical well. At first, oil and gas rise to the surface of the well fueled by underground pressure. Once the pressure gives out, operators can inject gases or water from the initial drilling back into the formation to increase pressure and push additional resources to the surface, or install pumps to help provide artificial lift for oil production. Finally, operators can inject steam, gases, or other chemicals into the formation to change the oil’s composition so that it can more easily rise through the well.</p>
-
-    <p>Extraction methods for oil and gas changed significantly starting in the early 2000s, with the new applications of horizontal drilling and hydraulic fracturing, commonly known as fracking. Horizontal drilling creates lateral wells for oil and gas to flow through. Hydraulic fracturing pumps water, sand, and chemicals into the earth to fracture the shale rock so that natural gas and oil can flow through the cracks into the well and then to the surface. These methods made extracting oil and gas trapped in almost impermeable shale rock formations deep below the surface of the earth profitable for extractive industries.</p>
-
-    <p>In the past decade, these changing extraction methods and rising natural gas prices have made shale oil and gas increasingly attractive to extractive industries. Major oil and gas shale rock formations include the Permian, Haynesville, and Eagle Ford Regions mostly in Texas; the Marcellus Region in West Virginia, Pennsylvania, and New York; the Niobrara Region in Wyoming and Colorado; and the Bakken Region in North Dakota and Montana.</p>
-
-    <p>In addition to these shale formations, the Green River Formation, which is located at the intersection of Colorado, Utah, and Wyoming, is estimated to hold <a href="http://pubs.usgs.gov/fs/2011/3063/pdf/FS11-3063.pdf">1.44 trillion barrels of oil</a>. In shale gas, the Marcellus Play (spanning nine states from New York to Tennessee) is the largest shale gas play, accounting for <a href="http://www.eia.gov/pressroom/presentations/sieminski_01042014.pdf">75% of natural gas production growth</a>. To see where oil and gas resources exist and where exploration is taking place, visit the following:</p>
-
-    <ul class="list-bullet">
-  	  <li><a href="http://energy.usgs.gov/OilGas/AssessmentsData/NationalOilGasAssessment.aspx#.VlMX5BCrSV7">Different types of oil and gas plays</a></li>
-  	  <li><a href="http://www.eia.gov/oil_gas/rpd/shale_gas.pdf">Current and prospective shale plays</a></li>
-  	  <li><a href="http://certmapper.cr.usgs.gov/data/noga00/natl/graphic/2013/total_mean_gas_2013.pdf">Undiscovered, technically recoverable gas resources</a></li>
-  	  <li><a href="http://www.data.boem.gov/homepg/data_center/plans/plans/master.asp">Offshore exploration and development plans</a></li>
-    </ul>
-
-    <h3>Coal</h3>
-
-    <p>Coal forms in the ground in coal seams or beds. Miners extract coal through surface and subsurface mining. In surface mining, the coal is close to the surface. Miners remove the “overburden,” or the soil and rock covering the coal, before mining it. In subsurface mining, the coal is farther down in the earth. Through passages that go into the earth, miners remove the coal from <a href="http://teeic.indianaffairs.gov/er/coal/restech/tech/index.htm">underground rooms or long coal seams</a>. In 2013, the U.S. was the world’s second largest coal producer after China.</p>
-
-    <p>Coal is concentrated in three regions: the Appalachian Region, the Interior Region, and the Western Region. In recent years, the Western Region—most of which is the Powder River Basin—produced <a href="http://www.eia.gov/Energyexplained/index.cfm?page=coal_where">more than half of U.S. coal</a>. From 2012 to 2013, proved coal reserves <a href="http://www.eia.gov/coal/annual/pdf/table14.pdf">increased by 5.8%</a>.</p>
-
-    <p>See <a href="http://www.eia.gov/Energyexplained/index.cfm?page=coal_where">where the U.S. gets its coal</a>, or learn about <a href="http://www.eia.gov/coal/reserves/">coal reserves and their locations</a>.</p>
-
-    <h4>What are reserves?</h4>
-
-    <p>There are three common types of reserves, or the amount of a particular natural resource available for extraction:</p>
-
-    <ul class="list-bullet">
-  	  <li><strong>Proved reserves</strong> are the estimated volumes of a natural resource that geological and engineering data demonstrate with reasonable certainty to be recoverable in future years from known reservoirs under existing economic and operating conditions</li>
-  	  <li><strong>Technically recoverable resources</strong> include natural resources that can be produced based on current technology, industry practices, and geological knowledge</li>
-  	  <li><strong>Economically recoverable resources</strong> are the portion of technically recoverable natural resources that can be profitably produced</li>
-    </ul>
-
-    <h2>Renewable energy</h2>
-
-    <p>Renewable energy resources include geothermal, solar, wind, biomass, and hydrokinetic energy, all of which constitute growing sources of environmentally sustainable energy to meet the country’s electricity needs. Renewable energy sources comprised about <a href="http://www.eia.gov/totalenergy/data/monthly/archive/00351405.pdf">10% of total U.S. energy consumption in 2013</a>.</p>
-
-    <h3>Geothermal energy</h3>
-
-    <p>Geothermal energy comes from the earth’s heat, which is captured as steam or hot water and converted into energy. Most geothermal resources are found along the boundaries of tectonic plates and manifest themselves as volcanoes, hot springs, or geysers. California produces more geothermal energy than any other state, accounting for more than <a href="http://www.eia.gov/todayinenergy/detail.cfm?id=17871">75% of the country’s total geothermal output in 2013</a>.</p>
-
-    <p>Many sites for potential geothermal development are on federal land; currently, about <a href="http://www.blm.gov/wo/st/en/prog/energy/geothermal.html">40% of U.S. geothermal energy capacity is on leased federal lands</a>. Advances in extraction methods and technology could result in new sources of geothermal energy.</p>
-
-    <p>See where <a href="http://www.nrel.gov/gis/images/geothermal_resource2009-final.jpg">geothermal energy production happens</a>.</p>
-
-    <h3>Solar energy</h3>
-
-    <p>Solar energy can be generated in two ways: by converting solar radiation into heat and electricity via photovoltaic panels or by using the sun’s radiation to heat a fluid and produce steam for a power generator. California leads the country in producing solar energy, followed by New Jersey. As of 2014, California is the first state to receive <a href="http://www.eia.gov/todayinenergy/detail.cfm?id=20492">5% or more of its electricity from solar energy sources</a>.</p>
-
-    <p>The solar industry has experienced rapid growth in the past decade due to government programs such as <a href="http://www.eia.gov/forecasts/aeo/pdf/0383(2015).pdf">tax credits and state renewable portfolio standards</a>, increased public awareness of its environmental benefits, and decreasing technology costs. Manufacturing costs for solar panels have <a href="http://www.cnbc.com/2015/04/26/like-shale-oil-solar-power-is-shaking-up-global-energy.html">decreased by 80%</a>, and private industry has created better batteries to store solar energy. In southwestern states, solar radiation levels are some of the best in the world for solar energy production. Currently, there are <a href="http://www.blm.gov/wo/st/en/prog/energy/solar_energy.html">70 pending applications to develop solar energy projects</a> on federal lands.</p>
-
-    <p>See <a href="http://energy.gov/maps/solar-energy-potential">areas of the U.S. with solar energy potential</a>.</p>
-
-    <h3>Wind power</h3>
-
-    <p>Wind power takes advantage of daily wind cycles to rotate wind turbines, which can be clustered together on wind farms. In 2013, wind power accounted for more than <a href="http://www.energy.gov/sites/prod/files/wind_vision_highlights.pdf">4% of total U.S. energy production</a>, with more than 61 gigawatts (GW) installed across 39 states. Texas (12.3 GW), California (5.8 GW), and Iowa (5.2 GW) are the leading producers.</p>
-
-    <p>No offshore wind projects have been completed to date. <a href="http://www.nrel.gov/">The National Renewable Energy Laboratory</a> estimated in 2012 that there is enough wind energy potential offshore to generate <a href="http://www.boem.gov/renewable-energy-program/renewable-energy-guide/offshore-wind-energy.aspx">four times the electricity held by the U.S. power grid</a>. While wind speeds off the Atlantic Coast and in the Gulf of Mexico are lower than in the Pacific, the presence of shallower waters in the Atlantic makes developing wind projects there more affordable in the short term. To date, the Bureau of Ocean Energy Management (BOEM) has issued nine commercial wind energy leases on the Atlantic Outer Continental Shelf, including those offshore of <a href="http://www.boem.gov/Lease-and-Grant-Information/">Delaware, Maryland, Massachusetts, Rhode Island, and Virginia</a>. BOEM expects to hold lease sales for areas offshore of <a href="http://www.boem.gov/State-Activities-New-Jersey/">New Jersey</a> and <a href="http://www.boem.gov/state-activities-north-carolina/">North Carolina</a> in the near future and is considering a number of other commercial wind energy planning areas.</p>
-
-    <p>See a map of <a href="http://apps2.eere.energy.gov/wind/windexchange/wind_installed_capacity.asp">current wind power capacity</a>, <a href="http://apps2.eere.energy.gov/wind/windexchange/wind_maps.asp">potential onshore power</a>, and <a href="http://apps2.eere.energy.gov/wind/windexchange/windmaps/offshore.asp">potential offshore power</a>.</p>
-
-    <h2>Nonenergy minerals</h2>
-
-    <p>Nonenergy minerals include base and precious metals, industrial metals, and gemstones, amongst others. The 2015 USEITI Report focuses on nonenergy minerals, specifically gold, copper, and iron. In 2013, these minerals accounted for most of the valuable metal produced in the United States: <a href="http://minerals.usgs.gov/minerals/pubs/mcs/2014/mcs2014.pdf">gold, copper, and iron made up 32%, 29%, and 17%, respectively, of $32 billion worth of metal extracted</a>.</p>
-
-    <p>The 2013 estimated exploration budget for nonenergy minerals decreased by 38% from 2012, dropping from $1.7 billion to $1 billion. Continued uncertainty about the U.S. and European economies, as well as weakened demand from China, either depressed or maintained prices for nonenergy minerals. Noteworthy exploration sites for nonenergy minerals are located in <a href="http://minerals.usgs.gov/minerals/mflow/exploration-2013.pdf">Alaska, Idaho, Nevada, and Wyoming</a>, more than half of which are for gold and silver.</p>
-
-    <h3>Gold</h3>
-
-    <p>Gold can be found in both loose materials and hard rocks. Miners extract gold from placer mines using sluicing, dredging, jigging, and amalgamation devices that separate the gold from water, silt, rock, and other compounds. Lode mining, both open pit and underground, extracts gold embedded within rock walls. Once mined, gold is used to make jewelry, electronics, dental treatments, and other products.</p>
-
-    <p>In 2013, the majority of U.S. gold came from <a href="http://minerals.usgs.gov/minerals/pubs/commodity/gold/mis-201311_12-gold.pdf">Nevada (172,000 kilograms) and Alaska (30,600 kilograms)</a>. In Nevada, recent exploration for gold resulted in discoveries along the Carlin and Battle Mountain-Eureka (Cortez) trends in Eureka and Elko Counties, as well as in the <a href="http://pubs.nbmg.unr.edu/The-NV-mineral-industry-2011-p/mi2011.htm">Pequop Mountains in Elko County</a>. Alaska continues to be a prominent site for gold exploration, although exploration spending in the state in 2013 made up less than <a href="http://minerals.er.usgs.gov/minerals/mflow/exploration-2014.pdf">half the peak expenditure in 2011</a>. Half of the estimated 2013 total $1 billion budget for nonenergy mineral exploration was for gold.</p>
-
-    <h3>Copper</h3>
-
-    <p>Copper is found in hard rocks in the form of copper ore. Miners extract copper from open pit and underground mines through traditional quarrying to separate the copper from rock, or leaching which involves treating the ore with diluted sulfuric acid. Once produced, copper has a variety of uses, including as a building material, as an effective conductor of electricity, and within the health care sector.</p>
-
-    <p>In 2013, Arizona accounted for the most copper production out of all U.S. states with <a href="http://minerals.usgs.gov/minerals/pubs/commodity/copper/mis-201401-coppe.pdf">795,000 metric tons</a>. In terms of exploration, an estimated <a href="http://minerals.usgs.gov/minerals/mflow/exploration-2013.pdf">36% of the 2013 total $1 billion</a> U.S. budget for nonenergy mineral exploration was for base metals, primarily copper.</p>
-
-    <h3>Iron</h3>
-
-    <p>Iron is found in underground rocks. Miners extract iron by drilling holes in the ground in carefully engineered patterns and blasting out rocks with explosives. Next, miners crush the rocks and separate out the iron ore from other materials. Almost all iron is used to make steel, which in turn is used to make buildings, infrastructure, machines, and vehicles.</p>
-
-    <p>In 2013, 99% of the iron ore shipped in the U.S. came from <a href="http://minerals.usgs.gov/minerals/pubs/commodity/iron_ore/mcs-2014-feore.pdf">Minnesota and Michigan</a>. Exploration continues on the <a href="http://files.dnr.state.mn.us/lands_minerals/mineral_faq/mn_expdrilling_map_2013.pdf">Mesabi Iron Range</a> in Minnesota; in 2013, companies drilled nearly 200 exploratory holes for iron along the Mesabi Range.</p>
-
-  </article>
-
+<div>
+<a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+/
 </div>
+<h1 id="introduction" data-nav-header="introduction">Production</h1>
+
+<p class="case_studies_intro-para">The United States is home to many different natural resources, including fossil fuel (i.e., oil, gas, and coal), renewable energy (i.e., geothermal, solar, and wind), and nonenergy mineral resources (i.e., gold, copper, and iron). Since the 19th century, natural resource extraction has been a major industry in the U.S., with fluctuations throughout time.</p>
+
+<p><img src="{{site.baseurl}}/img/landing-placeholders/global-rank-production.png"></p>
+
+<h2>Fossil fuels</h2>
+
+<p>Fossil fuels are our main source of electricity, and the primary fuel for powering motor vehicles and heating homes. Fossil fuel resources comprised approximately <a href="http://www.eia.gov/totalenergy/data/monthly/archive/00351405.pdf">82% of total U.S. energy consumption in 2013</a> (nuclear energy comprised 8%, and renewable energy 10%).</p>
+
+<p>Besides creating energy, these natural resources are also used to make many products. For example, manufacturers use oil to make asphalt and coal to make steel. Through natural processes over hundreds of millions of years, plant and animal matter becomes energy resources in the form of oil, gas, and coal. While fossil fuels are abundant, they are not renewable.</p>
+
+<h3 id="oil" data-nav-header="oil">Oil</h3>
+
+<p>Oil forms in underground reservoirs on land and under the ocean. Crude oil occurs naturally, while petroleum products (e.g., jet fuel, diesel fuel, and heating oil) come from refining and otherwise processing crude oil and other liquids. Petroleum is a broad term that can mean both crude oil and petroleum products. In 2013, <a href="http://www.eia.gov/todayinenergy/detail.cfm?id=15631">five states</a>—Texas, North Dakota, California, Alaska, and Oklahoma—and federal submerged lands in the Gulf of Mexico supplied more than 80% of the crude oil produced here.</p>
+
+<h3 id="gas" data-nav-header="gas">Gas</h3>
+
+<p>Gas, also called natural gas, forms underground on land and offshore in beds under the ocean. There are two types of natural gas: dry and wet. Dry natural gas is mostly methane. Wet natural gas contains a small amount of methane, as well as other liquid hydrocarbons—such as ethane, propane, and butane—and nonhydrocarbon gases. Wet natural gas is the source of natural gas liquids. Once wet natural gas is extracted from the ground, natural gas liquids are separated from the gas stream close to the well or at a gas processing plant. This leaves both dry gas and natural gas liquids such as ethane, propane, and butane.</p>
+
+<p>The U.S. produces more gas than any other country in the world. In 2013, <a href="http://www.eia.gov/dnav/ng/ng_prod_sum_a_epg0_vgm_mmcf_a.htm">five states</a> produced 67% of the total dry natural gas: Texas, Pennsylvania, Louisiana, Wyoming, and Oklahoma.</p>
+
+<p>In conventional extraction, companies extract oil and gas by drilling a vertical well. At first, oil and gas rise to the surface of the well fueled by underground pressure. Once the pressure gives out, operators can inject gases or water from the initial drilling back into the formation to increase pressure and push additional resources to the surface, or install pumps to help provide artificial lift for oil production. Finally, operators can inject steam, gases, or other chemicals into the formation to change the oil’s composition so that it can more easily rise through the well.</p>
+
+<p>Extraction methods for oil and gas changed significantly starting in the early 2000s, with the new applications of horizontal drilling and hydraulic fracturing, commonly known as fracking. Horizontal drilling creates lateral wells for oil and gas to flow through. Hydraulic fracturing pumps water, sand, and chemicals into the earth to fracture the shale rock so that natural gas and oil can flow through the cracks into the well and then to the surface. These methods made extracting oil and gas trapped in almost impermeable shale rock formations deep below the surface of the earth profitable for extractive industries.</p>
+
+<p>In the past decade, these changing extraction methods and rising natural gas prices have made shale oil and gas increasingly attractive to extractive industries. Major oil and gas shale rock formations include the Permian, Haynesville, and Eagle Ford Regions mostly in Texas; the Marcellus Region in West Virginia, Pennsylvania, and New York; the Niobrara Region in Wyoming and Colorado; and the Bakken Region in North Dakota and Montana.</p>
+
+<p>In addition to these shale formations, the Green River Formation, which is located at the intersection of Colorado, Utah, and Wyoming, is estimated to hold <a href="http://pubs.usgs.gov/fs/2011/3063/pdf/FS11-3063.pdf">1.44 trillion barrels of oil</a>. In shale gas, the Marcellus Play (spanning nine states from New York to Tennessee) is the largest shale gas play, accounting for <a href="http://www.eia.gov/pressroom/presentations/sieminski_01042014.pdf">75% of natural gas production growth</a>. To see where oil and gas resources exist and where exploration is taking place, visit the following:</p>
+
+<ul class="list-bullet">
+  <li><a href="http://energy.usgs.gov/OilGas/AssessmentsData/NationalOilGasAssessment.aspx#.VlMX5BCrSV7">Different types of oil and gas plays</a></li>
+  <li><a href="http://www.eia.gov/oil_gas/rpd/shale_gas.pdf">Current and prospective shale plays</a></li>
+  <li><a href="http://certmapper.cr.usgs.gov/data/noga00/natl/graphic/2013/total_mean_gas_2013.pdf">Undiscovered, technically recoverable gas resources</a></li>
+  <li><a href="http://www.data.boem.gov/homepg/data_center/plans/plans/master.asp">Offshore exploration and development plans</a></li>
+</ul>
+
+<h3 id="coal" data-nav-header="coal">Coal</h3>
+
+<p>Coal forms in the ground in coal seams or beds. Miners extract coal through surface and subsurface mining. In surface mining, the coal is close to the surface. Miners remove the “overburden,” or the soil and rock covering the coal, before mining it. In subsurface mining, the coal is farther down in the earth. Through passages that go into the earth, miners remove the coal from <a href="http://teeic.indianaffairs.gov/er/coal/restech/tech/index.htm">underground rooms or long coal seams</a>. In 2013, the U.S. was the world’s second largest coal producer after China.</p>
+
+<p>Coal is concentrated in three regions: the Appalachian Region, the Interior Region, and the Western Region. In recent years, the Western Region—most of which is the Powder River Basin—produced <a href="http://www.eia.gov/Energyexplained/index.cfm?page=coal_where">more than half of U.S. coal</a>. From 2012 to 2013, proved coal reserves <a href="http://www.eia.gov/coal/annual/pdf/table14.pdf">increased by 5.8%</a>.</p>
+
+<p>See <a href="http://www.eia.gov/Energyexplained/index.cfm?page=coal_where">where the U.S. gets its coal</a>, or learn about <a href="http://www.eia.gov/coal/reserves/">coal reserves and their locations</a>.</p>
+
+<h4>What are reserves?</h4>
+
+<p>There are three common types of reserves, or the amount of a particular natural resource available for extraction:</p>
+
+<ul class="list-bullet">
+  <li><strong>Proved reserves</strong> are the estimated volumes of a natural resource that geological and engineering data demonstrate with reasonable certainty to be recoverable in future years from known reservoirs under existing economic and operating conditions</li>
+  <li><strong>Technically recoverable resources</strong> include natural resources that can be produced based on current technology, industry practices, and geological knowledge</li>
+  <li><strong>Economically recoverable resources</strong> are the portion of technically recoverable natural resources that can be profitably produced</li>
+</ul>
+
+<h2>Renewable energy</h2>
+
+<p>Renewable energy resources include geothermal, solar, wind, biomass, and hydrokinetic energy, all of which constitute growing sources of environmentally sustainable energy to meet the country’s electricity needs. Renewable energy sources comprised about <a href="http://www.eia.gov/totalenergy/data/monthly/archive/00351405.pdf">10% of total U.S. energy consumption in 2013</a>.</p>
+
+<h3 id="geothermal-energy" data-nav-header="geothermal-energy">Geothermal energy</h3>
+
+<p>Geothermal energy comes from the earth’s heat, which is captured as steam or hot water and converted into energy. Most geothermal resources are found along the boundaries of tectonic plates and manifest themselves as volcanoes, hot springs, or geysers. California produces more geothermal energy than any other state, accounting for more than <a href="http://www.eia.gov/todayinenergy/detail.cfm?id=17871">75% of the country’s total geothermal output in 2013</a>.</p>
+
+<p>Many sites for potential geothermal development are on federal land; currently, about <a href="http://www.blm.gov/wo/st/en/prog/energy/geothermal.html">40% of U.S. geothermal energy capacity is on leased federal lands</a>. Advances in extraction methods and technology could result in new sources of geothermal energy.</p>
+
+<p>See where <a href="http://www.nrel.gov/gis/images/geothermal_resource2009-final.jpg">geothermal energy production happens</a>.</p>
+
+<h3 id="solar-energy" data-nav-header="solar-energy">Solar energy</h3>
+
+<p>Solar energy can be generated in two ways: by converting solar radiation into heat and electricity via photovoltaic panels or by using the sun’s radiation to heat a fluid and produce steam for a power generator. California leads the country in producing solar energy, followed by New Jersey. As of 2014, California is the first state to receive <a href="http://www.eia.gov/todayinenergy/detail.cfm?id=20492">5% or more of its electricity from solar energy sources</a>.</p>
+
+<p>The solar industry has experienced rapid growth in the past decade due to government programs such as <a href="http://www.eia.gov/forecasts/aeo/pdf/0383(2015).pdf">tax credits and state renewable portfolio standards</a>, increased public awareness of its environmental benefits, and decreasing technology costs. Manufacturing costs for solar panels have <a href="http://www.cnbc.com/2015/04/26/like-shale-oil-solar-power-is-shaking-up-global-energy.html">decreased by 80%</a>, and private industry has created better batteries to store solar energy. In southwestern states, solar radiation levels are some of the best in the world for solar energy production. Currently, there are <a href="http://www.blm.gov/wo/st/en/prog/energy/solar_energy.html">70 pending applications to develop solar energy projects</a> on federal lands.</p>
+
+<p>See <a href="http://energy.gov/maps/solar-energy-potential">areas of the U.S. with solar energy potential</a>.</p>
+
+<h3 id="wind-power" data-nav-header="wind-power">Wind power</h3>
+
+<p>Wind power takes advantage of daily wind cycles to rotate wind turbines, which can be clustered together on wind farms. In 2013, wind power accounted for more than <a href="http://www.energy.gov/sites/prod/files/wind_vision_highlights.pdf">4% of total U.S. energy production</a>, with more than 61 gigawatts (GW) installed across 39 states. Texas (12.3 GW), California (5.8 GW), and Iowa (5.2 GW) are the leading producers.</p>
+
+<p>No offshore wind projects have been completed to date. <a href="http://www.nrel.gov/">The National Renewable Energy Laboratory</a> estimated in 2012 that there is enough wind energy potential offshore to generate <a href="http://www.boem.gov/renewable-energy-program/renewable-energy-guide/offshore-wind-energy.aspx">four times the electricity held by the U.S. power grid</a>. While wind speeds off the Atlantic Coast and in the Gulf of Mexico are lower than in the Pacific, the presence of shallower waters in the Atlantic makes developing wind projects there more affordable in the short term. To date, the Bureau of Ocean Energy Management (BOEM) has issued nine commercial wind energy leases on the Atlantic Outer Continental Shelf, including those offshore of <a href="http://www.boem.gov/Lease-and-Grant-Information/">Delaware, Maryland, Massachusetts, Rhode Island, and Virginia</a>. BOEM expects to hold lease sales for areas offshore of <a href="http://www.boem.gov/State-Activities-New-Jersey/">New Jersey</a> and <a href="http://www.boem.gov/state-activities-north-carolina/">North Carolina</a> in the near future and is considering a number of other commercial wind energy planning areas.</p>
+
+<p>See a map of <a href="http://apps2.eere.energy.gov/wind/windexchange/wind_installed_capacity.asp">current wind power capacity</a>, <a href="http://apps2.eere.energy.gov/wind/windexchange/wind_maps.asp">potential onshore power</a>, and <a href="http://apps2.eere.energy.gov/wind/windexchange/windmaps/offshore.asp">potential offshore power</a>.</p>
+
+<h2>Nonenergy minerals</h2>
+
+<p>Nonenergy minerals include base and precious metals, industrial metals, and gemstones, amongst others. The 2015 USEITI Report focuses on nonenergy minerals, specifically gold, copper, and iron. In 2013, these minerals accounted for most of the valuable metal produced in the United States: <a href="http://minerals.usgs.gov/minerals/pubs/mcs/2014/mcs2014.pdf">gold, copper, and iron made up 32%, 29%, and 17%, respectively, of $32 billion worth of metal extracted</a>.</p>
+
+<p>The 2013 estimated exploration budget for nonenergy minerals decreased by 38% from 2012, dropping from $1.7 billion to $1 billion. Continued uncertainty about the U.S. and European economies, as well as weakened demand from China, either depressed or maintained prices for nonenergy minerals. Noteworthy exploration sites for nonenergy minerals are located in <a href="http://minerals.usgs.gov/minerals/mflow/exploration-2013.pdf">Alaska, Idaho, Nevada, and Wyoming</a>, more than half of which are for gold and silver.</p>
+
+<h3 id="gold" data-nav-header="gold">Gold</h3>
+
+<p>Gold can be found in both loose materials and hard rocks. Miners extract gold from placer mines using sluicing, dredging, jigging, and amalgamation devices that separate the gold from water, silt, rock, and other compounds. Lode mining, both open pit and underground, extracts gold embedded within rock walls. Once mined, gold is used to make jewelry, electronics, dental treatments, and other products.</p>
+
+<p>In 2013, the majority of U.S. gold came from <a href="http://minerals.usgs.gov/minerals/pubs/commodity/gold/mis-201311_12-gold.pdf">Nevada (172,000 kilograms) and Alaska (30,600 kilograms)</a>. In Nevada, recent exploration for gold resulted in discoveries along the Carlin and Battle Mountain-Eureka (Cortez) trends in Eureka and Elko Counties, as well as in the <a href="http://pubs.nbmg.unr.edu/The-NV-mineral-industry-2011-p/mi2011.htm">Pequop Mountains in Elko County</a>. Alaska continues to be a prominent site for gold exploration, although exploration spending in the state in 2013 made up less than <a href="http://minerals.er.usgs.gov/minerals/mflow/exploration-2014.pdf">half the peak expenditure in 2011</a>. Half of the estimated 2013 total $1 billion budget for nonenergy mineral exploration was for gold.</p>
+
+<h3 id="copper" data-nav-header="copper">Copper</h3>
+
+<p>Copper is found in hard rocks in the form of copper ore. Miners extract copper from open pit and underground mines through traditional quarrying to separate the copper from rock, or leaching which involves treating the ore with diluted sulfuric acid. Once produced, copper has a variety of uses, including as a building material, as an effective conductor of electricity, and within the health care sector.</p>
+
+<p>In 2013, Arizona accounted for the most copper production out of all U.S. states with <a href="http://minerals.usgs.gov/minerals/pubs/commodity/copper/mis-201401-coppe.pdf">795,000 metric tons</a>. In terms of exploration, an estimated <a href="http://minerals.usgs.gov/minerals/mflow/exploration-2013.pdf">36% of the 2013 total $1 billion</a> U.S. budget for nonenergy mineral exploration was for base metals, primarily copper.</p>
+
+<h3 id="iron" data-nav-header="iron">Iron</h3>
+
+<p>Iron is found in underground rocks. Miners extract iron by drilling holes in the ground in carefully engineered patterns and blasting out rocks with explosives. Next, miners crush the rocks and separate out the iron ore from other materials. Almost all iron is used to make steel, which in turn is used to make buildings, infrastructure, machines, and vehicles.</p>
+
+<p>In 2013, 99% of the iron ore shipped in the U.S. came from <a href="http://minerals.usgs.gov/minerals/pubs/commodity/iron_ore/mcs-2014-feore.pdf">Minnesota and Michigan</a>. Exploration continues on the <a href="http://files.dnr.state.mn.us/lands_minerals/mineral_faq/mn_expdrilling_map_2013.pdf">Mesabi Iron Range</a> in Minnesota; in 2013, companies drilled nearly 200 exploratory holes for iron along the Mesabi Range.</p>
+

--- a/_how-it-works/natural-resources/revenues.md
+++ b/_how-it-works/natural-resources/revenues.md
@@ -1,85 +1,93 @@
 ---
 title: Revenues | How It Works
-layout: default
+layout: narrative
 permalink: /how-it-works/revenues/
+nav_description: Jump to a section
+nav_items:
+  - name: introduction
+    title: Top
+  - name: federal-lands-and-waters
+    title: Extraction from federal lands and waters
+  - name: all-lands-and-waters
+    title: Extraction from any land or water
+  - name: corporate-income-tax
+    title: Corporate income tax
+  - name: revenue-policy-provisions
+    title: Revenue policy provisions
+  - name: tax-expenditures
+    title: Tax expenditures
+  - name: federal-budget-process
+    title: Federal budget process
 ---
 
-<div class="container-outer container-padded">
-
-  <article class="container-left-7">
-
-    <div>
-      <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
-      /
-    </div>
-    <h1>Revenue</h1>
-
-    <p class="case_studies_intro-para">Companies pay a wide range of fees, rates and taxes to extract natural resources in the U.S. The amounts differ depending on what the <a href="{{ site.baseurl }}/how-it-works/ownership/">ownership</a> of the natural resource looks like. We'll cover some of the major types of payments companies make here. They are usually called 'revenue' because they represent revenue to the American public.</p>
-
-    <h2>Payments to extract natural resources from federal land and waters</h2>
-
-    <p>When companies extract natural resources on federal onshore lands and the Outer Continental Shelf, they pay revenue to the Department of the Interior (DOI). In general, companies pay bonuses, rents, royalties, or fees and penalties (if incurred) to ONRR, and in some cases bonuses and rents to BLM. Royalties, a percentage of the sales value of extracted resources, make up most of the revenue paid to DOI.</p>
-
-    <p>Lease holders also pay different fees to BLM, BSEE, and BOEM, often to reimburse the federal government for costs associated with awarding, administering, and enforcing leases. For extracting locatable hardrock minerals on federal lands, companies pay fees, but not royalties under the Mining Law of 1872.</p>
-
-    <img src="{{site.baseurl}}/img/landing-placeholders/revenue-type-summary-table.png">
-
-    <h2>Payments to extract natural resources from any land or water in the U.S.</h2>
-
-    <h3>Corporate income taxes</h3>
-
-    <p>Corporations operating in the extractive industries pay taxes to the IRS on their income. These companies pay federal corporate income taxes regardless of whether they extract natural resources from federal, state, or privately held lands, so long as they have a liability. These companies also pay taxes on income from extracting natural resources and processing them into other products and commodities. There are different types of companies operating in these industries, with different ownership structures, and as a result, they are treated as different taxpayers:</p>
-
-    <ul class="list-bullet">
-  	  <li>C-corporations with many shareholders who own the company; these companies pays corporate income taxes to the IRS</li>
-  	  <li>S-corporations with 100 shareholders or less who own the company; shareholders pay personal income taxes to the IRS</li>
-  	  <li>Partnerships where two or more members own the business; members individually pay income taxes to the IRS</li>
-  	  <li>Sole proprietorships with one individual owner; the individual owner pays personal income tax to the IRS</li>
-    </ul>
-
-    <p>Only income taxes from C-corporations are included in the 2015 USEITI Report.</p>
-
-    <h3>Revenue policy provisions</h3>
-
-    <p>While royalty rates can reach as high as 18.75%, and the federal corporate income tax rate can reach as high as 35% depending on company income, companies may pay less. Revenue policy provisions, including royalty relief and tax expenditures, can result in smaller revenue and tax payments to the federal government to promote other policy goals.</p>
-
-    <h4>Royalty relief</h4>
-
-    <p>To incentivize companies to produce additional oil and gas on certain leases on the Outer Continental Shelf where extraction is anticipated to be unprofitable, the federal government may grant some lease holders royalty relief. Royalty relief means that these lease holders do not have to pay royalties on some amount of production, or they pay a smaller percentage of royalties, for the oil and gas they extract. There are four situations in which a lease holder may gain royalty relief:</p>
-
-    <ul class="list-bullet">
-  	  <li>Leases in deep waters with depths greater than 200 meters in the Gulf of Mexico. (This type of relief has not been offered in several years, though existing leases do include it currently.)</li>
-  	  <li>Leases in shallow waters with depths under 400 meters for deep gas production</li>
-  	  <li>Leases towards the end of their lives in which halving royalties would encourage additional production</li>
-  	  <li>Special cases in which continued production under existing terms is projected to be unprofitable</li>
-    </ul>
-
-    <p>In some situations, if oil and gas prices rise above certain thresholds, lease holders that previously gained royalty relief must start paying royalties at the regular rate again.</p>
-
-    <h3>Tax expenditures</h3>
-
-    <p>Tax expenditures are <a href="https://www.treasury.gov/resource-center/tax-policy/Documents/Tax-Expenditures-FY2017-Revised.pdf">defined in the law</a> as “revenue losses attributable to provisions of the federal tax laws which allow a special exclusion, exemption, or deduction from gross income or which provide a special credit, a preferential rate of tax, or a deferral of tax liability.” These exceptions may be viewed as alternatives to other policy instruments, such as spending or regulatory programs.</p>
-
-    <p>The Treasury estimates the total dollar amount of each tax expenditure in a given year, and publishes a <a href="https://www.treasury.gov/resource-center/tax-policy/Documents/Tax-Expenditures-FY2015.pdf">report of these estimates</a>:</p>
-
-    <ul class="list-bullet">
-  	  <li><strong>Fossil fuels:</strong> For FY 2013, expensing of exploration and development costs for fuels was the largest of five expenditures, totaling $550 million.</li>
-  	  <li><strong>Renewable energy:</strong> For FY 2013, the energy investment credit was the largest of four expenditures, totaling $2 billion. The energy production credit was the second largest, totaling $1.7 billion.</li>
-  	  <li><strong>Nonenergy materials:</strong> For FY 2013, the excess of percentage-over-cost depletion for nonenergy minerals was the largest of two expenditures, totaling $580 million.</li>
-    </ul>
-
-    <p>The federal budget also includes annual estimates of the net revenue effects of eliminating a wider range of fossil fuel related tax expenditures outlined in <a href="https://www.treasury.gov/open/Documents/USA%20FFSR%20progress%20report%20to%20G20%202014%20Final.pdf">United States – Progress Report on Fossil Fuel Subsidies</a>. When added together, eliminating fossil fuel tax expenditures would decrease the U.S. deficit by $4.4 billion a year on average over a 10-year window, per estimates in the White House report, <a href="https://www.whitehouse.gov/sites/default/files/omb/budget/fy2016/assets/16msr.pdf">Fiscal Year 2016 Mid-Session Review: Budget of the U.S. Government</a>. The report did not include estimates of the effects of eliminating renewable and nonenergy mineral tax expenditures.</p>
-
-    <h2>After a payment, what happens to the revenue?</h2>
-
-    <h3>Federal budget process</h3>
-
-    <p>Once revenue is collected by the federal government, it passes through a series of budgetary gateways before ultimately funding public services and community development. These gateways are described below:</p>
-
-    <img src="{{site.baseurl}}/img/landing-placeholders/disbursements.png">
-
-    <p>You can explore disbursement data on our site <a href="{{ site.baseurl }}/explore/disbursements/">here</a>.</p>
-
-  </article>
-
+<div>
+  <a class="revenues_subpage-breadcrumb" href="{{ site.baseurl }}/how-it-works/">How it works</a>
+  /
 </div>
+<h1 id="introduction" data-nav-header="introduction">Revenue</h1>
+
+<p class="case_studies_intro-para">Companies pay a wide range of fees, rates and taxes to extract natural resources in the U.S. The amounts differ depending on what the <a href="{{ site.baseurl }}/how-it-works/ownership/">ownership</a> of the natural resource looks like. We'll cover some of the major types of payments companies make here. They are usually called 'revenue' because they represent revenue to the American public.</p>
+
+<h2 id="federal-lands-and-waters" data-nav-header="federal-lands-and-waters">Payments to extract natural resources from federal land and waters</h2>
+
+<p>When companies extract natural resources on federal onshore lands and the Outer Continental Shelf, they pay revenue to the Department of the Interior (DOI). In general, companies pay bonuses, rents, royalties, or fees and penalties (if incurred) to ONRR, and in some cases bonuses and rents to BLM. Royalties, a percentage of the sales value of extracted resources, make up most of the revenue paid to DOI.</p>
+
+<p>Lease holders also pay different fees to BLM, BSEE, and BOEM, often to reimburse the federal government for costs associated with awarding, administering, and enforcing leases. For extracting locatable hardrock minerals on federal lands, companies pay fees, but not royalties under the Mining Law of 1872.</p>
+
+<img src="{{site.baseurl}}/img/landing-placeholders/revenue-type-summary-table.png">
+
+<h2 id="all-lands-and-waters" data-nav-header="all-lands-and-waters">Payments to extract natural resources from any land or water in the U.S.</h2>
+
+<h3 id="corporate-income-tax" data-nav-header="corporate-income-tax">Corporate income taxes</h3>
+
+<p>Corporations operating in the extractive industries pay taxes to the IRS on their income. These companies pay federal corporate income taxes regardless of whether they extract natural resources from federal, state, or privately held lands, so long as they have a liability. These companies also pay taxes on income from extracting natural resources and processing them into other products and commodities. There are different types of companies operating in these industries, with different ownership structures, and as a result, they are treated as different taxpayers:</p>
+
+<ul class="list-bullet">
+  <li>C-corporations with many shareholders who own the company; these companies pays corporate income taxes to the IRS</li>
+  <li>S-corporations with 100 shareholders or less who own the company; shareholders pay personal income taxes to the IRS</li>
+  <li>Partnerships where two or more members own the business; members individually pay income taxes to the IRS</li>
+  <li>Sole proprietorships with one individual owner; the individual owner pays personal income tax to the IRS</li>
+</ul>
+
+<p>Only income taxes from C-corporations are included in the 2015 USEITI Report.</p>
+
+<h3 id="revenue-policy-provisions" data-nav-header="revenue-policy-provisions">Revenue policy provisions</h3>
+
+<p>While royalty rates can reach as high as 18.75%, and the federal corporate income tax rate can reach as high as 35% depending on company income, companies may pay less. Revenue policy provisions, including royalty relief and tax expenditures, can result in smaller revenue and tax payments to the federal government to promote other policy goals.</p>
+
+<h4>Royalty relief</h4>
+
+<p>To incentivize companies to produce additional oil and gas on certain leases on the Outer Continental Shelf where extraction is anticipated to be unprofitable, the federal government may grant some lease holders royalty relief. Royalty relief means that these lease holders do not have to pay royalties on some amount of production, or they pay a smaller percentage of royalties, for the oil and gas they extract. There are four situations in which a lease holder may gain royalty relief:</p>
+
+<ul class="list-bullet">
+  <li>Leases in deep waters with depths greater than 200 meters in the Gulf of Mexico. (This type of relief has not been offered in several years, though existing leases do include it currently.)</li>
+  <li>Leases in shallow waters with depths under 400 meters for deep gas production</li>
+  <li>Leases towards the end of their lives in which halving royalties would encourage additional production</li>
+  <li>Special cases in which continued production under existing terms is projected to be unprofitable</li>
+</ul>
+
+<p>In some situations, if oil and gas prices rise above certain thresholds, lease holders that previously gained royalty relief must start paying royalties at the regular rate again.</p>
+
+<h3 id="tax-expenditures" data-nav-header="tax-expenditures">Tax expenditures</h3>
+
+<p>Tax expenditures are <a href="https://www.treasury.gov/resource-center/tax-policy/Documents/Tax-Expenditures-FY2017-Revised.pdf">defined in the law</a> as “revenue losses attributable to provisions of the federal tax laws which allow a special exclusion, exemption, or deduction from gross income or which provide a special credit, a preferential rate of tax, or a deferral of tax liability.” These exceptions may be viewed as alternatives to other policy instruments, such as spending or regulatory programs.</p>
+
+<p>The Treasury estimates the total dollar amount of each tax expenditure in a given year, and publishes a <a href="https://www.treasury.gov/resource-center/tax-policy/Documents/Tax-Expenditures-FY2015.pdf">report of these estimates</a>:</p>
+
+<ul class="list-bullet">
+  <li><strong>Fossil fuels:</strong> For FY 2013, expensing of exploration and development costs for fuels was the largest of five expenditures, totaling $550 million.</li>
+  <li><strong>Renewable energy:</strong> For FY 2013, the energy investment credit was the largest of four expenditures, totaling $2 billion. The energy production credit was the second largest, totaling $1.7 billion.</li>
+  <li><strong>Nonenergy materials:</strong> For FY 2013, the excess of percentage-over-cost depletion for nonenergy minerals was the largest of two expenditures, totaling $580 million.</li>
+</ul>
+
+<p>The federal budget also includes annual estimates of the net revenue effects of eliminating a wider range of fossil fuel related tax expenditures outlined in <a href="https://www.treasury.gov/open/Documents/USA%20FFSR%20progress%20report%20to%20G20%202014%20Final.pdf">United States – Progress Report on Fossil Fuel Subsidies</a>. When added together, eliminating fossil fuel tax expenditures would decrease the U.S. deficit by $4.4 billion a year on average over a 10-year window, per estimates in the White House report, <a href="https://www.whitehouse.gov/sites/default/files/omb/budget/fy2016/assets/16msr.pdf">Fiscal Year 2016 Mid-Session Review: Budget of the U.S. Government</a>. The report did not include estimates of the effects of eliminating renewable and nonenergy mineral tax expenditures.</p>
+
+<h2>After a payment, what happens to the revenue?</h2>
+
+<h3 id="federal-budget-process" data-nav-header="federal-budget-process">Federal budget process</h3>
+
+<p>Once revenue is collected by the federal government, it passes through a series of budgetary gateways before ultimately funding public services and community development. These gateways are described below:</p>
+
+<img src="{{site.baseurl}}/img/landing-placeholders/disbursements.png">
+
+<p>You can explore disbursement data on our site <a href="{{ site.baseurl }}/explore/disbursements/">here</a>.</p>

--- a/_includes/hash_selector.html
+++ b/_includes/hash_selector.html
@@ -2,11 +2,11 @@
 <select data-nav-options onchange="openListNav.changeHandler(this)">
   {% if page.nav_items %}
     {% for item in page.nav_items %}
-    	{% if item.nav_group %}
+      {% if item.nav_group %}
         <optgroup label="{{item.nav_group}}">
-    	{% else %}
-    		<option value="{{item.name}}">{{item.title}}</option>
-  		{% endif %}
+      {% else %}
+        <option value="{{item.name}}">{{item.title}}</option>
+      {% endif %}
     {% endfor %}
   {% endif %}
 </select>

--- a/_includes/hash_selector.html
+++ b/_includes/hash_selector.html
@@ -2,7 +2,11 @@
 <select data-nav-options onchange="openListNav.changeHandler(this)">
   {% if page.nav_items %}
     {% for item in page.nav_items %}
-        <option value="{{item.name}}">{{item.title}}</option>
+    	{% if item.nav_group %}
+        <optgroup label="{{item.nav_group}}">
+    	{% else %}
+    		<option value="{{item.name}}">{{item.title}}</option>
+  		{% endif %}
     {% endfor %}
   {% endif %}
 </select>


### PR DESCRIPTION
Addresses part of #995. This doesn't fix this whole issue, only part of it

* Adds narrative layout/sticky nav to the how it works > natural resources pages.
* Adds a `nav_group` option to the sticky nav so that we can have select `opt-group`s

ready for review!