### PR TITLE
Change offshore area names to include the word offshore

### DIFF
--- a/_data/offshore_regions.csv
+++ b/_data/offshore_regions.csv
@@ -1,6 +1,6 @@
 name,id,viewbox
-Alaska (offshore),alaska,75 415 202 173
-Atlantic (offshore),atlantic,730 125 230 440
-Gulf (offshore),gulf,470 440 295 135
-Pacific (offshore),pacific,20 60 161 341
-Pacific-Alaska (offshore),pacific alaska,20 60 180 530
+Offshore Alaska,alaska,75 415 202 173
+Atlantic Ocean,atlantic,730 125 230 440
+Gulf of Mexico,gulf,470 440 295 135
+Pacific Ocean,pacific,20 60 161 341
+Offshore Pacific-Alaska,pacific alaska,20 60 180 530

--- a/_data/offshore_regions.csv
+++ b/_data/offshore_regions.csv
@@ -1,6 +1,6 @@
 name,id,viewbox
-Alaska,alaska,75 415 202 173
-Atlantic,atlantic,730 125 230 440
-Gulf,gulf,470 440 295 135
-Pacific,pacific,20 60 161 341
-Pacific alaska,pacific alaska,20 60 180 530
+Alaska (offshore),alaska,75 415 202 173
+Atlantic (offshore),atlantic,730 125 230 440
+Gulf (offshore),gulf,470 440 295 135
+Pacific (offshore),pacific,20 60 161 341
+Pacific-Alaska (offshore),pacific alaska,20 60 180 530


### PR DESCRIPTION
This is for #1057. Right now, our offshore areas are called, for example, `Alaska`. This causes confusion when they're listed in the bar chart, for example next to the state of Alaska.

I searched for the only instance of `Pacific alaska` and found what I think is the csv that controls those names. I think the data needs to be re-loaded or something tho before the changes can take effect. Either way, someone else should look at my suggested change.

/cc @gemfarmer @shawnbot 