### PR TITLE
Adds additional material variance explanations

### DIFF
--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -103,21 +103,24 @@ permalink: /explore/reconciliation/
         <div class="footnotes container-padded">
           <h3>Footnotes</h3>
           <ol>
-            <li id="fn:1" class="hashoffset"><p>$54,318,974 was paid by Chevron Corporation in 2012 and recorded in 2013. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
-            <li id="fn:2" class="hashoffset"><p>Payment transactions for tax refunds totaling $6,345,527 were shown as paid by the IRS in 2013 and recorded by Shell E&amp;P Company in January 2014. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
-            <li id="fn:3" class="hashoffset"><p>$11,232,000 was paid by Exxon Mobil Corporation in 2012 and recorded in 2013. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
-            <li id="fn:4" class="hashoffset"><p>$8,300,214 was paid by Peabody Energy Corporation in 2013 and recorded in 2014. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
-            <li id="fn:5" class="hashoffset"><p>$91,500 was paid by Anadarko Petroleum Corporation in 2012 and recorded in 2013. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
-            <li id="fn:6" class="hashoffset"><p>$280,655 was paid by ConocoPhillips in 2013 and recorded in 2014. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
-            <li id="fn:7" class="hashoffset"><p>$17,000 was paid by ConocoPhillips in 2013 and recorded in 2014. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
-            <li id="fn:8" class="hashoffset"><p>$240,500 was paid by ConocoPhillips in 2013 and recorded in 2014. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
-            <li id="fn:9" class="hashoffset"><p>Freeport McMoRan Inc. records rental payment transactions in their accounting system differently from how ONRR records transactions, including different lumping of rents and bonuses. <a href="#fnref:9" class="reversefootnote">↩</a></p></li>
-            <li id="fn:10" class="hashoffset"><p>$5,520,487 was paid by Statoil Gulf of Mexico in 2013 and recorded in 2014. <a href="#fnref:10" class="reversefootnote">↩</a></p></li>
-            <li id="fn:11" class="hashoffset"><p>$31,500 was paid by Noble Energy, Inc. in 2012 and recorded in 2013. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
-            <li id="fn:12" class="hashoffset"><p>$19,500 was paid by Noble Energy, Inc. in 2013 and recorded in 2014. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
-            <li id="fn:13" class="hashoffset"><p>$32,500 was paid by Cimarex Energy in 2013 and recorded in 2014. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
-            <li id="fn:14" class="hashoffset"><p>BLM included revenue for permit fees collected for activity they administered on multiple tribal leases. However, Newfield Exploration Company did not include this revenue in this category, as it was not for federal leases. This helps to explain why a variance exists between the reported numbers. <a href="#fnref:14" class="reversefootnote">↩</a></p></li>
-            <li id="fn:15" class="hashoffset"><p>$1,383,084 was paid by ANKOR Energy LLC in 2012 and recorded in 2013. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
+
+            <li id="fn:1" class="hashoffset"><p>$711,360 was paid by BP America in 2012 but recorded in 2013. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+            <li id="fn:2" class="hashoffset"><p>$54,318,974 was paid by Chevron Corporation in 2012 and recorded in 2013. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+            <li id="fn:3" class="hashoffset"><p>Payment transactions for tax refunds totaling $6,345,527 were shown as paid by the IRS in 2013 and recorded by Shell E&amp;P Company in January 2014. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
+            <li id="fn:4" class="hashoffset"><p>$11,232,000 was paid by Exxon Mobil Corporation in 2012 and recorded in 2013. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
+            <li id="fn:5" class="hashoffset"><p>$8,300,214 was paid by Peabody Energy Corporation in 2013 and recorded in 2014. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
+            <li id="fn:6" class="hashoffset"><p>$91,500 was paid by Anadarko Petroleum Corporation in 2012 and recorded in 2013. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
+            <li id="fn:7" class="hashoffset"><p>$280,655 was paid by ConocoPhillips in 2013 and recorded in 2014. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
+            <li id="fn:8" class="hashoffset"><p>$17,000 was paid by ConocoPhillips in 2013 and recorded in 2014. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
+            <li id="fn:9" class="hashoffset"><p>$240,500 was paid by ConocoPhillips in 2013 and recorded in 2014. <a href="#fnref:9" class="reversefootnote">↩</a></p></li>
+            <li id="fn:10" class="hashoffset"><p>Freeport McMoRan Inc. records rental payment transactions in their accounting system differently from how ONRR records transactions, including different lumping of rents and bonuses. <a href="#fnref:10" class="reversefootnote">↩</a></p></li>
+            <li id="fn:11" class="hashoffset"><p>$5,520,487 was paid by Statoil Gulf of Mexico in 2013 and recorded in 2014. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
+            <li id="fn:12" class="hashoffset"><p>$1,086,317 was paid by Ultra Resources in 2012 and recorded in 2013; $47,724 was paid in 2013 and recorded in 2014. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
+            <li id="fn:13" class="hashoffset"><p>$31,500 was paid by Noble Energy, Inc. in 2012 and recorded in 2013. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
+            <li id="fn:14" class="hashoffset"><p>$19,500 was paid by Noble Energy, Inc. in 2013 and recorded in 2014. <a href="#fnref:14" class="reversefootnote">↩</a></p></li>
+            <li id="fn:15" class="hashoffset"><p>$32,500 was paid by Cimarex Energy in 2013 and recorded in 2014. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
+            <li id="fn:16" class="hashoffset"><p>BLM included revenue for permit fees collected for activity they administered on multiple tribal leases. However, Newfield Exploration Company did not include this revenue in this category, as it was not for federal leases. This helps to explain why a variance exists between the reported numbers. <a href="#fnref:16" class="reversefootnote">↩</a></p></li>
+            <li id="fn:17" class="hashoffset"><p>$1,383,084 was paid by ANKOR Energy LLC in 2012 and recorded in 2013. <a href="#fnref:17" class="reversefootnote">↩</a></p></li>
           </ol>
         </div>
       </div>

--- a/data/reconciliation/revenue.tsv
+++ b/data/reconciliation/revenue.tsv
@@ -8,25 +8,25 @@ Alpha Natural Resources, Inc.	ONRR Civil Penalties	0	0	0	0
 Alpha Natural Resources, Inc.	Bonus & 1st Year Rental	0	0	0	0
 Alpha Natural Resources, Inc.	Permit Fees	50749	50749	0	0
 Alpha Natural Resources, Inc.	Renewables	0	0	0	0
-Alpha Natural Resources, Inc.	AML Fees	19128754	19322861	-194107	1
+Alpha Natural Resources, Inc.	AML Fees	19128754	19322861	-194107	1.01
 Alpha Natural Resources, Inc.	OSMRE Civil Penalties	0	0	0	0
 Alpha Natural Resources, Inc.	Corporate Income Tax	0	did not report	N/A	N/A
-Anadarko Petroleum Corporation	Royalties	384154902	382748703	1406199	0.4
-Anadarko Petroleum Corporation	Rents	19860986	20252345	-391359	2
-Anadarko Petroleum Corporation	Bonus	49651028	49808312	-157284	0.3
+Anadarko Petroleum Corporation	Royalties	384154902	382748703	1406199	0.37
+Anadarko Petroleum Corporation	Rents	19860986	20252345	-391359	1.97
+Anadarko Petroleum Corporation	Bonus	49651028	49808312	-157284	0.32
 Anadarko Petroleum Corporation	Other Revenue	3159531	3143781	15750	0.5
-Anadarko Petroleum Corporation	Offshore Inspection Fee	2213500	2122000	91500	4.1
+Anadarko Petroleum Corporation	Offshore Inspection Fee	2213500	2122000	91500	4.13
 Anadarko Petroleum Corporation	ONRR Civil Penalties	50000	50000	0	0
-Anadarko Petroleum Corporation	Bonus & 1st Year Rental	268065	267723	342	0.1
-Anadarko Petroleum Corporation	Permit Fees	2696255	2704823	-8568	0.3
+Anadarko Petroleum Corporation	Bonus & 1st Year Rental	268065	267723	342	0.13
+Anadarko Petroleum Corporation	Permit Fees	2696255	2704823	-8568	0.32
 Anadarko Petroleum Corporation	Renewables	0	0	0	0
 Anadarko Petroleum Corporation	AML Fees	0	0	0	0
 Anadarko Petroleum Corporation	OSMRE Civil Penalties	0	0	0	0
 Anadarko Petroleum Corporation	Corporate Income Tax	0	did not report	N/A	N/A
-ANKOR Energy LLC	Royalties	58091785	56708700	1383085	2.4
-ANKOR Energy LLC	Rents	177490	193970	-16480	9
+ANKOR Energy LLC	Royalties	58091785	56708700	1383085	2.38
+ANKOR Energy LLC	Rents	177490	193970	-16480	9.29
 ANKOR Energy LLC	Bonus	0	0	0	0
-ANKOR Energy LLC	Other Revenue	-12222	-19657	7435	60.8
+ANKOR Energy LLC	Other Revenue	-12222	-19657	7435	60.83
 ANKOR Energy LLC	Offshore Inspection Fee	1049300	1049300	0	0
 ANKOR Energy LLC	ONRR Civil Penalties	0	0	0	0
 ANKOR Energy LLC	Bonus & 1st Year Rental	0	0	0	0
@@ -48,7 +48,7 @@ Apache Corporation	AML Fees	0	did not participate	N/A	N/A
 Apache Corporation	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 Apache Corporation	Corporate Income Tax	0	did not participate	N/A	N/A
 Arch Coal, Inc.	Royalties	182167078	182167078	0	0
-Arch Coal, Inc.	Rents	232049	250989	-18940	8
+Arch Coal, Inc.	Rents	232049	250989	-18940	8.16
 Arch Coal, Inc.	Bonus	60000202	60000202	0	0
 Arch Coal, Inc.	Other Revenue	3583453	3583453	0	0
 Arch Coal, Inc.	Offshore Inspection Fee	0	0	0	0
@@ -59,8 +59,8 @@ Arch Coal, Inc.	Renewables	0	0	0	0
 Arch Coal, Inc.	AML Fees	34025339	34025339	0	0
 Arch Coal, Inc.	OSMRE Civil Penalties	0	0	0	0
 Arch Coal, Inc.	Corporate Income Tax	0	did not report	N/A	N/A
-Arena Energy, LLC	Royalties	85536515	85549962	-13447	0
-Arena Energy, LLC	Rents	1182340	1180362	1978	0
+Arena Energy, LLC	Royalties	85536515	85549962	-13447	0.02
+Arena Energy, LLC	Rents	1182340	1180362	1978	0.17
 Arena Energy, LLC	Bonus	1307000	1307000	0	0
 Arena Energy, LLC	Other Revenue	81422	81908	-486	0.6
 Arena Energy, LLC	Offshore Inspection Fee	2030000	2030000	0	0
@@ -71,11 +71,11 @@ Arena Energy, LLC	Renewables	0	0	0	0
 Arena Energy, LLC	AML Fees	0	0	0	0
 Arena Energy, LLC	OSMRE Civil Penalties	0	0	0	0
 Arena Energy, LLC	Corporate Income Tax	0	N/A	N/A	N/A
-BHP Billiton LTD	Royalties	290943513	290876410	67103	0
-BHP Billiton LTD	Rents	11531065	11715699	-184634	2
-BHP Billiton LTD	Bonus	121705398	123566486	-1861088	1.5
-BHP Billiton LTD	Other Revenue	190198	192928	-2730	1.4
-BHP Billiton LTD	Offshore Inspection Fee	505980	506128	-148	0
+BHP Billiton LTD	Royalties	290943513	290876410	67103	0.02
+BHP Billiton LTD	Rents	11531065	11715699	-184634	1.6
+BHP Billiton LTD	Bonus	121705398	123566486	-1861088	1.53
+BHP Billiton LTD	Other Revenue	190198	192928	-2730	1.44
+BHP Billiton LTD	Offshore Inspection Fee	505980	506128	-148	0.03
 BHP Billiton LTD	ONRR Civil Penalties	0	0	0	0
 BHP Billiton LTD	Bonus & 1st Year Rental	0	0	0	0
 BHP Billiton LTD	Permit Fees	92644	92644	0	0
@@ -95,56 +95,56 @@ BOPCO, LP	Renewables	0	did not participate	N/A	N/A
 BOPCO, LP	AML Fees	0	did not participate	N/A	N/A
 BOPCO, LP	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 BOPCO, LP	Corporate Income Tax	0	did not participate	N/A	N/A
-BP America	Royalties	847156065	847036243	119822	0
-BP America	Rents	25739425	25199393	540032	2
+BP America	Royalties	847156065	847036243	119822	0.01
+BP America	Rents	25739425	25199393	540032	2.1
 BP America	Bonus	0	0	0	0
-BP America	Other Revenue	3004327	2943014	61313	2
+BP America	Other Revenue	3004327	2943014	61313	2.04
 BP America	Offshore Inspection Fee	1944000	1944000	0	0
 BP America	ONRR Civil Penalties	60000	60000	0	0
 BP America	Bonus & 1st Year Rental	0	0	0	0
-BP America	Permit Fees	130935	130500	435	0.3
+BP America	Permit Fees	130935	130500	435	0.33
 BP America	Renewables	0	0	0	0
 BP America	AML Fees	0	0	0	0
 BP America	OSMRE Civil Penalties	0	0	0	0
 BP America	Corporate Income Tax	85000000	85000000	0	0
-Chevron Corporation	Royalties	827397767	772842106	54555661	6.6
-Chevron Corporation	Rents	19149064	19003698	145366	1
+Chevron Corporation	Royalties	827397767	772842106	54555661	6.59
+Chevron Corporation	Rents	19149064	19003698	145366	0.76
 Chevron Corporation	Bonus	101636143	101636143	0	0
-Chevron Corporation	Other Revenue	3164566	3158448	6118	0.2
-Chevron Corporation	Offshore Inspection Fee	7394900	7364400	30500	0.4
+Chevron Corporation	Other Revenue	3164566	3158448	6118	0.19
+Chevron Corporation	Offshore Inspection Fee	7394900	7364400	30500	0.41
 Chevron Corporation	ONRR Civil Penalties	40000	40000	0	0
 Chevron Corporation	Bonus & 1st Year Rental	0	0	0	0
-Chevron Corporation	Permit Fees	218878	215043	3835	1.8
+Chevron Corporation	Permit Fees	218878	215043	3835	1.75
 Chevron Corporation	Renewables	0	0	0	0
 Chevron Corporation	AML Fees	0	0	0	0
 Chevron Corporation	OSMRE Civil Penalties	13680	13680	0	0
 Chevron Corporation	Corporate Income Tax	0	did not report	N/A	N/A
 Cimarex Energy Co.	Royalties	67020156	67020148	8	0
-Cimarex Energy Co.	Rents	45254	47972	-2718	6
+Cimarex Energy Co.	Rents	45254	47972	-2718	6.01
 Cimarex Energy Co.	Bonus	0	0	0	0
-Cimarex Energy Co.	Other Revenue	3711779	3712145	-366	0
+Cimarex Energy Co.	Other Revenue	3711779	3712145	-366	0.01
 Cimarex Energy Co.	Offshore Inspection Fee	134800	134800	0	0
 Cimarex Energy Co.	ONRR Civil Penalties	327450	327450	0	0
-Cimarex Energy Co.	Bonus & 1st Year Rental	8266400	8268117	-1717	0
+Cimarex Energy Co.	Bonus & 1st Year Rental	8266400	8268117	-1717	0.02
 Cimarex Energy Co.	Permit Fees	1075805	1121342	-45537	4.23
 Cimarex Energy Co.	Renewables	0	0	0	0
 Cimarex Energy Co.	AML Fees	0	0	0	0
 Cimarex Energy Co.	OSMRE Civil Penalties	0	0	0	0
 Cimarex Energy Co.	Corporate Income Tax	-427025	-427025	0	0
 Cloud Peak Energy Resources, LLC	Royalties	120674727	120674728	-1	0
-Cloud Peak Energy Resources, LLC	Rents	100997	104484	-3487	3
+Cloud Peak Energy Resources, LLC	Rents	100997	104484	-3487	3.45
 Cloud Peak Energy Resources, LLC	Bonus	79026630	79026631	-1	0
 Cloud Peak Energy Resources, LLC	Other Revenue	214	0	214	100
 Cloud Peak Energy Resources, LLC	Offshore Inspection Fee	0	0	0	0
 Cloud Peak Energy Resources, LLC	ONRR Civil Penalties	0	0	0	0
 Cloud Peak Energy Resources, LLC	Bonus & 1st Year Rental	0	3614	-3614	100
-Cloud Peak Energy Resources, LLC	Permit Fees	222366	218752	3614	1.6
+Cloud Peak Energy Resources, LLC	Permit Fees	222366	218752	3614	1.63
 Cloud Peak Energy Resources, LLC	Renewables	0	0	0	0
 Cloud Peak Energy Resources, LLC	AML Fees	24335853	24335853	0	0
 Cloud Peak Energy Resources, LLC	OSMRE Civil Penalties	0	0	0	0
 Cloud Peak Energy Resources, LLC	Corporate Income Tax	9500000	9500000	0	0
 Cobalt International Energy, Inc.	Royalties	0	0	0	0
-Cobalt International Energy, Inc.	Rents	9848675	9958115	-109440	1
+Cobalt International Energy, Inc.	Rents	9848675	9958115	-109440	1.11
 Cobalt International Energy, Inc.	Bonus	54536650	54536650	0	0
 Cobalt International Energy, Inc.	Other Revenue	0	0	0	0
 Cobalt International Energy, Inc.	Offshore Inspection Fee	335500	335500	0	0
@@ -167,14 +167,14 @@ Concho Resources, Inc.	Renewables	0	did not participate	N/A	N/A
 Concho Resources, Inc.	AML Fees	0	did not participate	N/A	N/A
 Concho Resources, Inc.	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 Concho Resources, Inc.	Corporate Income Tax	0	did not participate	N/A	N/A
-ConocoPhillips	Royalties	261150468	262682834	-1532366	0.6
-ConocoPhillips	Rents	24411479	24609486	-198007	1
-ConocoPhillips	Bonus	131941971	131781972	159999	0.1
-ConocoPhillips	Other Revenue	2632282	2914786	-282504	10.7
-ConocoPhillips	Offshore Inspection Fee	322000	352500	-30500	9.5
+ConocoPhillips	Royalties	261150468	262682834	-1532366	0.59
+ConocoPhillips	Rents	24411479	24609486	-198007	0.81
+ConocoPhillips	Bonus	131941971	131781972	159999	0.12
+ConocoPhillips	Other Revenue	2632282	2914786	-282504	10.73
+ConocoPhillips	Offshore Inspection Fee	322000	352500	-30500	9.47
 ConocoPhillips	ONRR Civil Penalties	0	0	0	0
 ConocoPhillips	Bonus & 1st Year Rental	117347	117347	0	0
-ConocoPhillips	Permit Fees	659300	851500	-192200	29.2
+ConocoPhillips	Permit Fees	659300	851500	-192200	29.15
 ConocoPhillips	Renewables	0	0	0	0
 ConocoPhillips	AML Fees	0	0	0	0
 ConocoPhillips	OSMRE Civil Penalties	0	0	0	0
@@ -192,13 +192,13 @@ Continental Resources, Inc.	AML Fees	0	did not participate	N/A	N/A
 Continental Resources, Inc.	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 Continental Resources, Inc.	Corporate Income Tax	0	did not participate	N/A	N/A
 Devon Energy Corporation	Royalties	122680600	122554109	126491	0.1
-Devon Energy Corporation	Rents	370479	379276	-8797	2
+Devon Energy Corporation	Rents	370479	379276	-8797	2.37
 Devon Energy Corporation	Bonus	0	0	0	0
-Devon Energy Corporation	Other Revenue	2580410	2504376	76034	3
+Devon Energy Corporation	Other Revenue	2580410	2504376	76034	2.95
 Devon Energy Corporation	Offshore Inspection Fee	0	0	0	0
 Devon Energy Corporation	ONRR Civil Penalties	0	0	0	0
 Devon Energy Corporation	Bonus & 1st Year Rental	10889200	10889200	0	0
-Devon Energy Corporation	Permit Fees	1605762	1602291	3471	0.2
+Devon Energy Corporation	Permit Fees	1605762	1602291	3471	0.22
 Devon Energy Corporation	Renewables	0	0	0	0
 Devon Energy Corporation	AML Fees	0	0	0	0
 Devon Energy Corporation	OSMRE Civil Penalties	0	0	0	0
@@ -216,9 +216,9 @@ Encana Corporation	AML Fees	0	did not participate	N/A	N/A
 Encana Corporation	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 Encana Corporation	Corporate Income Tax	0	did not participate	N/A	N/A
 Energy XXI	Royalties	206116211	206116211	0	0
-Energy XXI	Rents	195740	185978	9762	5
+Energy XXI	Rents	195740	185978	9762	4.99
 Energy XXI	Bonus	302242	302242	0	0
-Energy XXI	Other Revenue	1984809	1954584	30225	1.5
+Energy XXI	Other Revenue	1984809	1954584	30225	1.52
 Energy XXI	Offshore Inspection Fee	684700	684700	0	0
 Energy XXI	ONRR Civil Penalties	40000	40000	0	0
 Energy XXI	Bonus & 1st Year Rental	0	0	0	0
@@ -227,11 +227,11 @@ Energy XXI	Renewables	0	0	0	0
 Energy XXI	AML Fees	0	0	0	0
 Energy XXI	OSMRE Civil Penalties	0	0	0	0
 Energy XXI	Corporate Income Tax	0	did not report	N/A	N/A
-EPL Oil & Gas, Inc.	Royalties	106133424	105996710	136714	0.1
-EPL Oil & Gas, Inc.	Rents	378149	349766	28383	8
-EPL Oil & Gas, Inc.	Bonus	2143100	2205358	-62258	2.9
+EPL Oil & Gas, Inc.	Royalties	106133424	105996710	136714	0.13
+EPL Oil & Gas, Inc.	Rents	378149	349766	28383	7.51
+EPL Oil & Gas, Inc.	Bonus	2143100	2205358	-62258	2.91
 EPL Oil & Gas, Inc.	Other Revenue	2099041	2115823	-16782	0.8
-EPL Oil & Gas, Inc.	Offshore Inspection Fee	588400	605100	-16700	2.8
+EPL Oil & Gas, Inc.	Offshore Inspection Fee	588400	605100	-16700	2.84
 EPL Oil & Gas, Inc.	ONRR Civil Penalties	33000	33000	0	0
 EPL Oil & Gas, Inc.	Bonus & 1st Year Rental	0	0	0	0
 EPL Oil & Gas, Inc.	Permit Fees	0	0	0	0
@@ -263,14 +263,14 @@ EOG Resources, Inc.	Renewables	0	did not participate	N/A	N/A
 EOG Resources, Inc.	AML Fees	0	did not participate	N/A	N/A
 EOG Resources, Inc.	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 EOG Resources, Inc.	Corporate Income Tax	0	did not participate	N/A	N/A
-Exxon Mobil Corporation	Royalties	474509808	474364629	145179	0
-Exxon Mobil Corporation	Rents	16978503	17005977	-27474	0
-Exxon Mobil Corporation	Bonus	226166445	224984045	1182400	0.5
-Exxon Mobil Corporation	Other Revenue	24422341	13190341	11232000	46
-Exxon Mobil Corporation	Offshore Inspection Fee	850000	839500	10500	1.2
+Exxon Mobil Corporation	Royalties	474509808	474364629	145179	0.03
+Exxon Mobil Corporation	Rents	16978503	17005977	-27474	0.16
+Exxon Mobil Corporation	Bonus	226166445	224984045	1182400	0.52
+Exxon Mobil Corporation	Other Revenue	24422341	13190341	11232000	45.99
+Exxon Mobil Corporation	Offshore Inspection Fee	850000	839500	10500	1.24
 Exxon Mobil Corporation	ONRR Civil Penalties	0	0	0	0
 Exxon Mobil Corporation	Bonus & 1st Year Rental	903700	903700	0	0
-Exxon Mobil Corporation	Permit Fees	910679	887250	23429	2.6
+Exxon Mobil Corporation	Permit Fees	910679	887250	23429	2.57
 Exxon Mobil Corporation	Renewables	0	0	0	0
 Exxon Mobil Corporation	AML Fees	0	0	0	0
 Exxon Mobil Corporation	OSMRE Civil Penalties	0	0	0	0
@@ -288,25 +288,25 @@ Fieldwood Energy LLC	AML Fees	0	did not participate	N/A	N/A
 Fieldwood Energy LLC	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 Fieldwood Energy LLC	Corporate Income Tax	0	did not participate	N/A	N/A
 Freeport-McMoRan Inc.	Royalties	312946187	312946187	0	0
-Freeport-McMoRan Inc.	Rents	4285169	4066778	218391	5
-Freeport-McMoRan Inc.	Bonus	83880250	83873645	6605	0
-Freeport-McMoRan Inc.	Other Revenue	-264552	-288024	23472	8.9
-Freeport-McMoRan Inc.	Offshore Inspection Fee	2128285	2098756	29529	1.4
+Freeport-McMoRan Inc.	Rents	4285169	4066778	218391	5.1
+Freeport-McMoRan Inc.	Bonus	83880250	83873645	6605	0.01
+Freeport-McMoRan Inc.	Other Revenue	-264552	-288024	23472	8.87
+Freeport-McMoRan Inc.	Offshore Inspection Fee	2128285	2098756	29529	1.39
 Freeport-McMoRan Inc.	ONRR Civil Penalties	84750	84750	0	0
 Freeport-McMoRan Inc.	Bonus & 1st Year Rental	0	0	0	0
-Freeport-McMoRan Inc.	Permit Fees	2203711	2185400	18311	0.8
+Freeport-McMoRan Inc.	Permit Fees	2203711	2185400	18311	0.83
 Freeport-McMoRan Inc.	Renewables	0	0	0	0
 Freeport-McMoRan Inc.	AML Fees	0	0	0	0
 Freeport-McMoRan Inc.	OSMRE Civil Penalties	0	0	0	0
 Freeport-McMoRan Inc.	Corporate Income Tax	N/A	135071332	NaN	N/A
-Hess Corporation	Royalties	196061653	196096387	-34734	0
-Hess Corporation	Rents	7217114	7284097	-66983	1
+Hess Corporation	Royalties	196061653	196096387	-34734	0.02
+Hess Corporation	Rents	7217114	7284097	-66983	0.93
 Hess Corporation	Bonus	4000000	4000000	0	0
 Hess Corporation	Other Revenue	1025053	1042464	-17411	1.7
-Hess Corporation	Offshore Inspection Fee	885500	885000	500	0.1
+Hess Corporation	Offshore Inspection Fee	885500	885000	500	0.06
 Hess Corporation	ONRR Civil Penalties	0	0	0	0
 Hess Corporation	Bonus & 1st Year Rental	0	0	0	0
-Hess Corporation	Permit Fees	76701	75000	1701	2.2
+Hess Corporation	Permit Fees	76701	75000	1701	2.22
 Hess Corporation	Renewables	0	0	0	0
 Hess Corporation	AML Fees	0	0	0	0
 Hess Corporation	OSMRE Civil Penalties	0	0	0	0
@@ -335,38 +335,38 @@ LLOG Exploration Company LLC	Renewables	0	did not participate	N/A	N/A
 LLOG Exploration Company LLC	AML Fees	0	did not participate	N/A	N/A
 LLOG Exploration Company LLC	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 LLOG Exploration Company LLC	Corporate Income Tax	0	did not participate	N/A	N/A
-Marathon Oil Company	Royalties	126113758	126121724	-7966	0
-Marathon Oil Company	Rents	3086739	3085628	1111	0
+Marathon Oil Company	Royalties	126113758	126121724	-7966	0.01
+Marathon Oil Company	Rents	3086739	3085628	1111	0.04
 Marathon Oil Company	Bonus	32802916	32802916	0	0
-Marathon Oil Company	Other Revenue	432879	412358	20521	4.7
+Marathon Oil Company	Other Revenue	432879	412358	20521	4.74
 Marathon Oil Company	Offshore Inspection Fee	123000	123000	0	0
 Marathon Oil Company	ONRR Civil Penalties	0	0	0	0
-Marathon Oil Company	Bonus & 1st Year Rental	4391750	4394447	-2697	0.1
+Marathon Oil Company	Bonus & 1st Year Rental	4391750	4394447	-2697	0.06
 Marathon Oil Company	Permit Fees	159515	156000	3515	2.2
 Marathon Oil Company	Renewables	0	0	0	0
 Marathon Oil Company	AML Fees	0	0	0	0
 Marathon Oil Company	OSMRE Civil Penalties	0	0	0	0
 Marathon Oil Company	Corporate Income Tax	0	did not report	N/A	N/A
-Newfield Exploration Company	Royalties	56885635	56965192	-79557	0.1
-Newfield Exploration Company	Rents	228598	240521	-11923	5
+Newfield Exploration Company	Royalties	56885635	56965192	-79557	0.14
+Newfield Exploration Company	Rents	228598	240521	-11923	5.22
 Newfield Exploration Company	Bonus	4180	0	4180	100
-Newfield Exploration Company	Other Revenue	1737830	1733496	4334	0.3
+Newfield Exploration Company	Other Revenue	1737830	1733496	4334	0.25
 Newfield Exploration Company	Offshore Inspection Fee	0	0	0	0
 Newfield Exploration Company	ONRR Civil Penalties	0	0	0	0
 Newfield Exploration Company	Bonus & 1st Year Rental	0	0	0	0
-Newfield Exploration Company	Permit Fees	2307330	2073500	233830	10.1
+Newfield Exploration Company	Permit Fees	2307330	2073500	233830	10.13
 Newfield Exploration Company	Renewables	0	0	0	0
 Newfield Exploration Company	AML Fees	0	0	0	0
 Newfield Exploration Company	OSMRE Civil Penalties	0	0	0	0
 Newfield Exploration Company	Corporate Income Tax	0	did not report	N/A	N/A
 Noble Energy, Inc.	Royalties	96060667	95768855	291812	0.3
-Noble Energy, Inc.	Rents	4467818	4415783	52035	1
+Noble Energy, Inc.	Rents	4467818	4415783	52035	1.16
 Noble Energy, Inc.	Bonus	0	0	0	0
-Noble Energy, Inc.	Other Revenue	-1927906	-1945151	17245	0.9
-Noble Energy, Inc.	Offshore Inspection Fee	213500	183000	30500	14.3
+Noble Energy, Inc.	Other Revenue	-1927906	-1945151	17245	0.89
+Noble Energy, Inc.	Offshore Inspection Fee	213500	183000	30500	14.29
 Noble Energy, Inc.	ONRR Civil Penalties	0	0	0	0
 Noble Energy, Inc.	Bonus & 1st Year Rental	0	0	0	0
-Noble Energy, Inc.	Permit Fees	62399	86115	-23716	38
+Noble Energy, Inc.	Permit Fees	62399	86115	-23716	38.01
 Noble Energy, Inc.	Renewables	0	0	0	0
 Noble Energy, Inc.	AML Fees	0	0	0	0
 Noble Energy, Inc.	OSMRE Civil Penalties	0	0	0	0
@@ -383,16 +383,16 @@ Oxy USA, Inc.	Renewables	0	did not participate	N/A	N/A
 Oxy USA, Inc.	AML Fees	0	did not participate	N/A	N/A
 Oxy USA, Inc.	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 Oxy USA, Inc.	Corporate Income Tax	0	did not participate	N/A	N/A
-Peabody Energy Corporation	Royalties	188130401	196437152	-8306751	4.4
+Peabody Energy Corporation	Royalties	188130401	196437152	-8306751	4.42
 Peabody Energy Corporation	Rents	192199	192199	0	0
 Peabody Energy Corporation	Bonus	276773916	276773916	0	0
-Peabody Energy Corporation	Other Revenue	337707	336597	1110	0.3
+Peabody Energy Corporation	Other Revenue	337707	336597	1110	0.33
 Peabody Energy Corporation	Offshore Inspection Fee	0	0	0	0
 Peabody Energy Corporation	ONRR Civil Penalties	0	0	0	0
 Peabody Energy Corporation	Bonus & 1st Year Rental	475590	475590	0	0
-Peabody Energy Corporation	Permit Fees	3217	10305	-7088	220.3
+Peabody Energy Corporation	Permit Fees	3217	10305	-7088	220.33
 Peabody Energy Corporation	Renewables	0	0	0	0
-Peabody Energy Corporation	AML Fees	48492478	48532180	-39702	0.1
+Peabody Energy Corporation	AML Fees	48492478	48532180	-39702	0.08
 Peabody Energy Corporation	OSMRE Civil Penalties	2760	2760	0	0
 Peabody Energy Corporation	Corporate Income Tax	0	did not report	N/A	N/A
 QEP Resources, Inc.	Royalties	95653947	did not participate	N/A	N/A
@@ -432,21 +432,21 @@ SandRidge Energy, Inc.	AML Fees	0	did not participate	N/A	N/A
 SandRidge Energy, Inc.	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 SandRidge Energy, Inc.	Corporate Income Tax	0	did not participate	N/A	N/A
 Shell E&P Company	Royalties	737334054	737334054	0	0
-Shell E&P Company	Rents	26648489	26570830	77659	0
-Shell E&P Company	Bonus	142229840	142619480	-389640	0.3
-Shell E&P Company	Other Revenue	615584	608954	6630	1.1
+Shell E&P Company	Rents	26648489	26570830	77659	0.29
+Shell E&P Company	Bonus	142229840	142619480	-389640	0.27
+Shell E&P Company	Other Revenue	615584	608954	6630	1.08
 Shell E&P Company	Offshore Inspection Fee	3742000	3742000	0	0
 Shell E&P Company	ONRR Civil Penalties	0	0	0	0
-Shell E&P Company	Bonus & 1st Year Rental	673069	661319	11750	1.8
-Shell E&P Company	Permit Fees	22247	19537	2710	12.2
+Shell E&P Company	Bonus & 1st Year Rental	673069	661319	11750	1.75
+Shell E&P Company	Permit Fees	22247	19537	2710	12.18
 Shell E&P Company	Renewables	0	0	0	0
 Shell E&P Company	AML Fees	0	0	0	0
 Shell E&P Company	OSMRE Civil Penalties	0	0	0	0
 Shell E&P Company	Corporate Income Tax	-66297360	-60000000	-6297360	9.5
-Statoil Gulf of Mexico	Royalties	92607958	86991402	5616556	6.1
-Statoil Gulf of Mexico	Rents	10173404	10007698	165706	2
+Statoil Gulf of Mexico	Royalties	92607958	86991402	5616556	6.06
+Statoil Gulf of Mexico	Rents	10173404	10007698	165706	1.63
 Statoil Gulf of Mexico	Bonus	106091454	106091454	0	0
-Statoil Gulf of Mexico	Other Revenue	-385042	-389316	4274	1.1
+Statoil Gulf of Mexico	Other Revenue	-385042	-389316	4274	1.11
 Statoil Gulf of Mexico	Offshore Inspection Fee	152500	152500	0	0
 Statoil Gulf of Mexico	ONRR Civil Penalties	0	0	0	0
 Statoil Gulf of Mexico	Bonus & 1st Year Rental	0	0	0	0
@@ -456,7 +456,7 @@ Statoil Gulf of Mexico	AML Fees	0	0	0	0
 Statoil Gulf of Mexico	OSMRE Civil Penalties	0	0	0	0
 Statoil Gulf of Mexico	Corporate Income Tax	0	0	0	0
 Stone Energy Corporation	Royalties	124046998	124046998	0	0
-Stone Energy Corporation	Rents	3862272	3862032	240	0
+Stone Energy Corporation	Rents	3862272	3862032	240	0.01
 Stone Energy Corporation	Bonus	17802096	17802096	0	0
 Stone Energy Corporation	Other Revenue	2525739	2525739	0	0
 Stone Energy Corporation	Offshore Inspection Fee	2051200	2051200	0	0
@@ -479,10 +479,10 @@ Talos Energy LLC	Renewables	0	did not participate	N/A	N/A
 Talos Energy LLC	AML Fees	0	did not participate	N/A	N/A
 Talos Energy LLC	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 Talos Energy LLC	Corporate Income Tax	0	did not participate	N/A	N/A
-Ultra Resources Inc.	Royalties	101631395	100592803	1038592	1
-Ultra Resources Inc.	Rents	8699	8021	678	8
+Ultra Resources Inc.	Royalties	101631395	100592803	1038592	1.02
+Ultra Resources Inc.	Rents	8699	8021	678	7.79
 Ultra Resources Inc.	Bonus	0	0	0	0
-Ultra Resources Inc.	Other Revenue	671847	677785	-5938	0.9
+Ultra Resources Inc.	Other Revenue	671847	677785	-5938	0.88
 Ultra Resources Inc.	Offshore Inspection Fee	0	0	0	0
 Ultra Resources Inc.	ONRR Civil Penalties	0	0	0	0
 Ultra Resources Inc.	Bonus & 1st Year Rental	0	0	0	0
@@ -527,14 +527,14 @@ Walter Oil & Gas Corporation	Renewables	0	did not participate	N/A	N/A
 Walter Oil & Gas Corporation	AML Fees	0	did not participate	N/A	N/A
 Walter Oil & Gas Corporation	OSMRE Civil Penalties	0	did not participate	N/A	N/A
 Walter Oil & Gas Corporation	Corporate Income Tax	0	did not participate	N/A	N/A
-WPX Energy, Inc.	Royalties	88077827	88116556	-38729	0
-WPX Energy, Inc.	Rents	154045	123452	30593	20
+WPX Energy, Inc.	Royalties	88077827	88116556	-38729	0.04
+WPX Energy, Inc.	Rents	154045	123452	30593	19.86
 WPX Energy, Inc.	Bonus	0	0	0	0
-WPX Energy, Inc.	Other Revenue	1183618	1214994	-31376	2.7
+WPX Energy, Inc.	Other Revenue	1183618	1214994	-31376	2.65
 WPX Energy, Inc.	Offshore Inspection Fee	0	0	0	0
 WPX Energy, Inc.	ONRR Civil Penalties	0	214	-214	100
 WPX Energy, Inc.	Bonus & 1st Year Rental	0	0	0	0
-WPX Energy, Inc.	Permit Fees	1600395	1599000	1395	0.1
+WPX Energy, Inc.	Permit Fees	1600395	1599000	1395	0.09
 WPX Energy, Inc.	Renewables	0	0	0	0
 WPX Energy, Inc.	AML Fees	0	0	0	0
 WPX Energy, Inc.	OSMRE Civil Penalties	0	0	0	0

--- a/js/pages/reconciliation.js
+++ b/js/pages/reconciliation.js
@@ -91,9 +91,11 @@
   }
 
   function isMaterial (d) {
+    var varianceVal = Math.abs(d.value - d.company);
+
     var overThreshold = !!(varianceKey[d.name].threshold < d.variance);
     if (overThreshold) {
-      var varianceVal = Math.abs(d.value - d.company);
+
       if (varianceVal > varianceKey[d.name].floor) {
         return true;
       }
@@ -354,7 +356,6 @@
   }
 
   function updateRevenueItem(selection, extent) {
-
     selection.select('.name')
       .text(function(d) {
         return varianceKey[d.name].name;


### PR DESCRIPTION
Addresses #1242

[>>PREVIEW<<](https://federalist.18f.gov/preview/18F/doi-extractives-data/explanations/explore/reconciliation/#fn%3A17=1)

This PR refactored the code responsible for determining the 17 material variances. It was simply a rounding issue. 

@coreycaitlin, I also added the [two explanations you posted](https://github.com/18F/doi-extractives-data/issues/1242#issuecomment-181905500) and matched them with the appropriate footnote reference.