### PR TITLE
State pages design – take 1

### DIFF
--- a/_includes/case-studies/_nav-list.html
+++ b/_includes/case-studies/_nav-list.html
@@ -1,7 +1,14 @@
+{% if layout.nav_items %}
+	{% assign selector_nav_items = layout.nav_items %}
+{% else %}
+	{% assign selector_nav_items = page.nav_items %}
+{% endif %}
+
+
 <ul>
-  {% if page.nav_items %}
-    {% for item in page.nav_items %}
-      {% if item.name == page.nav_items[0].name %}
+  {% if selector_nav_items %}
+    {% for item in selector_nav_items %}
+      {% if item.name == selector_nav_items[0].name %}
         <a href="#{{item.name}}" class="sticky_nav-nav_item" data-nav-item="{{item.name}}" data-active="true">{{item.title}}</a>
       {% else %}
         <a href="#{{item.name}}" class="sticky_nav-nav_item" data-nav-item="{{item.name}}">{{item.title}}</a>

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -1,6 +1,6 @@
 {% assign all_products = site.data.state_all_production[state_id].products %}
 
-<section id="all-production" class="all-lands production">
+<section id="all-production" class="all-lands production" data-nav-header="all-production">
   <h2>Natural resource production in {{ state_name }}</h2>
 
   <p>The federal government collects data about what natural resources are produced each state. (For coal, there is also data about mining in each county.)</p>

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -1,4 +1,4 @@
-<section id="disbursements" class="disbursements">
+<section id="disbursements" class="disbursements" data-nav-header="disbursements">
   <h2>Disbursements</h2>
   <p>{{ disbursements_summary | strip_html }}</p>
 

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -1,4 +1,4 @@
-<section id="exports" class="economic exports">
+<section id="exports" class="economic exports" data-nav-header="exports">
   <h2>Exports</h2>
   <p>{{ exports_summary | strip_html }}</p>
 

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -1,6 +1,6 @@
 {% assign gdp = site.data.state_gdp[state_id] %}
 
-<section id="gdp" class="economic gdp">
+<section id="gdp" class="economic gdp" data-nav-header="gdp">
   <h2>Gross Domestic Product (GDP)</h2>
   <p>Extractive industries accounted for
     {% if gdp[year].dollars %}

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -1,6 +1,6 @@
 {% assign jobs = site.data.state_jobs[state_id] %}
 
-<section id="employment" class="economic employment">
+<section id="employment" class="economic employment" data-nav-header="jobs">
   <h2>Employment</h2>
 
   <p>One measure of the role of extractive industries is how many people are employed in jobs related to natural resource extraction. In {{ state_name }}, in {{ year }},

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -1,6 +1,6 @@
 {% assign jobs = site.data.state_jobs[state_id] %}
 
-<section id="employment" class="economic employment" data-nav-header="jobs">
+<section id="employment" class="economic employment" data-nav-header="employment">
   <h2>Employment</h2>
 
   <p>One measure of the role of extractive industries is how many people are employed in jobs related to natural resource extraction. In {{ state_name }}, in {{ year }},

--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -1,66 +1,80 @@
 <section id="overview" data-nav-header="overview">
-  <h2>Key Facts</h2>
-  <ul class="list-bullet key-facts">
 
-    <li class="revenue">{%
-      include location/key-revenue.html
-      location_id=state_id
-      location_name=state_name
-      year=year
-      top=top_products
-    %}</li>
+  <p>This is where an introduction to this page will go with a few nice words on what a regional profile is and what to expect here. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.</p>
 
-    <li class="production all-production">{%
-      include location/key-all-production.html
-      location_id=state_id
-      location_name=state_name
-      year=year
-      top=top_products
-    %}</li>
+  <section class="panel-gray">
 
-    <li class="production federal-production">{%
-      include location/key-federal-production.html
-      location_id=state_id
-      location_name=state_name
-      year=year
-      top=top_products
-    %}</li>
-
-    <li class="employment">{%
-      include location/key-jobs.html
-      location_id=state_id
-      location_name=state_name
-      year=year
-    %}</li>
-
-    <li class="gdp">{%
-      include location/key-gdp.html
-      location_id=state_id
-      location_name=state_name
-      year=year
-    %}</li>
-
-    <li class="exports">
-      {% capture exports_summary %}
-      {%
-        include location/key-exports.html
+    <p>{%
+        include location/key-gdp.html
         location_id=state_id
         location_name=state_name
         year=year
-      %}
-      {% endcapture %}{{ exports_summary }}
-    </li>
+      %}</p>
 
-    <li class="disbursements">
-      {% capture disbursements_summary %}
-      {%
-        include location/key-disbursements.html
+    <hr/>
+
+    <ul class="list-bullet key-facts">
+
+      <li class="revenue">{%
+        include location/key-revenue.html
         location_id=state_id
         location_name=state_name
         year=year
-      %}
-      {% endcapture %}{{ disbursements_summary }}
-    </li>
+        top=top_products
+      %}</li>
 
-  </ul>
+      <li class="production all-production">{%
+        include location/key-all-production.html
+        location_id=state_id
+        location_name=state_name
+        year=year
+        top=top_products
+      %}</li>
+
+      <li class="production federal-production">{%
+        include location/key-federal-production.html
+        location_id=state_id
+        location_name=state_name
+        year=year
+        top=top_products
+      %}</li>
+
+      <li class="employment">{%
+        include location/key-jobs.html
+        location_id=state_id
+        location_name=state_name
+        year=year
+      %}</li>
+
+      <li class="gdp">{%
+        include location/key-gdp.html
+        location_id=state_id
+        location_name=state_name
+        year=year
+      %}</li>
+
+      <li class="exports">
+        {% capture exports_summary %}
+        {%
+          include location/key-exports.html
+          location_id=state_id
+          location_name=state_name
+          year=year
+        %}
+        {% endcapture %}{{ exports_summary }}
+      </li>
+
+      <li class="disbursements">
+        {% capture disbursements_summary %}
+        {%
+          include location/key-disbursements.html
+          location_id=state_id
+          location_name=state_name
+          year=year
+        %}
+        {% endcapture %}{{ disbursements_summary }}
+      </li>
+
+    </ul>
+  </section>
 </section>

--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -1,4 +1,4 @@
-<section id="key-facts">
+<section id="overview" data-nav-header="overview">
   <h2>Key Facts</h2>
   <ul class="list-bullet key-facts">
 

--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -2,7 +2,7 @@
 
   <p>This is where an introduction to this page will go with a few nice words on what a regional profile is and what to expect here. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.</p>
 
-  <section class="panel-gray">
+  <section class="panel-gray container-outer">
 
     <p>{%
         include location/key-gdp.html

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -1,6 +1,6 @@
 {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
 {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ state_id }}.svg{% endcapture %}
-<section id="ownership">
+<section id="ownership" data-nav-header="ownership">
   <h2>Land ownership</h2>
   <p><strong>In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government.</strong></p>
 

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -1,39 +1,44 @@
 {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
 {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ state_id }}.svg{% endcapture %}
-<section id="ownership" data-nav-header="ownership">
+<section id="ownership" data-nav-header="ownership" class="container-outer">
   <h2>Land ownership</h2>
-  <p><strong>In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government.</strong></p>
 
-  <figure>
-    {% assign _width = 50 %}
-    {% assign _viewbox = site.data.viewboxes[state_id] %}
-    <div class="svg-container county map-container"{% if _viewbox %}
-      style="width: {{ _width }}%; padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %}>
-      <svg class="county ownership map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
-        <g class="states features">
-          <use xlink:href="{{ states_svg }}#states"></use>
-        </g>
-        <g class="states mesh">
-          <use xlink:href="{{ states_svg }}#states-mesh"></use>
-        </g>
-        <g class="counties features">
-          <use xlink:href="{{ state_svg }}#counties"></use>
-        </g>
-        {%
-          include maps/federal_land_ownership.svg
-          clip='#state-outline'
-        %}
-        <g class="counties mesh">
-          <use xlink:href="{{ state_svg }}#counties-mesh"></use>
-        </g>
-        <g class="state feature overlay">
-          <use xlink:href="{{ states_svg }}#state-{{ state_id }}"></use>
-        </g>
-      </svg>
-    </div>
 
-    <figcaption>Federally owned land (gray)</figcaption>
-  </figure>
+  <section class="container-half">
+    <h3>In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government.</h3>
 
-  <p>When companies extract natural resources on federal land, they pay royalties, rents, bonuses, and other fees — much like they would to any landowner. They also have to report more data about their activities on government-owned land than on private land. Learn more about <a href="{{ site.baseurl }}/how-it-works/ownership/">natural resources and land ownership in the U.S.</a></p>
+    <p>When companies extract natural resources on federal land, they pay royalties, rents, bonuses, and other fees — much like they would to any landowner. They also have to report more data about their activities on government-owned land than on private land. Learn more about <a href="{{ site.baseurl }}/how-it-works/ownership/">natural resources and land ownership in the U.S.</a></p>
+  </section>
+
+  <aside class="container-half">
+    <figure>
+      {% assign _viewbox = site.data.viewboxes[state_id] %}
+      <div class="svg-container county map-container"{% if _viewbox %}
+        style="padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %}>
+        <svg class="county ownership map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
+          <g class="states features">
+            <use xlink:href="{{ states_svg }}#states"></use>
+          </g>
+          <g class="states mesh">
+            <use xlink:href="{{ states_svg }}#states-mesh"></use>
+          </g>
+          <g class="counties features">
+            <use xlink:href="{{ state_svg }}#counties"></use>
+          </g>
+          {%
+            include maps/federal_land_ownership.svg
+            clip='#state-outline'
+          %}
+          <g class="counties mesh">
+            <use xlink:href="{{ state_svg }}#counties-mesh"></use>
+          </g>
+          <g class="state feature overlay">
+            <use xlink:href="{{ states_svg }}#state-{{ state_id }}"></use>
+          </g>
+        </svg>
+      </div>
+
+      <figcaption><icon class="icon-plus-lg"></icon> Details</figcaption>
+    </figure>
+  </aside>
 </section>

--- a/_includes/location/section-process.html
+++ b/_includes/location/section-process.html
@@ -1,4 +1,4 @@
-<section id="process">
+<section id="process" data-nav-header="process">
   <h2>Process</h2>
   <p>When companies extract natural resources on federal land, they follow laws or policies that govern how rights are awarded and what fees they pay to the government. The specifics of the process depend on the kind of resource, and often affect how much revenue the federal government ultimately collects.</p>
   <p>For details, read more about the different processes for awarding rights and extracting resources: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -1,7 +1,7 @@
 {% assign revenue_commodities = site.data.state_revenues[state_id].commodities %}
 {% assign revenue_total = revenue_commodities.All[year].revenue %}
 
-<section id="revenue" class="federal revenue">
+<section id="revenue" class="federal revenue" data-nav-header="revenue">
   <h2>Revenue</h2>
 
   <p>When companies want to extract natural resources on federal land, they pay fees depending on where they are in the process of using the land. For instance, a company might pay for the right to explore for resources, pay rent while exploring the land, and then pay a percentage of production value once they start producing resources on the land.</p>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -3,7 +3,7 @@ layout: default
 nav_items:
   - name: overview
     title: Overview
-  - name: land-ownership
+  - name: ownership
     title: Land Ownership
   - name: process
     title: Process
@@ -71,7 +71,7 @@ nav_items:
   </div>
 
   <div class="container-right-5">
-    <div class="sticky_nav" data-offset-bottom="100">
+    <div class="sticky_nav">
       <nav class="sticky_nav-nav">
         {% include case-studies/_nav-list.html %}
       </nav>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -28,7 +28,7 @@ nav_items:
 {% assign commodity_names = site.data.commodity_names %}
 {% assign top_products = 10 %}
 
-<main id="state-{{ state_id }}" class="container-outer">
+<main id="state-{{ state_id }}" class="container-outer layout-state-pages">
 
   <div>
     <a class="breadcrumb" href="{{ site.baseurl }}/states/">State Profiles</a>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -1,5 +1,24 @@
 ---
 layout: default
+nav_items:
+  - name: overview
+    title: Overview
+  - name: land-ownership
+    title: Land Ownership
+  - name: process
+    title: Process
+  - name: revenue
+    title: Revenue
+  - name: all-production
+    title: Production
+  - name: employment
+    title: Employment
+  - name: gdp
+    title: GDP
+  - name: exports
+    title: Exports
+  - name: disbursements
+    title: Disbursements
 ---
 
 {% assign state_name = page.data.name %}
@@ -10,40 +29,57 @@ layout: default
 {% assign top_products = 10 %}
 
 <main id="state-{{ state_id }}" class="container-outer">
-  <h1>{{ state_name }}</h1>
 
-  {% include location/section-key-facts.html %}
+  <div>
+    <a class="breadcrumb" href="{{ site.baseurl }}/states/">State Profiles</a>
+    /
+  </div>
+  <h1 id="title">{{ state_name }}</h1>
 
-  {% include location/section-ownership.html %}
+  <div class="container-left-7">
 
-  {% include location/section-process.html %}
+    {% include location/section-overview.html %}
 
-  {% include location/section-revenue.html %}
+    {% include location/section-ownership.html %}
 
-  {% include location/section-all-production.html %}
+    {% include location/section-process.html %}
 
-  {% include location/section-federal-production.html %}
+    {% include location/section-revenue.html %}
 
-  {% include location/section-state-production.html %}
+    {% include location/section-all-production.html %}
 
-  {% include location/section-jobs.html %}
+    {% include location/section-federal-production.html %}
 
-  {% include location/section-gdp.html %}
+    {% include location/section-state-production.html %}
 
-  {% include location/section-exports.html %}
+    {% include location/section-jobs.html %}
 
-  {% include location/section-disbursements.html %}
+    {% include location/section-gdp.html %}
 
-  <!-- XXX setting display: none on this prevents the mask from working -->
-  <svg width="0" height="0">
-    <defs>
-      <clipPath id="state-outline">
-        <use xlink:href="{{ states_svg }}#state-{{ state_id }}"></use>
-      </clipPath>
-    </defs>
-  </svg>
+    {% include location/section-exports.html %}
+
+    {% include location/section-disbursements.html %}
+
+    <!-- XXX setting display: none on this prevents the mask from working -->
+    <svg width="0" height="0">
+      <defs>
+        <clipPath id="state-outline">
+          <use xlink:href="{{ states_svg }}#state-{{ state_id }}"></use>
+        </clipPath>
+      </defs>
+    </svg>
+  </div>
+
+  <div class="container-right-5">
+    <div class="sticky_nav" data-offset-bottom="100">
+      <nav class="sticky_nav-nav">
+        {% include case-studies/_nav-list.html %}
+      </nav>
+    </div>
+  </div>
 
 </main>
 
 <script src="{{ site.baseurl }}/js/components/bar-chart-table.js"></script>
 <script src="{{ site.baseurl }}/js/components/data-map.js"></script>
+<script type="text/javascript" src="{{ site.baseurl }}/js/lib/narrative.min.js" charset="utf-8"></script>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -60,7 +60,7 @@ $dark-gray: #4a4a4a;
 $light-black: #303030;
 
 // State pages
-$green-land: #D5E5CB;
+$green-land: #d5e5cb;
 
 // v2 - deprecate
 $putty: #f4f4f4;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -40,7 +40,7 @@ $z-negative: -1;
 // v3
 $white: #ffffff;
 $black: #040404;
-$green: #96bc7f;
+$green: #9fa63b;
 $blue: #157bac;
 $blue-contrast: #096fa0;
 $light-green: #d2e2cb;
@@ -59,10 +59,12 @@ $another-gray: #999;
 $dark-gray: #4a4a4a;
 $light-black: #303030;
 
+// State pages
+$green-land: #D5E5CB;
+
 // v2 - deprecate
 $putty: #f4f4f4;
 $dark-putty: #838383;
-$green: #9fa63b;
 $purple: #965bcd;
 $red: #c5403c;
 $cobalt: #1075a5;

--- a/_sass/blocks/_all.scss
+++ b/_sass/blocks/_all.scss
@@ -72,3 +72,11 @@
 //
 // Styleguide blocks.layout-content
 @import 'jekyll-layouts/content';
+
+
+// State page layout
+//
+// Styles for invalid pages
+//
+// Styleguide blocks.layout-state-pages
+@import 'jekyll-layouts/state-pages';

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -1,9 +1,9 @@
 .layout-state-pages {
 
   section + section {
-    padding-top: $base-padding-extra;
-    margin-top: $base-padding-extra;
     border-top: 1px solid $neutral-gray;
+    margin-top: $base-padding-extra;
+    padding-top: $base-padding-extra;
   }
 
   hr {

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -1,10 +1,20 @@
 .layout-state-pages {
 
   section + section {
+    padding-top: $base-padding-extra;
     margin-top: $base-padding-extra;
+    border-top: 1px solid $neutral-gray;
   }
 
   hr {
+    border-top: 1px solid $neutral-gray;
+    margin-bottom: $base-padding;
+    margin-top: $base-padding;
+  }
+
+  p + [class*='panel-'],
+  section + [class*='panel-'],
+  h3 + [class*='panel-'] {
     margin-bottom: $base-padding;
     margin-top: $base-padding;
   }

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -1,0 +1,11 @@
+.layout-state-pages {
+
+  section + section {
+    margin-top: $base-padding-extra;
+  }
+
+  hr {
+    margin-bottom: $base-padding;
+    margin-top: $base-padding;
+  }
+}

--- a/_sass/components/_all.scss
+++ b/_sass/components/_all.scss
@@ -18,3 +18,4 @@
 @import 'hash-selector';
 @import 'breadcrumbs';
 @import 'flowchart';
+@import 'panel';

--- a/_sass/components/_panel.scss
+++ b/_sass/components/_panel.scss
@@ -1,0 +1,4 @@
+.panel-gray {
+	background-color: $light-gray-dark;
+	padding: $base-padding;
+}

--- a/_sass/components/_panel.scss
+++ b/_sass/components/_panel.scss
@@ -1,4 +1,4 @@
 .panel-gray {
-	background-color: $light-gray-dark;
-	padding: $base-padding;
+  background-color: $light-gray-dark;
+  padding: $base-padding;
 }

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -70,7 +70,18 @@ svg.map {
     pointer-events: none;
   }
 
-  &.ownership .federal.ownership {
-    opacity: 0.15;
+  // To make land ownership more green!
+  &.ownership {
+    .ownership {
+      opacity: 0.25;
+    }
+
+    .federal.ownership {
+      opacity: 0.5;
+    }
+
+    .counties.features {
+      fill: $green-land;
+    }
   }
 }

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -49,7 +49,6 @@
       },
 
       addActive: function(el, name){
-        console.log('addActive', el, name)
         if (!el){
           el = document.querySelector('[data-nav-item="' + name + '"]');
           this.active = name;
@@ -110,7 +109,6 @@
          Array.prototype.forEach.call(this.navHeaders, function(header){
            var inViewPort = isElementInViewport(header);
            if (inViewPort && !self.navIsSelect && !updated) {
-              console.log('detectNavChange')
               var newName = header.name || header.id;
               self.update(null, newName);
               updated = true;

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -49,6 +49,7 @@
       },
 
       addActive: function(el, name){
+        console.log('addActive', el, name)
         if (!el){
           el = document.querySelector('[data-nav-item="' + name + '"]');
           this.active = name;
@@ -109,8 +110,10 @@
          Array.prototype.forEach.call(this.navHeaders, function(header){
            var inViewPort = isElementInViewport(header);
            if (inViewPort && !self.navIsSelect && !updated) {
-             self.update(null, header.name);
-             updated = true;
+              console.log('detectNavChange')
+              var newName = header.name || header.id;
+              self.update(null, newName);
+              updated = true;
            } else if(inViewPort && self.navIsSelect && !updated) {
              var newName = header.name || header.id;
             self.updateSelectField(newName);

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -103,7 +103,7 @@
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
 	  var d3 = {
-	    version: "3.5.17"
+	    version: "3.5.16"
 	  };
 	  var d3_arraySlice = [].slice, d3_array = function(list) {
 	    return d3_arraySlice.call(list);
@@ -3628,7 +3628,7 @@
 	        λ0 = λ, sinφ0 = sinφ, cosφ0 = cosφ, point0 = point;
 	      }
 	    }
-	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ winding & 1;
+	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ winding & 1;
 	  }
 	  function d3_geo_clipCircle(radius) {
 	    var cr = Math.cos(radius), smallRadius = cr > 0, notHemisphere = abs(cr) > ε, interpolate = d3_geo_circleInterpolate(radius, 6 * d3_radians);

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -346,7 +346,6 @@
 	      },
 
 	      addActive: function(el, name){
-	        console.log('addActive', el, name)
 	        if (!el){
 	          el = document.querySelector('[data-nav-item="' + name + '"]');
 	          this.active = name;
@@ -407,7 +406,6 @@
 	         Array.prototype.forEach.call(this.navHeaders, function(header){
 	           var inViewPort = isElementInViewport(header);
 	           if (inViewPort && !self.navIsSelect && !updated) {
-	              console.log('detectNavChange')
 	              var newName = header.name || header.id;
 	              self.update(null, newName);
 	              updated = true;

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -346,6 +346,7 @@
 	      },
 
 	      addActive: function(el, name){
+	        console.log('addActive', el, name)
 	        if (!el){
 	          el = document.querySelector('[data-nav-item="' + name + '"]');
 	          this.active = name;
@@ -406,8 +407,10 @@
 	         Array.prototype.forEach.call(this.navHeaders, function(header){
 	           var inViewPort = isElementInViewport(header);
 	           if (inViewPort && !self.navIsSelect && !updated) {
-	             self.update(null, header.name);
-	             updated = true;
+	              console.log('detectNavChange')
+	              var newName = header.name || header.id;
+	              self.update(null, newName);
+	              updated = true;
 	           } else if(inViewPort && self.navIsSelect && !updated) {
 	             var newName = header.name || header.id;
 	            self.updateSelectField(newName);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
   },
   "scripts": {
     "start": "bundle exec jekyll serve --incremental",
+    "start-states": "bundle exec jekyll serve --incremental --config _config.yml,_maps.yml",
+    "rebuild": "rm -rf _site && npm run start",
     "test": "mocha",
     "test-html": "bundle exec htmlproof --disable-external _site",
     "webpack": "webpack",

--- a/states/index.html
+++ b/states/index.html
@@ -11,7 +11,7 @@ permalink: /states/
       include state-map.html
       states=site.data.state_revenues
       value='products.All.2013.revenue'
-      href='%s/'
+      href='%/'
     %}
     <figcaption>State revenue (2013)</figcaption>
   </figure>


### PR DESCRIPTION
[:eyes: LE PREV :eyes:](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-pages-design/staates/UT/)

This is referencing @ericronne's [primordial design](https://github.com/18F/doi-extractives-data/issues/1348#issuecomment-221356826) from issue #1348 .

Basically this branch is a start.

- Adds a (somewhat janky) version of the sticky nav broken up by section. 
- Begins rough design for overview
- Adds a [state pages stylesheet](https://github.com/18F/doi-extractives-data/compare/state-pages...state-pages-design#diff-5ecb51504b490b962867c7df6844a8d8R1)
- makes the land ownership map green