### PR TITLE
Fix mobile search bar

### DIFF
--- a/_sass/components/_drawer.scss
+++ b/_sass/components/_drawer.scss
@@ -107,6 +107,7 @@ input.drawer-search_field {
   border-radius: 0 $base-border-radius $base-border-radius 0;
   float: right;
   height: 34px;
+  padding: 0.5em;
   position: relative;
   width: 14%;
 }


### PR DESCRIPTION
Fixes #1171. Small change to fix search icon in mobile.

Now looks like this:

![img_1282](https://cloud.githubusercontent.com/assets/4803473/12021863/f3e07d1a-ad4f-11e5-8be9-5ae3d50e74a6.PNG)
