### PR TITLE
Bug Fixes – round 2

### DIFF
--- a/_explore/default.md
+++ b/_explore/default.md
@@ -28,7 +28,7 @@ permalink: /explore/
 
   <section class="container">
     <a id="revenue" class="link-no_under"><h3 class="landing-section_category">Revenue data</h3></a>
-    <div class="container-half landing-section" accordion-item accordion-open="true">
+    <div class="container-half landing-section" accordion-item accordion-open="false">
       <h5 class="landing-heading"><a href="{{site.baseurl}}/explore/federal-revenue-by-location/">Federal revenue by location</a></h5>
       <button class="accordion-button" accordion-button title="Toggle for federal revenue by location"></button>
       <div class="accordion-content">

--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -131,7 +131,7 @@ permalink: /explore/exports/
 
         <h3 class="region-header-category">Exports by state</h3>
         <table class="subregions">
-          <thead class="region-header"></thead>
+          <tbody class="region-header"></tbody>
           <tbody></tbody>
         </table>
 

--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -24,12 +24,6 @@ permalink: /explore/exports/
   </div>
   <section class="container-right-8 filters-wrapper_outer">
     <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-        Exports from <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
-        in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-      </h1>
 
       <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
 
@@ -90,15 +84,14 @@ permalink: /explore/exports/
           </eiti-slider>
         </div>
 
-        <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-          Exports from <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a> in
-          <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-          (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-        </h1>
-
       </form>
-
-      <div class="container-outer">
+      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+        Exports from <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
+        in
+        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+      </h1>
+      <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
       </div>
 
@@ -106,6 +99,13 @@ permalink: /explore/exports/
 
 
   </div>
+
+  <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
+    Exports from <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
+    in
+    <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+    (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+  </h1>
 
   <div class="explore-exploration slab-alpha">
 
@@ -131,7 +131,7 @@ permalink: /explore/exports/
 
         <h3 class="region-header-category">Exports by state</h3>
         <table class="subregions">
-          <tbody class="region-header"></tbody>
+          <thead class="region-header"></thead>
           <tbody></tbody>
         </table>
 

--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -113,7 +113,7 @@ permalink: /explore/gdp/
 
         <h3 class="region-header-category">GDP by state</h3>
         <table class="subregions">
-          <thead class="region-header"></thead>
+          <tbody class="region-header"></tbody>
           <tbody></tbody>
         </table>
 

--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -26,12 +26,6 @@ permalink: /explore/gdp/
   </div>
   <section class="container-right-8 filters-wrapper_outer">
     <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-        GDP from extractives in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-      </h1>
-
       <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
 
       <form id="filters" aria-hidden="true" class="filters">
@@ -72,23 +66,26 @@ permalink: /explore/gdp/
           </eiti-slider>
         </div>
 
-        <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-          GDP from extractives in
-          <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-          (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-        </h1>
-
       </form>
 
-      <div class="container-outer">
+      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+        GDP from extractives in
+        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+      </h1>
+      <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
       </div>
 
     </div>
 
-
   </div>
 
+  <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
+    GDP from extractives in
+    <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+    (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+  </h1>
   <div class="explore-exploration slab-alpha">
 
     <div class="regions container">
@@ -113,7 +110,7 @@ permalink: /explore/gdp/
 
         <h3 class="region-header-category">GDP by state</h3>
         <table class="subregions">
-          <tbody class="region-header"></tbody>
+          <thead class="region-header"></thead>
           <tbody></tbody>
         </table>
 

--- a/_explore/economic-impact/jobs.html
+++ b/_explore/economic-impact/jobs.html
@@ -30,14 +30,6 @@ permalink: /explore/jobs/
   </div>
   <section class="container-right-8 filters-wrapper_outer">
     <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-        <a href="#units-selector" class="filter-part" data-key="units">Number</a>
-        of
-        <a href="#figure-selector" class="filter-part" data-key="figure">wage and salary</a>
-        extractive industry jobs in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-      </h1>
 
       <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
 
@@ -87,26 +79,33 @@ permalink: /explore/jobs/
             min="2004" max="2013" snap="1" value="2013">
           </eiti-slider>
         </div>
-
-        <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-          <a href="#units-selector" class="filter-part" data-key="units">Number</a>
-          of
-          <a href="#figure-selector" class="filter-part" data-key="figure">wage and salary</a>
-          extractive industry jobs in
-          <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-          (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-        </h1>
-
       </form>
 
-      <div class="container-outer">
+      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+        <a href="#units-selector" class="filter-part" data-key="units">Number</a>
+        of
+        <a href="#figure-selector" class="filter-part" data-key="figure">wage and salary</a>
+        extractive industry jobs in
+        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+      </h1>
+
+      <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show Filters" data-toggler="filters">Show filters</button>
       </div>
 
     </div>
 
-
   </div>
+
+  <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
+    <a href="#units-selector" class="filter-part" data-key="units">Number</a>
+    of
+    <a href="#figure-selector" class="filter-part" data-key="figure">wage and salary</a>
+    extractive industry jobs in
+    <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+    (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+  </h1>
 
   <div class="explore-exploration slab-alpha">
 

--- a/_explore/production/production-all-lands.html
+++ b/_explore/production/production-all-lands.html
@@ -25,12 +25,7 @@ permalink: /explore/all-lands-production/
   </div>
   <section class="container-right-8 filters-wrapper_outer">
     <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-        <a href="#product-selector" class="filter-part" data-key="product">All</a>
-        production on all lands and waters in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-      </h1>
+
       <button class="toggle-filters toggle-desktop" is="eiti-toggle"
         aria-controls="filters" aria-expanded="false"
         data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
@@ -80,20 +75,28 @@ permalink: /explore/all-lands-production/
             min="2004" max="2013" snap="1" value="2013">
           </eiti-slider>
         </div>
-        <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-          <a href="#product-selector" class="filter-part" data-key="product">All</a>
-          production on all lands and waters in
-          <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-          (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-        </h1>
 
       </form>
 
-      <div class="container-outer">
+      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+        <a href="#product-selector" class="filter-part" data-key="product">All</a>
+        production on all lands and waters in
+        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+      </h1>
+
+      <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
       </div>
 
     </div>
+
+    <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
+      <a href="#product-selector" class="filter-part" data-key="product">All</a>
+      production on all lands and waters in
+      <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+      (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+    </h1>
 
     <div class="explore-exploration slab-alpha">
 

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -26,12 +26,7 @@ permalink: /explore/federal-production/
   </div>
   <section class="container-right-8 filters-wrapper_outer">
     <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-        <a href="#product-selector" class="filter-part" data-key="product">All</a>
-        production on federal lands and waters in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-      </h1>
+
       <button class="toggle-filters toggle-desktop" is="eiti-toggle"
         aria-controls="filters" data-collapsed-text="Show filters" aria-expanded="false"
         data-expanded-text="Hide filters" data-toggler="filters">Show filters</button>
@@ -90,11 +85,25 @@ permalink: /explore/federal-production/
 
       </form>
 
-      <div class="container-outer">
+      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+        <a href="#product-selector" class="filter-part" data-key="product">All</a>
+        production on federal lands and waters in
+        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+      </h1>
+
+      <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
       </div>
 
     </div>
+
+    <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
+      <a href="#product-selector" class="filter-part" data-key="product">All</a>
+      production on federal lands and waters in
+      <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+      (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+    </h1>
 
     <div class="explore-exploration slab-alpha">
 

--- a/_explore/revenue/corporate-income-tax.md
+++ b/_explore/revenue/corporate-income-tax.md
@@ -28,9 +28,9 @@ permalink: /explore/corporate-income-tax/
 
     <p>SOI’s calculations of federal corporate income tax receipts from all returns in the mining and petroleum refining sectors for <a href="https://www.irs.gov/uac/SOI-Tax-Stats-Returns-of-Active-Corporations-Table-1">tax years 2009 to 2013</a> are presented below.<sup id="fnref:1"><a href="#fn:1" class="footnote">1</a></sup></p>
 
-    <table class="article_table article_table-indented">
+    <table class="article_table article_table-indented article_table-numbers">
       <tr>
-  		<th rowspan="2">Industry</th>
+  		<th rowspan="2" class="article_table-left">Industry</th>
       <th colspan="5">Total receipts (in millions USD)<sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup></th>
       </tr>
       <tr>
@@ -50,43 +50,43 @@ permalink: /explore/corporate-income-tax/
       </tr>
       <tr>
   		<td>Oil and gas extraction</td>
-  		<td>$1,424</td>
-  		<td>$2,152</td>
-  		<td>$1,811</td>
-  		<td>$1,642</td>
-  		<td>$1,943</td>
+  		<td>1,424</td>
+  		<td>2,152</td>
+  		<td>1,811</td>
+  		<td>1,642</td>
+  		<td>1,943</td>
       </tr>
       <tr>
   		<td>Coal mining</td>
-  		<td>$207</td>
-  		<td>$344</td>
-  		<td>$325</td>
-  		<td>$245</td>
-  		<td>$32</td>
+  		<td>207</td>
+  		<td>344</td>
+  		<td>325</td>
+  		<td>245</td>
+  		<td>32</td>
       </tr>
       <tr>
   		<td>Metal ore mining</td>
-  		<td>$866</td>
-  		<td>$1,573</td>
-  		<td>$1,945</td>
-  		<td>$1,329</td>
-  		<td>$755</td>
+  		<td>866</td>
+  		<td>1,573</td>
+  		<td>1,945</td>
+  		<td>1,329</td>
+  		<td>755</td>
       </tr>
       <tr>
   		<td>Nonmetallic mineral mining and quarrying</td>
-  		<td>$181</td>
-  		<td>$158</td>
-  		<td>$183</td>
-  		<td>$233</td>
-  		<td>$222</td>
+  		<td>181</td>
+  		<td>158</td>
+  		<td>183</td>
+  		<td>233</td>
+  		<td>222</td>
       </tr>
       <tr>
   		<td>Support activities for mining</td>
-  		<td>$1,153</td>
-  		<td>$1,494</td>
-  		<td>$1,677</td>
-  		<td>$1,800</td>
-  		<td>$1,944</td>
+  		<td>1,153</td>
+  		<td>1,494</td>
+  		<td>1,677</td>
+  		<td>1,800</td>
+  		<td>1,944</td>
       </tr>
       <tr class="article_table-head">
   		<td>Petroleum and coal products manufacturing<sup id="fnref:3"><a href="#fn:3" class="footnote">3</a></sup></td>
@@ -98,11 +98,11 @@ permalink: /explore/corporate-income-tax/
       </tr>
       <tr>
   		<td>Petroleum refineries (including integrated)</td>
-  		<td>$1,772</td>
-  		<td>$4,865</td>
-  		<td>$7,402</td>
-  		<td>$9,064</td>
-  		<td>$6,631</td>
+  		<td>1,772</td>
+  		<td>4,865</td>
+  		<td>7,402</td>
+  		<td>9,064</td>
+  		<td>6,631</td>
       </tr>
     </table>
 

--- a/_explore/revenue/corporate-income-tax.md
+++ b/_explore/revenue/corporate-income-tax.md
@@ -28,7 +28,7 @@ permalink: /explore/corporate-income-tax/
 
     <p>SOI’s calculations of federal corporate income tax receipts from all returns in the mining and petroleum refining sectors for <a href="https://www.irs.gov/uac/SOI-Tax-Stats-Returns-of-Active-Corporations-Table-1">tax years 2009 to 2013</a> are presented below.<sup id="fnref:1"><a href="#fn:1" class="footnote">1</a></sup></p>
 
-    <table class="article_table">
+    <table class="article_table article_table-indented">
       <tr>
   		<th rowspan="2">Industry</th>
       <th colspan="5">Total receipts (in millions USD)<sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup></th>
@@ -40,7 +40,7 @@ permalink: /explore/corporate-income-tax/
   		<th>2012</th>
   		<th>2013</th>
       </tr>
-      <tr>
+      <tr class="article_table-head">
   		<td>Mining</td>
   		<td>$3,831</td>
   		<td>$5,722</td>
@@ -88,8 +88,8 @@ permalink: /explore/corporate-income-tax/
   		<td>$1,800</td>
   		<td>$1,944</td>
       </tr>
-      <tr>
-  		<td>Petroleum and coal products manufacturing</td>
+      <tr class="article_table-head">
+  		<td>Petroleum and coal products manufacturing<sup id="fnref:3"><a href="#fn:3" class="footnote">3</a></sup></td>
   		<td>$1,897</td>
   		<td>$5,126</td>
   		<td>$7,630</td>
@@ -118,7 +118,8 @@ permalink: /explore/corporate-income-tax/
     <div class="footnotes">
       <ol>
         <li id="fn:1"><p>Statistics on corporate income taxes relative to companies performing extractive activities are generally classified under the NAICS Mining major industry. In addition, integrated companies that operate in both the downstream extractive and refining spaces are classified under the NAICS Petroleum and Coal Products Manufacturing major industry. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
-        <li id="fn:2"><p>All figures are estimates based on samples. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+        <li id="fn:2"><p>All figures are estimates based on samples. Internal Revenue Service, <a href="https://www.irs.gov/uac/SOI-Tax-Stats-Returns-of-Active-Corporations-Table-1">Tax Returns of Active Corporations</a>.<a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+        <li id="fn:3"><p>Petroleum and coal products manufacturing encompasses an additional industry subcategory, <em>Asphalt paving, roofing, other petroleum and coal products</em>, which as exluded because it is outside the scope of EITI.<a href="#fnref:3" class="reversefootnote">↩</a></p></li>
       </ol>
     </div>
   </article>

--- a/_explore/revenue/corporate-income-tax.md
+++ b/_explore/revenue/corporate-income-tax.md
@@ -30,8 +30,8 @@ permalink: /explore/corporate-income-tax/
 
     <table class="article_table article_table-indented article_table-numbers">
       <tr>
-  		<th rowspan="2" class="article_table-left">Industry</th>
-      <th colspan="5">Total receipts (in millions USD)<sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup></th>
+  		<th rowspan="2" class="article_table-left article_table-enlarge">Industry</th>
+      <th colspan="5" class="article_table-thin">Total receipts (in millions USD)<sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup></th>
       </tr>
       <tr>
   		<th>2009</th>

--- a/_explore/revenue/corporate-income-tax.md
+++ b/_explore/revenue/corporate-income-tax.md
@@ -118,7 +118,7 @@ permalink: /explore/corporate-income-tax/
     <div class="footnotes">
       <ol>
         <li id="fn:1"><p>Statistics on corporate income taxes relative to companies performing extractive activities are generally classified under the NAICS Mining major industry. In addition, integrated companies that operate in both the downstream extractive and refining spaces are classified under the NAICS Petroleum and Coal Products Manufacturing major industry. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
-        <li id="fn:2"><p>All figures are estimates based on samples. Internal Revenue Service, <a href="https://www.irs.gov/uac/SOI-Tax-Stats-Returns-of-Active-Corporations-Table-1">Tax Returns of Active Corporations</a>.<a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+        <li id="fn:2"><p>Internal Revenue Service, <a href="https://www.irs.gov/uac/SOI-Tax-Stats-Returns-of-Active-Corporations-Table-1">Tax Returns of Active Corporations</a>. All figures are estimates based on samples.<a href="#fnref:2" class="reversefootnote">↩</a></p></li>
         <li id="fn:3"><p>Petroleum and coal products manufacturing encompasses an additional industry subcategory, <em>Asphalt paving, roofing, other petroleum and coal products</em>, which as exluded because it is outside the scope of EITI.<a href="#fnref:3" class="reversefootnote">↩</a></p></li>
       </ol>
     </div>

--- a/_explore/revenue/federal-revenue-by-company.html
+++ b/_explore/revenue/federal-revenue-by-company.html
@@ -88,7 +88,7 @@ permalink: /explore/federal-revenue-by-company/
         <h2 class="h3 region-title">Companies</h2>
         <div>
           <label for="company-name-filter">Filter by company name:</label>
-          <input type="text" name="search" id="company-name-filter">
+          <input class="filter-search" type="text" name="search" id="company-name-filter">
         </div>
         <table id="companies" class="company-list subregions">
         </table>

--- a/_explore/revenue/federal-revenue-by-company.html
+++ b/_explore/revenue/federal-revenue-by-company.html
@@ -79,17 +79,21 @@ permalink: /explore/federal-revenue-by-company/
     <div class="explore-exploration slab-alpha">
 
       <div class="container">
-        <h2 class="h3 region-title">Total revenues by type</h2>
+        <div class="filter-summary_title">
+          <h2 class="h3 region-title">Total revenues by type</h2>
+        </div>
         <table id="revenue-types" class="revenue-type-list subregions">
         </table>
       </div>
 
       <div class="container">
-        <h2 class="h3 region-title">Companies</h2>
-        <div>
-          <label for="company-name-filter">Filter by company name:</label>
-          <input class="filter-search" type="text" name="search" id="company-name-filter">
-        </div>
+        <section class="filter-search_section">
+          <h2 class="h3 region-title">Companies</h2>
+          <div class="filter-search_form">
+            <label for="company-name-filter">Filter by company name:</label>
+            <input class="filter-search" type="text" name="search" id="company-name-filter">
+          </div>
+        </section>
         <table id="companies" class="company-list subregions">
         </table>
       </div>

--- a/_explore/revenue/federal-revenue-by-company.html
+++ b/_explore/revenue/federal-revenue-by-company.html
@@ -28,12 +28,7 @@ permalink: /explore/federal-revenue-by-company/
 
   <section class="container-right-8 filters-wrapper_outer">
     <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-        <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
-        from
-        <a href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</a>
-        extraction on federal lands (2013)
-      </h1>
+
       <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
 
       <form id="filters" aria-hidden="true" class="filters">
@@ -61,20 +56,27 @@ permalink: /explore/federal-revenue-by-company/
           </div>
         </div>
 
-        <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-          <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
-          from
-          <a href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</a>
-          extraction on federal lands (2013)
-        </h1>
-
       </form>
 
-      <div class="container-outer">
+      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+        <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
+        from
+        <a href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</a>
+        extraction on federal lands (2013)
+      </h1>
+
+      <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-toggler="filters" data-collapsed-text="Show filters">Show filters</button>
       </div>
 
     </div>
+
+    <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
+      <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
+      from
+      <a href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</a>
+      extraction on federal lands (2013)
+    </h1>
 
     <div class="explore-exploration slab-alpha">
 

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -25,13 +25,6 @@ permalink: /explore/federal-revenue-by-location/
   </div>
   <section class="container-right-8 filters-wrapper_outer">
     <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
-        <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-        Revenue from
-        <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
-        on federal lands and waters in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-      </h1>
       <button class="toggle-filters toggle-desktop button-primary" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
 
       <form id="filters" aria-hidden="true" class="filters">
@@ -87,26 +80,34 @@ permalink: /explore/federal-revenue-by-location/
           </eiti-slider>
         </div>
 
-        <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-        Revenue from
-          <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
-          on federal lands in
-          <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-          (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-        </h1>
+
 
       </form>
 
-      <div class="container-outer">
+      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+        Revenue from
+        <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
+        on federal lands in
+        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+      </h1>
+
+      <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
       </div>
     </div>
   </div>
 
+  <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
+    Revenue from
+    <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
+    on federal lands in
+    <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
+    (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+  </h1>
   <div class="explore-exploration slab-alpha">
 
     <div class="regions container">
-
       <!-- <p class="map-intro_text">Choose a state to view county-level data. For some states, only statewide revenues are available.</p> -->
 
       <section id="US" class="region active">

--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -49,11 +49,7 @@ permalink: /explore/reconciliation/
 
   <section class="container-right-8 filters-wrapper_outer">
     <div data-absolute="true" data-offset-parent="mobile" class="sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" data-max-width="675">
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-        <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
-        from
-        extraction on federal lands (2013)
-      </h1>
+
       <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
 
       <form id="filters" aria-hidden="true" class="filters">
@@ -71,18 +67,25 @@ permalink: /explore/reconciliation/
           </div>
         </div>
 
-        <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_closed">
-          <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
-          from extraction on federal lands (2013)
-        </h1>
-
       </form>
 
-      <div class="container-outer">
+      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+        <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
+        from
+        extraction on federal lands (2013)
+      </h1>
+
+      <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-toggler="filters" data-collapsed-text="Show filters">Show filters</button>
       </div>
 
     </div>
+
+    <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
+      <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
+      from
+      extraction on federal lands (2013)
+    </h1>
 
     <div class="explore-exploration slab-alpha">
 

--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -102,11 +102,13 @@ permalink: /explore/reconciliation/
       </div>
 
       <div class="container">
-        <h2 class="h3 region-title">Discrepancies in payments by company and revenue type</h2>
-        <div>
-          <label for="company-name-filter">Search by company name:</label>
-          <input type="text" name="search" id="company-name-filter">
-        </div>
+        <section class="filter-search_section">
+          <h2 class="h3 region-title">Discrepancies in payments by company and revenue type</h2>
+          <div class="filter-search_form">
+            <label for="company-name-filter">Search by company name:</label>
+            <input class="filter-search" type="text" name="search" id="company-name-filter">
+          </div>
+        </section>
         <table id="companies" class="company-list subregions">
           <thead class="list-heading">
             <tr>

--- a/_how-it-works/default.md
+++ b/_how-it-works/default.md
@@ -75,7 +75,7 @@ permalink: /how-it-works/
 
 	<section class="container">
 		<h3 id="natural-resources" class="landing-section_category">Natural resources</h3>
-		<div class="container landing-section" accordion-item accordion-open="true">
+		<div class="container landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/how-it-works/ownership/">Ownership</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for ownership"></button>
 			<div class="accordion-content">

--- a/_includes/how-it-works/coal_steps.html
+++ b/_includes/how-it-works/coal_steps.html
@@ -59,9 +59,9 @@
 
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
         <div class="revenues_subpage-steps_number">5</div>
-        <h3 class="revenues_subpage-steps_heading">Decommission and reclaim</h3>
+        <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">
           <p>At the close of a coal mining operation, the lease holder must decommission the mine and restore the land. State governments, with oversight from OSMRE, regulate and oversee this process. Even before gaining a lease, the lease holder must submit a bond to OSMRE or a state regulatory agency as insurance for complying with the lease and covering the cost of <span class="term term-p" data-term="reclamation" title="Click to define" tabindex="0">reclaiming<i class="icon-book"></i></span> the land.</p>

--- a/_includes/how-it-works/minerals_steps.html
+++ b/_includes/how-it-works/minerals_steps.html
@@ -57,9 +57,9 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
         <div class="revenues_subpage-steps_number">5</div>
-        <h3 class="revenues_subpage-steps_heading">Decommission and reclaim</h3>
+        <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">
           <p>In 1981, BLM issued regulations requiring miners to remove all facilities and return the land to a sound environmental state. In 2001, BLM expanded on these regulations, requiring miners to provide bonds or other financial reassurances regarding reclaiming the land before exploring or mining.</p>

--- a/_includes/how-it-works/offshore_oil_gas_steps.html
+++ b/_includes/how-it-works/offshore_oil_gas_steps.html
@@ -68,9 +68,9 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
         <div class="revenues_subpage-steps_number">5</div>
-        <h3 class="revenues_subpage-steps_heading">Decommission and reclaim</h3>
+        <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">
           <p>At the close of an operation, the lease holder or operator must return the ocean and seafloor to its pre-lease condition. Under the OCSLA regulations, the lease holder is required to submit a Decommissioning Plan to BSEE for approval two years before the termination of the lease. To satisfy NEPA obligations, BOEM prepares a site-specific Environmental Assessment for each removal application on behalf of BSEE.</p>

--- a/_includes/how-it-works/offshore_renewables_steps.html
+++ b/_includes/how-it-works/offshore_renewables_steps.html
@@ -57,9 +57,9 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
         <div class="revenues_subpage-steps_number">5</div>
-        <h3 class="revenues_subpage-steps_heading">Decommission and reclaim</h3>
+        <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">
           <p>Two years before the end of the lease, the developer must submit a plan to decommission and remove the facilities. BSEE will then issue decommissioning permits and licenses. Currently, the government is continuing to develop the decommissioning process. However, developers must post bonds held by the government as insurance for decommissioning projects and complying with lease and other terms. If developers decommission projects, the government returns the bonds to the lease holder. If developers fail to decommission projects, the government uses the bonds to cover the cost of decommissioning.</p>

--- a/_includes/how-it-works/onshore_oil_gas_steps.html
+++ b/_includes/how-it-works/onshore_oil_gas_steps.html
@@ -55,9 +55,9 @@
         </div>
 
       </li>
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
         <div class="revenues_subpage-steps_number">5</div>
-        <h3 class="revenues_subpage-steps_heading">Decommission and reclaim</h3>
+        <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">
           <p>Even before the close of an oil and gas operation, operators and lease holders must begin <span class="term term-p" data-term="reclamation" title="Click to define" tabindex="0">reclamation<i class="icon-book"></i></span>. At the start of an operation, the operator includes a Reclamation Plan in the Surface Use Plan that must be approved by BLM before construction can start.</p>

--- a/_includes/how-it-works/onshore_renewables_steps.html
+++ b/_includes/how-it-works/onshore_renewables_steps.html
@@ -62,9 +62,9 @@
         </div>
 
       </li>
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
         <div class="revenues_subpage-steps_number">5</div>
-        <h3 class="revenues_subpage-steps_heading">Decommission and reclaim</h3>
+        <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">
           <p>At the close of a solar or wind project, developers must remove all facilities and return the land to a sound environmental state. Under the proposed rule, when an applicant gains a solar or wind energy lease or grant, they must provide BLM a bond. BLM holds the bond through the life of the project to ensure compliance with terms and conditions, including site <span class="term term-p" data-term="reclamation" title="Click to define" tabindex="0">reclamation<i class="icon-book"></i></span>.</p>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -47,7 +47,7 @@ $blue-alt: darken($blue, 5%); //for constrast, darker
 $light-blue: #e6f9ff;
 $pale-blue: #f2fcff;
 $mid-blue: #c6e9ff;
-$mid-blue-opaque: rgba(198,233,255, 0.93);
+$mid-blue-opaque: rgba(198, 233, 255, 0.93);
 $dark-blue: #4b9bbf;
 $light-gray: #f7f7f7;
 $light-gray-alt: #fafafa; //for constrast, lighter

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -47,7 +47,7 @@ $blue-alt: darken($blue, 5%); //for constrast, darker
 $light-blue: #e6f9ff;
 $pale-blue: #f2fcff;
 $mid-blue: #c6e9ff;
-$mid-blue-opaque: rgba(198,233,255, 0.85);
+$mid-blue-opaque: rgba(198,233,255, 0.93);
 $dark-blue: #4b9bbf;
 $light-gray: #f7f7f7;
 $light-gray-alt: #fafafa; //for constrast, lighter

--- a/_sass/blocks/_about.scss
+++ b/_sass/blocks/_about.scss
@@ -93,3 +93,21 @@
     line-height: 2;
   }
 }
+
+.article_table-head {
+  font-weight: $weight-book;
+}
+
+.article_table-indented {
+  tr {
+    &.article_table-head {
+      td:first-child {
+        text-indent: 0rem;
+      }
+    }
+
+    td:first-child {
+      text-indent: 1rem;
+    }
+  }
+}

--- a/_sass/blocks/_about.scss
+++ b/_sass/blocks/_about.scss
@@ -102,7 +102,7 @@
   tr {
     &.article_table-head {
       td:first-child {
-        text-indent: 0rem;
+        text-indent: 0;
       }
     }
 

--- a/_sass/blocks/_about.scss
+++ b/_sass/blocks/_about.scss
@@ -75,6 +75,10 @@
     padding: $base-padding-lite;
     text-align: left;
     vertical-align: bottom;
+
+    &.article_table-thin {
+      border-bottom: 1px solid $light-green;
+    }
   }
 
   td {
@@ -112,6 +116,10 @@
       text-indent: 1rem;
     }
   }
+}
+
+.article_table-enlarge {
+  @include font-size(1.1);
 }
 
 .article_table-head {

--- a/_sass/blocks/_about.scss
+++ b/_sass/blocks/_about.scss
@@ -69,7 +69,7 @@
   width: 100%;
 
   th {
-    border-bottom: 1px solid $light-green;
+    border-bottom: 4px solid $light-green;
     font-weight: $weight-book;
     line-height: 1.2;
     padding: $base-padding-lite;

--- a/_sass/blocks/_about.scss
+++ b/_sass/blocks/_about.scss
@@ -66,9 +66,10 @@
   border: none;
   border-bottom: 1px solid $light-green;
   margin-bottom: $base-padding-extra;
+  width: 100%;
 
   th {
-    border-bottom: 4px solid $light-green;
+    border-bottom: 1px solid $light-green;
     font-weight: $weight-book;
     line-height: 1.2;
     padding: $base-padding-lite;
@@ -91,6 +92,25 @@
   span {
     font-weight: $weight-book;
     line-height: 2;
+  }
+
+  &.article_table-numbers {
+    th {
+      text-align: center;
+    }
+
+    .article_table-left {
+      text-align: left;
+    }
+
+    td {
+      text-align: right;
+    }
+
+    td:first-child {
+      text-align: left;
+      text-indent: 1rem;
+    }
   }
 }
 

--- a/_sass/blocks/_header.scss
+++ b/_sass/blocks/_header.scss
@@ -68,8 +68,9 @@ header,
 
   &.header-bars {
     display: inline-block;
-    padding-bottom: 0;
-    padding-top: 0;
+    margin-right: (-1 * $base-padding-lite); // unfortunately necessary hack
+    margin-top: 1px; // for alignment with logo
+    padding: 0 $base-padding-lite;
 
     icon {
       @include font-size(1.87);

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -10,9 +10,14 @@
   }
 }
 
+.explore_home-explore_heading {
+  margin-bottom: $base-padding-lite;
+}
+
 .explore_home-subhead {
   @include heading(para-md);
-  font-weight: $weight-bold;
+  font-weight: $weight-light;
+  margin-bottom: 0;
   padding-bottom: 0;
 
   + .explore_home-heading {

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -36,17 +36,13 @@
 
 .explore_home-tabs {
   @include heading(para-sm);
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   text-align: right;
 
   @include respond-to(tiny-down) {
     line-height: 0.75rem;
-<<<<<<< b8d37183c86528248b92933e377d029c6530e31c
     font-size: 0.95rem;
     margin-bottom: 9px;
-=======
-    font-size: 0.85rem;
->>>>>>> tiny tweaaks
     text-align: center;
   }
 

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -37,7 +37,7 @@
 .explore_home-tabs {
   @include heading(para-sm);
   margin-bottom: 8px;
-  text-align: right;
+  text-align: center;
 
   @include respond-to(tiny-down) {
     line-height: 0.75rem;

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -24,7 +24,7 @@
 .explore_home-tabs {
   @include heading(para-sm);
   margin-bottom: 8px;
-  text-align: right;
+  text-align: center;
 
   @include respond-to(tiny-down) {
     line-height: 0.75rem;

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -19,7 +19,7 @@
 }
 
 .explore_home-explore_heading {
-  margin-bottom: $base-padding-lite;
+  margin-bottom: ($base-padding-lite * 2);
 }
 
 .explore_home-subhead {

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -2,6 +2,14 @@
 //
 // Styleguide blocks.explore-home
 
+@mixin active-tab() {
+  background-color: $white;
+  border: 1px solid $neutral-gray;
+  border-bottom: 1px solid $white;
+  font-weight: $weight-bold;
+  text-decoration: none;
+}
+
 .explore_home-heading {
   margin-bottom: $base-padding;
 
@@ -45,16 +53,12 @@
     padding: $base-padding-lite ($base-padding / 2);
 
     &[aria-selected="true"] {
-      background-color: $white;
-      border: 1px solid $neutral-gray;
-      border-bottom: 1px solid $white;
-      font-weight: $weight-bold;
+      @include active-tab();
     }
 
     &:hover,
     &:focus {
-      background-color: $white;
-      text-decoration: none;
+      @include active-tab();
     }
   }
 

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -36,7 +36,7 @@
 
 .explore_home-tabs {
   @include heading(para-sm);
-  margin-bottom: 4px;
+  margin-bottom: 3px;
   text-align: right;
 
   @include respond-to(tiny-down) {
@@ -50,7 +50,7 @@
     border: 1px solid transparent;
     color: $black;
     margin-right: $base-padding-lite;
-    padding: $base-padding-lite ($base-padding / 2);
+    padding: $base-padding-lite;
 
     &[aria-selected="true"] {
       @include active-tab();

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -23,7 +23,8 @@
 
 .explore_home-tabs {
   @include heading(para-sm);
-  margin-bottom: 3px;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
   text-align: right;
 
   @include respond-to(tiny-down) {
@@ -53,6 +54,22 @@
   }
 
   li {
+    display: inline-block;
+  }
+}
+
+.explore_home-tab_mobile {
+  display: inline-block;
+
+  @include respond-to(small-up) {
+    display: none;
+  }
+}
+
+.explore_home-tab_desktop {
+  display: none;
+
+  @include respond-to(small-up) {
     display: inline-block;
   }
 }

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -36,7 +36,8 @@
 
 .explore_home-tabs {
   @include heading(para-sm);
-  margin-bottom: 3px;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
   text-align: right;
 
   @include respond-to(tiny-down) {
@@ -79,6 +80,22 @@
   display: none;
 
   @include respond-to(tiny-up) {
+    display: inline-block;
+  }
+}
+
+.explore_home-tab_mobile {
+  display: inline-block;
+
+  @include respond-to(small-up) {
+    display: none;
+  }
+}
+
+.explore_home-tab_desktop {
+  display: none;
+
+  @include respond-to(small-up) {
     display: inline-block;
   }
 }

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -23,7 +23,7 @@
 
 .explore_home-tabs {
   @include heading(para-sm);
-  margin-bottom: 4px;
+  margin-bottom: 3px;
   text-align: right;
 
   @include respond-to(tiny-down) {
@@ -37,7 +37,7 @@
     border: 1px solid transparent;
     color: $black;
     margin-right: $base-padding-lite;
-    padding: $base-padding-lite $base-padding;
+    padding: ($base-padding-lite / 2) $base-padding;
 
     &[aria-selected="true"] {
       background-color: $white;
@@ -48,7 +48,7 @@
 
     &:hover,
     &:focus {
-      background-color: $mid-gray;
+      background-color: $white;
       text-decoration: none;
     }
   }

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -24,7 +24,7 @@
 .explore_home-tabs {
   @include heading(para-sm);
   margin-bottom: 8px;
-  text-align: center;
+  text-align: right;
 
   @include respond-to(tiny-down) {
     line-height: 0.75rem;

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -28,8 +28,8 @@
 
   @include respond-to(tiny-down) {
     line-height: 0.75rem;
-    font-size: 0.85rem;
-    margin-bottom: 8px;
+    font-size: 0.95rem;
+    margin-bottom: 9px;
     text-align: center;
   }
 
@@ -37,7 +37,7 @@
     border: 1px solid transparent;
     color: $black;
     margin-right: $base-padding-lite;
-    padding: ($base-padding-lite / 2) $base-padding;
+    padding: $base-padding-lite ($base-padding / 2);
 
     &[aria-selected="true"] {
       background-color: $white;

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -36,14 +36,17 @@
 
 .explore_home-tabs {
   @include heading(para-sm);
-  font-size: 0.85rem;
   margin-bottom: 8px;
   text-align: right;
 
   @include respond-to(tiny-down) {
     line-height: 0.75rem;
+<<<<<<< b8d37183c86528248b92933e377d029c6530e31c
     font-size: 0.95rem;
     margin-bottom: 9px;
+=======
+    font-size: 0.85rem;
+>>>>>>> tiny tweaaks
     text-align: center;
   }
 
@@ -88,6 +91,7 @@
   display: inline-block;
 
   @include respond-to(small-up) {
+
     display: none;
   }
 }
@@ -95,7 +99,7 @@
 .explore_home-tab_desktop {
   display: none;
 
-  @include respond-to(small-up) {
+  @include respond-to(tiny-up) {
     display: inline-block;
   }
 }

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -37,7 +37,7 @@
 .explore_home-tabs {
   @include heading(para-sm);
   margin-bottom: 8px;
-  text-align: center;
+  text-align: right;
 
   @include respond-to(tiny-down) {
     line-height: 0.75rem;

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -23,13 +23,12 @@
 
 .explore_home-tabs {
   @include heading(para-sm);
-  font-size: 0.85rem;
   margin-bottom: 8px;
   text-align: right;
 
   @include respond-to(tiny-down) {
-    font-size: 0.6rem;
     line-height: 0.75rem;
+    font-size: 0.85rem;
     text-align: center;
   }
 
@@ -61,7 +60,7 @@
 .explore_home-tab_mobile {
   display: inline-block;
 
-  @include respond-to(small-up) {
+  @include respond-to(tiny-up) {
     display: none;
   }
 }
@@ -69,7 +68,7 @@
 .explore_home-tab_desktop {
   display: none;
 
-  @include respond-to(small-up) {
+  @include respond-to(tiny-up) {
     display: inline-block;
   }
 }

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -23,12 +23,13 @@
 
 .explore_home-tabs {
   @include heading(para-sm);
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   text-align: right;
 
   @include respond-to(tiny-down) {
     line-height: 0.75rem;
     font-size: 0.85rem;
+    margin-bottom: 8px;
     text-align: center;
   }
 

--- a/_sass/blocks/_landing.scss
+++ b/_sass/blocks/_landing.scss
@@ -143,4 +143,8 @@
 
 .landing-wrapper {
   margin-bottom: ($base-padding-extra * 1.4);
+
+  .accordion-button {
+    margin-top: -1px;
+  }
 }

--- a/_sass/blocks/_nav-drawer.scss
+++ b/_sass/blocks/_nav-drawer.scss
@@ -26,10 +26,6 @@ $nav-drawer-height: 593px;
     bottom: initial;
     overflow: hidden;
   }
-
-  .drawer-search_field {
-    @include font-size(0.875);
-  }
 }
 
 .nav_drawer-nav {
@@ -43,7 +39,7 @@ $nav-drawer-height: 593px;
 
   font-weight: $weight-bold;
   letter-spacing: 2px;
-  padding-bottom: $base-padding-large;
+  padding-bottom: 1.6em;
   text-transform: uppercase;
 
   &:last-of-type {

--- a/_sass/blocks/explore/_all.scss
+++ b/_sass/blocks/explore/_all.scss
@@ -13,4 +13,5 @@
   @import 'map';
   @import 'toggle';
   @import 'regions-list';
+  @import 'filtered-list';
 }

--- a/_sass/blocks/explore/_all.scss
+++ b/_sass/blocks/explore/_all.scss
@@ -9,9 +9,9 @@
   $negative-fill: #bbb;
 
   @import 'subpage';
-  @import 'filters';
   @import 'map';
   @import 'toggle';
+  @import 'filters';
   @import 'regions-list';
   @import 'filtered-list';
 }

--- a/_sass/blocks/explore/_filtered-list.scss
+++ b/_sass/blocks/explore/_filtered-list.scss
@@ -1,0 +1,12 @@
+.filter-search {
+  border-color: $dark-gray;
+
+  @include respond-to(medium-up) {
+    width: 50%;
+  }
+}
+
+.filter-search_section,
+.filter-summary_title {
+  @include padded-in-mobile();
+}

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -237,10 +237,14 @@
 
 .filter-search {
   border-color: $dark-gray;
+  margin-left: $base-padding;
+  margin-right: $base-padding;
   padding-left: $base-padding;
   padding-right: $base-padding;
 
   @include respond-to(medium-up) {
+    margin-left: 0;
+    margin-right: 0;
     padding-left: 0;
     padding-right: 0;
     width: 50%;

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -67,7 +67,7 @@
     border-bottom-right-radius: 0;
 
     @include respond-to(medium-up) {
-      background: transparent;
+      background: $white;
     }
   }
 }

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -226,3 +226,15 @@
     text-decoration: none;
   }
 }
+
+.filter-search {
+  border-color: $dark-gray;
+  padding-left: $base-padding;
+  padding-right: $base-padding;
+
+  @include respond-to(medium-up) {
+    padding-left: 0;
+    padding-right: 0;
+    width: 50%;
+  }
+}

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -85,6 +85,7 @@
   p {
     @include heading(para-md);
     color: $blue-alt;
+    font-weight: $weight-book;
   }
 }
 
@@ -94,7 +95,7 @@
   label {
     @include heading(para-sm);
     color: $blue-alt;
-    font-weight: $weight-light;
+    font-weight: $weight-book;
     letter-spacing: 0.7px;
     margin-bottom: 3px;
     text-transform: uppercase;

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -50,10 +50,14 @@
   }
 
   &.js-color {
-    background: $white;
+    background: $mid-blue;
     border-bottom: 2px solid lighten($neutral-gray, 5%);
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+
+    @include respond-to(medium-up) {
+      background: $white;
+    }
   }
 
   &.js-transparent {
@@ -203,13 +207,24 @@
   font-weight: $weight-bold;
   float: left;
   letter-spacing: -0.5px;
-  margin-bottom: $base-padding;
 
 
   @include respond-to(medium-up) {
     display: inline-block;
     float: left;
     width: 65%;
+  }
+
+  &.filter-description_open {
+    display: block;
+    margin-bottom: $base-padding;
+    margin-top: $base-padding;
+    padding-left: $base-padding;
+    padding-right: $base-padding;
+
+    @include respond-to(medium-up) {
+      display: none;
+    }
   }
 
   &.filter-description_closed {
@@ -232,5 +247,17 @@
     border-bottom: 2px dotted $light-black;
     color: inherit;
     text-decoration: none;
+  }
+}
+
+.filter-search {
+  border-color: $dark-gray;
+  padding-left: $base-padding;
+  padding-right: $base-padding;
+
+  @include respond-to(medium-up) {
+    padding-left: 0;
+    padding-right: 0;
+    width: 50%;
   }
 }

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -256,8 +256,6 @@
   padding-right: $base-padding;
 
   @include respond-to(medium-up) {
-    padding-left: 0;
-    padding-right: 0;
     width: 50%;
   }
 }

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -7,7 +7,6 @@
   background-color: $white;
   margin-left: 0;
   padding: $base-padding;
-  padding-left: 0;
   position: absolute;
   width: 100%;
   z-index: 3000;
@@ -17,6 +16,7 @@
     border-bottom-left-radius: $base-border-radius;
     border-bottom-right-radius: $base-border-radius;
     margin-right: $base-padding;
+    padding-left: 0;
     width: initial;
   }
 

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -234,19 +234,3 @@
     text-decoration: none;
   }
 }
-
-.filter-search {
-  border-color: $dark-gray;
-  margin-left: $base-padding;
-  margin-right: $base-padding;
-  padding-left: $base-padding;
-  padding-right: $base-padding;
-
-  @include respond-to(medium-up) {
-    margin-left: 0;
-    margin-right: 0;
-    padding-left: 0;
-    padding-right: 0;
-    width: 50%;
-  }
-}

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -4,7 +4,7 @@
 }
 
 .filters-wrapper {
-  background-color: $white;
+  background-color: $mid-blue;
   margin-left: 0;
   padding: $base-padding;
   position: absolute;
@@ -13,6 +13,7 @@
 
 
   @include respond-to(medium-up) {
+    background-color: $white;
     border-bottom-left-radius: $base-border-radius;
     border-bottom-right-radius: $base-border-radius;
     margin-right: $base-padding;
@@ -56,10 +57,14 @@
   }
 
   &.js-transparent {
-    background: transparent;
+    background: $mid-blue;
     border-bottom: 2px solid lighten($neutral-gray, 5%);
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+
+    @include respond-to(medium-up) {
+      background: transparent;
+    }
   }
 }
 
@@ -194,12 +199,15 @@
 
 .filter-description {
   @include heading(para-xl);
+  display: none;
   font-weight: $weight-bold;
   float: left;
   letter-spacing: -0.5px;
   margin-bottom: $base-padding;
 
+
   @include respond-to(medium-up) {
+    display: inline-block;
     float: left;
     width: 65%;
   }

--- a/_sass/blocks/explore/_subpage.scss
+++ b/_sass/blocks/explore/_subpage.scss
@@ -27,7 +27,7 @@
   display: none;
 
   &.active {
-    display: block;
+    display: inline-block;
   }
 }
 

--- a/_sass/blocks/explore/_subpage.scss
+++ b/_sass/blocks/explore/_subpage.scss
@@ -17,12 +17,6 @@
   padding-top: $base-padding;
 }
 
-.regions {
-  @include respond-to(medium-to-huge-plus) {
-    margin-right: $base-padding;
-  }
-}
-
 .regions .region {
   display: none;
 
@@ -40,7 +34,8 @@
     margin-right: $base-padding;
   }
 
-  @include respond-to(large-up) {
+  @include respond-to(huge-plus-up) {
     margin-right: 0;
   }
+
 }

--- a/_sass/blocks/explore/_subpage.scss
+++ b/_sass/blocks/explore/_subpage.scss
@@ -28,6 +28,7 @@
 
   &.active {
     display: inline-block;
+    width: 100%;
   }
 }
 

--- a/_sass/blocks/explore/_subpage.scss
+++ b/_sass/blocks/explore/_subpage.scss
@@ -32,7 +32,14 @@
 }
 
 .explore-exploration {
+
+
   @include respond-to(medium-up) {
     margin-top: 128px;
+    margin-right: $base-padding;
+  }
+
+  @include respond-to(large-up) {
+    margin-right: 0;
   }
 }

--- a/_sass/blocks/explore/_toggle.scss
+++ b/_sass/blocks/explore/_toggle.scss
@@ -41,6 +41,10 @@
     display: none;
     float: right;
   }
+
+  &:before {
+    vertical-align: text-top;
+  }
 }
 
 .toggle-desktop {
@@ -58,8 +62,10 @@
   @include respond-to(medium-up){
     display: inline-block;
   }
+}
 
-  &:before {
-    vertical-align: text-top;
-  }
+.toggle-filters:not(.toggle-desktop) {
+  background: transparent;
+  color: $blue-alt;
+  float: right;
 }

--- a/_sass/blocks/explore/_toggle.scss
+++ b/_sass/blocks/explore/_toggle.scss
@@ -12,7 +12,7 @@
     line-height: $base-line-height;
     padding-right: $base-padding-lite;
     text-decoration: inherit;
-    vertical-align: bottom;
+    vertical-align: text-top;
   }
 
   &[aria-expanded=true]:before {
@@ -40,10 +40,6 @@
   @include respond-to(medium-up) {
     display: none;
     float: right;
-  }
-
-  &::before {
-    vertical-align: text-top;
   }
 }
 

--- a/_sass/blocks/explore/_toggle.scss
+++ b/_sass/blocks/explore/_toggle.scss
@@ -4,7 +4,7 @@
   background: transparent;
   color: $blue;
 
-  &:before {
+  &::before {
     content: $icon-plus-sm;
     font-family: eiti;
     font-style: normal;
@@ -42,7 +42,7 @@
     float: right;
   }
 
-  &:before {
+  &::before {
     vertical-align: text-top;
   }
 }

--- a/_sass/blocks/how-it-works/_subpage_steps.scss
+++ b/_sass/blocks/how-it-works/_subpage_steps.scss
@@ -132,7 +132,35 @@ $onshore-renewables-secondary-color: $blue;
 
   &:last-of-type {
     border-radius: 0 0 $base-border-radius $base-border-radius;
+
+    .accordion-button {
+      margin-top: 0;
+    }
   }
+
+  &.revenues_subpage-steps_long {
+
+
+    .revenues_subpage-steps_number {
+      vertical-align: text-bottom;
+
+      @include respond-to(tiny-up) {
+        vertical-align: baseline;
+      }
+    }
+
+    .break {
+      display: block;
+
+      @include respond-to(tiny-up) {
+        display: inline-block;
+      }
+    }
+  }
+}
+
+.revenues_subpage-steps_heading {
+  padding-right: $base-padding;
 }
 
 .revenues_subpage-steps_heading,

--- a/_sass/components/_accordions.scss
+++ b/_sass/components/_accordions.scss
@@ -105,10 +105,10 @@
 .accordion-button {
   background-color: transparent;
   background-size: 50%;
+  float: right;
   height: 2rem;
   margin: 0;
-  position: absolute;
-  right: $base-padding;
+  margin-top: 8px;
   width: 2rem;
 
   @include respond-to(medium-up) {

--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -123,7 +123,7 @@ img.card-image {
   .card-content-subhead {
     color: $dark-gray;
     font-weight: $weight-light;
-    margin-bottom: ($base-padding-lite / 2);
+    margin-bottom: $base-padding-lite;
   }
 
   @include respond-to(medium-up) {

--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -116,14 +116,14 @@ img.card-image {
 
   p {
     @include heading(para-md);
-    color: darken($neutral-gray, 20%);
+    color: $dark-gray;
     line-height: 1.6;
   }
 
   .card-content-subhead {
     color: $dark-gray;
     font-weight: $weight-light;
-    margin-bottom: $base-padding-lite;
+    margin-bottom: ($base-padding-lite / 2);
   }
 
   @include respond-to(medium-up) {

--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -123,7 +123,7 @@ img.card-image {
   .card-content-subhead {
     color: $dark-gray;
     font-weight: $weight-light;
-    margin-bottom: $base-padding-lite;
+    margin-bottom: ($base-padding-lite / 2);
   }
 
   @include respond-to(medium-up) {

--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -122,7 +122,7 @@ img.card-image {
 
   .card-content-subhead {
     color: $dark-gray;
-    font-weight: $weight-bold;
+    font-weight: $weight-light;
     margin-bottom: $base-padding-lite;
   }
 

--- a/_sass/components/_drawer.scss
+++ b/_sass/components/_drawer.scss
@@ -62,7 +62,10 @@
     display: inline-block;
     float: right;
     margin-bottom: 0;
-    padding: 0;
+    padding: $base-padding-lite;
+    margin-bottom: (-1 * $base-padding-lite);
+    margin-right: (-1 * $base-padding-lite);
+    margin-top: (-1 * $base-padding-lite);
   }
 
 }

--- a/_sass/components/_drawer.scss
+++ b/_sass/components/_drawer.scss
@@ -97,16 +97,19 @@ input.drawer-search_field {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
   display: inline;
-  height: 34px;
+  font-size: 1rem;
+  height: 40px;
   margin-top: 0;
+  padding-left: 0.5em;
   width: 86%;
 }
 
 .drawer-search_button {
   background-color: $white;
   border-radius: 0 $base-border-radius $base-border-radius 0;
+  color: $blue;
   float: right;
-  height: 34px;
+  height: 40px;
   padding: 0.5em;
   position: relative;
   width: 14%;

--- a/_sass/components/_drawer.scss
+++ b/_sass/components/_drawer.scss
@@ -61,11 +61,10 @@
     color: $white;
     display: inline-block;
     float: right;
-    margin-bottom: 0;
-    padding: $base-padding-lite;
     margin-bottom: (-1 * $base-padding-lite);
     margin-right: (-1 * $base-padding-lite);
     margin-top: (-1 * $base-padding-lite);
+    padding: $base-padding-lite;
   }
 
 }

--- a/_sass/components/_eiti-map.scss
+++ b/_sass/components/_eiti-map.scss
@@ -1,7 +1,6 @@
 eiti-map {
   display: block;
   position: relative;
-  // border: 1px solid #ccc;
 
   svg {
     display: block;
@@ -14,7 +13,7 @@ eiti-map {
 
   path {
     fill: transparent;
-    stroke: none;
+    stroke: $neutral-gray;
   }
 
   &.clickable path.feature {
@@ -38,7 +37,7 @@ eiti-map {
   }
 
   path.feature.zoomed {
-    stroke: lighten($neutral-gray, 10%);
+    stroke: $neutral-gray;
     stroke-width: 3;
   }
 

--- a/_sass/mixins/_all.scss
+++ b/_sass/mixins/_all.scss
@@ -1,2 +1,3 @@
 @import 'type-mixins';
 @import 'rotate';
+@import 'padded-in-mobile';

--- a/_sass/mixins/_padded-in-mobile.scss
+++ b/_sass/mixins/_padded-in-mobile.scss
@@ -1,0 +1,9 @@
+@mixin padded-in-mobile() {
+  padding-left: $base-padding;
+  padding-right: $base-padding;
+
+  @include respond-to(medium-up) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/img/icons/chevron-dn-med.svg
+++ b/img/icons/chevron-dn-med.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="22px" height="13px" viewBox="0 0 22 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.5 (25232) - http://www.bohemiancoding.com/sketch -->
+    <title>chevron-med</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Home,-Level-2,-etc" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="chevron-med" sketch:type="MSArtboardGroup" fill="#000000">
+            <path d="M5.99580018,16.5708807 L4.58088097,15.1559615 L13.7418426,5.99580018 L4.58088097,-3.16596176 L5.99580018,-4.58088097 L16.5708807,5.99580018" id="Imported-Layers-Copy-5" sketch:type="MSShapeGroup" transform="translate(10.575881, 5.995000) rotate(-270.000000) translate(-10.575881, -5.995000) "></path>
+        </g>
+    </g>
+</svg>

--- a/img/icons/icon-chevron-dn-sm.svg
+++ b/img/icons/icon-chevron-dn-sm.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="10px" height="6px" viewBox="0 0 10 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.5 (25232) - http://www.bohemiancoding.com/sketch -->
+    <title>icon-chevron-dn-sm</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Home,-Level-2,-etc" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="icon-chevron-dn-sm" sketch:type="MSArtboardGroup" fill="#000000">
+            <path d="M2.763,7.67205882 L1.76470588,6.67394118 L5.48505882,2.95376471 L1.76470588,-0.766411765 L2.763,-1.76470588 L7.48147059,2.95376471 L2.763,7.67205882" id="Imported-Layers" sketch:type="MSShapeGroup" transform="translate(4.764706, 3.000000) rotate(-270.000000) translate(-4.764706, -3.000000) "></path>
+        </g>
+    </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ title: Home
   <div class="container-outer tab-interface">
 
     <p class="h5 explore_home-subhead">Explore data</p>
-    <h2 class="h3 explore_home-heading">Learn about extractive industries throughout the country</h2>
+    <h2 class="h3 explore_home-heading explore_home-explore_heading">Learn about extractive industries throughout the country</h2>
 
     <ul class="explore_home-tabs" role="tablist">
       <li role="presentation"><a href="#revenue" tabindex="0" role="tab" aria-controls="revenue" aria-selected="true" class="link-charlie">Revenue</a></li>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ title: Home
     <ul class="explore_home-tabs" role="tablist">
       <li role="presentation"><a href="#revenue" tabindex="0" role="tab" aria-controls="revenue" aria-selected="true" class="link-charlie">Revenue</a></li>
       <li role="presentation"><a href="#production" tabindex="-1" role="tab" aria-controls="production" class="link-charlie">Production</a></li>
-      <li role="presentation"><a href="#impact" tabindex="-1" role="tab" aria-controls="impact" class="link-charlie">Economic Impact</a></li>
+      <li role="presentation"><a href="#impact" tabindex="-1" role="tab" aria-controls="impact" class="link-charlie"><span class="explore_home-tab_mobile">Impact</span><span class="explore_home-tab_desktop">Economic Impact</span></a></li>
     </ul>
 
     <section class="explore_home-main" id="revenue" role="tabpanel">

--- a/js/pages/all-lands-production.js
+++ b/js/pages/all-lands-production.js
@@ -4,6 +4,8 @@
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
   var colorscheme = colorbrewer.GnBu;
+  var lightestGreen = '#e6f2e1';
+  colorscheme[3][0] = colorscheme[5][0] = colorscheme[7][0] = lightestGreen;
 
   // our state is immutable!
   var state = new Immutable.Map();

--- a/js/pages/exports.js
+++ b/js/pages/exports.js
@@ -4,6 +4,8 @@
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
   var colorscheme = colorbrewer.GnBu;
+  var lightestGreen = '#e6f2e1';
+  colorscheme[3][0] = colorscheme[5][0] = colorscheme[7][0] = lightestGreen;
 
   // our state is immutable!
   var state = new Immutable.Map();

--- a/js/pages/federal-production.js
+++ b/js/pages/federal-production.js
@@ -4,6 +4,8 @@
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
   var colorscheme = colorbrewer.GnBu;
+  var lightestGreen = '#e6f2e1';
+  colorscheme[3][0] = colorscheme[5][0] = colorscheme[7][0] = lightestGreen;
 
   // our state is immutable!
   var state = new Immutable.Map();

--- a/js/pages/gdp.js
+++ b/js/pages/gdp.js
@@ -4,6 +4,8 @@
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
   var colorscheme = colorbrewer.GnBu;
+  var lightestGreen = '#e6f2e1';
+  colorscheme[3][0] = colorscheme[5][0] = colorscheme[7][0] = lightestGreen;
 
   // our state is immutable!
   var state = new Immutable.Map();

--- a/js/pages/jobs.js
+++ b/js/pages/jobs.js
@@ -4,6 +4,8 @@
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
   var colorscheme = colorbrewer.GnBu;
+  var lightestGreen = '#e6f2e1';
+  colorscheme[3][0] = colorscheme[5][0] = colorscheme[7][0] = lightestGreen;
 
   // our state is immutable!
   var state = new Immutable.Map();

--- a/js/pages/revenue.js
+++ b/js/pages/revenue.js
@@ -4,6 +4,8 @@
   // local alias for region id => name lookups
   var REGION_ID_NAME = eiti.data.REGION_ID_NAME;
   var colorscheme = colorbrewer.GnBu;
+  var lightestGreen = '#e6f2e1';
+  colorscheme[3][0] = colorscheme[5][0] = colorscheme[7][0] = lightestGreen;
 
   // our state is immutable!
   var state = new Immutable.Map();
@@ -351,6 +353,7 @@
     var max = Math.max(extent[1], 0);
 
     var colors = colorscheme;
+
     if (max >= 2e9) {
       colors = colors[7];
     } else if (max >= 1e6) {


### PR DESCRIPTION
Addresses #1204, #1205, #1230, #1216
 
Another round of live edits ft. our very own @ericronne 

* [x] #1230 Formatting income tax chart 
* [x] By-company, reconcilliation company filter
* [x] hamburger location
* [x] homepage tab and header adjustments
* [x] mobile nav edits
* [x] mobile explore filter changes
* [x] filter opacity
* [x] How it works and Explore homepages have _all_ accordions closed by default.
* [x] #1216 - change map border stroke color to #ccc
* [x] change lightest color in map spectrum
- [x] explore charts width adjustment
- [x] Explore charts padding on descriptions
- [x] Explore charts color in mobile
- [x] Explore charts mobile discription placement
  - [x] Federal Revenue by Location
  - [x] Federal Revenue by Company
  - [x] Exports
  - [x] GDP
  - [x] Jobs
  - [x] Federal Production
  - [x] All Lands Production
  - [x] Reconciliation 
- [x] Filter – difference in width from filter to table in smaller desktop screens
<img width="817" alt="screen shot 2016-02-01 at 4 03 00 pm" src="https://cloud.githubusercontent.com/assets/4803473/12732899/59b4a530-c8fd-11e5-9d98-18432f564a11.png">
