### PR TITLE
slight adjustment to mobile filter

### DIFF
--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -11,6 +11,7 @@
   width: 100%;
   z-index: 3000;
 
+
   @include respond-to(medium-up) {
     border-bottom-left-radius: $base-border-radius;
     border-bottom-right-radius: $base-border-radius;
@@ -25,6 +26,7 @@
 
   &[aria-expanded=true] {
     background-color: $mid-blue-opaque !important;
+    height: 100%;
     overflow-y: scroll;
 
     &.js-transparent,

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -29,6 +29,10 @@
     height: 100%;
     overflow-y: scroll;
 
+    @include respond-to(medium-up) {
+      height: inherit;
+    }
+
     &.js-transparent,
     &.js-color {
       border-radius: $base-border-radius;

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -69,7 +69,6 @@
           : ( this.attrParent === 'mobile' && this.isMobile )
             ? this.elems.parent.offsetTop - this.elems.sticky.offsetHeight
             : this.elems.sticky.offsetTop
-      console.log('offsetSet', this.offset)
     },
     getPositions: function () {
 
@@ -180,7 +179,6 @@
     run: function(init) {
       findScrollPositions();
       if (init === 'init') {
-        console.log(init)
         this.setOffset();
       }
       this.getPositions();


### PR DESCRIPTION
Fixes #1149

This PR is spot is a very small set of changes that makes it so that the filter box on the Explore pages can be closed.

Larger improvements need to be made to the filter box on mobile, but for now, this should help.

Also removes a few console logs that flew under the radar last minute.