### PR TITLE
Make Beckley search more accessible, searchable from header, configured in yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ url: https://useiti.doi.gov
 # app version number
 version: v1.3.2
 
+beckley_api_key: LXJh2PKSC6zxY0YNuBRYgIj2JxSPcDwSPCZuHBG1
+
 sass:
   style: nested
   sass_dir: _sass

--- a/_includes/layout/header.html
+++ b/_includes/layout/header.html
@@ -19,7 +19,7 @@
       <li class="header-nav_item_top">
         <form action='{{ site.baseurl }}/search-results/'>
           <label class='sr-only' for="q">Search</label>
-          <input type="search" class="header-nav_search" placeholder="Search" id="q" role="search"/>
+          <input type="search" class="q header-nav_search" placeholder="Search" id="q" name="q" role="search"/>
           <button type="submit" class="header-nav_search_icon" title="search"><span class="icon-search"></span><label class="sr-only">Icon search button</label></button>
         </form>
       </li>

--- a/_includes/layout/nav-drawer.html
+++ b/_includes/layout/nav-drawer.html
@@ -8,7 +8,7 @@
 
   <form action='{{ site.baseurl }}/search-results/' class="drawer-search_form">
     <label for='q' class='sr-only'>Search</label>
-    <input class="glossary__search drawer-search_field" type="search" name="q">
+    <input class="q glossary__search drawer-search_field" type="search" name="q">
     <button type="submit" class="drawer-search_button icon-search" title="search"></button>
   </form>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,6 +58,7 @@
     <script src="{{ site.baseurl }}/js/lib/main.min.js" charset="utf-8"></script>
 
     <script>
+      eiti.beckleyApiKey = '{{ site.beckley_api_key }}' || '';
       eiti.data = eiti.data || {};
       eiti.data.path = '{{ site.baseurl }}/data/';
       eiti.commodities = ({{ site.data.commodities|jsonify }});

--- a/_sass/blocks/_nav-drawer.scss
+++ b/_sass/blocks/_nav-drawer.scss
@@ -29,6 +29,7 @@ $nav-drawer-height: 593px;
 }
 
 .nav_drawer-nav {
+  list-style-type: none;
   margin-bottom: 0;
   padding: $base-padding;
   padding-bottom: 0;

--- a/js/components/glossary.js
+++ b/js/components/glossary.js
@@ -69,7 +69,9 @@
 
       var hitsTriggers = $target.hasClass('js-glossary-toggle')
         || $target.hasClass('term')
-        || $target.hasClass('icon-bars');
+        || $target.hasClass('icon-bars')
+        || $target.hasClass('drawer-search_button')
+        || $target.hasClass('drawer-search_field');
 
       if (!hitsTriggers) {
         self.hide();

--- a/js/components/search.js
+++ b/js/components/search.js
@@ -21,9 +21,9 @@ $( document ).ready(function() {
 
   $('.search-string').append(query.replace(/%20/g,' '));
   $('.site-search-text').attr('value',query.replace(/%20/g,' '));
-  if(query) {
+  if (query) {
     $('input.q').val(query);
-    $('.search-result-list').append('<div class='loading'><span class='glyphicon glyphicon-refresh'></span> Loading</div>');
+    $('.search-result-list').append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
     var url = 'https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=' + query + '&size=50&from=0&api_key=' + apiKEY;
     $.ajax({
       url: url,
@@ -32,7 +32,7 @@ $( document ).ready(function() {
     })
       .done(function(json) {
         $('.loading').remove();
-        $('#search-results-count').append( json.hits.total + ' search results');
+        $('.search-results-count').append( json.hits.total + ' search results');
         if (json.hits.total == 0){
           $('.search-no-results').show();
         }

--- a/js/components/search.js
+++ b/js/components/search.js
@@ -16,14 +16,17 @@ $( document ).ready(function() {
     }
   }
 
-  var query = GetURLParameter('q') || '';
+  var query = GetURLParameter('q') || '',
+    apiKEY = eiti.beckleyApiKey;
+
   $(".search-string").append(query.replace(/%20/g,' '));
-  $("#site-search-text").attr('value',query.replace(/%20/g,' '));
+  $(".site-search-text").attr('value',query.replace(/%20/g,' '));
   if(query) {
-    $("input#q").val(query);
-    $("#search-result-list").append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
+    $("input.q").val(query);
+    $(".search-result-list").append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
+    var url = "https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=" + query + "&size=50&from=0&api_key=" + apiKEY;
     $.ajax({
-      url: "https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=" + query + "&size=50&from=0&api_key=LXJh2PKSC6zxY0YNuBRYgIj2JxSPcDwSPCZuHBG1",
+      url: url,
       cache: false,
       dataType: "json"
     })
@@ -31,10 +34,10 @@ $( document ).ready(function() {
         $(".loading").remove();
         $("#search-results-count").append( json.hits.total + ' search results');
         if (json.hits.total == 0){
-          $("#search-no-results").show();
+          $(".search-no-results").show();
         }
         else{
-          $("#search-no-results").remove();
+          $(".search-no-results").remove();
         }
 
         $.each(json.hits.hits, function(i, hit){
@@ -62,7 +65,7 @@ $( document ).ready(function() {
           else {
             content_type = '<span class="glyphicon glyphicon-file"></span> ' + hit._source.content_type + '';
           }
-          $("#search-results-container").append('<article class="search-result-list"><h1><a href="'
+          $(".search-results-container").append('<article class="search-result-list"><h1><a href="'
             + hit._source.url
             + '" target="_blank">'
             + hit._source.title
@@ -78,9 +81,9 @@ $( document ).ready(function() {
       });
   }
   else {
-    $("#search-no-results").show();
+    $(".search-no-results").show();
     $(".loading").remove();
-    $("#search-results-count").append( 0 + ' search results');
+    $(".search-results-count").append( 0 + ' search results');
 
   }
 });

--- a/js/components/search.js
+++ b/js/components/search.js
@@ -19,25 +19,25 @@ $( document ).ready(function() {
   var query = GetURLParameter('q') || '',
     apiKEY = eiti.beckleyApiKey;
 
-  $(".search-string").append(query.replace(/%20/g,' '));
-  $(".site-search-text").attr('value',query.replace(/%20/g,' '));
+  $('.search-string').append(query.replace(/%20/g,' '));
+  $('.site-search-text').attr('value',query.replace(/%20/g,' '));
   if(query) {
-    $("input.q").val(query);
-    $(".search-result-list").append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
-    var url = "https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=" + query + "&size=50&from=0&api_key=" + apiKEY;
+    $('input.q').val(query);
+    $('.search-result-list').append('<div class='loading'><span class='glyphicon glyphicon-refresh'></span> Loading</div>');
+    var url = 'https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=' + query + '&size=50&from=0&api_key=' + apiKEY;
     $.ajax({
       url: url,
       cache: false,
-      dataType: "json"
+      dataType: 'json'
     })
       .done(function(json) {
-        $(".loading").remove();
-        $("#search-results-count").append( json.hits.total + ' search results');
+        $('.loading').remove();
+        $('#search-results-count').append( json.hits.total + ' search results');
         if (json.hits.total == 0){
-          $(".search-no-results").show();
+          $('.search-no-results').show();
         }
         else{
-          $(".search-no-results").remove();
+          $('.search-no-results').remove();
         }
 
         $.each(json.hits.hits, function(i, hit){
@@ -55,35 +55,35 @@ $( document ).ready(function() {
             });
           }
 
-          var content_type = "";
-          if(hit._source.content_type == "text/html") {
+          var content_type = '';
+          if(hit._source.content_type == 'text/html') {
             content_type = '<span class="glyphicon glyphicon-link"></span> Website';
           }
-          else if(hit._source.content_type == "application/pdf") {
+          else if(hit._source.content_type == 'application/pdf') {
             content_type = '<span class="glyphicon glyphicon-file"></span> PDF';
           }
           else {
             content_type = '<span class="glyphicon glyphicon-file"></span> ' + hit._source.content_type + '';
           }
-          $(".search-results-container").append('<article class="search-result-list"><h1><a href="'
+          $('.search-results-container').append('<article class="search-result-list"><h1><a href="'
             + hit._source.url
             + '" target="_blank">'
             + hit._source.title
             + '</a></h1>'
-            +'<p>'
+            + '<p>'
             + result_description
             + '</p>'
             +'<p>Tagged&nbsp;/'
             + tags
-            +'</p>'
-            +'</article>');
+            + '</p>'
+            + '</article>');
         });
       });
   }
   else {
-    $(".search-no-results").show();
-    $(".loading").remove();
-    $(".search-results-count").append( 0 + ' search results');
+    $('.search-no-results').show();
+    $('.loading').remove();
+    $('.search-results-count').append( 0 + ' search results');
 
   }
 });

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -73,7 +73,7 @@
 	  exports.EITIToggle = __webpack_require__(17);
 
 	  // FIXME: does this export anything?
-	  __webpack_require__(18);
+	  __webpack_require__(!(function webpackMissingModule() { var e = new Error("Cannot find module \"../components/search\""); e.code = 'MODULE_NOT_FOUND'; throw e; }()));
 
 	  // XXX List.js's node module isn't CommonJS compatible, so we have to use a
 	  // built version.
@@ -23484,101 +23484,7 @@
 
 
 /***/ },
-/* 18 */
-/***/ function(module, exports) {
-
-	$( document ).ready(function() {
-	  // Beckley Search Form
-	  //
-	  // As a work of the United States Government, this package is in the public domain within the United States. Additionally, we waive copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication.
-	  //
-	  // By Sean Herron <sean@herron.io>
-	  //
-	  function GetURLParameter(sParam) {
-	    var sPageURL = window.location.search.substring(1);
-	    var sURLVariables = sPageURL.split('&');
-	    for (var i = 0; i < sURLVariables.length; i++) {
-	      var sParameterName = sURLVariables[i].split('=');
-	      if (sParameterName[0] == sParam) {
-	        return sParameterName[1];
-	      }
-	    }
-	  }
-
-	  var query = GetURLParameter('q') || '',
-	    apiKEY = eiti.beckleyApiKey;
-
-	  $(".search-string").append(query.replace(/%20/g,' '));
-	  $(".site-search-text").attr('value',query.replace(/%20/g,' '));
-	  if(query) {
-	    $("input.q").val(query);
-	    $(".search-result-list").append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
-	    var url = "https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=" + query + "&size=50&from=0&api_key=" + apiKEY;
-	    $.ajax({
-	      url: url,
-	      cache: false,
-	      dataType: "json"
-	    })
-	      .done(function(json) {
-	        $(".loading").remove();
-	        $("#search-results-count").append( json.hits.total + ' search results');
-	        if (json.hits.total == 0){
-	          $(".search-no-results").show();
-	        }
-	        else{
-	          $(".search-no-results").remove();
-	        }
-
-	        $.each(json.hits.hits, function(i, hit){
-
-	        var result_description = hit._source.description;
-
-	          var tags = '';
-	          if(hit._source.tag) {
-
-	            $.each(hit._source.tag, function(i, tag) {
-	              tags += '<span class="search-result-list-tag">&nbsp;<a href="../search-results/?q='
-	              + tag + '" title="Search for '
-	              + tag +'">'
-	              + tag + '</a>&nbsp;/</span>';
-	            });
-	          }
-
-	          var content_type = "";
-	          if(hit._source.content_type == "text/html") {
-	            content_type = '<span class="glyphicon glyphicon-link"></span> Website';
-	          }
-	          else if(hit._source.content_type == "application/pdf") {
-	            content_type = '<span class="glyphicon glyphicon-file"></span> PDF';
-	          }
-	          else {
-	            content_type = '<span class="glyphicon glyphicon-file"></span> ' + hit._source.content_type + '';
-	          }
-	          $(".search-results-container").append('<article class="search-result-list"><h1><a href="'
-	            + hit._source.url
-	            + '" target="_blank">'
-	            + hit._source.title
-	            + '</a></h1>'
-	            +'<p>'
-	            + result_description
-	            + '</p>'
-	            +'<p>Tagged&nbsp;/'
-	            + tags
-	            +'</p>'
-	            +'</article>');
-	        });
-	      });
-	  }
-	  else {
-	    $(".search-no-results").show();
-	    $(".loading").remove();
-	    $(".search-results-count").append( 0 + ' search results');
-
-	  }
-	});
-
-
-/***/ },
+/* 18 */,
 /* 19 */
 /***/ function(module, exports, __webpack_require__) {
 

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -73,7 +73,7 @@
 	  exports.EITIToggle = __webpack_require__(17);
 
 	  // FIXME: does this export anything?
-	  __webpack_require__(!(function webpackMissingModule() { var e = new Error("Cannot find module \"../components/search\""); e.code = 'MODULE_NOT_FOUND'; throw e; }()));
+	  __webpack_require__(18);
 
 	  // XXX List.js's node module isn't CommonJS compatible, so we have to use a
 	  // built version.
@@ -23484,7 +23484,101 @@
 
 
 /***/ },
-/* 18 */,
+/* 18 */
+/***/ function(module, exports) {
+
+	$( document ).ready(function() {
+	  // Beckley Search Form
+	  //
+	  // As a work of the United States Government, this package is in the public domain within the United States. Additionally, we waive copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication.
+	  //
+	  // By Sean Herron <sean@herron.io>
+	  //
+	  function GetURLParameter(sParam) {
+	    var sPageURL = window.location.search.substring(1);
+	    var sURLVariables = sPageURL.split('&');
+	    for (var i = 0; i < sURLVariables.length; i++) {
+	      var sParameterName = sURLVariables[i].split('=');
+	      if (sParameterName[0] == sParam) {
+	        return sParameterName[1];
+	      }
+	    }
+	  }
+
+	  var query = GetURLParameter('q') || '',
+	    apiKEY = eiti.beckleyApiKey;
+
+	  $('.search-string').append(query.replace(/%20/g,' '));
+	  $('.site-search-text').attr('value',query.replace(/%20/g,' '));
+	  if (query) {
+	    $('input.q').val(query);
+	    $('.search-result-list').append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
+	    var url = 'https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=' + query + '&size=50&from=0&api_key=' + apiKEY;
+	    $.ajax({
+	      url: url,
+	      cache: false,
+	      dataType: 'json'
+	    })
+	      .done(function(json) {
+	        $('.loading').remove();
+	        $('.search-results-count').append( json.hits.total + ' search results');
+	        if (json.hits.total == 0){
+	          $('.search-no-results').show();
+	        }
+	        else{
+	          $('.search-no-results').remove();
+	        }
+
+	        $.each(json.hits.hits, function(i, hit){
+
+	        var result_description = hit._source.description;
+
+	          var tags = '';
+	          if(hit._source.tag) {
+
+	            $.each(hit._source.tag, function(i, tag) {
+	              tags += '<span class="search-result-list-tag">&nbsp;<a href="../search-results/?q='
+	              + tag + '" title="Search for '
+	              + tag +'">'
+	              + tag + '</a>&nbsp;/</span>';
+	            });
+	          }
+
+	          var content_type = '';
+	          if(hit._source.content_type == 'text/html') {
+	            content_type = '<span class="glyphicon glyphicon-link"></span> Website';
+	          }
+	          else if(hit._source.content_type == 'application/pdf') {
+	            content_type = '<span class="glyphicon glyphicon-file"></span> PDF';
+	          }
+	          else {
+	            content_type = '<span class="glyphicon glyphicon-file"></span> ' + hit._source.content_type + '';
+	          }
+	          $('.search-results-container').append('<article class="search-result-list"><h1><a href="'
+	            + hit._source.url
+	            + '" target="_blank">'
+	            + hit._source.title
+	            + '</a></h1>'
+	            + '<p>'
+	            + result_description
+	            + '</p>'
+	            +'<p>Tagged&nbsp;/'
+	            + tags
+	            + '</p>'
+	            + '</article>');
+	        });
+	      });
+	  }
+	  else {
+	    $('.search-no-results').show();
+	    $('.loading').remove();
+	    $('.search-results-count').append( 0 + ' search results');
+
+	  }
+	});
+
+
+/***/ },
 /* 19 */
 /***/ function(module, exports, __webpack_require__) {
 
@@ -25039,7 +25133,9 @@
 
 	      var hitsTriggers = $target.hasClass('js-glossary-toggle')
 	        || $target.hasClass('term')
-	        || $target.hasClass('icon-bars');
+	        || $target.hasClass('icon-bars')
+	        || $target.hasClass('drawer-search_button')
+	        || $target.hasClass('drawer-search_field');
 
 	      if (!hitsTriggers) {
 	        self.hide();

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -23505,14 +23505,17 @@
 	    }
 	  }
 
-	  var query = GetURLParameter('q') || '';
+	  var query = GetURLParameter('q') || '',
+	    apiKEY = eiti.beckleyApiKey;
+
 	  $(".search-string").append(query.replace(/%20/g,' '));
-	  $("#site-search-text").attr('value',query.replace(/%20/g,' '));
+	  $(".site-search-text").attr('value',query.replace(/%20/g,' '));
 	  if(query) {
-	    $("input#q").val(query);
-	    $("#search-result-list").append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
+	    $("input.q").val(query);
+	    $(".search-result-list").append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
+	    var url = "https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=" + query + "&size=50&from=0&api_key=" + apiKEY;
 	    $.ajax({
-	      url: "https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=" + query + "&size=50&from=0&api_key=LXJh2PKSC6zxY0YNuBRYgIj2JxSPcDwSPCZuHBG1",
+	      url: url,
 	      cache: false,
 	      dataType: "json"
 	    })
@@ -23520,10 +23523,10 @@
 	        $(".loading").remove();
 	        $("#search-results-count").append( json.hits.total + ' search results');
 	        if (json.hits.total == 0){
-	          $("#search-no-results").show();
+	          $(".search-no-results").show();
 	        }
 	        else{
-	          $("#search-no-results").remove();
+	          $(".search-no-results").remove();
 	        }
 
 	        $.each(json.hits.hits, function(i, hit){
@@ -23551,7 +23554,7 @@
 	          else {
 	            content_type = '<span class="glyphicon glyphicon-file"></span> ' + hit._source.content_type + '';
 	          }
-	          $("#search-results-container").append('<article class="search-result-list"><h1><a href="'
+	          $(".search-results-container").append('<article class="search-result-list"><h1><a href="'
 	            + hit._source.url
 	            + '" target="_blank">'
 	            + hit._source.title
@@ -23567,9 +23570,9 @@
 	      });
 	  }
 	  else {
-	    $("#search-no-results").show();
+	    $(".search-no-results").show();
 	    $(".loading").remove();
-	    $("#search-results-count").append( 0 + ' search results');
+	    $(".search-results-count").append( 0 + ' search results');
 
 	  }
 	});

--- a/pages/search-results.md
+++ b/pages/search-results.md
@@ -12,25 +12,25 @@ permalink: /search-results/
 
     <p class="search-intro">This is a curated search.<br/> Results are drawn from related websites across the U.S. government so  you can find extractive industries resources in one place.</p>
 
-    <div id="search-results-container">
+    <div class="search-results-container">
 
       <div class="search-header">
         <p>Search results for <strong class='search-string'></strong></p>
-        <p id="search-results-count"></p>
+        <p class="search-results-count"></p>
       </div>
 
-      <div id="search-results-container">
+      <div class="search-results-container">
         <h1 class="loading">Loading...</h1>
       </div>
 
-      <div class="search-no-results" id="search-no-results" style="display:none;">
+      <div class="search-no-results" style="display:none;">
         <h1>Sorry, no results were found for your search.</h1>
         <h2 class="h3">Try a new search:</h2>
 
         <div class="search-container">
           <form action='{{ site.baseurl }}/search-results/'>
             <label for='q' class='sr-only'>Search</label>
-            <input type="search" placeholder="Search related resources..." name="q" id="q"/>
+            <input type="search" placeholder="Search related resources..." name="q" class="q"/>
             <button type="submit" class="search-icon icon-search"></button>
           </form>
         </div>


### PR DESCRIPTION
[PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/beckley-federalist/search-results/?q=oil)

For #1439 and #1438 

This PR makes it so that the header is searchable from the header input, moves the api_key for beckley into the `_config.yml`, and removes several of the repeating ids that were causing the `seach-results` page to be less accessible and fail the HTML_CodeSniffer.

