### PR TITLE
Reconciliation footnotes

### DIFF
--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -74,7 +74,7 @@ permalink: /explore/reconciliation/
           <p class="para-sm container-left-6">When the U.S. independent administrator compared company payments to government revenue, 17 discrepancies exceeded the margin of variance (highlighted in red below). The independent administrator worked with the companies and government entities to investigate these discrepancies, and was able to find explanations for all of them. Explanations included differences in when payments were recorded and how they were classified.</p>
         </div> -->
           <div class="container detached-header">
-            <h2 class="h3 u-margin-top detached-table_title">Median payment discrepancies by revenue type</h2>
+            <h2 class="h3 region-title">Median payment discrepancies by revenue type</h2>
             <span class="detached-table_header">
               <span class="term term-p" data-term="material variance" title="Click to define" tabindex="0">Material variance <i class="icon-book"></i></span>
               <br/><strong>threshold</strong>

--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -27,21 +27,21 @@ permalink: /explore/reconciliation/
       <div class="footnotes container-padded">
         <h3>Footnotes</h3>
         <ol>
-          <li id="fn:1"><p>Sample footnote. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
-          <li id="fn:2"><p>Sample footnote. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
-          <li id="fn:3"><p>Sample footnote. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
-          <li id="fn:4"><p>Sample footnote. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
-          <li id="fn:5"><p>Sample footnote. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
-          <li id="fn:6"><p>Sample footnote. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
-          <li id="fn:7"><p>Sample footnote. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
-          <li id="fn:8"><p>Sample footnote. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
-          <li id="fn:9"><p>Sample footnote. <a href="#fnref:9" class="reversefootnote">↩</a></p></li>
-          <li id="fn:10"><p>Sample footnote. <a href="#fnref:10" class="reversefootnote">↩</a></p></li>
-          <li id="fn:11"><p>Sample footnote. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
-          <li id="fn:12"><p>Sample footnote. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
-          <li id="fn:13"><p>Sample footnote. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
-          <li id="fn:14"><p>Sample footnote. <a href="#fnref:14" class="reversefootnote">↩</a></p></li>
-          <li id="fn:15"><p>Sample footnote. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
+          <li id="fn:1"><p>$54,318,974 was paid by Chevron Corporation in 2012 but recorded in 2013. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
+          <li id="fn:2"><p>Payment transactions for tax refunds totaling $6,345,527 were shown as paid by the IRS in 2013 but recorded by Shell E&amp;P Company in January 2014. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+          <li id="fn:3"><p>$11,232,000 was paid by Exxon Mobil Corporation in 2012 but recorded in 2013. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
+          <li id="fn:4"><p>$8,300,214 was paid by Peabody Energy Corporation in 2013 but recorded in 2014. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
+          <li id="fn:5"><p>$91,500 was paid by Anadarko Petroleum Corporation in 2012 but recorded in 2013. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
+          <li id="fn:6"><p>$280,655 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
+          <li id="fn:7"><p>$17,000 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
+          <li id="fn:8"><p>$240,500 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
+          <li id="fn:9"><p>Freeport McMoRan Inc. records rental payment transactions in their accounting system differently from how ONRR records transactions, including different lumping of rents and bonuses. <a href="#fnref:9" class="reversefootnote">↩</a></p></li>
+          <li id="fn:10"><p>$5,520,487 was paid by Statoil Gulf of Mexico in 2013 but recorded in 2014. <a href="#fnref:10" class="reversefootnote">↩</a></p></li>
+          <li id="fn:11"><p>$31,500 was paid by Noble Energy, Inc. in 2012 but recorded in 2013. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
+          <li id="fn:12"><p>$19,500 was paid by Noble Energy, Inc. in 2013 but recorded in 2014. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
+          <li id="fn:13"><p>$32,500 was paid by Cimarex Energy in 2013 but recorded in 2014. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
+          <li id="fn:14"><p>BLM included revenue for permit fees collected for activity they administered on multiple tribal leases. However, Newfield Exploration Company did not include this revenue in this category, as it was not for federal leases. This helps to explain why a variance exists between the reported numbers. <a href="#fnref:14" class="reversefootnote">↩</a></p></li>
+          <li id="fn:15"><p>$1,383,084 was paid by ANKOR Energy LLC in 2012 but recorded in 2013. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
         </ol>
       </div>
     </div>

--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -23,27 +23,6 @@ permalink: /explore/reconciliation/
       <a href="{{site.baseurl}}/downloads/reconciliation/">
         <i class="fa fa-file-text-o u-padding-right"></i>Data and documentation
       </a>
-
-      <div class="footnotes container-padded">
-        <h3>Footnotes</h3>
-        <ol>
-          <li id="fn:1"><p>$54,318,974 was paid by Chevron Corporation in 2012 but recorded in 2013. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
-          <li id="fn:2"><p>Payment transactions for tax refunds totaling $6,345,527 were shown as paid by the IRS in 2013 but recorded by Shell E&amp;P Company in January 2014. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
-          <li id="fn:3"><p>$11,232,000 was paid by Exxon Mobil Corporation in 2012 but recorded in 2013. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
-          <li id="fn:4"><p>$8,300,214 was paid by Peabody Energy Corporation in 2013 but recorded in 2014. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
-          <li id="fn:5"><p>$91,500 was paid by Anadarko Petroleum Corporation in 2012 but recorded in 2013. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
-          <li id="fn:6"><p>$280,655 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
-          <li id="fn:7"><p>$17,000 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
-          <li id="fn:8"><p>$240,500 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
-          <li id="fn:9"><p>Freeport McMoRan Inc. records rental payment transactions in their accounting system differently from how ONRR records transactions, including different lumping of rents and bonuses. <a href="#fnref:9" class="reversefootnote">↩</a></p></li>
-          <li id="fn:10"><p>$5,520,487 was paid by Statoil Gulf of Mexico in 2013 but recorded in 2014. <a href="#fnref:10" class="reversefootnote">↩</a></p></li>
-          <li id="fn:11"><p>$31,500 was paid by Noble Energy, Inc. in 2012 but recorded in 2013. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
-          <li id="fn:12"><p>$19,500 was paid by Noble Energy, Inc. in 2013 but recorded in 2014. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
-          <li id="fn:13"><p>$32,500 was paid by Cimarex Energy in 2013 but recorded in 2014. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
-          <li id="fn:14"><p>BLM included revenue for permit fees collected for activity they administered on multiple tribal leases. However, Newfield Exploration Company did not include this revenue in this category, as it was not for federal leases. This helps to explain why a variance exists between the reported numbers. <a href="#fnref:14" class="reversefootnote">↩</a></p></li>
-          <li id="fn:15"><p>$1,383,084 was paid by ANKOR Energy LLC in 2012 but recorded in 2013. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
-        </ol>
-      </div>
     </div>
   </div>
 
@@ -120,6 +99,26 @@ permalink: /explore/reconciliation/
             </tr>
           </thead>
         </table>
+        <div class="footnotes container-padded">
+          <h3>Footnotes</h3>
+          <ol>
+            <li id="fn:1" class="hashoffset"><p>$54,318,974 was paid by Chevron Corporation in 2012 but recorded in 2013. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
+            <li id="fn:2" class="hashoffset"><p>Payment transactions for tax refunds totaling $6,345,527 were shown as paid by the IRS in 2013 but recorded by Shell E&amp;P Company in January 2014. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+            <li id="fn:3" class="hashoffset"><p>$11,232,000 was paid by Exxon Mobil Corporation in 2012 but recorded in 2013. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
+            <li id="fn:4" class="hashoffset"><p>$8,300,214 was paid by Peabody Energy Corporation in 2013 but recorded in 2014. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
+            <li id="fn:5" class="hashoffset"><p>$91,500 was paid by Anadarko Petroleum Corporation in 2012 but recorded in 2013. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
+            <li id="fn:6" class="hashoffset"><p>$280,655 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
+            <li id="fn:7" class="hashoffset"><p>$17,000 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
+            <li id="fn:8" class="hashoffset"><p>$240,500 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
+            <li id="fn:9" class="hashoffset"><p>Freeport McMoRan Inc. records rental payment transactions in their accounting system differently from how ONRR records transactions, including different lumping of rents and bonuses. <a href="#fnref:9" class="reversefootnote">↩</a></p></li>
+            <li id="fn:10" class="hashoffset"><p>$5,520,487 was paid by Statoil Gulf of Mexico in 2013 but recorded in 2014. <a href="#fnref:10" class="reversefootnote">↩</a></p></li>
+            <li id="fn:11" class="hashoffset"><p>$31,500 was paid by Noble Energy, Inc. in 2012 but recorded in 2013. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
+            <li id="fn:12" class="hashoffset"><p>$19,500 was paid by Noble Energy, Inc. in 2013 but recorded in 2014. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
+            <li id="fn:13" class="hashoffset"><p>$32,500 was paid by Cimarex Energy in 2013 but recorded in 2014. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
+            <li id="fn:14" class="hashoffset"><p>BLM included revenue for permit fees collected for activity they administered on multiple tribal leases. However, Newfield Exploration Company did not include this revenue in this category, as it was not for federal leases. This helps to explain why a variance exists between the reported numbers. <a href="#fnref:14" class="reversefootnote">↩</a></p></li>
+            <li id="fn:15" class="hashoffset"><p>$1,383,084 was paid by ANKOR Energy LLC in 2012 but recorded in 2013. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
+          </ol>
+        </div>
       </div>
 
     </div>

--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -102,21 +102,21 @@ permalink: /explore/reconciliation/
         <div class="footnotes container-padded">
           <h3>Footnotes</h3>
           <ol>
-            <li id="fn:1" class="hashoffset"><p>$54,318,974 was paid by Chevron Corporation in 2012 but recorded in 2013. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
-            <li id="fn:2" class="hashoffset"><p>Payment transactions for tax refunds totaling $6,345,527 were shown as paid by the IRS in 2013 but recorded by Shell E&amp;P Company in January 2014. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
-            <li id="fn:3" class="hashoffset"><p>$11,232,000 was paid by Exxon Mobil Corporation in 2012 but recorded in 2013. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
-            <li id="fn:4" class="hashoffset"><p>$8,300,214 was paid by Peabody Energy Corporation in 2013 but recorded in 2014. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
-            <li id="fn:5" class="hashoffset"><p>$91,500 was paid by Anadarko Petroleum Corporation in 2012 but recorded in 2013. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
-            <li id="fn:6" class="hashoffset"><p>$280,655 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
-            <li id="fn:7" class="hashoffset"><p>$17,000 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
-            <li id="fn:8" class="hashoffset"><p>$240,500 was paid by ConocoPhillips in 2013 but recorded in 2014. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
+            <li id="fn:1" class="hashoffset"><p>$54,318,974 was paid by Chevron Corporation in 2012 and recorded in 2013. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
+            <li id="fn:2" class="hashoffset"><p>Payment transactions for tax refunds totaling $6,345,527 were shown as paid by the IRS in 2013 and recorded by Shell E&amp;P Company in January 2014. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+            <li id="fn:3" class="hashoffset"><p>$11,232,000 was paid by Exxon Mobil Corporation in 2012 and recorded in 2013. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
+            <li id="fn:4" class="hashoffset"><p>$8,300,214 was paid by Peabody Energy Corporation in 2013 and recorded in 2014. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
+            <li id="fn:5" class="hashoffset"><p>$91,500 was paid by Anadarko Petroleum Corporation in 2012 and recorded in 2013. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
+            <li id="fn:6" class="hashoffset"><p>$280,655 was paid by ConocoPhillips in 2013 and recorded in 2014. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
+            <li id="fn:7" class="hashoffset"><p>$17,000 was paid by ConocoPhillips in 2013 and recorded in 2014. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
+            <li id="fn:8" class="hashoffset"><p>$240,500 was paid by ConocoPhillips in 2013 and recorded in 2014. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
             <li id="fn:9" class="hashoffset"><p>Freeport McMoRan Inc. records rental payment transactions in their accounting system differently from how ONRR records transactions, including different lumping of rents and bonuses. <a href="#fnref:9" class="reversefootnote">↩</a></p></li>
-            <li id="fn:10" class="hashoffset"><p>$5,520,487 was paid by Statoil Gulf of Mexico in 2013 but recorded in 2014. <a href="#fnref:10" class="reversefootnote">↩</a></p></li>
-            <li id="fn:11" class="hashoffset"><p>$31,500 was paid by Noble Energy, Inc. in 2012 but recorded in 2013. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
-            <li id="fn:12" class="hashoffset"><p>$19,500 was paid by Noble Energy, Inc. in 2013 but recorded in 2014. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
-            <li id="fn:13" class="hashoffset"><p>$32,500 was paid by Cimarex Energy in 2013 but recorded in 2014. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
+            <li id="fn:10" class="hashoffset"><p>$5,520,487 was paid by Statoil Gulf of Mexico in 2013 and recorded in 2014. <a href="#fnref:10" class="reversefootnote">↩</a></p></li>
+            <li id="fn:11" class="hashoffset"><p>$31,500 was paid by Noble Energy, Inc. in 2012 and recorded in 2013. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
+            <li id="fn:12" class="hashoffset"><p>$19,500 was paid by Noble Energy, Inc. in 2013 and recorded in 2014. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
+            <li id="fn:13" class="hashoffset"><p>$32,500 was paid by Cimarex Energy in 2013 and recorded in 2014. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
             <li id="fn:14" class="hashoffset"><p>BLM included revenue for permit fees collected for activity they administered on multiple tribal leases. However, Newfield Exploration Company did not include this revenue in this category, as it was not for federal leases. This helps to explain why a variance exists between the reported numbers. <a href="#fnref:14" class="reversefootnote">↩</a></p></li>
-            <li id="fn:15" class="hashoffset"><p>$1,383,084 was paid by ANKOR Energy LLC in 2012 but recorded in 2013. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
+            <li id="fn:15" class="hashoffset"><p>$1,383,084 was paid by ANKOR Energy LLC in 2012 and recorded in 2013. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
           </ol>
         </div>
       </div>

--- a/_sass/blocks/explore/_all.scss
+++ b/_sass/blocks/explore/_all.scss
@@ -14,4 +14,5 @@
   @import 'filters';
   @import 'regions-list';
   @import 'filtered-list';
+  @import 'hash-offset';
 }

--- a/_sass/blocks/explore/_hash-offset.scss
+++ b/_sass/blocks/explore/_hash-offset.scss
@@ -1,0 +1,14 @@
+$default-offset: 120px;
+
+// as reference for variable filter blocks
+// *[id^="#fn:"],
+// *[id^="#fnref:"],
+.hashoffset {
+	margin-top: -1 * $default-offset;
+	padding-top: $default-offset;
+}
+
+.footnotes {
+	padding-left: $base-padding;
+	padding-right: $base-padding;
+}

--- a/_sass/components/_footnotes.scss
+++ b/_sass/components/_footnotes.scss
@@ -56,3 +56,12 @@ body {
   @extend .link-charlie;
   vertical-align: super; // 2
 }
+
+// $default-offset: 130px;
+
+// *[id^="#fn:"],
+// *[id^="#fnref:"],
+// .hashoffset {
+//   margin-top: -1 * $default-offset;
+//   padding-top: $default-offset;
+// }

--- a/js/pages/reconciliation.js
+++ b/js/pages/reconciliation.js
@@ -387,7 +387,7 @@
           return '<strong>' + variance +
             '<sup id="fnref:' + refNumber +
             '"><a href="#fn:' + refNumber +
-            '" class="footnote">' + refNumber +
+            '" class="footnote hashoffset">' + refNumber +
             '</a></sup></strong>';
         }
         return isMaterial(d)


### PR DESCRIPTION
For #1242 #1233 

This branch was started by @coreycaitlin to add explanations to Explore > Reconciliation.

I have placed the footnotes below the company list.

Ready for review, @meiqimichelle --> [Preview](https://federalist.18f.gov/preview/18F/doi-extractives-data/reconciliation-footnotes/explore/reconciliation)

@coreycaitlin I'm not sure where you were drawing your explanations from, so it was difficult for me to check them. Where were you looking?