### PR TITLE
Fix company subtotals

### DIFF
--- a/_sass/blocks/explore/_regions-list.scss
+++ b/_sass/blocks/explore/_regions-list.scss
@@ -63,6 +63,7 @@
   td.value,
   th.value {
     text-align: right;
+    white-space: nowrap;
   }
 
   thead {

--- a/js/pages/company-revenue.js
+++ b/js/pages/company-revenue.js
@@ -193,12 +193,13 @@
         return {
           name: d.key,
           total: total,
-          types: d.values.map(function(d) {
-            return {
-              name: d[innerKey],
-              value: d.Revenue
-            };
-          })
+          types: grouper.entries(d.values)
+            .map(function(d) {
+              return {
+                name: d.key,
+                value: d.values
+              };
+            })
         };
       });
 


### PR DESCRIPTION
[:sunglasses: preview on Federalist](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-company-subtotals/explore/federal-revenue-by-company/2015/)

This hotfix addresses #1312 by restoring the summing logic for per-company totals to its original form. I assumed (incorrectly) that there was only one row in the data for each row in these tables.

I also fixed a text wrapping issue with long negative values, which you can see [here, before](https://useiti.doi.gov/explore/federal-revenue-by-company/2015/#type=Other+Revenues):

![image](https://cloud.githubusercontent.com/assets/113896/13613027/2c49984c-e51f-11e5-895b-1bcd0dd915b0.png)

and [after](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-company-subtotals/explore/federal-revenue-by-company/2015/#type=Other+Revenues):

![image](https://cloud.githubusercontent.com/assets/113896/13613097/6d2fc2aa-e51f-11e5-8c16-8fcc82073d75.png)