### PR TITLE
Adds version number to footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,9 @@ description: USEITI is part of an international effort to promote open and accou
 # permanent url, for use in meta references
 url: https://useiti.doi.gov
 
+# app version number
+version: v1.1.0
+
 sass:
   style: nested
   sass_dir: _sass

--- a/_includes/layout/footer.html
+++ b/_includes/layout/footer.html
@@ -51,7 +51,7 @@
   	      <p class="footer-para">Contact the USEITI Secretariat at <a class="link-active-beta" href="mailto:useiti@ios.doi.gov">USEITI@ios.doi.gov</a>.</p>
 
   	      <p class="footer-para_callout">Built in the open</p>
-  	      <p class="footer-para">This site is powered by <a class="link-active-beta" href="{{ site.baseurl }}/downloads">USEITI data</a> and open source code. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/18F/doi-extractives-data/">GitHub</a>.</p>
+  	      <p class="footer-para">This site (<a href="https://github.com/18F/doi-extractives-data/releases/{{ site.version }}" class="link-active-beta">{{ site.version }}</a>) is powered by <a class="link-active-beta" href="{{ site.baseurl }}/downloads">USEITI data</a> and open source code. We welcome contributions and comments on <a class="link-active-beta" href="https://github.com/18F/doi-extractives-data/">GitHub</a>.</p>
 
   	      <p class="footer-para footer-para_last">Mail: USEITI Secretariat, 1849 C Street NW MS 4211, Washington, D.C. 20240</p>
 


### PR DESCRIPTION
This PR adds a version number that is set in `_config.yml` to the footer of the site so we can keep track of where the site is at. It links the version number directly to that release on GitHub.

Looks like:
![screenshot 2015-12-18 15 42 23](https://cloud.githubusercontent.com/assets/4827522/11908906/fab19d2c-a59d-11e5-8dce-b8d045eb3834.png)
