### PR TITLE
Add Circle CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
-# gem "rails"
 gem 'jekyll', '3.0.5'
 gem 'scss_lint', require: false
 gem 'html-proofer'

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+## Customize the test machine
+machine:
+  # Version of ruby to use
+  ruby:
+    version:
+      2.2.3
+
+## Customize dependencies
+dependencies:
+  pre:
+    - gem install jekyll -v '3.0.5'
+    - bundle install
+    - bundle exec jekyll build
+
+## Customize test commands
+test:
+  pre:
+    # - npm run test-html
+    - npm run test


### PR DESCRIPTION
This PR adds a basic config for `circle.yml` that essentially builds the site and runs `npm run tests` to catch the established mocha tests!

In the future we could add `npm run test-html`, but this is a good start.

See tests passing [here](https://circleci.com/gh/18F/doi-extractives-data/10)‼️‼️ 