### PR TITLE
Sticky case studies

### DIFF
--- a/_layouts/case-studies.html
+++ b/_layouts/case-studies.html
@@ -295,7 +295,7 @@ layout: default
 
     </div>
 
-		<div class="sticky_nav" data-offset-bottom="100">
+		<div class="sticky_nav" data-offset-bottom="100" data-load-delay="1200">
 
 		  <nav class="sticky_nav-nav">
 

--- a/_sass/blocks/case-studies/_content.scss
+++ b/_sass/blocks/case-studies/_content.scss
@@ -45,3 +45,11 @@
     text-decoration: none;
   }
 }
+
+.case-studies-maps {
+  display: block;
+
+  eiti-map {
+    display: block;
+  }
+}

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -51,13 +51,8 @@
       return isAbsolute;
     }
 
-    this.offset = this.attrStickyOffset
-      ? parseInt(this.attrStickyOffset)
-      : !this.elems.parent
-        ? this.elems.sticky.offsetTop
-        : ( this.attrParent === 'mobile' && this.isMobile )
-          ? this.elems.parent.offsetTop - this.elems.sticky.offsetHeight
-          : this.elems.sticky.offsetTop
+
+
 
     this.status;
     this.lastStatus;
@@ -66,6 +61,16 @@
   };
 
   StickyNav.prototype = {
+    setOffset: function () {
+      this.offset = this.attrStickyOffset
+        ? parseInt(this.attrStickyOffset)
+        : !this.elems.parent
+          ? this.elems.sticky.offsetTop
+          : ( this.attrParent === 'mobile' && this.isMobile )
+            ? this.elems.parent.offsetTop - this.elems.sticky.offsetHeight
+            : this.elems.sticky.offsetTop
+      console.log('offsetSet', this.offset)
+    },
     getPositions: function () {
 
       this.height = this.elems.sticky.clientHeight;
@@ -101,7 +106,7 @@
         updateNeeded = 'size';
       } else if (statusChange && !sizeChange) {
         updateNeeded = 'status';
-      } else if (statusChange && sizeChange || init) {
+      } else if (statusChange && sizeChange || init === 'init') {
         updateNeeded = 'both';
       }
       return updateNeeded;
@@ -174,6 +179,10 @@
     },
     run: function(init) {
       findScrollPositions();
+      if (init === 'init') {
+        console.log(init)
+        this.setOffset();
+      }
       this.getPositions();
       this.update(this.needsUpdate(init));
     }
@@ -181,7 +190,9 @@
 
   var stickyNav = new StickyNav();
 
-  stickyNav.run();
+  setTimeout(function() {
+    stickyNav.run('init');
+  },500);
 
   window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -190,11 +190,18 @@
 
   var stickyNav = new StickyNav();
 
-  setTimeout(function() {
+  var loadDelay = stickyNav.elems.sticky.getAttribute('data-load-delay');
+  if (loadDelay) {
+    setTimeout(function() {
+      stickyNav.run('init');
+    }, parseInt(loadDelay));
+  } else {
     stickyNav.run('init');
-  },500);
+  }
 
-  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 150, stickyNav));
+
+
+  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
 
   window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 


### PR DESCRIPTION
Fixes a bug in the case studies subpages, where the sticknav would render on top of the map. I created a bit of a hack with the data-attributes in the sticky nav to get around this.

Can be reviewed!