### PR TITLE
Updates filter description

### DIFF
--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -85,12 +85,14 @@ permalink: /explore/exports/
         </div>
 
       </form>
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-        Exports from <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
+
+      <h1 data-filter-description="" class="filter-description">
+        Exports from <span href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</span>
         in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+        <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+        (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
       </h1>
+
       <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
       </div>
@@ -100,12 +102,14 @@ permalink: /explore/exports/
 
   </div>
 
-  <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
-    Exports from <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
-    in
-    <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-    (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-  </h1>
+  <div class="filter-description_wrapper">
+    <h1 data-filter-description="" class="filter-description filter-description_open">
+      Exports from <span href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</span>
+      in
+      <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+      (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
+    </h1>
+  </div>
 
   <div class="explore-exploration slab-alpha">
 

--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -68,11 +68,12 @@ permalink: /explore/gdp/
 
       </form>
 
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+      <h1 data-filter-description="" class="filter-description">
         GDP from extractives in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+        <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+        (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
       </h1>
+
       <div class="container">
         <button class="toggle-filters toggle" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
       </div>
@@ -81,11 +82,14 @@ permalink: /explore/gdp/
 
   </div>
 
-  <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
-    GDP from extractives in
-    <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-    (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-  </h1>
+  <div class="filter-description_wrapper">
+    <h1 data-filter-description="" class="filter-description filter-description_open">
+      GDP from extractives in
+      <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+      (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
+    </h1>
+  </div>
+
   <div class="explore-exploration slab-alpha">
 
     <div class="regions container">

--- a/_explore/economic-impact/jobs.html
+++ b/_explore/economic-impact/jobs.html
@@ -81,13 +81,13 @@ permalink: /explore/jobs/
         </div>
       </form>
 
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-        <a href="#units-selector" class="filter-part" data-key="units">Number</a>
+      <h1 data-filter-description="" class="filter-description">
+        <span href="#units-selector" class="filter-part" data-key="units">Number</span>
         of
-        <a href="#figure-selector" class="filter-part" data-key="figure">wage and salary</a>
+        <span href="#figure-selector" class="filter-part" data-key="figure">wage and salary</span>
         extractive industry jobs in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+        <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+        (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
       </h1>
 
       <div class="container">
@@ -98,14 +98,16 @@ permalink: /explore/jobs/
 
   </div>
 
-  <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
-    <a href="#units-selector" class="filter-part" data-key="units">Number</a>
-    of
-    <a href="#figure-selector" class="filter-part" data-key="figure">wage and salary</a>
-    extractive industry jobs in
-    <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-    (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-  </h1>
+  <div class="filter-description_wrapper">
+    <h1 data-filter-description="" class="filter-description filter-description_open">
+      <span href="#units-selector" class="filter-part" data-key="units">Number</span>
+      of
+      <span href="#figure-selector" class="filter-part" data-key="figure">wage and salary</span>
+      extractive industry jobs in
+      <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+      (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
+    </h1>
+  </div>
 
   <div class="explore-exploration slab-alpha">
 

--- a/_explore/production/production-all-lands.html
+++ b/_explore/production/production-all-lands.html
@@ -30,7 +30,7 @@ permalink: /explore/all-lands-production/
         aria-controls="filters" aria-expanded="false"
         data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
 
-      <form id="filters" aria-hidden="true" class="filters container-outer">
+      <form id="filters" aria-hidden="true" class="filters">
 
         <div class="filters-heading">
           <h3>Filter all lands production</h3>
@@ -78,11 +78,11 @@ permalink: /explore/all-lands-production/
 
       </form>
 
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-        <a href="#product-selector" class="filter-part" data-key="product">All</a>
+      <h1 data-filter-description="" class="filter-description">
+        <span href="#product-selector" class="filter-part" data-key="product">All</span>
         production on all lands and waters in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+        <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+        (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
       </h1>
 
       <div class="container">
@@ -91,12 +91,14 @@ permalink: /explore/all-lands-production/
 
     </div>
 
-    <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
-      <a href="#product-selector" class="filter-part" data-key="product">All</a>
-      production on all lands and waters in
-      <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-      (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-    </h1>
+    <div class="filter-description_wrapper">
+      <h1 data-filter-description="" class="filter-description filter-description_open">
+        <span href="#product-selector" class="filter-part" data-key="product">All</span>
+        production on all lands and waters in
+        <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+        (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
+      </h1>
+    </div>
 
     <div class="explore-exploration slab-alpha">
 

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -31,7 +31,7 @@ permalink: /explore/federal-production/
         aria-controls="filters" data-collapsed-text="Show filters" aria-expanded="false"
         data-expanded-text="Hide filters" data-toggler="filters">Show filters</button>
 
-      <form id="filters" aria-hidden="true" class="filters container-outer">
+      <form id="filters" aria-hidden="true" class="filters">
 
         <div class="filters-heading">
           <h3>Filter federal production</h3>
@@ -76,20 +76,13 @@ permalink: /explore/federal-production/
           </eiti-slider>
         </div>
 
-        <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-          <a href="#product-selector" class="filter-part" data-key="product">All</a>
-          production on federal lands in
-          <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-          (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-        </h1>
-
       </form>
 
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-        <a href="#product-selector" class="filter-part" data-key="product">All</a>
+      <h1 data-filter-description="" class="filter-description">
+        <span href="#product-selector" class="filter-part" data-key="product">All</span>
         production on federal lands and waters in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+        <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+        (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
       </h1>
 
       <div class="container">
@@ -98,12 +91,14 @@ permalink: /explore/federal-production/
 
     </div>
 
-    <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
-      <a href="#product-selector" class="filter-part" data-key="product">All</a>
-      production on federal lands and waters in
-      <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-      (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-    </h1>
+    <div class="filter-description_wrapper">
+      <h1 data-filter-description="" class="filter-description filter-description_open">
+        <span href="#product-selector" class="filter-part" data-key="product">All</span>
+        production on federal lands and waters in
+        <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+        (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
+      </h1>
+    </div>
 
     <div class="explore-exploration slab-alpha">
 

--- a/_explore/revenue/federal-revenue-by-company.html
+++ b/_explore/revenue/federal-revenue-by-company.html
@@ -58,10 +58,10 @@ permalink: /explore/federal-revenue-by-company/
 
       </form>
 
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
-        <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
+      <h1 data-filter-description="" class="filter-description">
+        <span href="#type-selector" class="filter-part" data-key="type">All revenue</span>
         from
-        <a href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</a>
+        <span href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</span>
         extraction on federal lands (2013)
       </h1>
 
@@ -71,12 +71,14 @@ permalink: /explore/federal-revenue-by-company/
 
     </div>
 
-    <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
-      <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
-      from
-      <a href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</a>
-      extraction on federal lands (2013)
-    </h1>
+    <div class="filter-description_wrapper">
+      <h1 data-filter-description="" class="filter-description filter-description_open">
+        <span href="#type-selector" class="filter-part" data-key="type">All revenue</span>
+        from
+        <span href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</span>
+        extraction on federal lands (2013)
+      </h1>
+    </div>
 
     <div class="explore-exploration slab-alpha">
 

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -84,12 +84,12 @@ permalink: /explore/federal-revenue-by-location/
 
       </form>
 
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+      <h1 data-filter-description="" class="filter-description">
         Revenue from
-        <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
+        <span href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</span>
         on federal lands in
-        <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-        (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
+        <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+        (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
       </h1>
 
       <div class="container">
@@ -98,13 +98,15 @@ permalink: /explore/federal-revenue-by-location/
     </div>
   </div>
 
-  <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
-    Revenue from
-    <a href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</a>
-    on federal lands in
-    <a href="#region-selector" class="filter-part" data-key="region">the entire U.S.</a>
-    (<a href="#year-selector" class="filter-part" data-key="year">2013</a>)
-  </h1>
+  <div class="filter-description_wrapper">
+    <h1 data-filter-description="" class="filter-description filter-description_open">
+      Revenue from
+      <span href="#commodity-group-selector" class="filter-part" data-key="commodity">all commodities</span>
+      on federal lands in
+      <span href="#region-selector" class="filter-part" data-key="region">the entire U.S.</span>
+      (<span href="#year-selector" class="filter-part" data-key="year">2013</span>)
+    </h1>
+  </div>
   <div class="explore-exploration slab-alpha">
 
     <div class="regions container">

--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -48,7 +48,7 @@ permalink: /explore/reconciliation/
 
       </form>
 
-      <h1 data-toggler="filters" data-filter-description="" class="filter-description">
+      <h1 class="filter-description">
         <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
         from
         extraction on federal lands (2013)
@@ -60,7 +60,7 @@ permalink: /explore/reconciliation/
 
     </div>
 
-    <h1 data-toggler="filters" data-filter-description="" class="filter-description filter-description_open">
+    <h1 class="filter-description filter-description_open">
       <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
       from
       extraction on federal lands (2013)

--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -48,8 +48,8 @@ permalink: /explore/reconciliation/
 
       </form>
 
-      <h1 class="filter-description">
-        <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
+      <h1 class="filter-description" data-filter-description="">
+        <span href="#type-selector" class="filter-part" data-key="type">All revenue</span>
         from
         extraction on federal lands (2013)
       </h1>
@@ -60,11 +60,13 @@ permalink: /explore/reconciliation/
 
     </div>
 
-    <h1 class="filter-description filter-description_open">
-      <a href="#type-selector" class="filter-part" data-key="type">All revenue</a>
-      from
-      extraction on federal lands (2013)
-    </h1>
+    <div class="filter-description_wrapper">
+      <h1 class="filter-description filter-description_open" data-filter-description="">
+        <span href="#type-selector" class="filter-part" data-key="type">All revenue</span>
+        from
+        extraction on federal lands (2013)
+      </h1>
+    </div>
 
     <div class="explore-exploration slab-alpha">
 

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -25,50 +25,52 @@
     border: 0;
     height: 50px;
   }
+}
 
-  &[aria-expanded=true] {
-    background-color: $mid-blue-opaque !important;
-    height: 100%;
-    overflow-y: auto;
-    padding-left: $base-padding;
+.filters-wrapper[aria-expanded=true] {
+  background-color: $mid-blue-opaque !important;
+  height: 100%;
+  overflow-y: auto;
+  padding-left: $base-padding;
 
-    @include respond-to(medium-up) {
-      height: inherit;
-      overflow-y: initial;
-    }
+  @include respond-to(medium-up) {
+    height: inherit;
+    overflow-y: initial;
+  }
 
-    &.js-transparent,
-    &.js-color {
-      border-radius: $base-border-radius;
-      border-bottom: none;
-    }
-
-    &.js-color {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-    }
+  &.js-transparent,
+  &.js-color {
+    border-bottom: none;
+    border-radius: 0;
   }
 
   &.js-color {
-    background: $mid-blue;
-    border-bottom: 2px solid lighten($neutral-gray, 5%);
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-
     @include respond-to(medium-up) {
-      background: $white;
+      border-bottom-left-radius: $base-border-radius;
+      border-bottom-right-radius: $base-border-radius;
     }
   }
+}
 
-  &.js-transparent {
-    background: $mid-blue;
-    border-bottom: 2px solid lighten($neutral-gray, 5%);
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+.js-color {
+  background: $mid-blue;
+  border-bottom: 2px solid lighten($neutral-gray, 5%);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 
-    @include respond-to(medium-up) {
-      background: $white;
-    }
+  @include respond-to(medium-up) {
+    background: $white;
+  }
+}
+
+.js-transparent {
+  background: $mid-blue;
+  border-bottom: 2px solid lighten($neutral-gray, 5%);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+
+  @include respond-to(medium-up) {
+    background: $white;
   }
 }
 
@@ -126,7 +128,6 @@
 // Crazy checkbox magic
 // http://cssdeck.com/labs/css-checkbox-styles
 // for guide on firefox compatibility
-
 .unit-filter {
   position: relative;
 
@@ -215,10 +216,7 @@
 
   &.filter-description_open {
     display: block;
-    margin-bottom: $base-padding;
-    margin-top: $base-padding;
-    padding-left: $base-padding;
-    padding-right: $base-padding;
+    float: none;
 
     @include respond-to(medium-up) {
       display: none;
@@ -242,10 +240,21 @@
   }
 
   .filter-part {
-    // border-bottom: 2px dotted $light-black;
-    font-weight: $weight-book;
     color: inherit;
+    font-weight: $weight-book;
     text-decoration: none;
+  }
+}
+
+.filter-description_wrapper {
+  display: block;
+  margin-bottom: $base-padding-extra;
+  margin-top: $base-padding;
+  padding-left: $base-padding;
+  padding-right: $base-padding;
+
+  @include respond-to(medium-up) {
+    display: none;
   }
 }
 

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -202,12 +202,10 @@
 }
 
 .filter-description {
-  @include heading(para-xl);
   display: none;
-  font-weight: $weight-bold;
+  font-weight: $weight-light;
   float: left;
   letter-spacing: -0.5px;
-
 
   @include respond-to(medium-up) {
     display: inline-block;
@@ -244,7 +242,8 @@
   }
 
   .filter-part {
-    border-bottom: 2px dotted $light-black;
+    // border-bottom: 2px dotted $light-black;
+    font-weight: $weight-book;
     color: inherit;
     text-decoration: none;
   }

--- a/_sass/blocks/explore/_filters.scss
+++ b/_sass/blocks/explore/_filters.scss
@@ -44,6 +44,12 @@
     border-radius: 0;
   }
 
+  &.js-transparent {
+    @include respond-to(medium-up) {
+      border-radius: $base-border-radius;
+    }
+  }
+
   &.js-color {
     @include respond-to(medium-up) {
       border-bottom-left-radius: $base-border-radius;
@@ -220,22 +226,6 @@
 
     @include respond-to(medium-up) {
       display: none;
-    }
-  }
-
-  &.filter-description_closed {
-    margin-bottom: $base-padding-lite;
-
-    &[aria-expanded=true] {
-      display: none;
-    }
-
-    &[aria-expanded=false] {
-      display: block;
-    }
-
-    @include respond-to(medium-up) {
-      margin-bottom: 0;
     }
   }
 

--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -174,7 +174,7 @@
 }
 
 .region-title {
-  padding-top: $base-padding-large;
+  padding-top: 0;
 }
 
 .region-notes {

--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -212,6 +212,14 @@
 
 .detached-header {
   position: relative;
+  padding-left: $base-padding;
+  padding-right: $base-padding;
+
+  @include respond-to(medium-up) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
 }
 
 .detached-table_title {

--- a/_sass/blocks/explore/_subpage.scss
+++ b/_sass/blocks/explore/_subpage.scss
@@ -30,8 +30,8 @@
 
 
   @include respond-to(medium-up) {
-    margin-top: 190px;
     margin-right: $base-padding;
+    margin-top: 190px;
   }
 
   @include respond-to(huge-plus-up) {

--- a/_sass/blocks/explore/_subpage.scss
+++ b/_sass/blocks/explore/_subpage.scss
@@ -30,7 +30,7 @@
 
 
   @include respond-to(medium-up) {
-    margin-top: 128px;
+    margin-top: 190px;
     margin-right: $base-padding;
   }
 

--- a/js/pages/all-lands-production.js
+++ b/js/pages/all-lands-production.js
@@ -26,19 +26,6 @@
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');
 
-  // FIXME: componentize these too
-  var filterParts = root.selectAll('a[data-key]');
-  filterParts.on('click', function(e, index) {
-    var key = filterParts[0][index].getAttribute('data-key');
-    if (key) {
-      root.select('.filters-wrapper').attr('aria-expanded', true);
-      filterToggle.attr('aria-expanded', true);
-      root.select('.filter-description_closed').attr('aria-expanded', true);
-      document.querySelector('#'+ key + '-selector').focus();
-    }
-    d3.event.preventDefault();
-  });
-
   // get the filters and add change event handlers
   var filters = root.selectAll('.filters [name]')
     // intialize the state props

--- a/js/pages/company-revenue.js
+++ b/js/pages/company-revenue.js
@@ -21,19 +21,6 @@
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');
 
-  // FIXME: componentize these too
-  var filterParts = root.selectAll('a[data-key]');
-  filterParts.on('click', function(e, index) {
-    var key = filterParts[0][index].getAttribute('data-key');
-    if (key) {
-      root.select('.filters-wrapper').attr('aria-expanded', true);
-      filterToggle.attr('aria-expanded', true);
-      root.select('.filter-description_closed').attr('aria-expanded', true);
-      document.querySelector('#'+ key + '-selector').focus();
-    }
-    d3.event.preventDefault();
-  });
-
   var model = eiti.explore.model(eiti.data.path + 'company/revenue.tsv')
     .transform(removeRevenueTypePrefix)
     .filter('commodity', function(data, commodity) {

--- a/js/pages/exports.js
+++ b/js/pages/exports.js
@@ -27,19 +27,6 @@
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');
 
-  // FIXME: componentize these too
-  var filterParts = root.selectAll('a[data-key]');
-  filterParts.on('click', function(e, index) {
-    var key = filterParts[0][index].getAttribute('data-key');
-    if (key) {
-      root.select('.filters-wrapper').attr('aria-expanded', true);
-      filterToggle.attr('aria-expanded', true);
-      root.select('.filter-description_closed').attr('aria-expanded', true);
-      document.querySelector('#'+ key + '-selector').focus();
-    }
-    d3.event.preventDefault();
-  });
-
   // get the filters and add change event handlers
   var filters = root.selectAll('.filters [name]');
 

--- a/js/pages/federal-production.js
+++ b/js/pages/federal-production.js
@@ -25,19 +25,6 @@
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');
 
-  // FIXME: componentize these too
-  var filterParts = root.selectAll('a[data-key]');
-  filterParts.on('click', function(e, index) {
-    var key = filterParts[0][index].getAttribute('data-key');
-    if (key) {
-      root.select('.filters-wrapper').attr('aria-expanded', true);
-      filterToggle.attr('aria-expanded', true);
-      root.select('.filter-description_closed').attr('aria-expanded', true);
-      document.querySelector('#'+ key + '-selector').focus();
-    }
-    d3.event.preventDefault();
-  });
-
   // get the filters and add change event handlers
   var filters = root.selectAll('.filters [name]')
     // intialize the state props

--- a/js/pages/gdp.js
+++ b/js/pages/gdp.js
@@ -27,19 +27,6 @@
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');
 
-  // FIXME: componentize these too
-  var filterParts = root.selectAll('a[data-key]');
-  filterParts.on('click', function(e, index) {
-    var key = filterParts[0][index].getAttribute('data-key');
-    if (key) {
-      root.select('.filters-wrapper').attr('aria-expanded', true);
-      filterToggle.attr('aria-expanded', true);
-      root.select('.filter-description_closed').attr('aria-expanded', true);
-      document.querySelector('#'+ key + '-selector').focus();
-    }
-    d3.event.preventDefault();
-  });
-
   // get the filters and add change event handlers
   var filters = root.selectAll('.filters [name]');
 

--- a/js/pages/jobs.js
+++ b/js/pages/jobs.js
@@ -42,19 +42,6 @@
   // aggregation function
   var aggregate;
 
-  // FIXME: componentize these too
-  var filterParts = root.selectAll('a[data-key]');
-  filterParts.on('click', function(e, index) {
-    var key = filterParts[0][index].getAttribute('data-key');
-    if (key) {
-      root.select('.filters-wrapper').attr('aria-expanded', true);
-      filterToggle.attr('aria-expanded', true);
-      root.select('.filter-description_closed').attr('aria-expanded', true);
-      document.querySelector('#'+ key + '-selector').focus();
-    }
-    d3.event.preventDefault();
-  });
-
   // get the filters and add change event handlers
   var filters = root.selectAll('.filters [name]')
     // intialize the state props

--- a/js/pages/reconciliation.js
+++ b/js/pages/reconciliation.js
@@ -102,17 +102,17 @@
   }
 
   // FIXME: componentize these too
-  var filterParts = root.selectAll('a[data-key]');
-  filterParts.on('click', function(e, index) {
-    var key = filterParts[0][index].getAttribute('data-key');
-    if (key) {
-      root.select('.filters-wrapper').attr('aria-expanded', true);
-      filterToggle.attr('aria-expanded', true);
-      root.select('.filter-description_closed').attr('aria-expanded', true);
-      document.querySelector('#'+ key + '-selector').focus();
-    }
-    d3.event.preventDefault();
-  });
+  // var filterParts = root.selectAll('a[data-key]');
+  // filterParts.on('click', function(e, index) {
+  //   var key = filterParts[0][index].getAttribute('data-key');
+  //   if (key) {
+  //     root.select('.filters-wrapper').attr('aria-expanded', true);
+  //     filterToggle.attr('aria-expanded', true);
+  //     root.select('.filter-description_closed').attr('aria-expanded', true);
+  //     document.querySelector('#'+ key + '-selector').focus();
+  //   }
+  //   d3.event.preventDefault();
+  // });
 
   var model = eiti.explore.model(eiti.data.path + 'reconciliation/revenue.tsv')
     .transform(removeRevenueTypePrefix)

--- a/js/pages/reconciliation.js
+++ b/js/pages/reconciliation.js
@@ -101,19 +101,6 @@
     return false;
   }
 
-  // FIXME: componentize these too
-  // var filterParts = root.selectAll('a[data-key]');
-  // filterParts.on('click', function(e, index) {
-  //   var key = filterParts[0][index].getAttribute('data-key');
-  //   if (key) {
-  //     root.select('.filters-wrapper').attr('aria-expanded', true);
-  //     filterToggle.attr('aria-expanded', true);
-  //     root.select('.filter-description_closed').attr('aria-expanded', true);
-  //     document.querySelector('#'+ key + '-selector').focus();
-  //   }
-  //   d3.event.preventDefault();
-  // });
-
   var model = eiti.explore.model(eiti.data.path + 'reconciliation/revenue.tsv')
     .transform(removeRevenueTypePrefix)
     .filter('type', function(data, type) {

--- a/js/pages/revenue.js
+++ b/js/pages/revenue.js
@@ -25,19 +25,6 @@
   // buttons that expand and collapse other elements
   var filterToggle = root.select('button.toggle-filters');
 
-  // FIXME: componentize these too
-  var filterParts = root.selectAll('a[data-key]');
-  filterParts.on('click', function(e, index) {
-    var key = filterParts[0][index].getAttribute('data-key');
-    if (key) {
-      root.select('.filters-wrapper').attr('aria-expanded', true);
-      filterToggle.attr('aria-expanded', true);
-      root.select('.filter-description_closed').attr('aria-expanded', true);
-      document.querySelector('#'+ key + '-selector').focus();
-    }
-    d3.event.preventDefault();
-  });
-
   // get the filters and add change event handlers
   var filters = root.selectAll('.filters [name]')
     // intialize the state props


### PR DESCRIPTION
Fixes #1134 

This PR updates the filter description in accordance with @ericronne's mock (below). The description has larger (h1), thinner (light) text, more padding, and no longer opens the filter. 

Changes were made on all of the explore pages and the branch is ready for review [---> PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/filter-description/explore/)

![](https://cloud.githubusercontent.com/assets/9259185/12867432/30a52ec6-ccb3-11e5-98a2-e85346ebb996.png)