### PR TITLE
Updated color palette

### DIFF
--- a/_includes/layout/banner.html
+++ b/_includes/layout/banner.html
@@ -1,4 +1,4 @@
-<section class="banner slab-beta-alt">
+<section class="banner slab-beta-light">
   <span class="banner-left">An official website of the U.S. government <img class="banner-image" src="{{ site.baseurl }}/img/us-flag-small.png" alt="U.S. flag signifying that this is a United States Federal Government website"></span>
   <span class="banner-right"><a class="link-alpha" tabindex="0" href="{{ site.baseurl }}/about/whats-new/">See what’s new</a> or <a class="link-alpha" href="https://ethn.io/38933">help us improve the site</a>.</span>
 </section>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -49,7 +49,8 @@ $mid-blue: #c9eeff;
 $mid-blue-opaque: rgba(198, 233, 255, 0.93);
 $dark-blue: #4b9bbf;
 $light-gray: #f7f7f7;
-$light-gray-alt: #fafafa; //for constrast, lighter
+$light-gray-light: #fafafa; //for constrast, lighter
+$light-gray-dark: #f2f2f2; // for contrast, darker
 $mid-gray: #ebebeb;
 $neutral-gray: #ccc;
 $dark-gray: #4a4a4a;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -33,7 +33,6 @@ $z-negative: -1;
 // <p class="icon-map" style="color: #ebebeb;">$mid-gray</p>
 // <p class="icon-map" style="color: #4a4a4a;">$dark-gray</p>
 // <p class="icon-map" style="color: #303030;">$light-black</p>
-// <p class="icon-map" style="color: #acb626;">$shock-green</p>
 //
 // Styleguide colors
 
@@ -44,9 +43,9 @@ $green: #96bc7f;
 $blue: #157bac;
 $light-green: #d2e2cb;
 $blue-alt: darken($blue, 5%); //for constrast, darker
-$light-blue: #e6f9ff;
-$pale-blue: #f2fcff;
-$mid-blue: #c6e9ff;
+$light-blue: #e3f8ff;
+$pale-blue: #f0fcff;
+$mid-blue: #c9eeff;
 $mid-blue-opaque: rgba(198, 233, 255, 0.93);
 $dark-blue: #4b9bbf;
 $light-gray: #f7f7f7;
@@ -60,7 +59,6 @@ $light-black: #303030;
 $putty: #f4f4f4;
 $dark-putty: #838383;
 $green: #9fa63b;
-$shock-green: #acb626;
 $purple: #965bcd;
 $red: #c5403c;
 $cobalt: #1075a5;

--- a/_sass/blocks/how-it-works/_footer.scss
+++ b/_sass/blocks/how-it-works/_footer.scss
@@ -22,7 +22,7 @@
   }
 
   i {
-    color: $shock-green;
+    color: $blue;
   }
 
 }

--- a/_sass/layout/_slabs.scss
+++ b/_sass/layout/_slabs.scss
@@ -27,8 +27,12 @@
   background-color: $light-gray;
 }
 
-.slab-beta-alt {
-  background-color: $light-gray-alt; //slightly lighter, for contrast
+.slab-beta-light {
+  background-color: $light-gray-light; //slightly lighter, for contrast
+}
+
+.slab-beta-dark {
+  background-color: $light-gray-dark; //slightly darker, for contrast
 }
 
 .slab-charlie {

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@ title: Home
   </div>
 </section>
 
-<section class="slab-beta container-padded">
+<section class="slab-beta-dark container-padded">
   <div class="container-outer">
 
     <div class="container-left-3">

--- a/styleguide/section-colors.html
+++ b/styleguide/section-colors.html
@@ -114,7 +114,6 @@
 <p class="icon-map" style="color: #ebebeb;">$mid-gray</p>
 <p class="icon-map" style="color: #4a4a4a;">$dark-gray</p>
 <p class="icon-map" style="color: #303030;">$light-black</p>
-<p class="icon-map" style="color: #acb626;">$shock-green</p>
         </div>
       </div>
 
@@ -129,8 +128,7 @@
 &lt;p class=&quot;icon-map&quot; style=&quot;color: #f7f7f7;&quot;&gt;$light-gray&lt;/p&gt;
 &lt;p class=&quot;icon-map&quot; style=&quot;color: #ebebeb;&quot;&gt;$mid-gray&lt;/p&gt;
 &lt;p class=&quot;icon-map&quot; style=&quot;color: #4a4a4a;&quot;&gt;$dark-gray&lt;/p&gt;
-&lt;p class=&quot;icon-map&quot; style=&quot;color: #303030;&quot;&gt;$light-black&lt;/p&gt;
-&lt;p class=&quot;icon-map&quot; style=&quot;color: #acb626;&quot;&gt;$shock-green&lt;/p&gt;</code></pre>
+&lt;p class=&quot;icon-map&quot; style=&quot;color: #303030;&quot;&gt;$light-black&lt;/p&gt;</code></pre>
       </div>
 
       </div>


### PR DESCRIPTION
Fixes #1247 

[Preview](https://federalist.18f.gov/preview/18F/doi-extractives-data/palette-tweaks/)

@ericronne I have replaced all of the colors _except_ `$light-gray`. 
[See my comments](https://github.com/18F/doi-extractives-data/issues/1247#issuecomment-180033220) to see if we should remove it, and if so what we should replace it with.