### PR TITLE
Adds required links to footer and associated styles

### DIFF
--- a/_includes/layout/footer.html
+++ b/_includes/layout/footer.html
@@ -55,6 +55,8 @@
 
   	      <p class="footer-para footer-para_last">Mail: USEITI Secretariat, 1849 C Street NW MS 4211, Washington, D.C. 20240</p>
 
+          <p class="footer-para footer-para_last"><a href="https://www.doi.gov/" class="link-beta">Department of the Interior Home</a> | <a href="https://www.doi.gov/privacy" class="link-beta">Privacy Policy</a> | <a href="https://www.doi.gov/foia" class="link-beta">FOIA</a> | <a href="https://www.usa.gov/" class="link-beta">USA.gov</a></p>
+
         </div>
 
         <div class="footer-bottom-right">

--- a/_sass/blocks/_footer.scss
+++ b/_sass/blocks/_footer.scss
@@ -46,6 +46,13 @@ footer,
 }
 
 .footer-para_last {
+  .link-beta {
+    &:hover,
+    &:active {
+      text-decoration: underline;
+    }
+  }
+
   @include heading(para-sm);
   color: $white;
 


### PR DESCRIPTION
This replaces PR #1331 , which I accidentally branched off of `master` instead of `dev`. That branch is still open so that DOI can review the work there at [this location](https://federalist.18f.gov/preview/18F/doi-extractives-data/add-footer-requ-links/). This is related to #1275 .

:sunglasses: [PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/footer-requ-links/)

Looks like:
![screenshot 2016-03-21 10 21 16](https://cloud.githubusercontent.com/assets/4827522/13927426/eda8ab52-ef4e-11e5-9b30-720097e9a47a.png)