### PR TITLE
Adds Issue and PR templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Expected Behavior
+
+## Actual Behavior
+
+## Steps to reproduce the behavior

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Fixes issue(s) # .
+
+[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/[BRANCH_NAME]/)
+
+Changes proposed in this pull request:
+
+-
+-
+-
+
+/cc relevant people


### PR DESCRIPTION
This adds templates that will jumpstart our issues and PRs. I mostly did this so that the preview link info exists when starting a PR.

```
[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/[BRANCH_NAME]/)
```