### PR TITLE
Fixes hash selector on narrative pages

### DIFF
--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -16,7 +16,7 @@
           rect.top < (window.innerHeight || document. documentElement.clientHeight);
     }
 
-    var OpenListNav = function() {
+    exports.OpenListNav = function() {
       // init OpenListNav Properties
       this.active = window.location.hash || '#intro';
       this.navItems = document.querySelectorAll('[data-nav-item]');
@@ -28,97 +28,97 @@
         prev: getScrollTop(),
         direction: 'down'
       };
+
+      this.registerEventHandlers();
     };
 
-    OpenListNav.prototype.updateScrollTop = function() {
-      this.scrollTop.prev = this.scrollTop.current;
-      this.scrollTop.current = getScrollTop();
-      this.scrollTop.direction = (this.scrollTop.current >= this.scrollTop.prev)
-        ? 'down'
-        : 'up';
-    };
+    exports.OpenListNav.prototype = {
+      updateScrollTop: function() {
+        this.scrollTop.prev = this.scrollTop.current;
+        this.scrollTop.current = getScrollTop();
+        this.scrollTop.direction = (this.scrollTop.current >= this.scrollTop.prev)
+          ? 'down'
+          : 'up';
+      },
 
-    OpenListNav.prototype.removeActive = function(){
-      this.active = null;
-      for (var i = 0; i < this.navItems.length; i++) {
-        this.navItems[i].setAttribute('data-active', false);
-      }
-    };
-
-    OpenListNav.prototype.addActive = function(el, name){
-      if (!el){
-        el = document.querySelector('[data-nav-item="' + name + '"]');
-        this.active = name;
-        el.setAttribute('data-active', true);
-      } else {
-        this.active = el.getAttribute('data-nav-item');
-        el.setAttribute('data-active', true);
-      }
-    };
-
-    OpenListNav.prototype.update = function(el, name){
-      this.removeActive();
-      this.addActive(el, name);
-    };
-
-    OpenListNav.prototype.updateSelectField = function(newValue) {
-      if (newValue){
-        this.navSelect.val(newValue);
-      }
-    };
-
-    OpenListNav.prototype.registerEventHandlers = function(){
-      var self = this;
-      if (!this.navIsSelect) {
+      removeActive: function(){
+        this.active = null;
         for (var i = 0; i < this.navItems.length; i++) {
-          var item = this.navItems[i];
-          item.addEventListener('click', function () {
-            self.update(this);
-          });
+          this.navItems[i].setAttribute('data-active', false);
         }
+      },
+
+      addActive: function(el, name){
+        if (!el){
+          el = document.querySelector('[data-nav-item="' + name + '"]');
+          this.active = name;
+          el.setAttribute('data-active', true);
+        } else {
+          this.active = el.getAttribute('data-nav-item');
+          el.setAttribute('data-active', true);
+        }
+      },
+
+      update: function(el, name){
+        this.removeActive();
+        this.addActive(el, name);
+      },
+
+      updateSelectField: function(newValue) {
+        if (newValue){
+          this.navSelect.val(newValue);
+        }
+      },
+
+      registerEventHandlers: function(){
+        var self = this;
+        if (!this.navIsSelect) {
+          for (var i = 0; i < this.navItems.length; i++) {
+            var item = this.navItems[i];
+            item.addEventListener('click', function () {
+              self.update(this);
+            });
+          }
+        }
+
+        window.addEventListener('scroll', function() {
+          self.updateScrollTop();
+          // TODO: throttle
+          self.detectNavChange();
+        });
+
+        window.addEventListener('resize', function(){
+          // TODO: throttle
+          self.detectNavChange();
+        });
+
+      },
+
+      changeHandler: function(selector) {
+        window.location.hash = selector.value;
+      },
+
+
+      detectNavChange: function(){
+
+        var self = this;
+
+        // initialize nav status as not updated
+        var updated = false;
+
+         Array.prototype.forEach.call(this.navHeaders, function(header){
+           var inViewPort = isElementInViewport(header);
+           if (inViewPort && !self.navIsSelect && !updated) {
+             self.update(null, header.name);
+             updated = true;
+           } else if(inViewPort && self.navIsSelect && !updated) {
+             var newName = header.name || header.id;
+            self.updateSelectField(newName);
+             updated = true;
+           }
+        });
       }
-
-      window.addEventListener('scroll', function() {
-        self.updateScrollTop();
-        // TODO: throttle
-        self.detectNavChange();
-      });
-
-      window.addEventListener('resize', function(){
-        // TODO: throttle
-        self.detectNavChange();
-      });
-
     };
 
-    OpenListNav.prototype.changeHandler = function(selector) {
-      window.location.hash = selector.value;
-    };
-
-
-    OpenListNav.prototype.detectNavChange = function(){
-
-      var self = this;
-
-      // initialize nav status as not updated
-      var updated = false;
-
-       Array.prototype.forEach.call(this.navHeaders, function(header){
-         var inViewPort = isElementInViewport(header);
-         if (inViewPort && !self.navIsSelect && !updated) {
-           self.update(null, header.name);
-           updated = true;
-         } else if(inViewPort && self.navIsSelect && !updated) {
-           var newName = header.name || header.id;
-          self.updateSelectField(newName);
-           updated = true;
-         }
-      });
-    };
-
-    var openListNav = new OpenListNav();
-
-    openListNav.registerEventHandlers();
-
-    module.exports = openListNav;
+    module.exports = exports.OpenListNav;
   })(this);

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -49,12 +49,12 @@
 	  'use strict';
 
 	  __webpack_require__(1);
-		exports.OpenListNav = __webpack_require__(22);
+	  exports.OpenListNav = __webpack_require__(22);
 
-		// exporting instance of OpenListNav because openListNav is
-		// referenced in the markup:
-		// _includes/hash_selecor.html
-		exports.openListNav = new OpenListNav();
+	  // exporting instance of OpenListNav because openListNav is
+	  // referenced in the markup:
+	  // _includes/hash_selecor.html
+	  exports.openListNav = new OpenListNav();
 
 	})(window);
 

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -49,7 +49,12 @@
 	  'use strict';
 
 	  __webpack_require__(1);
-		__webpack_require__(21);
+		exports.OpenListNav = __webpack_require__(22);
+
+		// exporting instance of OpenListNav because openListNav is
+		// referenced in the markup:
+		// _includes/hash_selecor.html
+		exports.openListNav = new OpenListNav();
 
 	})(window);
 
@@ -287,7 +292,7 @@
 
 /***/ },
 
-/***/ 21:
+/***/ 22:
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -308,7 +313,7 @@
 	          rect.top < (window.innerHeight || document. documentElement.clientHeight);
 	    }
 
-	    var OpenListNav = function() {
+	    exports.OpenListNav = function() {
 	      // init OpenListNav Properties
 	      this.active = window.location.hash || '#intro';
 	      this.navItems = document.querySelectorAll('[data-nav-item]');
@@ -320,99 +325,99 @@
 	        prev: getScrollTop(),
 	        direction: 'down'
 	      };
+
+	      this.registerEventHandlers();
 	    };
 
-	    OpenListNav.prototype.updateScrollTop = function() {
-	      this.scrollTop.prev = this.scrollTop.current;
-	      this.scrollTop.current = getScrollTop();
-	      this.scrollTop.direction = (this.scrollTop.current >= this.scrollTop.prev)
-	        ? 'down'
-	        : 'up';
-	    };
+	    exports.OpenListNav.prototype = {
+	      updateScrollTop: function() {
+	        this.scrollTop.prev = this.scrollTop.current;
+	        this.scrollTop.current = getScrollTop();
+	        this.scrollTop.direction = (this.scrollTop.current >= this.scrollTop.prev)
+	          ? 'down'
+	          : 'up';
+	      },
 
-	    OpenListNav.prototype.removeActive = function(){
-	      this.active = null;
-	      for (var i = 0; i < this.navItems.length; i++) {
-	        this.navItems[i].setAttribute('data-active', false);
-	      }
-	    };
-
-	    OpenListNav.prototype.addActive = function(el, name){
-	      if (!el){
-	        el = document.querySelector('[data-nav-item="' + name + '"]');
-	        this.active = name;
-	        el.setAttribute('data-active', true);
-	      } else {
-	        this.active = el.getAttribute('data-nav-item');
-	        el.setAttribute('data-active', true);
-	      }
-	    };
-
-	    OpenListNav.prototype.update = function(el, name){
-	      this.removeActive();
-	      this.addActive(el, name);
-	    };
-
-	    OpenListNav.prototype.updateSelectField = function(newValue) {
-	      if (newValue){
-	        this.navSelect.val(newValue);
-	      }
-	    };
-
-	    OpenListNav.prototype.registerEventHandlers = function(){
-	      var self = this;
-	      if (!this.navIsSelect) {
+	      removeActive: function(){
+	        this.active = null;
 	        for (var i = 0; i < this.navItems.length; i++) {
-	          var item = this.navItems[i];
-	          item.addEventListener('click', function () {
-	            self.update(this);
-	          });
+	          this.navItems[i].setAttribute('data-active', false);
 	        }
+	      },
+
+	      addActive: function(el, name){
+	        if (!el){
+	          el = document.querySelector('[data-nav-item="' + name + '"]');
+	          this.active = name;
+	          el.setAttribute('data-active', true);
+	        } else {
+	          this.active = el.getAttribute('data-nav-item');
+	          el.setAttribute('data-active', true);
+	        }
+	      },
+
+	      update: function(el, name){
+	        this.removeActive();
+	        this.addActive(el, name);
+	      },
+
+	      updateSelectField: function(newValue) {
+	        if (newValue){
+	          this.navSelect.val(newValue);
+	        }
+	      },
+
+	      registerEventHandlers: function(){
+	        var self = this;
+	        if (!this.navIsSelect) {
+	          for (var i = 0; i < this.navItems.length; i++) {
+	            var item = this.navItems[i];
+	            item.addEventListener('click', function () {
+	              self.update(this);
+	            });
+	          }
+	        }
+
+	        window.addEventListener('scroll', function() {
+	          self.updateScrollTop();
+	          // TODO: throttle
+	          self.detectNavChange();
+	        });
+
+	        window.addEventListener('resize', function(){
+	          // TODO: throttle
+	          self.detectNavChange();
+	        });
+
+	      },
+
+	      changeHandler: function(selector) {
+	        window.location.hash = selector.value;
+	      },
+
+
+	      detectNavChange: function(){
+
+	        var self = this;
+
+	        // initialize nav status as not updated
+	        var updated = false;
+
+	         Array.prototype.forEach.call(this.navHeaders, function(header){
+	           var inViewPort = isElementInViewport(header);
+	           if (inViewPort && !self.navIsSelect && !updated) {
+	             self.update(null, header.name);
+	             updated = true;
+	           } else if(inViewPort && self.navIsSelect && !updated) {
+	             var newName = header.name || header.id;
+	            self.updateSelectField(newName);
+	             updated = true;
+	           }
+	        });
 	      }
-
-	      window.addEventListener('scroll', function() {
-	        self.updateScrollTop();
-	        // TODO: throttle
-	        self.detectNavChange();
-	      });
-
-	      window.addEventListener('resize', function(){
-	        // TODO: throttle
-	        self.detectNavChange();
-	      });
-
 	    };
 
-	    OpenListNav.prototype.changeHandler = function(selector) {
-	      window.location.hash = selector.value;
-	    };
-
-
-	    OpenListNav.prototype.detectNavChange = function(){
-
-	      var self = this;
-
-	      // initialize nav status as not updated
-	      var updated = false;
-
-	       Array.prototype.forEach.call(this.navHeaders, function(header){
-	         var inViewPort = isElementInViewport(header);
-	         if (inViewPort && !self.navIsSelect && !updated) {
-	           self.update(null, header.name);
-	           updated = true;
-	         } else if(inViewPort && self.navIsSelect && !updated) {
-	           var newName = header.name || header.id;
-	          self.updateSelectField(newName);
-	           updated = true;
-	         }
-	      });
-	    };
-
-	    var openListNav = new OpenListNav();
-
-	    openListNav.registerEventHandlers();
-
-	    module.exports = openListNav;
+	    module.exports = exports.OpenListNav;
 	  })(this);
 
 

--- a/js/src/narrative.js
+++ b/js/src/narrative.js
@@ -2,6 +2,11 @@
   'use strict';
 
   require('./../components/sticky-nav.js');
-	require('./../components/open-list-nav.js');
+	exports.OpenListNav = require('./../components/open-list-nav.js');
+
+	// exporting instance of OpenListNav because openListNav is
+	// referenced in the markup:
+	// _includes/hash_selecor.html
+	exports.openListNav = new OpenListNav();
 
 })(window);

--- a/js/src/narrative.js
+++ b/js/src/narrative.js
@@ -2,11 +2,11 @@
   'use strict';
 
   require('./../components/sticky-nav.js');
-	exports.OpenListNav = require('./../components/open-list-nav.js');
+  exports.OpenListNav = require('./../components/open-list-nav.js');
 
-	// exporting instance of OpenListNav because openListNav is
-	// referenced in the markup:
-	// _includes/hash_selecor.html
-	exports.openListNav = new OpenListNav();
+  // exporting instance of OpenListNav because openListNav is
+  // referenced in the markup:
+  // _includes/hash_selecor.html
+  exports.openListNav = new OpenListNav();
 
 })(window);


### PR DESCRIPTION
Fixes #1272

This PR fixes the bug that was preventing users from using the hash selector as a page navigation tool.

To see the fix, go [here](https://federalist.18f.gov/preview/18F/doi-extractives-data/open-nav-list/how-it-works/federal-laws/) and try to use the selector on the right to skip down the page. It should work as expected.

The origin of the bug was the new way that we configured the build for optimization purposes.