### PR TITLE
Glossary term opens on click

### DIFF
--- a/_explore/default.md
+++ b/_explore/default.md
@@ -24,7 +24,7 @@ permalink: /explore/
 	</div>
 </section>
 
-<section accordion class="container-outer landing-wrapper">
+<section accordion accordion-desktop="false" class="container-outer landing-wrapper">
 
   <section class="container">
     <a id="revenue" class="link-no_under"><h3 class="landing-section_category">Revenue data</h3></a>
@@ -35,28 +35,28 @@ permalink: /explore/
         <p class="landing-description">Revenue from extractive industries on federal lands and waters in fiscal year 2013 totaled about $13.4 billion, or 0.4% of total $3.4 trillion in revenue collected across the federal government. <a href="{{site.baseurl}}/explore/federal-revenue-by-location/">Explore revenue on federal lands and waters</a> from 2004 to 2013 by state, county, or offshore area.</p>
       </div>
     </div>
-    <div class="container-half landing-section" accordion-item accordion-open="true">
+    <div class="container-half landing-section" accordion-item accordion-open="false">
       <h5 class="landing-heading"><a href="{{site.baseurl}}/explore/federal-revenue-by-company/">Federal revenue by company</a></h5>
       <button class="accordion-button" accordion-button title="Toggle for federal revenue by company"></button>
       <div class="accordion-content">
         <p class="landing-description">In 2013, the federal government collected over $9.8 billion in royalties from resources extracted on federal lands. Some of the companies that paid the most include Chevron, Shell, BP, and Exxon Mobile. <a href="{{site.baseurl}}/explore/federal-revenue-by-company/">Explore revenues on federal lands and waters in 2013 by company</a> and revenue type.</p>
       </div>
     </div>
-    <div class="container-half landing-section" accordion-item accordion-open="true">
+    <div class="container-half landing-section" accordion-item accordion-open="false">
       <h5 class="landing-heading"><a href="{{site.baseurl}}/explore/reconciliation/">Reconciliation</a></h5>
       <button class="accordion-button" accordion-button title="Toggle for reconciliation"></button>
       <div class="accordion-content">
         <p class="landing-description">As part of USEITI, companies report payments to the government and the government reports what it received. These figures are compiled, reconciled, and published. In the future, this dataset will be interactive. For now, you can <a href="{{site.baseurl}}/explore/reconciliation/">learn about the reconciliation process</a> or <a href="{{site.baseurl}}/downloads/#reconciliation">download the dataset</a>.</p>
       </div>
     </div>
-    <div class="container-half landing-section" accordion-item accordion-open="true">
+    <div class="container-half landing-section" accordion-item accordion-open="false">
       <h5 class="landing-heading"><a href="{{site.baseurl}}/explore/corporate-income-tax/">Corporate income tax</a></h5>
       <button class="accordion-button" accordion-button title="Toggle for corporate income tax"></button>
       <div class="accordion-content">
         <p class="landing-description">Publicly listed companies are required to report tax information in their annual financial statement filings, including cash flows, income statements, and balance sheets. <a href="{{site.baseurl}}/explore/corporate-income-tax/">See information on federal corporate income taxes</a> and data from 2009 to 2013.</p>
       </div>
     </div>
-    <div class="container-half landing-section" accordion-item accordion-open="true">
+    <div class="container-half landing-section" accordion-item accordion-open="false">
       <h5 class="landing-heading"><a href="{{site.baseurl}}/explore/disbursements/">Disbursements</a></h5>
       <button class="accordion-button" accordion-button title="Toggle for disbursements"></button>
       <div class="accordion-content">
@@ -67,14 +67,14 @@ permalink: /explore/
 
 	<section class="container">
 		<a id="production" class="link-no_under"><h3 class="landing-section_category">Production data</h3></a>
-		<div class="container-half landing-section" accordion-item accordion-open="true">
+		<div class="container-half landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/explore/all-lands-production/">All lands and waters</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for all lands production"></button>
 			<div class="accordion-content">
 				<p class="landing-description">In 2013, total U.S. energy production from oil, gas, mining, and renewables reached 73.67 quadrillion British thermal units (Btus). <a href="{{site.baseurl}}/explore/all-lands-production/">Explore production on all U.S. lands and waters</a> from 2004 to 2013 by state and county.</p>
 			</div>
 		</div>
-		<div class="container-half landing-section" accordion-item accordion-open="true">
+		<div class="container-half landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/explore/federal-production/">Federal lands and waters</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for federal production"></button>
 			<div class="accordion-content">
@@ -85,21 +85,21 @@ permalink: /explore/
 
 	<section class="container">
 		<a id="economic-impact" name="economic-impact" class="link-no_under"><h3 class="landing-section_category">Economic impact</h3></a>
-		<div class="container-half landing-section" accordion-item accordion-open="true">
+		<div class="container-half landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/explore/gdp/">Gross Domestic Product</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for GDP"></button>
 			<div class="accordion-content">
 				<p class="landing-description">Extractive industries account for 2.6% of the economy, outpacing utilities, agriculture, and education services in contributions to the national GDP. <a href="{{site.baseurl}}/explore/gdp/">Explore GDP from extractive insustries</a> by state from 2004 to 2013.</p>
 			</div>
 		</div>
-		<div class="container-half landing-section" accordion-item accordion-open="true">
+		<div class="container-half landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/explore/exports/">Exports</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for exports"></button>
 			<div class="accordion-content">
 				<p class="landing-description">Commodities from extractive industries are among the top exports in 22 states — and, for a few states, these industries accounted for more than 40% of all exports in 2013. <a href="{{site.baseurl}}/explore/exports/">Explore extractive industries exports</a> by state from 2011 to 2013.</p>
 			</div>
 		</div>
-		<div class="container-half landing-section" accordion-item accordion-open="true">
+		<div class="container-half landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/explore/jobs/">Jobs</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for jobs"></button>
 			<div class="accordion-content">
@@ -113,6 +113,3 @@ permalink: /explore/
     <h3>Not sure where to go? Start here &#8230;</h3>
     <h2><a href="{{ site.baseurl }}/how-it-works/">Learn how natural resources result in federal revenues</a></h2>
 </section> -->
-
-<!-- Accordion -->
-<script src="{{ site.baseurl }}/js/components/accordion.js"></script>

--- a/_how-it-works/default.md
+++ b/_how-it-works/default.md
@@ -24,7 +24,7 @@ permalink: /how-it-works/
   </div>
 </section>
 
-<section accordion class="container-outer landing-wrapper">
+<section accordion accordion-desktop="false" class="container-outer landing-wrapper">
   <section class="container">
     <h3 id="process" class="landing-section_category">The process</h3>
     <div class="container landing-section_open overview">
@@ -83,7 +83,7 @@ permalink: /how-it-works/
         <a href="{{site.baseurl}}/how-it-works/ownership/">Learn about land and resource ownership &#8594;</a></p>
 			</div>
 		</div>
-		<div class="container landing-section" accordion-item accordion-open="true">
+		<div class="container landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/how-it-works/production/">Production</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for production"></button>
 			<div class="accordion-content">
@@ -91,7 +91,7 @@ permalink: /how-it-works/
         <a href="{{site.baseurl}}/how-it-works/production/">Learn about production &#8594;</a></p>
 			</div>
 		</div>
-		<div class="container landing-section" accordion-item accordion-open="true">
+		<div class="container landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/how-it-works/revenues/">Revenues</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for revenues"></button>
 			<div class="accordion-content">
@@ -103,7 +103,7 @@ permalink: /how-it-works/
 
 	<section class="container">
 		<h3 id="laws-governance" class="landing-section_category">Laws and governance</h3>
-		<div class="container landing-section" accordion-item accordion-open="true">
+		<div class="container landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/how-it-works/federal-laws/">Federal laws and regulations</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for federal laws"></button>
 			<div class="accordion-content">
@@ -111,7 +111,7 @@ permalink: /how-it-works/
         <a href="{{site.baseurl}}/how-it-works/federal-laws/">Learn about federal laws &#8594;</a></p>
 			</div>
 		</div>
-		<div class="container landing-section" accordion-item accordion-open="true">
+		<div class="container landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/how-it-works/federal-reforms/">Federal reforms</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for federal reforms"></button>
 			<div class="accordion-content">
@@ -119,7 +119,7 @@ permalink: /how-it-works/
         <a href="{{site.baseurl}}/how-it-works/federal-reforms/">Learn about reforms &#8594;</a></p>
 			</div>
 		</div>
-		<div class="container landing-section" accordion-item accordion-open="true">
+		<div class="container landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/how-it-works/state-laws-and-regulations/" id="state-laws-and-regulations">State laws and regulations</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for state laws and regulations"></button>
 			<div class="accordion-content">
@@ -127,7 +127,7 @@ permalink: /how-it-works/
         <a href="{{site.baseurl}}/how-it-works/state-laws-and-regulations/">Learn about state laws &#8594;</a></p>
 			</div>
 		</div>
-		<div class="container landing-section" accordion-item accordion-open="true">
+		<div class="container landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/how-it-works/state-legal-fiscal-info/">Regulations in 18 states</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for regulations in 18 states"></button>
 			<div class="accordion-content">
@@ -135,7 +135,7 @@ permalink: /how-it-works/
         <a href="{{site.baseurl}}/how-it-works/state-legal-fiscal-info/">Learn about 18 states &#8594;</a></p>
 			</div>
 		</div>
-		<div class="container landing-section" accordion-item accordion-open="true">
+		<div class="container landing-section" accordion-item accordion-open="false">
 			<h5 class="landing-heading"><a href="{{site.baseurl}}/how-it-works/tribal-laws-and-regulations/">Tribal laws and regulations</a></h5>
 			<button class="accordion-button" accordion-button title="Toggle for tribal laws and regulations"></button>
 			<div class="accordion-content">
@@ -145,6 +145,3 @@ permalink: /how-it-works/
 		</div>
 	</section>
 </section>
-
-<!-- Accordion -->
-<script src="{{ site.baseurl }}/js/components/accordion.js"></script>

--- a/_how-it-works/the-process/coal.html
+++ b/_how-it-works/the-process/coal.html
@@ -32,4 +32,4 @@ permalink: /how-it-works/coal/
 
 
 <!-- Accordion -->
-<script src="{{ site.baseurl }}/js/components/accordion.js"></script>
+<!-- <script src="{{ site.baseurl }}/js/components/accordion.js"></script> -->

--- a/_how-it-works/the-process/coal.html
+++ b/_how-it-works/the-process/coal.html
@@ -28,8 +28,3 @@ permalink: /how-it-works/coal/
 <div class="container-outer revenues_page-footer">
   {% include how-it-works/footer.html %}
 </div>
-
-
-
-<!-- Accordion -->
-<!-- <script src="{{ site.baseurl }}/js/components/accordion.js"></script> -->

--- a/_how-it-works/the-process/minerals.html
+++ b/_how-it-works/the-process/minerals.html
@@ -30,8 +30,3 @@ permalink: /how-it-works/minerals/
 <div class="container-outer revenues_page-footer">
   {% include how-it-works/footer.html %}
 </div>
-
-
-
-<!-- Accordion -->
-<script src="{{ site.baseurl }}/js/components/accordion.js"></script>

--- a/_how-it-works/the-process/offshore-oil-gas.html
+++ b/_how-it-works/the-process/offshore-oil-gas.html
@@ -43,8 +43,3 @@ permalink: /how-it-works/offshore-oil-gas/
       {% include how-it-works/footer.html %}
 
   </div>
-
-
-
-<!-- Accordion -->
-<script src="{{ site.baseurl }}/js/components/accordion.js"></script>

--- a/_how-it-works/the-process/offshore-renewables.html
+++ b/_how-it-works/the-process/offshore-renewables.html
@@ -41,9 +41,3 @@ permalink: /how-it-works/offshore-renewables/
   {% include how-it-works/footer.html %}
 </div>
 
-<!-- Accordion -->
-<script src="{{ site.baseurl }}/js/components/accordion.js"></script>
-
-
-
-

--- a/_how-it-works/the-process/onshore-oil-gas.html
+++ b/_how-it-works/the-process/onshore-oil-gas.html
@@ -43,6 +43,3 @@ permalink: /how-it-works/onshore-oil-gas/
     {% include how-it-works/footer.html %}
 
 </div>
-
-<!-- Accordion -->
-<script src="{{ site.baseurl }}/js/components/accordion.js"></script>

--- a/_how-it-works/the-process/onshore-renewables.html
+++ b/_how-it-works/the-process/onshore-renewables.html
@@ -40,8 +40,3 @@ permalink: /how-it-works/onshore-renewables/
 <div class="container-outer revenues_page-footer">
     {% include how-it-works/footer.html %}
 </div>
-
-
-<!-- Accordion -->
-<script src="{{ site.baseurl }}/js/components/accordion.js"></script>
-

--- a/_how-it-works/the-process/process-overview.md
+++ b/_how-it-works/the-process/process-overview.md
@@ -128,6 +128,3 @@ permalink: /how-it-works/process-overview/
 
 	</div>
 </section>
-
-<!-- Accordion -->
-<script src="{{ site.baseurl }}/js/components/accordion.js"></script>

--- a/_includes/glossary.html
+++ b/_includes/glossary.html
@@ -8,11 +8,11 @@
 
   <h2 class="drawer-header"><i class="icon-book"></i> Glossary </h2>
   <label for="drawer-search" class="label">Filter glossary terms</label>
-  <input class="glossary__search drawer-search" type="search" placeholder="e.g. Fossil fuel">
-  <div class="drawer__content" id="glossary-result">
-    <ul class="glossary__list" accordion>
+  <input class="js-glossary-search drawer-search" type="search" placeholder="e.g. Fossil fuel">
+  <div id="glossary-result">
+    <ul class="js-glossary-list" accordion>
       {% for term in site.data.terms %}
-      <li class="drawer__item" accordion-item accordion-open="false">
+      <li class="glossary-item" accordion-item accordion-open="false">
         <h5 class="glossary-term">{{term[0]}}</h5>
         <button accordion-button class="accordion-button" title="Toggle for {{term[0]}}"></button>
         <p class="glossary-definition accordion-content">{{term[1]}}</p>

--- a/_includes/glossary.html
+++ b/_includes/glossary.html
@@ -10,17 +10,12 @@
   <label for="drawer-search" class="label">Filter glossary terms</label>
   <input class="glossary__search drawer-search" type="search" placeholder="e.g. Fossil fuel">
   <div class="drawer__content" id="glossary-result">
-    <ul class="glossary__list js-accordion">
+    <ul class="glossary__list" accordion>
       {% for term in site.data.terms %}
-      <li class="drawer__item">
-        <div class="js-accordion_header accordion__header">
-          <h5 class="glossary-term">{{term[0]}}</h5>
-          <button class="button button--secondary accordion__button js-accordion_button" title="Toggle for {{term[0]}}">
-          <i class="fa fa-chevron-down"></i>
-            <span class="js-accordion_text u-visually-hidden" data-show="Show definition" data-hide="Hide definition"></span>
-          </button>
-        </div>
-        <p class="glossary-definition js-accordion_item hidden">{{term[1]}}</p>
+      <li class="drawer__item" accordion-item accordion-open="false">
+        <h5 class="glossary-term">{{term[0]}}</h5>
+        <button accordion-button class="accordion-button" title="Toggle for {{term[0]}}"></button>
+        <p class="glossary-definition accordion-content">{{term[1]}}</p>
       </li>
       {% endfor %}
     </ul>

--- a/_includes/how-it-works/coal_steps.html
+++ b/_includes/how-it-works/coal_steps.html
@@ -10,7 +10,7 @@
 
   <div class="container">
 
-    <ul accordion class="revenues_subpage-steps_group">
+    <ul accordion accordion-desktop="false" class="revenues_subpage-steps_group">
       <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
           <div class="revenues_subpage-steps_number">1</div>
           <h3 class="revenues_subpage-steps_heading">Plan</h3>

--- a/_includes/how-it-works/coal_steps.html
+++ b/_includes/how-it-works/coal_steps.html
@@ -28,7 +28,7 @@
           </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">2</div>
         <h3 class="revenues_subpage-steps_heading">Lease</h3>
         <button class="accordion-button" accordion-button></button>
@@ -39,7 +39,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">3</div>
         <h3 class="revenues_subpage-steps_heading">Explore</h3>
         <button class="accordion-button" accordion-button></button>
@@ -49,7 +49,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">4</div>
         <h3 class="revenues_subpage-steps_heading">Develop</h3>
         <button class="accordion-button" accordion-button></button>
@@ -59,7 +59,7 @@
 
       </li>
 
-      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">5</div>
         <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
@@ -72,7 +72,7 @@
 
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <h3 class="revenues_subpage-steps_heading_more">Learn more</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">

--- a/_includes/how-it-works/minerals_steps.html
+++ b/_includes/how-it-works/minerals_steps.html
@@ -13,7 +13,7 @@
 
   <div class="container">
 
-    <ul accordion class="revenues_subpage-steps_group">
+    <ul accordion accordion-desktop="false" class="revenues_subpage-steps_group">
       <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
           <div class="revenues_subpage-steps_number">1</div>
           <h3 class="revenues_subpage-steps_heading">Plan</h3>
@@ -24,7 +24,7 @@
           </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">2</div>
         <h3 class="revenues_subpage-steps_heading">Claim</h3>
         <button class="accordion-button" accordion-button></button>
@@ -35,7 +35,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">3</div>
         <h3 class="revenues_subpage-steps_heading">Explore</h3>
         <button class="accordion-button" accordion-button></button>
@@ -46,7 +46,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">4</div>
         <h3 class="revenues_subpage-steps_heading">Develop</h3>
         <button class="accordion-button" accordion-button></button>
@@ -57,7 +57,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">5</div>
         <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
@@ -67,7 +67,7 @@
 
       </li>
 
-    <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+    <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
       <h3 class="revenues_subpage-steps_heading_more">Learn more</h3>
       <button class="accordion-button" accordion-button></button>
       <div class="accordion-content">

--- a/_includes/how-it-works/offshore_oil_gas_steps.html
+++ b/_includes/how-it-works/offshore_oil_gas_steps.html
@@ -22,7 +22,7 @@
 
   <div class="container">
 
-    <ul accordion class="revenues_subpage-steps_group">
+    <ul accordion accordion-desktop="false" class="revenues_subpage-steps_group">
       <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
           <div class="revenues_subpage-steps_number">1</div>
           <h3 class="revenues_subpage-steps_heading">Plan</h3>
@@ -34,7 +34,7 @@
 
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">2</div>
         <h3 class="revenues_subpage-steps_heading">Lease</h3>
         <button class="accordion-button" accordion-button></button>
@@ -48,7 +48,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">3</div>
         <h3 class="revenues_subpage-steps_heading">Explore</h3>
         <button class="accordion-button" accordion-button></button>
@@ -58,7 +58,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">4</div>
         <h3 class="revenues_subpage-steps_heading">Develop</h3>
         <button class="accordion-button" accordion-button></button>
@@ -68,7 +68,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">5</div>
         <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
@@ -79,7 +79,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <h3 class="revenues_subpage-steps_heading_more">Learn more</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">

--- a/_includes/how-it-works/offshore_renewables_steps.html
+++ b/_includes/how-it-works/offshore_renewables_steps.html
@@ -12,7 +12,7 @@
 
   <div class="container">
 
-    <ul accordion class="revenues_subpage-steps_group">
+    <ul accordion accordion-desktop="false" class="revenues_subpage-steps_group">
       <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
           <div class="revenues_subpage-steps_number">1</div>
           <h3 class="revenues_subpage-steps_heading">Plan</h3>
@@ -22,7 +22,7 @@
           </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">2</div>
         <h3 class="revenues_subpage-steps_heading">Lease</h3>
         <button class="accordion-button" accordion-button></button>
@@ -31,7 +31,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">3</div>
         <h3 class="revenues_subpage-steps_heading">Explore</h3>
         <button class="accordion-button" accordion-button></button>
@@ -42,7 +42,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">4</div>
         <h3 class="revenues_subpage-steps_heading">Develop</h3>
         <button class="accordion-button" accordion-button></button>
@@ -57,7 +57,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">5</div>
         <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
@@ -66,7 +66,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <h3 class="revenues_subpage-steps_heading_more">Learn more</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">

--- a/_includes/how-it-works/onshore_oil_gas_steps.html
+++ b/_includes/how-it-works/onshore_oil_gas_steps.html
@@ -14,7 +14,7 @@
 
   <div class="container">
 
-    <ul accordion class="revenues_subpage-steps_group">
+    <ul accordion accordion-desktop="false" class="revenues_subpage-steps_group">
       <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
           <div class="revenues_subpage-steps_number">1</div>
           <h3 class="revenues_subpage-steps_heading">Plan</h3>
@@ -24,7 +24,7 @@
           </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">2</div>
         <h3 class="revenues_subpage-steps_heading">Lease</h3>
         <button class="accordion-button" accordion-button></button>
@@ -35,7 +35,7 @@
 
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">3</div>
         <h3 class="revenues_subpage-steps_heading">Explore</h3>
         <button class="accordion-button" accordion-button></button>
@@ -45,7 +45,7 @@
       <p>Once granted, the APD expires within two years. During the explore phase, companies pay <span class="term term-p" data-term="rent" title="Click to define" tabindex="0">rent<i class="icon-book"></i></span> to ONRR.</p>
         </div>
       </li>
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">4</div>
         <h3 class="revenues_subpage-steps_heading">Develop</h3>
         <button class="accordion-button" accordion-button></button>
@@ -55,7 +55,7 @@
         </div>
 
       </li>
-      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">5</div>
         <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
@@ -66,7 +66,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <h3 class="revenues_subpage-steps_heading_more">Learn more</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">

--- a/_includes/how-it-works/onshore_renewables_steps.html
+++ b/_includes/how-it-works/onshore_renewables_steps.html
@@ -13,7 +13,7 @@
 
   <div class="container">
 
-    <ul accordion class="revenues_subpage-steps_group">
+    <ul accordion accordion-desktop="false" class="revenues_subpage-steps_group">
             <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
           <div class="revenues_subpage-steps_number">1</div>
           <h3 class="revenues_subpage-steps_heading">Plan</h3>
@@ -29,7 +29,7 @@
           </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">2</div>
         <h3 class="revenues_subpage-steps_heading">Lease</h3>
         <button class="accordion-button" accordion-button></button>
@@ -43,7 +43,7 @@
 
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">3</div>
         <h3 class="revenues_subpage-steps_heading">Explore</h3>
         <button class="accordion-button" accordion-button></button>
@@ -53,7 +53,7 @@
           <p>Exploration for onshore renewables is easier and faster than for offshore renewables. Within designated leasing areas, a developer has two years to find a suitable site for infrastructure and submit a Plan of Development. Outside of designated leasing areas, a developer has two years to begin construction. Companies can choose whether or not to extend their leases based on their findings. During exploration, companies pay <span class="term term-p" data-term="rent" title="Click to define" tabindex="0">rent<i class="icon-book"></i></span> to BLM.</p>
         </div>
       </li>
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">4</div>
         <h3 class="revenues_subpage-steps_heading">Develop</h3>
         <button class="accordion-button" accordion-button></button>
@@ -62,7 +62,7 @@
         </div>
 
       </li>
-      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item revenues_subpage-steps_long" accordion-item accordion-open="false">
         <div class="revenues_subpage-steps_number">5</div>
         <h3 class="revenues_subpage-steps_heading">Decommission <span class="break"></span>and reclaim</h3>
         <button class="accordion-button" accordion-button></button>
@@ -75,7 +75,7 @@
         </div>
       </li>
 
-      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="true">
+      <li class="revenues_subpage-steps_group_item" accordion-item accordion-open="false">
         <h3 class="revenues_subpage-steps_heading_more">Learn more</h3>
         <button class="accordion-button" accordion-button></button>
         <div class="accordion-content">

--- a/_sass/components/_accordions.scss
+++ b/_sass/components/_accordions.scss
@@ -84,16 +84,16 @@
       display: none;
     }
   }
+}
 
-  &[accordion-mobile=false] {
-    @include respond-to(medium-up) {
-      .accordion-content {
-        display: inline-block;
-      }
+[accordion][accordion-desktop=false] {
+  @include respond-to(medium-up) {
+    .accordion-content {
+      display: inline-block;
+    }
 
-      .accordion-button {
-        display: none;
-      }
+    .accordion-button {
+      display: none;
     }
   }
 }

--- a/_sass/components/_accordions.scss
+++ b/_sass/components/_accordions.scss
@@ -78,14 +78,22 @@
 
     .accordion-content {
       display: none;
-
-      @include respond-to(medium-up) {
-        display: inline-block;
-      }
     }
 
     .accordion-more {
       display: none;
+    }
+  }
+
+  &[accordion-mobile=false] {
+    @include respond-to(medium-up) {
+      .accordion-content {
+        display: inline-block;
+      }
+
+      .accordion-button {
+        display: none;
+      }
     }
   }
 }
@@ -110,8 +118,6 @@
   margin: 0;
   margin-top: 8px;
   width: 2rem;
-
-  @include respond-to(medium-up) {
-    display: none;
-  }
 }
+
+

--- a/_sass/components/_drawer.scss
+++ b/_sass/components/_drawer.scss
@@ -116,27 +116,3 @@ input.drawer-search_field {
   position: relative;
   width: 14%;
 }
-
-.drawer__item {
-  border-bottom: 1px solid $mid-gray;
-
-  &:first-child {
-    border-top: 1px solid $mid-gray;
-  }
-
-  .accordion__header {
-    padding: 1rem 4rem 1rem 0;
-    position: relative;
-  }
-
-  .accordion__button {
-    background-color: transparent;
-    background-size: 50%;
-    height: 2rem;
-    margin-top: -1rem;
-    position: absolute;
-    right: 1rem;
-    top: 50%;
-    width: 2rem;
-  }
-}

--- a/_sass/components/_glossary.scss
+++ b/_sass/components/_glossary.scss
@@ -4,24 +4,46 @@
 // //
 // // Styleguide components.glossary
 
+$drawer-width: 300px;
+$term-width: 200px;
+$term-width-max: 375px;
+
 #glossary {
   width: 100%;
 
   @include respond-to(tiny-up) {
-    width: 300px;
+    width: $drawer-width;
   }
 }
 
 .drawer__item {
+  padding-top: $base-padding;
+
 
   .glossary-term {
     color: $white;
+    display: inline-block;
     margin: 0;
+    max-width: $term-width-max;
+    padding-bottom: $base-padding;
+    width: 100%;
+
+    @include respond-to(tiny-up) {
+      width: $term-width;
+    }
   }
 
   .glossary-definition {
     font-family: $base-font-family;
-    padding-bottom: 1rem;
+    margin-bottom: $base-padding-lite;
+    padding-bottom: $base-padding;
+  }
+
+  .accordion-button {
+    color: $white;
+    margin: 0;
+    top: 0;
+
   }
 }
 

--- a/_sass/components/_glossary.scss
+++ b/_sass/components/_glossary.scss
@@ -16,37 +16,39 @@ $term-width-max: 375px;
   }
 }
 
-.drawer__item {
+.glossary-item {
+  border-bottom: 1px solid $mid-gray;
   padding-top: $base-padding;
 
-
-  .glossary-term {
-    color: $white;
-    display: inline-block;
-    margin: 0;
-    max-width: $term-width-max;
-    padding-bottom: $base-padding;
-    width: 100%;
-
-    @include respond-to(tiny-up) {
-      width: $term-width;
-    }
-  }
-
-  .glossary-definition {
-    font-family: $base-font-family;
-    margin-bottom: $base-padding-lite;
-    padding-bottom: $base-padding;
+  &:first-child {
+    border-top: 1px solid $mid-gray;
   }
 
   .accordion-button {
     color: $white;
     margin: 0;
     top: 0;
-
   }
 }
 
+.glossary-term {
+  color: $white;
+  display: inline-block;
+  margin: 0;
+  max-width: $term-width-max;
+  padding-bottom: $base-padding;
+  width: 100%;
+
+  @include respond-to(tiny-up) {
+    width: $term-width;
+  }
+}
+
+.glossary-definition {
+  font-family: $base-font-family;
+  margin-bottom: $base-padding-lite;
+  padding-bottom: $base-padding;
+}
 
 // Term classes
 //

--- a/js/components/accordion.js
+++ b/js/components/accordion.js
@@ -1,68 +1,69 @@
 (function() {
+  document.addEventListener("DOMContentLoaded", function(event) {
 
-  var Accordion = function() {
-    this.accordionButtons = document.querySelectorAll('[accordion-button]');
-  };
+    var Accordion = function() {
+      this.accordionButtons = document.querySelectorAll('[accordion-button]');
+    };
 
-  Accordion.prototype = {
-    /**
-     * Used to traverse up the DOM tree to find a parent with
-     * the a specific attribute
-     *
-     * @param String parentAttr
-     * @param Object childObj
-     * @return Obj
-     */
-    findParentNode: function (parentAttr, childObj) {
-      var obj = childObj.parentNode;
+    Accordion.prototype = {
+      /**
+       * Used to traverse up the DOM tree to find a parent with
+       * the a specific attribute
+       *
+       * @param String parentAttr
+       * @param Object childObj
+       * @return Obj
+       */
+      findParentNode: function (parentAttr, childObj) {
+        var obj = childObj.parentNode;
 
-      while(obj.getAttribute(parentAttr)) {
-          obj = obj.parentNode;
-      }
-      return obj;
-    },
-    /**
-     * Triggered by a click handler
-     * finds a parent node and toggles the 'accordion-open' attribute
-     *
-     * @return void
-     */
-    toggleAccordion: function (e) {
+        while(obj.getAttribute(parentAttr)) {
+            obj = obj.parentNode;
+        }
+        return obj;
+      },
+      /**
+       * Triggered by a click handler
+       * finds a parent node and toggles the 'accordion-open' attribute
+       *
+       * @return void
+       */
+      toggleAccordion: function (e) {
+        var e = e || window.event;
+        var target = e.target || e.srcElement;
 
-      var e = e || window.event;
-      var target = e.target || e.srcElement;
+        var accordionItem = this.findParentNode('accordion-item', target),
+          accordionStatus = accordionItem.getAttribute('accordion-open');
 
-      var accordionItem = this.findParentNode('accordion-item', target),
-        accordionStatus = accordionItem.getAttribute('accordion-open');
+        accordionStatus = (accordionStatus == 'true') ? 'false' : 'true';
+        accordionItem.setAttribute('accordion-open', accordionStatus);
+      },
+      /**
+       * Event handler that binds
+       * to the toggleAccordion function
+       *
+       * @return void
+       */
+      registerEventListeners: function () {
+        var nextStep = false;
+        for (var i = 0; i < this.accordionButtons.length; i++) {
+          this.accordionButtons[i].addEventListener('click',
+            this.toggleAccordion.bind(this));
 
-      accordionStatus = (accordionStatus == 'true') ? 'false' : 'true';
-      accordionItem.setAttribute('accordion-open', accordionStatus);
-    },
-    /**
-     * Event handler that binds
-     * to the toggleAccordion function
-     *
-     * @return void
-     */
-    registerEventListeners: function () {
-      var nextStep = false;
-      for (var i = 0; i < this.accordionButtons.length; i++) {
-        this.accordionButtons[i].addEventListener('click',
-          this.toggleAccordion.bind(this));
-
-        if (this.accordionButtons[i].classList.contains('accordion-button')) {
-          if (nextStep) {
-            this.accordionButtons[i].click();
-          } else {
-            nextStep = true;
-          }
+          // if (this.accordionButtons[i].classList.contains('accordion-button')) {
+          //   // if (nextStep) {
+          //     // this.accordionButtons[i].click();
+          //   // } else {
+          //   //   nextStep = true;
+          //   // }
+          // }
         }
       }
-    }
-  };
+    };
 
-  var accordion = new Accordion();
+    var accordion = new Accordion();
 
-  accordion.registerEventListeners();
+    accordion.registerEventListeners();
 
+  });
 })(this);

--- a/js/components/accordion.js
+++ b/js/components/accordion.js
@@ -49,14 +49,6 @@
         for (var i = 0; i < this.accordionButtons.length; i++) {
           this.accordionButtons[i].addEventListener('click',
             this.toggleAccordion.bind(this));
-
-          // if (this.accordionButtons[i].classList.contains('accordion-button')) {
-          //   // if (nextStep) {
-          //     // this.accordionButtons[i].click();
-          //   // } else {
-          //   //   nextStep = true;
-          //   // }
-          // }
         }
       }
     };

--- a/js/components/glossary.js
+++ b/js/components/glossary.js
@@ -114,8 +114,10 @@
     this.list.search();
 
     this.list.visibleItems.forEach(function(item){
-      var $elm = $(item.elm).find('div');
-      $elm.find('.js-accordion_button').click();
+      var $elm = $(item.elm);
+      // debugger
+      $elm.attr('accordion-open', true);
+      // $elm.find('.js-accordion_button').click();
     })
   };
 

--- a/js/components/glossary.js
+++ b/js/components/glossary.js
@@ -112,10 +112,11 @@
 
     // Hack: Expand text for selected item
     this.list.search();
-    $.each(this.list.visibleItems, function(item) {
+
+    this.list.visibleItems.forEach(function(item){
       var $elm = $(item.elm).find('div');
-        $elm.find('.accordion__button').click();
-    });
+      $elm.find('.js-accordion_button').click();
+    })
   };
 
   Glossary.prototype.toggle = function() {

--- a/js/components/glossary.js
+++ b/js/components/glossary.js
@@ -24,7 +24,6 @@
     body: '#glossary',
     toggle: '.js-glossary-toggle',
     term: '.term',
-    accordionButton: '.accordion__button',
     navToggle: '[data-toggler="nav-drawer"]',
     navDrawer: '#nav-drawer'
   };
@@ -43,8 +42,7 @@
 
     self.$body = $(self.selectors.body);
     self.$toggle = $(self.selectors.toggle);
-    self.$search = this.$body.find('.glossary__search');
-    self.$accordionButton = $(self.selectors.accordionButton);
+    self.$search = this.$body.find('.js-glossary-search');
     self.$navToggle =  document.querySelector(self.selectors.navToggle);
     self.$navDrawer = $(self.selectors.navDrawer);
 
@@ -63,7 +61,6 @@
     self.$body.on('click', '.toggle', this.toggle.bind(this));
     self.$search.on('input', this.handleInput.bind(this));
     $(document.body).on('keyup', this.handleKeyup.bind(this));
-    self.$accordionButton.on('click', this.toggleAccordion.bind(this));
   }
 
   Glossary.prototype.isMobile = function() {
@@ -75,8 +72,8 @@
   Glossary.prototype.connectList = function() {
     var options = {
       valueNames: ['glossary-term'],
-      listClass: 'glossary__list',
-      searchClass: 'glossary__search'
+      listClass: 'js-glossary-list',
+      searchClass: 'js-glossary-search'
     };
     this.list = new List('glossary', options);
   };
@@ -115,9 +112,7 @@
 
     this.list.visibleItems.forEach(function(item){
       var $elm = $(item.elm);
-      // debugger
       $elm.attr('accordion-open', true);
-      // $elm.find('.js-accordion_button').click();
     })
   };
 
@@ -164,24 +159,6 @@
     }
   };
 
-  /** Toggles the state of an accordian nav item */
-  Glossary.prototype.toggleAccordion = function(e) {
-    var $thisButton = $(e.currentTarget);
-    var $thisHeader = $(e.currentTarget.offsetParent);
-    var $thisDefinition = $($thisHeader.siblings()[0]);
-
-    // toggleClass is more concise, but this couples the button text
-    // and hide/show logic
-    if ($thisDefinition.hasClass('hidden')){
-        $thisButton.find('i').removeClass('fa-chevron-down')
-          .addClass('fa-chevron-up');
-        $thisDefinition.removeClass('hidden');
-    } else {
-        $thisButton.find('i').removeClass('fa-chevron-up')
-          .addClass('fa-chevron-down');
-        $thisDefinition.addClass('hidden');
-    }
-  };
   $(function(){
     var glossary = new Glossary({body: '#glossary'});
   });

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -24333,7 +24333,6 @@
 	    body: '#glossary',
 	    toggle: '.js-glossary-toggle',
 	    term: '.term',
-	    accordionButton: '.accordion__button',
 	    navToggle: '[data-toggler="nav-drawer"]',
 	    navDrawer: '#nav-drawer'
 	  };
@@ -24352,8 +24351,7 @@
 
 	    self.$body = $(self.selectors.body);
 	    self.$toggle = $(self.selectors.toggle);
-	    self.$search = this.$body.find('.glossary__search');
-	    self.$accordionButton = $(self.selectors.accordionButton);
+	    self.$search = this.$body.find('.js-glossary-search');
 	    self.$navToggle =  document.querySelector(self.selectors.navToggle);
 	    self.$navDrawer = $(self.selectors.navDrawer);
 
@@ -24372,7 +24370,6 @@
 	    self.$body.on('click', '.toggle', this.toggle.bind(this));
 	    self.$search.on('input', this.handleInput.bind(this));
 	    $(document.body).on('keyup', this.handleKeyup.bind(this));
-	    self.$accordionButton.on('click', this.toggleAccordion.bind(this));
 	  }
 
 	  Glossary.prototype.isMobile = function() {
@@ -24384,8 +24381,8 @@
 	  Glossary.prototype.connectList = function() {
 	    var options = {
 	      valueNames: ['glossary-term'],
-	      listClass: 'glossary__list',
-	      searchClass: 'glossary__search'
+	      listClass: 'js-glossary-list',
+	      searchClass: 'js-glossary-search'
 	    };
 	    this.list = new List('glossary', options);
 	  };
@@ -24424,9 +24421,7 @@
 
 	    this.list.visibleItems.forEach(function(item){
 	      var $elm = $(item.elm);
-	      // debugger
 	      $elm.attr('accordion-open', true);
-	      // $elm.find('.js-accordion_button').click();
 	    })
 	  };
 
@@ -24473,24 +24468,6 @@
 	    }
 	  };
 
-	  /** Toggles the state of an accordian nav item */
-	  Glossary.prototype.toggleAccordion = function(e) {
-	    var $thisButton = $(e.currentTarget);
-	    var $thisHeader = $(e.currentTarget.offsetParent);
-	    var $thisDefinition = $($thisHeader.siblings()[0]);
-
-	    // toggleClass is more concise, but this couples the button text
-	    // and hide/show logic
-	    if ($thisDefinition.hasClass('hidden')){
-	        $thisButton.find('i').removeClass('fa-chevron-down')
-	          .addClass('fa-chevron-up');
-	        $thisDefinition.removeClass('hidden');
-	    } else {
-	        $thisButton.find('i').removeClass('fa-chevron-up')
-	          .addClass('fa-chevron-down');
-	        $thisDefinition.addClass('hidden');
-	    }
-	  };
 	  $(function(){
 	    var glossary = new Glossary({body: '#glossary'});
 	  });

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -24420,10 +24420,11 @@
 
 	    // Hack: Expand text for selected item
 	    this.list.search();
-	    $.each(this.list.visibleItems, function(item) {
+
+	    this.list.visibleItems.forEach(function(item){
 	      var $elm = $(item.elm).find('div');
-	        $elm.find('.accordion__button').click();
-	    });
+	      $elm.find('.js-accordion_button').click();
+	    })
 	  };
 
 	  Glossary.prototype.toggle = function() {

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -24531,14 +24531,6 @@
 	        for (var i = 0; i < this.accordionButtons.length; i++) {
 	          this.accordionButtons[i].addEventListener('click',
 	            this.toggleAccordion.bind(this));
-
-	          // if (this.accordionButtons[i].classList.contains('accordion-button')) {
-	          //   // if (nextStep) {
-	          //     // this.accordionButtons[i].click();
-	          //   // } else {
-	          //   //   nextStep = true;
-	          //   // }
-	          // }
 	        }
 	      }
 	    };

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -81,6 +81,7 @@
 
 	  // FIXME: does this export anything?
 	  __webpack_require__(20);
+	  __webpack_require__(22);
 
 	  // Google Analytics
 	  /* jshint ignore:start */
@@ -24422,8 +24423,10 @@
 	    this.list.search();
 
 	    this.list.visibleItems.forEach(function(item){
-	      var $elm = $(item.elm).find('div');
-	      $elm.find('.js-accordion_button').click();
+	      var $elm = $(item.elm);
+	      // debugger
+	      $elm.attr('accordion-open', true);
+	      // $elm.find('.js-accordion_button').click();
 	    })
 	  };
 
@@ -24492,6 +24495,82 @@
 	    var glossary = new Glossary({body: '#glossary'});
 	  });
 
+	})(this);
+
+
+/***/ },
+/* 21 */,
+/* 22 */
+/***/ function(module, exports) {
+
+	(function() {
+	  document.addEventListener("DOMContentLoaded", function(event) {
+
+	    var Accordion = function() {
+	      this.accordionButtons = document.querySelectorAll('[accordion-button]');
+	    };
+
+	    Accordion.prototype = {
+	      /**
+	       * Used to traverse up the DOM tree to find a parent with
+	       * the a specific attribute
+	       *
+	       * @param String parentAttr
+	       * @param Object childObj
+	       * @return Obj
+	       */
+	      findParentNode: function (parentAttr, childObj) {
+	        var obj = childObj.parentNode;
+
+	        while(obj.getAttribute(parentAttr)) {
+	            obj = obj.parentNode;
+	        }
+	        return obj;
+	      },
+	      /**
+	       * Triggered by a click handler
+	       * finds a parent node and toggles the 'accordion-open' attribute
+	       *
+	       * @return void
+	       */
+	      toggleAccordion: function (e) {
+	        var e = e || window.event;
+	        var target = e.target || e.srcElement;
+
+	        var accordionItem = this.findParentNode('accordion-item', target),
+	          accordionStatus = accordionItem.getAttribute('accordion-open');
+
+	        accordionStatus = (accordionStatus == 'true') ? 'false' : 'true';
+	        accordionItem.setAttribute('accordion-open', accordionStatus);
+	      },
+	      /**
+	       * Event handler that binds
+	       * to the toggleAccordion function
+	       *
+	       * @return void
+	       */
+	      registerEventListeners: function () {
+	        var nextStep = false;
+	        for (var i = 0; i < this.accordionButtons.length; i++) {
+	          this.accordionButtons[i].addEventListener('click',
+	            this.toggleAccordion.bind(this));
+
+	          // if (this.accordionButtons[i].classList.contains('accordion-button')) {
+	          //   // if (nextStep) {
+	          //     // this.accordionButtons[i].click();
+	          //   // } else {
+	          //   //   nextStep = true;
+	          //   // }
+	          // }
+	        }
+	      }
+	    };
+
+	    var accordion = new Accordion();
+
+	    accordion.registerEventListeners();
+
+	  });
 	})(this);
 
 

--- a/js/src/main.js
+++ b/js/src/main.js
@@ -35,6 +35,7 @@
 
   // FIXME: does this export anything?
   require('../components/glossary');
+  require('../components/accordion');
 
   // Google Analytics
   /* jshint ignore:start */


### PR DESCRIPTION
Fixes #1251 

Clicking on a glossary term reference now opens the definition of that item when it opens the glossary.

[>>PREVIEW<<](https://federalist.18f.gov/preview/18F/doi-extractives-data/glossary-click)

The primary goal of this PR was quite simple, and was fixed with the first commit (6177ac1). There was an easier way to do this, so most of this PR is actually a refinement of the glossary markup, which includes adding the existing accordion component instead of using glossary-specific code.

The changes on the How it Works and Explore landing pages, and diving graphics pages are markup alterations needed after refactoring the accordion js. It was previously a bit hacky, this is better.

Ready for review! Please take a look at the pages mentioned above as well. I want to make sure I didn't miss anything! I was pretty thorough, so this shouldn't be an issue. :)