### PR TITLE
Explore filter bugs

### DIFF
--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -23,7 +23,7 @@ permalink: /explore/exports/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         Exports from <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
         in

--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -23,7 +23,7 @@ permalink: /explore/exports/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="true" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         Exports from <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
         in
@@ -165,7 +165,7 @@ permalink: /explore/exports/
     </div>
   </section>
 </section>
-
+<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
 <script src="{{ site.baseurl }}/js/vendor/immutable.min.js"></script>
 <script src="{{ site.baseurl }}/js/components/eiti-bar.js"></script>
 <script>
@@ -180,4 +180,4 @@ permalink: /explore/exports/
   };
 </script>
 <script src="{{ site.baseurl }}/js/pages/exports.js"></script>
-<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
+

--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -25,7 +25,7 @@ permalink: /explore/gdp/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         GDP from extractives in
         <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>

--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -25,7 +25,7 @@ permalink: /explore/gdp/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="true" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         GDP from extractives in
         <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
@@ -146,7 +146,7 @@ permalink: /explore/gdp/
     </div>
   </section>
 </section>
-
+<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
 <script src="{{ site.baseurl }}/js/vendor/immutable.min.js"></script>
 <script src="{{ site.baseurl }}/js/components/eiti-bar.js"></script>
 <script>
@@ -161,4 +161,3 @@ permalink: /explore/gdp/
   };
 </script>
 <script src="{{ site.baseurl }}/js/pages/gdp.js"></script>
-<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>

--- a/_explore/economic-impact/jobs.html
+++ b/_explore/economic-impact/jobs.html
@@ -27,7 +27,7 @@ permalink: /explore/jobs/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
           Extractive industries jobs
           (<a href="#figure-selector" class="filter-part" data-key="figure">wage and salary</a>)

--- a/_explore/economic-impact/jobs.html
+++ b/_explore/economic-impact/jobs.html
@@ -27,7 +27,7 @@ permalink: /explore/jobs/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="true" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
           Extractive industries jobs
           (<a href="#figure-selector" class="filter-part" data-key="figure">wage and salary</a>)
@@ -159,7 +159,7 @@ permalink: /explore/jobs/
     </div>
   </section>
 </section>
-
+<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
 <script src="{{ site.baseurl }}/js/vendor/immutable.min.js"></script>
 <script src="{{ site.baseurl }}/js/components/eiti-bar.js"></script>
 <script>
@@ -174,4 +174,3 @@ permalink: /explore/jobs/
   };
 </script>
 <script src="{{ site.baseurl }}/js/pages/jobs.js"></script>
-<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>

--- a/_explore/production/production-all-lands.html
+++ b/_explore/production/production-all-lands.html
@@ -24,7 +24,7 @@ permalink: /explore/all-lands-production/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="true" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         <a href="#commodity-group-selector" class="filter-part" data-key="commodity">All</a>
         production on all lands and waters in
@@ -199,6 +199,7 @@ permalink: /explore/all-lands-production/
     </div>
   </section>
 </section>
+<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
 <script src="{{ site.baseurl }}/js/vendor/immutable.min.js"></script>
 <script src="{{ site.baseurl }}/js/components/eiti-bar.js"></script>
 <script>
@@ -213,4 +214,3 @@ permalink: /explore/all-lands-production/
   };
 </script>
 <script src="{{ site.baseurl }}/js/pages/all-lands-production.js"></script>
-<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>

--- a/_explore/production/production-all-lands.html
+++ b/_explore/production/production-all-lands.html
@@ -24,7 +24,7 @@ permalink: /explore/all-lands-production/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         <a href="#commodity-group-selector" class="filter-part" data-key="commodity">All</a>
         production on all lands and waters in

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -27,7 +27,7 @@ permalink: /explore/federal-production/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="true" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         <a href="#commodity-group-selector" class="filter-part" data-key="commodity">All</a>
         production on federal lands and waters in

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -204,6 +204,7 @@ permalink: /explore/federal-production/
     </div>
   </section>
 </section>
+<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
 <script src="{{ site.baseurl }}/js/vendor/immutable.min.js"></script>
 <script src="{{ site.baseurl }}/js/components/eiti-bar.js"></script>
 <script>
@@ -220,5 +221,6 @@ permalink: /explore/federal-production/
     'US': 'the entire U.S.'
   };
 </script>
+
 <script src="{{ site.baseurl }}/js/pages/federal-production.js"></script>
-<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
+

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -27,7 +27,7 @@ permalink: /explore/federal-production/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         <a href="#commodity-group-selector" class="filter-part" data-key="commodity">All</a>
         production on federal lands and waters in

--- a/_explore/revenue/federal-revenue-by-company.html
+++ b/_explore/revenue/federal-revenue-by-company.html
@@ -26,7 +26,7 @@ permalink: /explore/federal-revenue-by-company/
   </div>
 
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         <a href="#revenue-type-selector" class="filter-part" data-key="type">All revenue</a>
         from

--- a/_explore/revenue/federal-revenue-by-company.html
+++ b/_explore/revenue/federal-revenue-by-company.html
@@ -26,7 +26,7 @@ permalink: /explore/federal-revenue-by-company/
   </div>
 
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="true" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
       <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         <a href="#revenue-type-selector" class="filter-part" data-key="type">All revenue</a>
         from
@@ -96,9 +96,9 @@ permalink: /explore/federal-revenue-by-company/
     </section>
 
 </section>
-
+<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
 <script src="{{ site.baseurl }}/js/vendor/immutable.min.js"></script>
 <script src="{{ site.baseurl }}/js/components/eiti-bar.js"></script>
 <script src="{{ site.baseurl }}/js/eiti.explore.js"></script>
 <script src="{{ site.baseurl }}/js/pages/company-revenue.js"></script>
-<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
+

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -24,7 +24,7 @@ permalink: /explore/federal-revenue-by-location/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
         <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         Revenue from
         <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -24,7 +24,7 @@ permalink: /explore/federal-revenue-by-location/
     </div>
   </div>
   <section class="container-right-8 filters-wrapper_outer">
-    <div data-absolute="true" data-offset-parent="true" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
+    <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters">
         <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
         Revenue from
         <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
@@ -211,6 +211,7 @@ permalink: /explore/federal-revenue-by-location/
   </section>
 </section>
 
+<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>
 <script src="{{ site.baseurl }}/js/vendor/immutable.min.js"></script>
 <script src="{{ site.baseurl }}/js/components/eiti-bar.js"></script>
 <script>
@@ -228,4 +229,3 @@ permalink: /explore/federal-revenue-by-location/
   };
 </script>
 <script src="{{ site.baseurl }}/js/pages/revenue.js"></script>
-<script src="{{ site.baseurl }}/js/components/sticky-nav.js"></script>

--- a/_layouts/case-studies.html
+++ b/_layouts/case-studies.html
@@ -271,7 +271,7 @@ layout: default
 
     </div>
 
-		<div class="sticky_nav">
+		<div class="sticky_nav" data-offset-bottom="50">
 
 		  <nav class="sticky_nav-nav">
 

--- a/_layouts/case-studies.html
+++ b/_layouts/case-studies.html
@@ -271,7 +271,7 @@ layout: default
 
     </div>
 
-		<div class="sticky_nav" data-offset-bottom="50">
+		<div class="sticky_nav" data-offset-bottom="100">
 
 		  <nav class="sticky_nav-nav">
 

--- a/_layouts/narrative.html
+++ b/_layouts/narrative.html
@@ -11,7 +11,7 @@ layout: default
 
 	<div class="container-right-5">
 
-	<div class="sticky_nav" data-sticky-offset="50">
+	<div class="sticky_nav" data-sticky-offset="50" data-offset-bottom="50">
 	  <nav class="sticky_nav-nav">
 		  {% include hash_selector.html %}
 	  </nav>

--- a/_sass/_grid.scss
+++ b/_sass/_grid.scss
@@ -34,6 +34,8 @@ $massive-up: new-breakpoint(min-width $massive);
     @media only screen and (max-width: $medium) { @content; }
   } @else if $media == medium-up {
     @media only screen and (min-width: $medium) { @content; }
+  } @else if $media == medium-to-huge-plus {
+    @media only screen and (min-width: $medium) and (max-width: $huge-plus) { @content; }
   } @else if $media == large-up {
     @media only screen and (min-width: $large) { @content; }
   } @else if $media == huge-down {

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -14,11 +14,12 @@
   @include respond-to(medium-up) {
     border-radius: $base-border-radius;
     margin-right: $base-padding;
-    max-width: 674.309px;
+    width: initial;
+    // max-width: 674.309px;
   }
 
   @include respond-to(huge-plus-up) {
-    margin-right: 0;
+    // margin-right: 0;
   }
 
   select {

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -1,6 +1,9 @@
 
 .filters-wrapper_outer {
   position: relative;
+  // @include respond-to(medium-to-huge-plus) {
+  //   margin-right: $base-padding;
+  // }
 }
 
 .filters-wrapper {
@@ -12,7 +15,8 @@
   z-index: 3000;
 
   @include respond-to(medium-up) {
-    border-radius: $base-border-radius;
+    border-bottom-left-radius: $base-border-radius;
+    border-bottom-right-radius: $base-border-radius;
     margin-right: $base-padding;
     width: initial;
     // max-width: 674.309px;
@@ -29,6 +33,13 @@
 
   &[aria-expanded=true] {
     background-color: $mid-blue-opaque !important;
+    // height: 100%;
+    overflow-y: scroll;
+
+    // @include respond-to(medium-up) {
+    //   overflow-y: none;
+    //   height: initial;
+    // }
   }
 
   &.js-color {

--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -89,7 +89,7 @@
   }
 
   tr > *:last-child {
-    // padding-right: $base-padding;
+
   }
 
   .bar_negative {

--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -89,7 +89,7 @@
   }
 
   tr > *:last-child {
-    padding-right: $base-padding;
+    // padding-right: $base-padding;
   }
 
   .bar_negative {

--- a/_sass/blocks/explore/_subpage.scss
+++ b/_sass/blocks/explore/_subpage.scss
@@ -18,7 +18,7 @@
 }
 
 .regions {
-  @include respond-to(medium-up) {
+  @include respond-to(medium-to-huge-plus) {
     margin-right: $base-padding;
   }
 }

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -26,6 +26,7 @@
 
     this.attrStickyOffset = this.elems.sticky.getAttribute('data-sticky-offset');
     this.attrOffsetBottom = parseInt(this.elems.sticky.getAttribute('data-offset-bottom')) || 0;
+    this.maxWidth = this.elems.sticky.getAttribute('data-max-width');
     var attrAbsolute = this.elems.sticky.getAttribute('data-absolute');
 
     this.attrParent = this.elems.sticky.getAttribute('data-offset-parent');
@@ -74,7 +75,7 @@
         windowBump = windowWidth > 1044 || this.isMobile ? 0 : -20;
       this.width = this.elems.parent
         ? this.elems.parent.clientWidth + windowBump + 'px'
-        : '675px';
+        : this.maxWidth
 
       this.mainOffset = this.elems.main.offsetTop;
       this.mainHeight = this.elems.main.clientHeight;

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -38,7 +38,7 @@
       var windowWidth = window.innerWidth || document.body.clientWidth;
       this.wasMobile = this.isMobile;
       this.isMobile = windowWidth < 768;
-    }
+    };
 
     this.determineScreen();
 
@@ -65,13 +65,13 @@
   };
 
   StickyNav.prototype = {
-    getPositions: function (mutate) {
+    getPositions: function () {
 
       this.height = this.elems.sticky.clientHeight;
 
       this.lastWidth = this.width || 'initial';
-      var windowWidth = window.innerWidth || document.body.clientWidth;
-      windowBump = windowWidth > 1044 || this.isMobile ? 0 : -20;
+      var windowWidth = window.innerWidth || document.body.clientWidth,
+        windowBump = windowWidth > 1044 || this.isMobile ? 0 : -20;
       this.width = this.elems.parent
         ? this.elems.parent.clientWidth + windowBump + 'px'
         : '675px';
@@ -187,7 +187,7 @@
   window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 
   // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
-  var observer = new MutationObserver(function (mutations) {
+  var observer = new MutationObserver(function () {
     stickyNav.run();
   });
 

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -18,19 +18,27 @@
   };
 
   var StickyNav = function() {
+
+
+
     this.elems = {
       sticky : document.querySelector('.sticky_nav'),
       main: document.querySelector('main')
     };
 
     var attrStickyOffset = this.elems.sticky.getAttribute('data-sticky-offset'),
-      attrAbsolute = this.elems.sticky.getAttribute('data-absolute'),
-      attrParent = this.elems.sticky.getAttribute('data-offset-parent');
+      attrAbsolute = this.elems.sticky.getAttribute('data-absolute');
+
+    this.attrParent = this.elems.sticky.getAttribute('data-offset-parent');
+
+    this.elems.parent = this.elems.sticky.getAttribute('data-offset-parent')
+      ? this.elems.sticky.parentNode
+      : null;
 
     this.offset = attrStickyOffset
       ? parseInt(attrStickyOffset)
-      : attrParent
-        ? this.elems.sticky.offsetParent.offsetTop - this.elems.sticky.offsetHeight - 50
+      : this.parent
+        ? this.elems.parent.offsetTop - this.elems.sticky.offsetHeight - 50
         : this.elems.sticky.offsetTop;
 
     this.isAbsolute = function() {
@@ -42,6 +50,7 @@
         : false;
       return isAbsolute;
     }
+
     this.status;
     this.lastStatus;
   };
@@ -49,11 +58,19 @@
   StickyNav.prototype = {
     setPositions : function () {
       this.height = this.elems.sticky.clientHeight;
+
+      this.lastWidth = this.width || 'initial';
+      this.width = this.elems.parent
+      ? this.elems.parent.clientWidth + 'px'
+      : 'initial';
+
       this.mainOffset = this.elems.main.offsetTop;
       this.mainHeight = this.elems.main.clientHeight;
       this.diffTop = scrollTop - this.mainOffset - this.offset;
       this.diffBottom = scrollTop + this.height - this.mainHeight - this.mainOffset;
       this.lastStatus = this.status;
+      this.lastWidth;
+
       if (this.diffTop >= 0){
         this.status = 'fixed';
         if (this.diffBottom >= 0){
@@ -66,7 +83,9 @@
       }
     },
     needsUpdate : function() {
-      return this.status !== this.lastStatus;
+      var statusChange = this.status !== this.lastStatus;
+      var sizeChange = this.width !== this.lastWidth;
+      return statusChange || sizeChange;
     },
     update: function(){
       if (this.diffTop >= 0){
@@ -74,20 +93,24 @@
         this.elems.sticky.style.top = 0;
         this.elems.sticky.classList.remove('js-transparent');
         this.elems.sticky.classList.add('js-color');
+        this.elems.sticky.style.width = this.width;
         if (this.diffBottom >= 0){
           this.elems.sticky.style.position = 'absolute';
           this.elems.sticky.style.top = this.mainHeight - this.height - 50 + 'px';
           this.elems.sticky.classList.remove('js-transparent');
           this.elems.sticky.classList.add('js-color');
+          this.elems.sticky.style.width = this.width;
         } else {
           this.elems.sticky.style.position = 'fixed';
           this.elems.sticky.style.top = 0;
           this.elems.sticky.classList.remove('js-transparent');
           this.elems.sticky.classList.add('js-color');
+          this.elems.sticky.style.width = this.width;
         }
       } else {
         this.elems.sticky.classList.remove('js-color');
         this.elems.sticky.classList.add('js-transparent');
+        this.elems.sticky.style.width = this.width;
 
         if (this.isAbsolute()) {
           this.elems.sticky.style.position = 'absolute';
@@ -119,11 +142,36 @@
   var scrollTimer, lastScrollFireTime = 0;
 
   window.addEventListener('scroll', function() {
+    console.log('scroll')
 
     var minScrollTime = 100;
     var now = new Date().getTime();
 
     function processScroll() {
+      // console.log(new Date().getTime().toString());
+      runStickyPositions();
+    }
+
+    if (!scrollTimer) {
+        if (now - lastScrollFireTime > (3 * minScrollTime)) {
+            processScroll();   // fire immediately on first scroll
+            lastScrollFireTime = now;
+        }
+        scrollTimer = setTimeout(function() {
+            scrollTimer = null;
+            lastScrollFireTime = new Date().getTime();
+            processScroll();
+        }, minScrollTime);
+    }
+  });
+
+  window.addEventListener('resize', function() {
+    console.log('resize')
+    var minScrollTime = 100;
+    var now = new Date().getTime();
+
+    function processScroll() {
+      console.log('process resize')
       // console.log(new Date().getTime().toString());
       runStickyPositions();
     }

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -120,31 +120,6 @@
 
       }
     },
-    // throttle = function(fn, frequency) {
-    //   console.log('scroll')
-    //   var scrollTimer, lastScrollFireTime = 0;
-
-    //   var minScrollTime = 100;
-    //   var now = new Date().getTime();
-
-    //   function processScroll() {
-    //     // console.log(new Date().getTime().toString());
-    //     // runStickyPositions();
-    //     fn()
-    //   }
-
-    //   if (!scrollTimer) {
-    //       if (now - lastScrollFireTime > (3 * minScrollTime)) {
-    //           processScroll();   // fire immediately on first scroll
-    //           lastScrollFireTime = now;
-    //       }
-    //       scrollTimer = setTimeout(function() {
-    //           scrollTimer = null;
-    //           lastScrollFireTime = new Date().getTime();
-    //           processScroll();
-    //       }, minScrollTime);
-    //   }
-    // },
     throttle : function (fn, threshhold, scope) {
       console.log('throttle')
       threshhold || (threshhold = 250);
@@ -167,83 +142,25 @@
           fn.apply(context, args);
         }
       };
+    },
+    run: function() {
+      findScrollPositions();
+      this.setPositions();
+      if (this.needsUpdate()) {
+        this.update();
+      }
     }
   };
 
   var stickyNav = new StickyNav();
 
-  findScrollPositions();
-  stickyNav.setPositions();
-  if (stickyNav.needsUpdate()) {
-    stickyNav.update();
-  }
-
-  var runStickyPositions = function () {
-
-    findScrollPositions();
-    console.log('run sticky', stickyNav.needsUpdate())
-    stickyNav.setPositions();
-    if (stickyNav.needsUpdate()) {
-      stickyNav.update();
-    }
-  };
-
-  var scrollTimer, lastScrollFireTime = 0;
-
-  window.addEventListener('scroll', runStickyPositions, 100)
-
-  window.addEventListener('resize', runStickyPositions, 100)
+  stickyNav.run();
 
 
-  // window.addEventListener('scroll', function() {
-  //   // console.log('scroll')
+  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 
-  //   // var minScrollTime = 100;
-  //   // var now = new Date().getTime();
+  window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 
-  //   // function processScroll() {
-  //   //   // console.log(new Date().getTime().toString());
-  //   //   runStickyPositions();
-  //   // }
-
-  //   // if (!scrollTimer) {
-  //   //     if (now - lastScrollFireTime > (3 * minScrollTime)) {
-  //   //         processScroll();   // fire immediately on first scroll
-  //   //         lastScrollFireTime = now;
-  //   //     }
-  //   //     scrollTimer = setTimeout(function() {
-  //   //         scrollTimer = null;
-  //   //         lastScrollFireTime = new Date().getTime();
-  //   //         processScroll();
-  //   //     }, minScrollTime);
-  //   // }
-  //   stickyNav.throttle(runStickyPositions, 100);
-  // });
-
-  // window.addEventListener('resize', function() {
-    // console.log('resize')
-    // var minScrollTime = 100;
-    // var now = new Date().getTime();
-
-    // function processScroll() {
-    //   console.log('process resize')
-    //   // console.log(new Date().getTime().toString());
-    //   runStickyPositions();
-    // }
-
-    // if (!scrollTimer) {
-    //     if (now - lastScrollFireTime > (3 * minScrollTime)) {
-    //         processScroll();   // fire immediately on first scroll
-    //         lastScrollFireTime = now;
-    //     }
-    //     scrollTimer = setTimeout(function() {
-    //         scrollTimer = null;
-    //         lastScrollFireTime = new Date().getTime();
-    //         processScroll();
-    //     }, minScrollTime);
-    // }
-  //   stickyNav.throttle(runStickyPositions, 100);
-  // });
 
   exports.stickyNav = stickyNav;
 

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -119,6 +119,54 @@
         }
 
       }
+    },
+    // throttle = function(fn, frequency) {
+    //   console.log('scroll')
+    //   var scrollTimer, lastScrollFireTime = 0;
+
+    //   var minScrollTime = 100;
+    //   var now = new Date().getTime();
+
+    //   function processScroll() {
+    //     // console.log(new Date().getTime().toString());
+    //     // runStickyPositions();
+    //     fn()
+    //   }
+
+    //   if (!scrollTimer) {
+    //       if (now - lastScrollFireTime > (3 * minScrollTime)) {
+    //           processScroll();   // fire immediately on first scroll
+    //           lastScrollFireTime = now;
+    //       }
+    //       scrollTimer = setTimeout(function() {
+    //           scrollTimer = null;
+    //           lastScrollFireTime = new Date().getTime();
+    //           processScroll();
+    //       }, minScrollTime);
+    //   }
+    // },
+    throttle : function (fn, threshhold, scope) {
+      console.log('throttle')
+      threshhold || (threshhold = 250);
+      var last,
+          deferTimer;
+      return function () {
+        var context = scope || this;
+
+        var now = +new Date,
+            args = arguments;
+        if (last && now < last + threshhold) {
+          // hold on to it
+          clearTimeout(deferTimer);
+          deferTimer = setTimeout(function () {
+            last = now;
+            fn.apply(context, args);
+          }, threshhold);
+        } else {
+          last = now;
+          fn.apply(context, args);
+        }
+      };
     }
   };
 
@@ -131,8 +179,9 @@
   }
 
   var runStickyPositions = function () {
-    findScrollPositions();
 
+    findScrollPositions();
+    console.log('run sticky', stickyNav.needsUpdate())
     stickyNav.setPositions();
     if (stickyNav.needsUpdate()) {
       stickyNav.update();
@@ -141,54 +190,60 @@
 
   var scrollTimer, lastScrollFireTime = 0;
 
-  window.addEventListener('scroll', function() {
-    console.log('scroll')
+  window.addEventListener('scroll', runStickyPositions, 100)
 
-    var minScrollTime = 100;
-    var now = new Date().getTime();
+  window.addEventListener('resize', runStickyPositions, 100)
 
-    function processScroll() {
-      // console.log(new Date().getTime().toString());
-      runStickyPositions();
-    }
 
-    if (!scrollTimer) {
-        if (now - lastScrollFireTime > (3 * minScrollTime)) {
-            processScroll();   // fire immediately on first scroll
-            lastScrollFireTime = now;
-        }
-        scrollTimer = setTimeout(function() {
-            scrollTimer = null;
-            lastScrollFireTime = new Date().getTime();
-            processScroll();
-        }, minScrollTime);
-    }
-  });
+  // window.addEventListener('scroll', function() {
+  //   // console.log('scroll')
 
-  window.addEventListener('resize', function() {
-    console.log('resize')
-    var minScrollTime = 100;
-    var now = new Date().getTime();
+  //   // var minScrollTime = 100;
+  //   // var now = new Date().getTime();
 
-    function processScroll() {
-      console.log('process resize')
-      // console.log(new Date().getTime().toString());
-      runStickyPositions();
-    }
+  //   // function processScroll() {
+  //   //   // console.log(new Date().getTime().toString());
+  //   //   runStickyPositions();
+  //   // }
 
-    if (!scrollTimer) {
-        if (now - lastScrollFireTime > (3 * minScrollTime)) {
-            processScroll();   // fire immediately on first scroll
-            lastScrollFireTime = now;
-        }
-        scrollTimer = setTimeout(function() {
-            scrollTimer = null;
-            lastScrollFireTime = new Date().getTime();
-            processScroll();
-        }, minScrollTime);
-    }
-  });
+  //   // if (!scrollTimer) {
+  //   //     if (now - lastScrollFireTime > (3 * minScrollTime)) {
+  //   //         processScroll();   // fire immediately on first scroll
+  //   //         lastScrollFireTime = now;
+  //   //     }
+  //   //     scrollTimer = setTimeout(function() {
+  //   //         scrollTimer = null;
+  //   //         lastScrollFireTime = new Date().getTime();
+  //   //         processScroll();
+  //   //     }, minScrollTime);
+  //   // }
+  //   stickyNav.throttle(runStickyPositions, 100);
+  // });
 
+  // window.addEventListener('resize', function() {
+    // console.log('resize')
+    // var minScrollTime = 100;
+    // var now = new Date().getTime();
+
+    // function processScroll() {
+    //   console.log('process resize')
+    //   // console.log(new Date().getTime().toString());
+    //   runStickyPositions();
+    // }
+
+    // if (!scrollTimer) {
+    //     if (now - lastScrollFireTime > (3 * minScrollTime)) {
+    //         processScroll();   // fire immediately on first scroll
+    //         lastScrollFireTime = now;
+    //     }
+    //     scrollTimer = setTimeout(function() {
+    //         scrollTimer = null;
+    //         lastScrollFireTime = new Date().getTime();
+    //         processScroll();
+    //     }, minScrollTime);
+    // }
+  //   stickyNav.throttle(runStickyPositions, 100);
+  // });
 
   exports.stickyNav = stickyNav;
 

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -75,7 +75,7 @@
         windowBump = windowWidth > 1044 || this.isMobile ? 0 : -20;
       this.width = this.elems.parent
         ? this.elems.parent.clientWidth + windowBump + 'px'
-        : this.maxWidth
+        : this.maxWidth;
 
       this.mainOffset = this.elems.main.offsetTop;
       this.mainHeight = this.elems.main.clientHeight;

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -64,17 +64,17 @@
   };
 
   StickyNav.prototype = {
-    setOffset: function() {
-      console.log('~~offset before~~~~', this.offset)
-      this.offset = this.attrStickyOffset
-        ? parseInt(this.attrStickyOffset)
-        : !this.elems.parent
-          ? this.elems.sticky.offsetTop
-          : this.attrParent === 'mobile' && this.isMobile
-            ? this.elems.parent.offsetTop - this.elems.sticky.offsetHeight
-            : this.elems.sticky.offsetTop
-      console.log('~~offset after~~~~', this.offset)
-    },
+    // setOffset: function() {
+    //   console.log('~~offset before~~~~', this.offset)
+    //   this.offset = this.attrStickyOffset
+    //     ? parseInt(this.attrStickyOffset)
+    //     : !this.elems.parent
+    //       ? this.elems.sticky.offsetTop
+    //       : this.attrParent === 'mobile' && this.isMobile
+    //         ? this.elems.parent.offsetTop - this.elems.sticky.offsetHeight
+    //         : this.elems.sticky.offsetTop
+    //   console.log('~~offset after~~~~', this.offset)
+    // },
     setPositions: function (mutate) {
 
       this.height = this.elems.sticky.clientHeight;
@@ -91,7 +91,8 @@
       // Todo diff bottom and diff top aren't working, and aren't
       // maintainable
       this.diffTop = scrollTop - this.mainOffset - this.offset;
-
+      console.log(scrollTop, this.offset)
+      // this.diffTop = scrollTop - this.offset;
       // this.diffBottom = distance from top of screen to bottom of stickyNav (scrollTop + this.height)
       // minus height of height of main and it
       this.diffBottom = scrollTop + this.height - this.mainHeight - this.mainOffset;
@@ -140,7 +141,8 @@
       // this.diffBottom = scrollTop + this.height - this.mainHeight - this.mainOffset;
           console.log(this.mainHeight - this.height - this.offset - this.mainOffset + 'px')
           // this.elems.sticky.style.top = this.mainHeight - this.mainOffset - this.height + 'px';
-          this.elems.sticky.style.top = this.mainHeight - this.height - this.mainOffset - this.offset - 50 + 'px';
+          // this.elems.sticky.style.top = this.mainHeight - this.mainOffset - this.height + 'px';
+          this.elems.sticky.style.top = this.mainHeight - this.height - this.offset + 'px';
 
           this.elems.sticky.classList.remove('js-transparent');
           this.elems.sticky.classList.add('js-color');
@@ -189,22 +191,22 @@
       };
     },
     run: function(mutate) {
-      if (mutate === 'mutate') {
-        console.log('------mutate event------')
-        this.setPositions();
-        this.setOffset();
-        if (this.needsUpdate()) {
-          this.update();
-        }
-      } else {
+      // if (mutate === 'mutate') {
+      //   console.log('------mutate event------')
+      //   this.setPositions();
+      //   this.setOffset();
+      //   if (this.needsUpdate()) {
+      //     this.update();
+      //   }
+      // } else {
         findScrollPositions();
-        this.determineScreen();
-        this.screenUpdate();
+        // this.determineScreen();
+        // this.screenUpdate();
         this.setPositions();
         if (this.needsUpdate()) {
           this.update();
         }
-      }
+      // }
 
     }
   };
@@ -218,16 +220,16 @@
   window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 
   // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
-  var observer = new MutationObserver(function (mutations) {
-    stickyNav.run('mutate');
-  });
+  // var observer = new MutationObserver(function (mutations) {
+  //   stickyNav.run('mutate');
+  // });
 
   // set up your configuration
   // this will watch to see if you insert or remove any children
-  var config = { subtree: true, childList: true };
+  // var config = { subtree: true, childList: true };
 
   //start observing
-  observer.observe(stickyNav.elems.sticky, config);
+  // observer.observe(stickyNav.elems.sticky, config);
 
   // other potential elem listener
   // http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/

--- a/js/pages/all-lands-production.js
+++ b/js/pages/all-lands-production.js
@@ -77,9 +77,6 @@
 
   function initialize() {
     var props = parseHash();
-    if (Object.keys(props).length) {
-      filterToggle.attr('aria-expanded', true);
-    }
     return mutateState(function(state) {
       return state.merge(props);
     }) || render(state);

--- a/js/pages/company-revenue.js
+++ b/js/pages/company-revenue.js
@@ -45,9 +45,6 @@
     .on('change', filterChange);
 
   var initialState = hash.read();
-  if (Object.keys(initialState).length) {
-    filterToggle.attr('aria-expanded', true);
-  }
 
   state.init(initialState);
 

--- a/js/pages/exports.js
+++ b/js/pages/exports.js
@@ -122,9 +122,7 @@
 
   function initialize() {
     var props = parseHash();
-    if (Object.keys(props).length) {
-      filterToggle.attr('aria-expanded', true);
-    }
+
     return mutateState(function(state) {
       return state.merge(props);
     }) || render(state);

--- a/js/pages/federal-production.js
+++ b/js/pages/federal-production.js
@@ -77,9 +77,7 @@
 
   function initialize() {
     var props = parseHash();
-    if (Object.keys(props).length) {
-      filterToggle.attr('aria-expanded', true);
-    }
+
     return mutateState(function(state) {
       return state.merge(props);
     }) || render(state);

--- a/js/pages/gdp.js
+++ b/js/pages/gdp.js
@@ -123,9 +123,7 @@
 
   function initialize() {
     var props = parseHash();
-    if (Object.keys(props).length) {
-      filterToggle.attr('aria-expanded', true);
-    }
+
     return mutateState(function(state) {
       return state.merge(props);
     }) || render(state);

--- a/js/pages/jobs.js
+++ b/js/pages/jobs.js
@@ -66,9 +66,7 @@
 
   function initialize() {
     var props = parseHash();
-    if (Object.keys(props).length) {
-      filterToggle.attr('aria-expanded', true);
-    }
+
     return mutateState(function(state) {
       return state.merge(props);
     }) || render(state);

--- a/js/pages/revenue.js
+++ b/js/pages/revenue.js
@@ -66,9 +66,7 @@
 
   function initialize() {
     var props = parseHash();
-    if (Object.keys(props).length) {
-      filterToggle.attr('aria-expanded', true);
-    }
+
     return mutateState(function(state) {
       return state.merge(props);
     }) || render(state);

--- a/styleguide/section-blocks.html
+++ b/styleguide/section-blocks.html
@@ -62,50 +62,62 @@
               </a>
             </li>
             <li class="kss-nav__menu-item">
-              <a href="section-blocks.html#kssref-blocks-downloads">
+              <a href="section-blocks.html#kssref-blocks-disbursements">
                 <span class="kss-nav__ref">1.4</span
-                ><span class="kss-nav__name">Downloads</span>
+                ><span class="kss-nav__name">Disbursements</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
-              <a href="section-blocks.html#kssref-blocks-downloads">
+              <a href="section-blocks.html#kssref-blocks-disbursements">
                 <span class="kss-nav__ref">1.4</span
                 ><span class="kss-nav__name"></span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
-              <a href="section-blocks.html#kssref-blocks-explore">
+              <a href="section-blocks.html#kssref-blocks-downloads">
                 <span class="kss-nav__ref">1.5</span
+                ><span class="kss-nav__name"></span>
+              </a>
+            </li>
+            <li class="kss-nav__menu-item">
+              <a href="section-blocks.html#kssref-blocks-downloads">
+                <span class="kss-nav__ref">1.5</span
+                ><span class="kss-nav__name">Downloads</span>
+              </a>
+            </li>
+            <li class="kss-nav__menu-item">
+              <a href="section-blocks.html#kssref-blocks-explore">
+                <span class="kss-nav__ref">1.6</span
                 ><span class="kss-nav__name">Explore</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-explore-home">
-                <span class="kss-nav__ref">1.6</span
+                <span class="kss-nav__ref">1.7</span
                 ><span class="kss-nav__name">Explore data callout on homepage</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-footer">
-                <span class="kss-nav__ref">1.7</span
+                <span class="kss-nav__ref">1.8</span
                 ><span class="kss-nav__name">Footer</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-header">
-                <span class="kss-nav__ref">1.8</span
+                <span class="kss-nav__ref">1.9</span
                 ><span class="kss-nav__name">Header</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-how-it-works">
-                <span class="kss-nav__ref">1.9</span
+                <span class="kss-nav__ref">1.10</span
                 ><span class="kss-nav__name">How it Works</span>
               </a>
             </li>
             <li class="kss-nav__menu-item">
               <a href="section-blocks.html#kssref-blocks-search">
-                <span class="kss-nav__ref">1.10</span
+                <span class="kss-nav__ref">1.11</span
                 ><span class="kss-nav__name">Search</span>
               </a>
             </li>
@@ -330,13 +342,77 @@ input from the American people.</p>
 
 
       </section>
+      <section id="kssref-blocks-disbursements" class="kss-section kss-section--depth-2">
+
+    <div class="kss-style">
+      <h2 class="kss-title kss-title--level-2">
+        <a class="kss-title__permalink" href="#kssref-blocks-disbursements">
+          <span class="kss-title__ref">
+              1.4
+            <span class="kss-title__permalink-hash">
+                #blocks.disbursements
+            </span>
+          </span>
+          Disbursements
+        </a>
+      </h2>
+
+
+      <div class="kss-description">
+        <p>Styles for the page at /explore/disbursements/</p>
+
+      </div>
+    </div>
+
+
+      </section>
+      <section id="kssref-blocks-disbursements" class="kss-section kss-section--depth-2">
+
+    <div class="kss-style">
+      <h2 class="kss-title kss-title--level-2">
+        <a class="kss-title__permalink" href="#kssref-blocks-disbursements">
+          <span class="kss-title__ref">
+              1.4
+            <span class="kss-title__permalink-hash">
+                #blocks.disbursements
+            </span>
+          </span>
+          
+        </a>
+      </h2>
+
+
+    </div>
+
+
+      </section>
       <section id="kssref-blocks-downloads" class="kss-section kss-section--depth-2">
 
     <div class="kss-style">
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-downloads">
           <span class="kss-title__ref">
-              1.4
+              1.5
+            <span class="kss-title__permalink-hash">
+                #blocks.downloads
+            </span>
+          </span>
+          
+        </a>
+      </h2>
+
+
+    </div>
+
+
+      </section>
+      <section id="kssref-blocks-downloads" class="kss-section kss-section--depth-2">
+
+    <div class="kss-style">
+      <h2 class="kss-title kss-title--level-2">
+        <a class="kss-title__permalink" href="#kssref-blocks-downloads">
+          <span class="kss-title__ref">
+              1.5
             <span class="kss-title__permalink-hash">
                 #blocks.downloads
             </span>
@@ -354,33 +430,13 @@ input from the American people.</p>
 
 
       </section>
-      <section id="kssref-blocks-downloads" class="kss-section kss-section--depth-2">
-
-    <div class="kss-style">
-      <h2 class="kss-title kss-title--level-2">
-        <a class="kss-title__permalink" href="#kssref-blocks-downloads">
-          <span class="kss-title__ref">
-              1.4
-            <span class="kss-title__permalink-hash">
-                #blocks.downloads
-            </span>
-          </span>
-          
-        </a>
-      </h2>
-
-
-    </div>
-
-
-      </section>
       <section id="kssref-blocks-explore" class="kss-section kss-section--depth-2">
 
     <div class="kss-style">
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-explore">
           <span class="kss-title__ref">
-              1.5
+              1.6
             <span class="kss-title__permalink-hash">
                 #blocks.explore
             </span>
@@ -405,7 +461,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-explore-home">
           <span class="kss-title__ref">
-              1.6
+              1.7
             <span class="kss-title__permalink-hash">
                 #blocks.explore-home
             </span>
@@ -425,7 +481,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-footer">
           <span class="kss-title__ref">
-              1.7
+              1.8
             <span class="kss-title__permalink-hash">
                 #blocks.footer
             </span>
@@ -449,7 +505,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-header">
           <span class="kss-title__ref">
-              1.8
+              1.9
             <span class="kss-title__permalink-hash">
                 #blocks.header
             </span>
@@ -517,7 +573,7 @@ all styles namespaced within .explore-subpage class</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works">
           <span class="kss-title__ref">
-              1.9
+              1.10
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works
             </span>
@@ -541,7 +597,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.forms">
           <span class="kss-title__ref">
-              1.9.1
+              1.10.1
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.forms
             </span>
@@ -561,7 +617,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.intro">
           <span class="kss-title__ref">
-              1.9.2
+              1.10.2
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.intro
             </span>
@@ -581,7 +637,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.intro">
           <span class="kss-title__ref">
-              1.9.2
+              1.10.2
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.intro
             </span>
@@ -605,7 +661,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.steps">
           <span class="kss-title__ref">
-              1.9.3
+              1.10.3
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.steps
             </span>
@@ -629,7 +685,7 @@ all styles namespaced within .explore-subpage class</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.subpage_involved">
           <span class="kss-title__ref">
-              1.9.4
+              1.10.4
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.subpage_involved
             </span>
@@ -654,7 +710,7 @@ media links on how to become involved</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.subpage_nav">
           <span class="kss-title__ref">
-              1.9.5
+              1.10.5
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.subpage_nav
             </span>
@@ -679,7 +735,7 @@ like subpages</p>
       <h3 class="kss-title kss-title--level-3">
         <a class="kss-title__permalink" href="#kssref-blocks-how-it-works.subpage_steps">
           <span class="kss-title__ref">
-              1.9.6
+              1.10.6
             <span class="kss-title__permalink-hash">
                 #blocks.how-it-works.subpage_steps
             </span>
@@ -703,7 +759,7 @@ like subpages</p>
       <h2 class="kss-title kss-title--level-2">
         <a class="kss-title__permalink" href="#kssref-blocks-search">
           <span class="kss-title__ref">
-              1.10
+              1.11
             <span class="kss-title__permalink-hash">
                 #blocks.search
             </span>


### PR DESCRIPTION
This PR addresses some of the bugginess with the explore filter

* [x] Fix issue with filter opening up automatically
* [x] Fix issue with filter extending into footer when it is opened
* [x] When filter is open on scroll, it switches to `position: absolute` (correct), but hides the toggle in the process (bad)
* [x] fine tune scroll on bottom of page
* [ ] filter width off on different screen sizes

@meiqimichelle ready for review! Moving remaining known bugs to a new issue: #1118