### PR TITLE
Starts to add proper meta tags to head

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,9 @@
-title: US EITI
+title: USEITI
+
+description: USEITI is part of an international effort to promote open and accountable management of natural resources. This site provides data about how the U.S. manages extractive industries.
+
+# permanent url, for use in meta references
+url: https://useiti.doi.gov
 
 sass:
   style: nested

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,8 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Basic Page Needs
+    ================================================== -->
     <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+
+    <!-- Mobile Specific Metas
+    ================================================== -->
+    <meta name="HandheldFriendly" content="True">
+    <meta name="MobileOptimized" content="320">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Twitter and OpenGraph data
+    ================================================== -->
+    <!-- type -->
+    <meta property="og:type" content="website">
+
+    <!-- title -->
+    {% if page.title %}
+      <title>{{ page.title }}</title>
+      <meta property="og:title" content="{{ page.title | xml_escape }}" />
+      <meta name="twitter:title" content="{{ page.title | xml_escape }}">
+    {% else %}
+      <title>{{ site.title }}</title>
+      <meta property="og:title" content="{{ site.title | xml_escape }}" />
+      <meta name="twitter:title" content="{{ site.title | xml_escape }}">
+    {% endif %}
+
+    <!-- url -->
+    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
+    <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
+
+    <!-- img -->
+    <meta property="og:img" content="{{ site.url }}/img/explore-home-revenue.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{{ site.url }}/explore-home-revenue.png">
+
+    <!-- description -->
+    <meta property="og:description" content="{{ site.description }}">
+    <meta name="twitter:description" content="{{ site.description }}">
+
+    <!-- Favicons
+    ================================================== -->
+    <!-- <link rel="icon" type="image/x-icon" href="{{ site.baseurl }}/img/favicon.ico">
+    <link rel="icon" type="image/png" href="{{ site.baseurl }}/img/favicon-16x16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="{{ site.baseurl }}/img/favicon-32x32.png" sizes="32x32"> -->
+
+    <!-- Styles
+    ================================================== -->
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
+
+    <!-- Scripts
+    ================================================== -->
 
     <!-- 3rd party dependencies -->
     <script src="{{ site.baseurl }}/js/vendor/d3.v3.min.js"></script>
@@ -32,9 +83,6 @@
     <!-- Glossary -->
     <script src="{{ site.baseurl }}/js/vendor/lodash.min.js"></script>
     <script src="{{ site.baseurl }}/js/vendor/list.min.js"></script>
-
-    <!-- Styles -->
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
 
     <!-- Google Analytics -->
     <script>


### PR DESCRIPTION
This PR starts to add proper meta tags to head. It should close #949 and address part of #989.

We now have:
- mobile metas
- twitter and open graph info (tho I'd like to test more)
- a space reserved for favicons when we have those