### PR TITLE
Update Search Bar Height

### DIFF
--- a/_sass/blocks/_header.scss
+++ b/_sass/blocks/_header.scss
@@ -202,6 +202,7 @@ header,
     color: $white;
     cursor: pointer;
     float: right;
+    height: 30px;
     padding: 0.42rem;
     width: 37px;
   }

--- a/_sass/blocks/_search.scss
+++ b/_sass/blocks/_search.scss
@@ -50,6 +50,7 @@
     color: $white;
     cursor: pointer;
     float: right;
+    height: 30px;
     padding: 0.42rem;
     width: 37px;
   }


### PR DESCRIPTION
The branch name is a bit of a misnomer. This makes it so that the search bar and corresponding button are the same height. It was a bit of an eye sore before 