### PR TITLE
Lighens up svg lines. Adds hover state.

### DIFF
--- a/_sass/components/_eiti-map.scss
+++ b/_sass/components/_eiti-map.scss
@@ -19,18 +19,19 @@ svg[is="eiti-map"] {
   }
 
   a:hover path.feature {
-    // fill: #ccc;
+    stroke: $neutral-gray;
+    stroke-width: 2;
   }
 
   path.mesh {
     fill: none;
     pointer-events: none;
-    stroke: #aaa;
+    stroke: lighten($neutral-gray, 10%); // #aaa
     stroke-width: 1;
   }
 
   path.feature.zoomed {
-    stroke: #aaa;
+    stroke: lighten($neutral-gray, 10%);
     stroke-width: 3;
   }
 


### PR DESCRIPTION
For #1040.

- Lightens svg lines a tad as per design direction
- Adds simple hover state, although this could be improved later. Right now, any hover comes in behind the `style` being set in the JS so we can't use fill, and stroke is also a little wonky. Ideally, we'd replace this solution with something that truly loads on top of the svg.

<img width="701" alt="screenshot 2015-12-10 16 32 34" src="https://cloud.githubusercontent.com/assets/4827522/11731847/d042bf78-9f5b-11e5-9d54-09a0496decc5.png">
