### PR TITLE
Revenues/Process tab table

### DIFF
--- a/_includes/location/revenue-type-table.html
+++ b/_includes/location/revenue-type-table.html
@@ -5,7 +5,7 @@
   {% if include.id %}id="{{ include.id }}"{% endif %}>
   <thead>
     <tr>
-      <th class="arrow_box">Commodity</th>
+      <th class="arrow_box">Phase:</th>
       <th class="arrow_box">Securing a lease</th>
       <th class="arrow_box">Before production</th>
       <th class="arrow_box-last">During production</th>

--- a/_includes/location/revenue-type-table.html
+++ b/_includes/location/revenue-type-table.html
@@ -5,10 +5,10 @@
   {% if include.id %}id="{{ include.id }}"{% endif %}>
   <thead>
     <tr>
-      <th>Commodity</th>
-      <th>Securing a lease</th>
-      <th>Before production</th>
-      <th>During production</th>
+      <th class="arrow_box">Commodity</th>
+      <th class="arrow_box">Securing a lease</th>
+      <th class="arrow_box">Before production</th>
+      <th class="arrow_box-last">During production</th>
       <th>Other revenues</th>
     </tr>
   </thead>

--- a/_includes/location/revenue-type-table.html
+++ b/_includes/location/revenue-type-table.html
@@ -1,7 +1,7 @@
 {% assign revenue_types = site.data.state_revenues_by_type[include.location_id] %}
 {% assign revenue_type_names = 'Bonus;Rents;Royalties;Other Revenues' | split: ';' %}
 
-<table is="bar-chart-table" class="revenue"
+<table is="bar-chart-table" class="revenue table-basic"
   {% if include.id %}id="{{ include.id }}"{% endif %}>
   <thead>
     <tr>

--- a/_includes/location/section-process.html
+++ b/_includes/location/section-process.html
@@ -10,7 +10,7 @@
       <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" class="link-charlie">The story behind the numbers</a></li>
     </ul>
 
-    <article class="eiti-tab-panel info-tab-panel" id="revenues" role="tabpanel">
+    <article class="eiti-tab-panel" id="revenues" role="tabpanel">
       {%
         include location/revenue-type-table.html
         id='revenue-types'
@@ -20,7 +20,7 @@
       %}
     </article>
 
-    <article class="eiti-tab-panel info-tab-panel" id="story" role="tabpanel" aria-hidden="true">
+    <article class="eiti-tab-panel" id="story" role="tabpanel" aria-hidden="true">
       <img src="{{site.baseurl}}/img/revenue-streams-chart.png" alt="Select federal revenue streams and statutory and regulatory rates" class="article_img-100">
     </article>
 </div>

--- a/_includes/location/section-process.html
+++ b/_includes/location/section-process.html
@@ -21,6 +21,6 @@
     </article>
 
     <article class="eiti-tab-panel info-tab-panel" id="story" role="tabpanel" aria-hidden="true">
-      STORY
+      <img src="{{site.baseurl}}/img/revenue-streams-chart.png" alt="Select federal revenue streams and statutory and regulatory rates" class="article_img-100">
     </article>
 </div>

--- a/_includes/location/section-process.html
+++ b/_includes/location/section-process.html
@@ -3,3 +3,24 @@
   <p>When companies extract natural resources on federal land, they follow laws or policies that govern how rights are awarded and what fees they pay to the government. The specifics of the process depend on the kind of resource, and often affect how much revenue the federal government ultimately collects.</p>
   <p>For details, read more about the different processes for awarding rights and extracting resources: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 </section>
+
+<div class="tab-interface">
+    <ul class="eiti-tabs info-tabs" role="tablist">
+      <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" aria-selected="true">Commodity Revenues</a></li>
+      <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" class="link-charlie">The story behind the numbers</a></li>
+    </ul>
+
+    <article class="eiti-tab-panel info-tab-panel" id="revenues" role="tabpanel">
+      {%
+        include location/revenue-type-table.html
+        id='revenue-types'
+        location_id=state_id
+        location_name=state_name
+        year=year
+      %}
+    </article>
+
+    <article class="eiti-tab-panel info-tab-panel" id="story" role="tabpanel" aria-hidden="true">
+      STORY
+    </article>
+</div>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -80,6 +80,5 @@ nav_items:
 
 </main>
 
-<script src="{{ site.baseurl }}/js/components/bar-chart-table.js"></script>
-<script src="{{ site.baseurl }}/js/components/data-map.js"></script>
-<script type="text/javascript" src="{{ site.baseurl }}/js/lib/narrative.min.js" charset="utf-8"></script>
+<script type="text/javascript" src="{{ site.baseurl }}/js/lib/state-pages.min.js" charset="utf-8"></script>
+

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -61,6 +61,9 @@ $light-black: #303030;
 
 // State pages
 $green-land: #d5e5cb;
+$green-mint: #d2e2cc;
+$green-sea: #b1d39c;
+$green-dark: #657c60;
 
 // v2 - deprecate
 $putty: #f4f4f4;

--- a/_sass/blocks/_all.scss
+++ b/_sass/blocks/_all.scss
@@ -29,6 +29,15 @@
 @import 'landing';
 @import 'explore/all';
 
+
+// State pages
+//
+// Styles for the page at /states/
+//
+// Styleguide blocks.state-pages
+@import 'state-pages/info-tabs';
+@import 'state-pages/arrow-box';
+
 // About
 //
 // Styles for the page at /about/

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -1,15 +1,6 @@
 // Explore data callout on homepage
 //
 // Styleguide blocks.explore-home
-
-@mixin active-tab() {
-  background-color: $white;
-  border: 1px solid $neutral-gray;
-  border-bottom: 1px solid $white;
-  font-weight: $weight-bold;
-  text-decoration: none;
-}
-
 .explore_home-heading {
   margin-bottom: $base-padding;
 
@@ -64,6 +55,7 @@
 
   li {
     display: inline-block;
+    padding-bottom: 3px;
   }
 }
 

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -26,8 +26,6 @@
 }
 
 .explore_home-tabs {
-  @include heading(para-sm);
-  margin: 0;
   text-align: right;
 
   @include respond-to(tiny-down) {
@@ -41,16 +39,6 @@
     border: 1px solid transparent;
     color: $black;
     margin-right: $base-padding-lite;
-    padding: $base-padding-lite;
-
-    &[aria-selected="true"] {
-      @include active-tab();
-    }
-
-    &:hover,
-    &:focus {
-      @include active-tab();
-    }
   }
 
   li {
@@ -93,7 +81,6 @@
 }
 
 .explore_home-main {
-  border-top: 1px solid $neutral-gray;
   padding-top: $base-padding-large;
 }
 

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -27,7 +27,7 @@
 
 .explore_home-tabs {
   @include heading(para-sm);
-  margin-bottom: 3px;
+  margin: 0;
   text-align: right;
 
   @include respond-to(tiny-down) {

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -1,0 +1,90 @@
+table#revenue-types {
+  width: 100%;
+}
+
+#revenue-types {
+  thead th {
+    background-color: $green-mint;
+    height: 70px;
+    padding-left: 30px;
+    padding-right: 30px;
+    z-index: 100;
+    text-align: left;
+    font-size: 12px;
+    vertical-align: middle;
+    line-height: 1rem;
+  }
+
+  th:nth-child(1) {
+    padding-left: 15px;
+  }
+
+  th:nth-child(2) {
+    z-index: 50;
+  }
+
+  th:nth-child(3) {
+    z-index: 40;
+  }
+
+  th:nth-child(4) {
+    z-index: 30;
+  }
+
+  th:nth-child(5) {
+    z-index: 20;
+  }
+
+  th:last-child {
+    padding-left: 15px;
+    z-index: 0;
+  }
+
+
+  .arrow_box,
+  .arrow_box-last {
+    position: relative;
+    background: $green-mint;
+  }
+
+  .arrow_box-last {
+    border-right: 2px solid $white;
+  }
+
+  .arrow_box:first-of-type {
+    background: $green-sea;
+    font-weight: $weight-bold;
+
+    &::after {
+      border-left-color: $green-sea;
+    }
+  }
+
+  .arrow_box:after, .arrow_box:before {
+    left: 100%;
+    top: 50%;
+    border: solid transparent;
+    content: "";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+  }
+
+  .arrow_box:after {
+    border-color: rgba(136, 183, 213, 0);
+    border-left-color: $green-mint;
+    border-width: 36px 0 36px 16px;
+    margin-top: -36px;
+  }
+
+  .arrow_box:before {
+    border-color: transparent;
+    border-left-color: white;
+    border-width: 40px 0 40px 18px;
+    margin-top: -40px;
+  }
+
+
+
+}

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -83,7 +83,7 @@ $ab-padding-half: $ab-padding / 2;
 
   .arrow_box::before {
     border-color: transparent;
-    border-left-color: white;
+    border-left-color: $white;
     border-width: $ab-wrap 0 $ab-wrap $ab-w-indent;
     margin-top: -$ab-wrap;
   }

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -1,49 +1,52 @@
-$arrow-box-height: 70px;
-$arrow-box-half: $arrow-box-height / 2;
-$arrow-box-gutter: 2px;
-$arrow-box-wrap: $arrow-box-half + (2 * $arrow-box-gutter);
-$arrow-box-h-indent: ($arrow-box-half / 2);
-$arrow-box-w-indent: ($arrow-box-half / 2) + $arrow-box-gutter;
-$arrow-box-padding: 30px;
+$ab-height: 70px;
+$ab-height-half: $ab-height / 2;
+$ab-gutter: 2px;
+$ab-wrap: $ab-height-half + (2 * $ab-gutter);
+$ab-h-indent: ($ab-height-half / 2);
+$ab-w-indent: ($ab-height-half / 2) + $ab-gutter;
+$ab-padding: 30px;
+$ab-padding-half: $ab-padding / 2;
 
 #revenue-types {
   width: 100%;
 
-  thead th {
-    background-color: $green-mint;
-    font-size: 12px;
-    height: $arrow-box-height;
-    line-height: $base-line-height;
-    padding-left: $arrow-box-padding;
-    padding-right: $arrow-box-padding;
-    text-align: left;
-    vertical-align: middle;
-    z-index: 100;
-  }
+  thead {
+    th {
+      @include heading('para-md');
 
-  th:nth-child(1) {
-    padding-left: $arrow-box-padding / 2;
-  }
+      background-color: $green-mint;
+      height: $ab-height;
+      padding-left: $ab-padding;
+      padding-right: $ab-padding-half;
+      text-align: left;
+      vertical-align: middle;
+      z-index: 100;
+    }
 
-  th:nth-child(2) {
-    z-index: 50;
-  }
+    th:nth-child(1) {
+      padding-left: $ab-padding-half;
+    }
 
-  th:nth-child(3) {
-    z-index: 40;
-  }
+    th:nth-child(2) {
+      z-index: 50;
+    }
 
-  th:nth-child(4) {
-    z-index: 30;
-  }
+    th:nth-child(3) {
+      z-index: 40;
+    }
 
-  th:nth-child(5) {
-    z-index: 20;
-  }
+    th:nth-child(4) {
+      z-index: 30;
+    }
 
-  th:last-child {
-    padding-left: $arrow-box-padding / 2;
-    z-index: 0;
+    th:nth-child(5) {
+      z-index: 20;
+    }
+
+    th:last-child {
+      padding-left: $ab-padding-half;
+      z-index: 0;
+    }
   }
 
   .arrow_box,
@@ -53,7 +56,7 @@ $arrow-box-padding: 30px;
   }
 
   .arrow_box-last {
-    border-right: $arrow-box-gutter solid $white;
+    border-right: $ab-gutter solid $white;
   }
 
   .arrow_box:first-of-type {
@@ -81,14 +84,14 @@ $arrow-box-padding: 30px;
   .arrow_box::before {
     border-color: transparent;
     border-left-color: white;
-    border-width: $arrow-box-wrap 0 $arrow-box-wrap $arrow-box-w-indent;
-    margin-top: -$arrow-box-wrap;
+    border-width: $ab-wrap 0 $ab-wrap $ab-w-indent;
+    margin-top: -$ab-wrap;
   }
 
   .arrow_box:after {
     border-color: transparent;
     border-left-color: $green-mint;
-    border-width: $arrow-box-half 0 $arrow-box-half $arrow-box-h-indent;
-    margin-top: -$arrow-box-half;
+    border-width: $ab-height-half 0 $ab-height-half $ab-h-indent;
+    margin-top: -$ab-height-half;
   }
 }

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -69,8 +69,8 @@ $ab-padding-half: $ab-padding / 2;
     }
   }
 
-  .arrow_box:before,
-  .arrow_box:after {
+  .arrow_box::before,
+  .arrow_box::after {
     border: solid transparent;
     content: '';
     height: 0;
@@ -81,14 +81,14 @@ $ab-padding-half: $ab-padding / 2;
     width: 0;
   }
 
-  .arrow_box:before {
+  .arrow_box::before {
     border-color: transparent;
     border-left-color: $white;
     border-width: $ab-wrap 0 $ab-wrap $ab-w-indent;
     margin-top: -$ab-wrap;
   }
 
-  .arrow_box:after {
+  .arrow_box::after {
     border-color: transparent;
     border-left-color: $green-mint;
     border-width: $ab-height-half 0 $ab-height-half $ab-h-indent;

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -53,6 +53,7 @@ table#revenue-types {
 
   .arrow_box:first-of-type {
     background: $green-sea;
+    color: $white;
     font-weight: $weight-bold;
 
     &::after {

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -23,27 +23,27 @@ $ab-padding-half: $ab-padding / 2;
       z-index: 100;
     }
 
-    th::nth-child(1) {
+    th:nth-child(1) {
       padding-left: $ab-padding-half;
     }
 
-    th::nth-child(2) {
+    th:nth-child(2) {
       z-index: 50;
     }
 
-    th::nth-child(3) {
+    th:nth-child(3) {
       z-index: 40;
     }
 
-    th::nth-child(4) {
+    th:nth-child(4) {
       z-index: 30;
     }
 
-    th::nth-child(5) {
+    th:nth-child(5) {
       z-index: 20;
     }
 
-    th::last-child {
+    th:last-child {
       padding-left: $ab-padding-half;
       z-index: 0;
     }
@@ -59,7 +59,7 @@ $ab-padding-half: $ab-padding / 2;
     border-right: $ab-gutter solid $white;
   }
 
-  .arrow_box::first-of-type {
+  .arrow_box:first-of-type {
     background: $green-sea;
     color: $white;
     font-weight: $weight-bold;
@@ -69,8 +69,8 @@ $ab-padding-half: $ab-padding / 2;
     }
   }
 
-  .arrow_box::before,
-  .arrow_box::after {
+  .arrow_box:before,
+  .arrow_box:after {
     border: solid transparent;
     content: '';
     height: 0;
@@ -81,14 +81,14 @@ $ab-padding-half: $ab-padding / 2;
     width: 0;
   }
 
-  .arrow_box::before {
+  .arrow_box:before {
     border-color: transparent;
     border-left-color: $white;
     border-width: $ab-wrap 0 $ab-wrap $ab-w-indent;
     margin-top: -$ab-wrap;
   }
 
-  .arrow_box::after {
+  .arrow_box:after {
     border-color: transparent;
     border-left-color: $green-mint;
     border-width: $ab-height-half 0 $ab-height-half $ab-h-indent;

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -1,22 +1,28 @@
-table#revenue-types {
-  width: 100%;
-}
+$arrow-box-height: 70px;
+$arrow-box-half: $arrow-box-height / 2;
+$arrow-box-gutter: 2px;
+$arrow-box-wrap: $arrow-box-half + (2 * $arrow-box-gutter);
+$arrow-box-h-indent: ($arrow-box-half / 2);
+$arrow-box-w-indent: ($arrow-box-half / 2) + $arrow-box-gutter;
+$arrow-box-padding: 30px;
 
 #revenue-types {
+  width: 100%;
+
   thead th {
     background-color: $green-mint;
-    height: 70px;
-    padding-left: 30px;
-    padding-right: 30px;
-    z-index: 100;
-    text-align: left;
     font-size: 12px;
+    height: $arrow-box-height;
+    line-height: $base-line-height;
+    padding-left: $arrow-box-padding;
+    padding-right: $arrow-box-padding;
+    text-align: left;
     vertical-align: middle;
-    line-height: 1rem;
+    z-index: 100;
   }
 
   th:nth-child(1) {
-    padding-left: 15px;
+    padding-left: $arrow-box-padding / 2;
   }
 
   th:nth-child(2) {
@@ -36,19 +42,18 @@ table#revenue-types {
   }
 
   th:last-child {
-    padding-left: 15px;
+    padding-left: $arrow-box-padding / 2;
     z-index: 0;
   }
 
-
   .arrow_box,
   .arrow_box-last {
-    position: relative;
     background: $green-mint;
+    position: relative;
   }
 
   .arrow_box-last {
-    border-right: 2px solid $white;
+    border-right: $arrow-box-gutter solid $white;
   }
 
   .arrow_box:first-of-type {
@@ -61,31 +66,29 @@ table#revenue-types {
     }
   }
 
-  .arrow_box:after, .arrow_box:before {
-    left: 100%;
-    top: 50%;
+  .arrow_box::before,
+  .arrow_box::after {
     border: solid transparent;
     content: "";
     height: 0;
-    width: 0;
-    position: absolute;
+    left: 100%;
     pointer-events: none;
+    position: absolute;
+    top: 50%;
+    width: 0;
+  }
+
+  .arrow_box::before {
+    border-color: transparent;
+    border-left-color: white;
+    border-width: $arrow-box-wrap 0 $arrow-box-wrap $arrow-box-w-indent;
+    margin-top: -$arrow-box-wrap;
   }
 
   .arrow_box:after {
-    border-color: rgba(136, 183, 213, 0);
-    border-left-color: $green-mint;
-    border-width: 36px 0 36px 16px;
-    margin-top: -36px;
-  }
-
-  .arrow_box:before {
     border-color: transparent;
-    border-left-color: white;
-    border-width: 40px 0 40px 18px;
-    margin-top: -40px;
+    border-left-color: $green-mint;
+    border-width: $arrow-box-half 0 $arrow-box-half $arrow-box-h-indent;
+    margin-top: -$arrow-box-half;
   }
-
-
-
 }

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -23,27 +23,27 @@ $ab-padding-half: $ab-padding / 2;
       z-index: 100;
     }
 
-    th:nth-child(1) {
+    th::nth-child(1) {
       padding-left: $ab-padding-half;
     }
 
-    th:nth-child(2) {
+    th::nth-child(2) {
       z-index: 50;
     }
 
-    th:nth-child(3) {
+    th::nth-child(3) {
       z-index: 40;
     }
 
-    th:nth-child(4) {
+    th::nth-child(4) {
       z-index: 30;
     }
 
-    th:nth-child(5) {
+    th::nth-child(5) {
       z-index: 20;
     }
 
-    th:last-child {
+    th::last-child {
       padding-left: $ab-padding-half;
       z-index: 0;
     }
@@ -59,7 +59,7 @@ $ab-padding-half: $ab-padding / 2;
     border-right: $ab-gutter solid $white;
   }
 
-  .arrow_box:first-of-type {
+  .arrow_box::first-of-type {
     background: $green-sea;
     color: $white;
     font-weight: $weight-bold;
@@ -72,7 +72,7 @@ $ab-padding-half: $ab-padding / 2;
   .arrow_box::before,
   .arrow_box::after {
     border: solid transparent;
-    content: "";
+    content: '';
     height: 0;
     left: 100%;
     pointer-events: none;
@@ -88,7 +88,7 @@ $ab-padding-half: $ab-padding / 2;
     margin-top: -$ab-wrap;
   }
 
-  .arrow_box:after {
+  .arrow_box::after {
     border-color: transparent;
     border-left-color: $green-mint;
     border-width: $ab-height-half 0 $ab-height-half $ab-h-indent;

--- a/_sass/blocks/state-pages/_info-tabs.scss
+++ b/_sass/blocks/state-pages/_info-tabs.scss
@@ -26,7 +26,3 @@
   }
 
 }
-
-.info-tab-panel {
-  padding: 0;
-}

--- a/_sass/blocks/state-pages/_info-tabs.scss
+++ b/_sass/blocks/state-pages/_info-tabs.scss
@@ -10,23 +10,25 @@
 
   li {
     display: inline-block;
-    padding-bottom: 3px;
+    padding-bottom: $base-padding-lite;
+    padding-top: $base-padding-lite;
+
   }
 
   a {
     background-color: $mid-gray;
     border: 0;
+    border-bottom: 2px solid $mid-gray;
     color: $base-font-color;
     padding: $base-padding-lite;
 
-
     &[aria-selected="true"] {
-      @include active-tab('green');
+      @include active-tab('info');
     }
 
     &:hover,
     &:focus {
-      @include active-tab('green');
+      @include active-tab('info');
     }
   }
 

--- a/_sass/blocks/state-pages/_info-tabs.scss
+++ b/_sass/blocks/state-pages/_info-tabs.scss
@@ -1,18 +1,11 @@
 .info-tabs {
-  @include heading(para-sm);
-
   border-bottom: 5px solid $green-dark;
-  margin: 0;
   margin-bottom: $base-padding-lite;
   padding: 0;
-  text-align: left;
-
 
   li {
-    display: inline-block;
     padding-bottom: $base-padding-lite;
     padding-top: $base-padding-lite;
-
   }
 
   a {

--- a/_sass/blocks/state-pages/_info-tabs.scss
+++ b/_sass/blocks/state-pages/_info-tabs.scss
@@ -1,0 +1,37 @@
+.info-tabs {
+  @include heading(para-sm);
+
+  border-bottom: 5px solid $green-dark;
+  margin: 0;
+  margin-bottom: $base-padding-lite;
+  padding: 0;
+  text-align: left;
+
+
+  li {
+    display: inline-block;
+    padding-bottom: 3px;
+  }
+
+  a {
+    background-color: $mid-gray;
+    border: 0;
+    color: $base-font-color;
+    padding: $base-padding-lite;
+
+
+    &[aria-selected="true"] {
+      @include active-tab('green');
+    }
+
+    &:hover,
+    &:focus {
+      @include active-tab('green');
+    }
+  }
+
+}
+
+.info-tab-panel {
+  padding: 0;
+}

--- a/_sass/blocks/state-pages/_info-tabs.scss
+++ b/_sass/blocks/state-pages/_info-tabs.scss
@@ -13,7 +13,8 @@
     border: 0;
     border-bottom: 2px solid $mid-gray;
     color: $base-font-color;
-    padding: $base-padding-lite;
+    padding: $base-padding-lite $base-padding;
+
 
     &[aria-selected="true"] {
       @include active-tab('info');

--- a/_sass/components/_all.scss
+++ b/_sass/components/_all.scss
@@ -19,3 +19,4 @@
 @import 'breadcrumbs';
 @import 'flowchart';
 @import 'panel';
+@import 'tabs';

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -16,6 +16,7 @@
 
   a {
     padding: $base-padding-lite;
+    text-decoration: none;
 
     &[aria-selected="true"] {
       @include active-tab();

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -1,0 +1,34 @@
+.eiti-tabs {
+  @include heading(para-sm);
+
+  border-bottom: 1px solid $neutral-gray;
+  margin: 0;
+  padding: $base-padding-lite;
+  padding-bottom: 0;
+  text-align: left;
+
+
+
+  li {
+    display: inline-block;
+    padding-bottom: 3px;
+  }
+
+  a {
+    padding: $base-padding-lite;
+
+    &[aria-selected="true"] {
+      @include active-tab();
+    }
+
+    &:hover,
+    &:focus {
+      @include active-tab();
+    }
+  }
+
+}
+
+.eiti-tab-panel {
+  padding: $base-padding;
+}

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -31,5 +31,5 @@
 }
 
 .eiti-tab-panel {
-  padding: $base-padding;
+  padding: 0;
 }

--- a/_sass/elements/_tables.scss
+++ b/_sass/elements/_tables.scss
@@ -40,10 +40,10 @@ td {
 
   thead {
     border: 0;
-  }
 
-  thead tr {
-    border: 0;
+    tr {
+      border: 0;
+    }
   }
 
   tr {

--- a/_sass/elements/_tables.scss
+++ b/_sass/elements/_tables.scss
@@ -33,3 +33,25 @@ th:first-child {
 td {
   border: 1px solid $mid-gray;
 }
+
+
+.table-basic {
+  border: 0;
+
+  thead {
+    border: 0;
+  }
+
+  thead tr {
+    border: 0;
+  }
+
+  tr {
+    border: 0;
+    border-bottom: 2px solid $mid-gray;
+  }
+
+  td {
+    border: 0;
+  }
+}

--- a/_sass/mixins/_all.scss
+++ b/_sass/mixins/_all.scss
@@ -1,3 +1,4 @@
 @import 'type-mixins';
 @import 'rotate';
 @import 'padded-in-mobile';
+@import 'tabs';

--- a/_sass/mixins/_tabs.scss
+++ b/_sass/mixins/_tabs.scss
@@ -6,6 +6,7 @@
     background-color: $green-dark;
     border-bottom: 2px solid $green-dark;
     color: $white;
+    padding-bottom: 6px;
   } @else {
     background-color: $white;
     border: 1px solid $neutral-gray;

--- a/_sass/mixins/_tabs.scss
+++ b/_sass/mixins/_tabs.scss
@@ -1,0 +1,18 @@
+@mixin active-tab($color:"") {
+
+	@if $color == 'green' {
+		background-color: $green-dark;
+		color: $white;
+	  border-bottom: 1px solid $green-dark;
+	}
+
+	@else {
+		background-color: $white;
+    color: $base-font-color;
+    border: 1px solid $neutral-gray;
+	  border-bottom: 1px solid $white;
+	}
+
+  font-weight: $weight-bold;
+  text-decoration: none;
+}

--- a/_sass/mixins/_tabs.scss
+++ b/_sass/mixins/_tabs.scss
@@ -1,18 +1,15 @@
-@mixin active-tab($color:"") {
-
-	@if $color == 'info' {
-		background-color: $green-dark;
-		color: $white;
-	  border-bottom: 2px solid $green-dark;
-	}
-
-	@else {
-		background-color: $white;
-    color: $base-font-color;
-    border: 1px solid $neutral-gray;
-	  border-bottom: 1px solid $white;
-	}
-
+@mixin active-tab($color:'') {
   font-weight: $weight-bold;
   text-decoration: none;
+
+  @if $color == 'info' {
+    background-color: $green-dark;
+    border-bottom: 2px solid $green-dark;
+    color: $white;
+  } @else {
+    background-color: $white;
+    border: 1px solid $neutral-gray;
+    border-bottom: 1px solid $white;
+    color: $base-font-color;
+  }
 }

--- a/_sass/mixins/_tabs.scss
+++ b/_sass/mixins/_tabs.scss
@@ -1,9 +1,9 @@
 @mixin active-tab($color:"") {
 
-	@if $color == 'green' {
+	@if $color == 'info' {
 		background-color: $green-dark;
 		color: $white;
-	  border-bottom: 1px solid $green-dark;
+	  border-bottom: 2px solid $green-dark;
 	}
 
 	@else {

--- a/index.html
+++ b/index.html
@@ -22,13 +22,13 @@ title: Home
     <p class="h5 explore_home-subhead">Explore data</p>
     <h2 class="h3 explore_home-heading explore_home-explore_heading">Learn about extractive industries throughout the country</h2>
 
-    <ul class="explore_home-tabs" role="tablist">
+    <ul class="eiti-tabs explore_home-tabs" role="tablist">
       <li role="presentation"><a href="#revenue" tabindex="0" role="tab" aria-controls="revenue" aria-selected="true" class="link-charlie">Revenue</a></li>
       <li role="presentation"><a href="#production" tabindex="-1" role="tab" aria-controls="production" class="link-charlie">Production</a></li>
       <li role="presentation"><a href="#impact" tabindex="-1" role="tab" aria-controls="impact" class="link-charlie"><span class="explore_home-tab_mobile">Impact</span><span class="explore_home-tab_desktop">Economic Impact</span></a></li>
     </ul>
 
-    <section class="explore_home-main" id="revenue" role="tabpanel">
+    <section class="eiti-tab-panel explore_home-main" id="revenue" role="tabpanel">
       <div class="container-left-3">
         <p>Revenue data shows where federal revenue from extractive industries is coming from, who pays it, and where it goes.</p>
         <a href="{{ site.baseurl }}/explore/#revenue" class="button-primary explore_home-button">Explore data</a>
@@ -47,7 +47,7 @@ title: Home
       </aside>
     </section>
 
-    <section class="explore_home-main" id="production" role="tabpanel" aria-hidden="true">
+    <section class="eiti-tab-panel explore_home-main" id="production" role="tabpanel" aria-hidden="true">
       <div class="container-left-3">
         <p>For the first time, data on all production on federal lands is available publicly. See how much energy was produced nationally, or explore all resources extracted on federal lands.</p>
         <a href="{{ site.baseurl }}/explore/#production" class="button-primary explore_home-button">Explore data</a>

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -49,7 +49,7 @@
 	  'use strict';
 
 	  __webpack_require__(1);
-	  exports.OpenListNav = __webpack_require__(23);
+	  var OpenListNav = __webpack_require__(23);
 
 	  // exporting instance of OpenListNav because openListNav is
 	  // referenced in the markup:

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -53,7 +53,8 @@
 
 	  __webpack_require__(4);
 	  __webpack_require__(1);
-	  exports.OpenListNav = __webpack_require__(23);
+
+	  var OpenListNav = __webpack_require__(23);
 
 	  // exporting instance of OpenListNav because openListNav is
 	  // referenced in the markup:

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -1,0 +1,781 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 0:
+/***/ function(module, exports, __webpack_require__) {
+
+	(function(exports) {
+	  'use strict';
+
+	  __webpack_require__(24);
+	  __webpack_require__(25);
+
+	  __webpack_require__(4);
+	  __webpack_require__(1);
+	  exports.OpenListNav = __webpack_require__(23);
+
+	  // exporting instance of OpenListNav because openListNav is
+	  // referenced in the markup:
+	  // _includes/hash_selecor.html
+	  exports.openListNav = new OpenListNav();
+
+	})(window);
+
+
+
+/***/ },
+
+/***/ 1:
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  var scrollLeft,
+	    scrollTop;
+
+	  var findScrollPositions = function(){
+	    scrollLeft = (window.pageXOffset !== undefined)
+	      ? window.pageXOffset
+	      : (document.documentElement
+	        || document.body.parentNode
+	        || document.body).scrollLeft;
+	    scrollTop = (window.pageYOffset !== undefined)
+	      ? window.pageYOffset
+	      : (document.documentElement
+	        || document.body.parentNode
+	        || document.body).scrollTop;
+
+	  };
+
+	  var StickyNav = function() {
+
+	    this.elems = {
+	      sticky : document.querySelector('.sticky_nav'),
+	      main: document.querySelector('main')
+	    };
+
+	    this.attrStickyOffset = this.elems.sticky.getAttribute('data-sticky-offset');
+	    this.attrOffsetBottom = parseInt(this.elems.sticky.getAttribute('data-offset-bottom')) || 0;
+	    this.maxWidth = this.elems.sticky.getAttribute('data-max-width');
+	    var attrAbsolute = this.elems.sticky.getAttribute('data-absolute');
+
+	    this.attrParent = this.elems.sticky.getAttribute('data-offset-parent');
+
+	    this.elems.parent = this.elems.sticky.getAttribute('data-offset-parent')
+	      ? this.elems.sticky.parentNode
+	      : null;
+
+	    this.determineScreen = function() {
+	      var windowWidth = window.innerWidth || document.body.clientWidth;
+	      this.wasMobile = this.isMobile;
+	      this.isMobile = windowWidth < 768;
+	    };
+
+	    this.determineScreen();
+
+	    this.isAbsolute = function() {
+
+	      var isAbsolute = (attrAbsolute === 'true' && !this.isMobile)
+	        ? true
+	        : false;
+	      return isAbsolute;
+	    }
+
+
+
+
+	    this.status;
+	    this.lastStatus;
+	    this.lastWidth;
+	    this.lastWindowWidth;
+	  };
+
+	  StickyNav.prototype = {
+	    setOffset: function () {
+	      this.offset = this.attrStickyOffset
+	        ? parseInt(this.attrStickyOffset)
+	        : !this.elems.parent
+	          ? this.elems.sticky.offsetTop
+	          : ( this.attrParent === 'mobile' && this.isMobile )
+	            ? this.elems.parent.offsetTop - this.elems.sticky.offsetHeight
+	            : this.elems.sticky.offsetTop
+	    },
+	    getPositions: function () {
+
+	      this.height = this.elems.sticky.clientHeight;
+
+	      this.lastWidth = this.width || 'initial';
+	      var windowWidth = window.innerWidth || document.body.clientWidth,
+	        windowBump = windowWidth > 1044 || this.isMobile ? 0 : -20;
+	      this.width = this.elems.parent
+	        ? this.elems.parent.clientWidth + windowBump + 'px'
+	        : this.maxWidth;
+
+	      this.mainOffset = this.elems.main.offsetTop;
+	      this.mainHeight = this.elems.main.clientHeight;
+
+	      this.diffTop = scrollTop - this.mainOffset - this.offset;
+
+	      this.diffBottom = scrollTop + this.height - this.mainHeight - this.mainOffset;
+	      this.lastStatus = this.status;
+	      if (this.diffTop >= 0){
+	        this.status = 'fixed';
+	        if (this.diffBottom >= 0){
+	          this.status = 'absolute';
+	        }
+	      } else {
+	        this.status = 'static';
+	      }
+	    },
+	    needsUpdate: function(init) {
+	      var statusChange = this.status !== this.lastStatus;
+	      var sizeChange = this.width !== this.lastWidth;
+	      var updateNeeded = undefined;
+	      if (!statusChange && sizeChange) {
+	        updateNeeded = 'size';
+	      } else if (statusChange && !sizeChange) {
+	        updateNeeded = 'status';
+	      } else if (statusChange && sizeChange || init === 'init') {
+	        updateNeeded = 'both';
+	      }
+	      return updateNeeded;
+	    },
+	    update: function(updateNeeded) {
+	      if (!updateNeeded) {
+	        return;
+	      } else {
+	        if (this.diffTop >= 0){
+	          if (updateNeeded === 'status' || updateNeeded === 'both') {
+	            this.elems.sticky.style.position = 'fixed';
+	            this.elems.sticky.style.top = 0;
+	            this.elems.sticky.classList.remove('js-transparent');
+	            this.elems.sticky.classList.add('js-color');
+	          }
+
+	          if (updateNeeded === 'size' || updateNeeded === 'both') {
+	            this.elems.sticky.style.width = this.width;
+	          }
+
+	          if (this.diffBottom >= 0){
+	            if (updateNeeded === 'status' || updateNeeded === 'both') {
+	              this.elems.sticky.style.position = 'absolute';
+
+	              if ( this.attrParent === 'mobile' && this.isMobile ) {
+	                this.elems.sticky.style.top = this.mainHeight - this.offset - this.height - this.attrOffsetBottom + 'px';
+	              } else {
+	                this.elems.sticky.style.top = this.mainHeight - this.height - this.attrOffsetBottom + 'px';
+	              }
+	            }
+	          }
+	        } else {
+	          if (updateNeeded === 'status' || updateNeeded === 'both') {
+	            this.elems.sticky.classList.remove('js-color');
+	            this.elems.sticky.classList.add('js-transparent');
+	            if (this.isAbsolute()) {
+	              this.elems.sticky.style.position = 'absolute';
+	            } else {
+	              this.elems.sticky.style.position = 'static';
+	            }
+	          }
+
+	          if (updateNeeded === 'size' || updateNeeded === 'both') {
+	            this.elems.sticky.style.width = this.width;
+	          }
+	        }
+	      }
+	    },
+	    throttle : function (fn, threshhold, scope) {
+	      threshhold || (threshhold = 250);
+	      var last,
+	          deferTimer;
+	      return function () {
+	        var context = scope || this;
+
+	        var now = +new Date,
+	            args = arguments;
+	        if (last && now < last + threshhold) {
+	          // hold on to it
+	          clearTimeout(deferTimer);
+	          deferTimer = setTimeout(function () {
+	            last = now;
+	            fn.apply(context, args);
+	          }, threshhold);
+	        } else {
+	          last = now;
+	          fn.apply(context, args);
+	        }
+	      };
+	    },
+	    run: function(init) {
+	      findScrollPositions();
+	      if (init === 'init') {
+	        this.setOffset();
+	      }
+	      this.getPositions();
+	      this.update(this.needsUpdate(init));
+	    }
+	  };
+
+	  var stickyNav = new StickyNav();
+
+	  var loadDelay = stickyNav.elems.sticky.getAttribute('data-load-delay');
+	  if (loadDelay) {
+	    setTimeout(function() {
+	      stickyNav.run('init');
+	    }, parseInt(loadDelay));
+	  } else {
+	    stickyNav.run('init');
+	  }
+
+
+
+	  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
+
+	  window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
+
+	  // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+	  var observer = new MutationObserver(function () {
+	    stickyNav.run();
+	  });
+
+	  // set up your configuration
+	  // this will watch to see if you insert or remove any children
+	  var config = { subtree: true, childList: true };
+
+	  // start observing
+	  observer.observe(stickyNav.elems.sticky, config);
+
+	  // other potential elem listener
+	  // http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/
+
+	  exports.stickyNav = stickyNav;
+
+
+	})(this);
+
+
+/***/ },
+
+/***/ 4:
+/***/ function(module, exports) {
+
+	$( document ).ready(function() {
+	// ARIA Tab Interface
+	// Thanks to Practical ARIA Examples
+	// http://heydonworks.com/practical_aria_examples/#tab-interface
+
+	// The class for the container div
+
+	var $container = '.tab-interface';
+
+	// The setup
+
+	$($container +' ul').attr('role','tablist');
+	$($container +' [role="tablist"] li').attr('role','presentation');
+	$('[role="tablist"] a').attr({
+	    'role' : 'tab',
+	    'tabindex' : '-1'
+	});
+
+	// Make each aria-controls correspond id of targeted section (re href)
+
+	$('[role="tablist"] a').each(function() {
+	  $(this).attr(
+	    'aria-controls', $(this).attr('href').substring(1)
+	  );
+	});
+
+	// Make the first tab selected by default and allow it focus
+
+	$('[role="tablist"] li:first-child a').attr({
+	    'aria-selected' : 'true',
+	    'tabindex' : '0'
+	});
+
+	// Make each section focusable and give it the tabpanel role
+
+	$($container +' section').attr({
+	  'role' : 'tabpanel'
+	});
+
+	// Make first child of each panel focusable programmatically
+
+	$($container +' section > *:first-child').attr({
+	    'tabindex' : '0'
+	});
+
+	// Make all but the first section hidden (ARIA state and display CSS)
+
+	$('[role="tabpanel"]:not(:first-of-type)').attr({
+	  'aria-hidden' : 'true'
+	});
+
+	// Change focus between tabs with arrow keys
+
+	$('[role="tab"]').on('keydown', function(e) {
+
+	  // define current, previous and next (possible) tabs
+
+	  var $original = $(this);
+	  var $prev = $(this).parents('li').prev().children('[role="tab"]');
+	  var $next = $(this).parents('li').next().children('[role="tab"]');
+	  var $target;
+
+	  // find the direction (prev or next)
+
+	  switch (e.keyCode) {
+	    case 37:
+	      $target = $prev;
+	      break;
+	    case 39:
+	      $target = $next;
+	      break;
+	    default:
+	      $target = false
+	      break;
+	  }
+
+	  if ($target.length) {
+	      $original.attr({
+	        'tabindex' : '-1',
+	        'aria-selected' : null
+	      });
+	      $target.attr({
+	        'tabindex' : '0',
+	        'aria-selected' : true
+	      }).focus();
+	  }
+
+	  // Hide panels
+
+	  $($container +' [role="tabpanel"]')
+	    .attr('aria-hidden', 'true');
+
+	  // Show panel which corresponds to target
+
+	  $('#' + $(document.activeElement).attr('href').substring(1))
+	    .attr('aria-hidden', null);
+
+	});
+
+	// Handle click on tab to show + focus tabpanel
+
+	$('[role="tab"]').on('click', function(e) {
+
+	  e.preventDefault();
+
+	  // remove focusability [sic] and aria-selected
+
+	  $('[role="tab"]').attr({
+	    'tabindex': '-1',
+	    'aria-selected' : null
+	    });
+
+	  // replace above on clicked tab
+
+	  $(this).attr({
+	    'aria-selected' : true,
+	    'tabindex' : '0'
+	  });
+
+	  // Hide panels
+
+	  $($container +' [role="tabpanel"]').attr('aria-hidden', 'true');
+
+	  // show corresponding panel
+
+	  $('#' + $(this).attr('href').substring(1))
+	    .attr('aria-hidden', null);
+
+	});
+
+	});
+
+
+/***/ },
+
+/***/ 23:
+/***/ function(module, exports) {
+
+	(function(exports) {
+	    function getScrollTop() {
+	      return (window.pageYOffset !== undefined)
+	        ? window.pageYOffset
+	        : (document.documentElement
+	          || document.body.parentNode
+	          || document.body).scrollTop;
+	    }
+
+	    function isElementInViewport(el) {
+	      var rect = el.getBoundingClientRect();
+
+	      return rect.bottom > 0 &&
+	          rect.right > 0 &&
+	          rect.left < (window.innerWidth || document. documentElement.clientWidth) &&
+	          rect.top < (window.innerHeight || document. documentElement.clientHeight);
+	    }
+
+	    exports.OpenListNav = function() {
+	      // init OpenListNav Properties
+	      this.active = window.location.hash || '#intro';
+	      this.navItems = document.querySelectorAll('[data-nav-item]');
+	      this.navSelect = $('[data-nav-options]');
+	      this.navIsSelect = !!this.navSelect.length;
+	      this.navHeaders = document.querySelectorAll('[data-nav-header]');
+	      this.scrollTop = {
+	        current: getScrollTop(),
+	        prev: getScrollTop(),
+	        direction: 'down'
+	      };
+
+	      this.registerEventHandlers();
+	    };
+
+	    exports.OpenListNav.prototype = {
+	      updateScrollTop: function() {
+	        this.scrollTop.prev = this.scrollTop.current;
+	        this.scrollTop.current = getScrollTop();
+	        this.scrollTop.direction = (this.scrollTop.current >= this.scrollTop.prev)
+	          ? 'down'
+	          : 'up';
+	      },
+
+	      removeActive: function(){
+	        this.active = null;
+	        for (var i = 0; i < this.navItems.length; i++) {
+	          this.navItems[i].setAttribute('data-active', false);
+	        }
+	      },
+
+	      addActive: function(el, name){
+	        if (!el){
+	          el = document.querySelector('[data-nav-item="' + name + '"]');
+	          this.active = name;
+	          el.setAttribute('data-active', true);
+	        } else {
+	          this.active = el.getAttribute('data-nav-item');
+	          el.setAttribute('data-active', true);
+	        }
+	      },
+
+	      update: function(el, name){
+	        this.removeActive();
+	        this.addActive(el, name);
+	      },
+
+	      updateSelectField: function(newValue) {
+	        if (newValue){
+	          this.navSelect.val(newValue);
+	        }
+	      },
+
+	      registerEventHandlers: function(){
+	        var self = this;
+	        if (!this.navIsSelect) {
+	          for (var i = 0; i < this.navItems.length; i++) {
+	            var item = this.navItems[i];
+	            item.addEventListener('click', function () {
+	              self.update(this);
+	            });
+	          }
+	        }
+
+	        window.addEventListener('scroll', function() {
+	          self.updateScrollTop();
+	          // TODO: throttle
+	          self.detectNavChange();
+	        });
+
+	        window.addEventListener('resize', function(){
+	          // TODO: throttle
+	          self.detectNavChange();
+	        });
+
+	      },
+
+	      changeHandler: function(selector) {
+	        window.location.hash = selector.value;
+	      },
+
+
+	      detectNavChange: function(){
+
+	        var self = this;
+
+	        // initialize nav status as not updated
+	        var updated = false;
+
+	         Array.prototype.forEach.call(this.navHeaders, function(header){
+	           var inViewPort = isElementInViewport(header);
+	           if (inViewPort && !self.navIsSelect && !updated) {
+	              var newName = header.name || header.id;
+	              self.update(null, newName);
+	              updated = true;
+	           } else if(inViewPort && self.navIsSelect && !updated) {
+	             var newName = header.name || header.id;
+	            self.updateSelectField(newName);
+	             updated = true;
+	           }
+	        });
+	      }
+	    };
+
+	    module.exports = exports.OpenListNav;
+	  })(this);
+
+
+/***/ },
+
+/***/ 24:
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  var initialize = function() {
+	    this._cells = [].slice.call(this.querySelectorAll('tr > [data-value]'));
+	    this.update();
+	  };
+
+	  var update = function() {
+	    if (!this._cells.length) {
+	      return;
+	    }
+
+	    var series = {};
+	    var autolabel = this.getAttribute('autolabel') === 'true';
+
+	    this._cells.forEach(function(cell) {
+	      var key = cell.dataset.series || 'default';
+	      if (key in series) {
+	        series[key].push(cell);
+	      } else {
+	        series[key] = [cell];
+	      }
+	    });
+
+	    Object.keys(series).forEach(function(key) {
+	      var cells = series[key];
+	      var values = cells.map(function(cell) {
+	        return +cell.dataset.value;
+	      });
+
+	      var extent = d3.extent(values);
+	      if (this.hasAttribute('data-' + key + '-min')) {
+	        extent[0] = +this.dataset[key + 'Min'];
+	      } else if (this.hasAttribute('data-min')) {
+	        extent[0] = +this.dataset.min;
+	      } else {
+	        extent[0] = Math.min(extent[0], 0);
+	      }
+
+	      if (this.hasAttribute('data-' + key + '-max')) {
+	        extent[1] = +this.dataset[key + 'Max'];
+	      } else if (this.hasAttribute('data-max')) {
+	        extent[1] = +this.dataset.max;
+	      }
+
+	      var range = [0, 100];
+	      var min = extent[0];
+	      var max = extent[1];
+	      var negative = min < 0;
+	      var zero = 0;
+	      var width = d3.scale.linear()
+	        .domain(extent)
+	        .range(range)
+	        .clamp(true);
+
+	      var offset;
+	      var sizeProperty = 'width';
+	      var offsetProperty = 'margin-left';
+
+	      if (negative) {
+	        var length = max - min;
+	        zero = 100 * (0 - min) / length;
+	        offset = d3.scale.linear()
+	          .domain([min, 0, max])
+	          .range([0, zero, zero])
+	          .clamp(true);
+	        width = d3.scale.linear()
+	          .domain([min, 0, max])
+	          .range([100 * -min / length, 0, 100 * max / length])
+	          .clamp(true);
+	      }
+
+	      if (this.orient === 'vertical') {
+	        sizeProperty = 'height';
+	        offsetProperty = 'bottom';
+	      }
+
+	      cells.forEach(function(cell, i) {
+	        if (!cell) {
+	          console.warn('no cell @', i);
+	          return;
+	        }
+
+	        // TODO only do this if autolabel="true"?
+	        if (cell.childNodes.length === 1 && cell.firstChild.nodeType === Node.TEXT_NODE) {
+	          if (autolabel) {
+	            cell.setAttribute('aria-label', cell.firstChild.textContent);
+	            cell.removeChild(cell.firstChild);
+	          } else {
+	            var text = cell.removeChild(cell.firstChild);
+	            var span = cell.appendChild(document.createElement('span'));
+	            span.className = 'text';
+	            span.appendChild(text);
+	          }
+	        }
+
+	        var bar = cell.querySelector('.bar');
+	        if (!bar) {
+	          bar = document.createElement('div');
+	          bar.className = 'bar';
+	          cell.appendChild(bar);
+	        }
+
+	        var value = +cell.dataset.value;
+	        var size = width(value);
+	        bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
+	        if (offset) {
+	          bar.style.setProperty(offsetProperty, offset(value) + '%');
+	        } else {
+	          bar.style.removeProperty(offsetProperty);
+	        }
+	      });
+
+	    }, this);
+	  };
+
+	  exports.EITIBarChartTable = document.registerElement('bar-chart-table', {
+	    'extends': 'table',
+	    prototype: Object.create(
+	      HTMLTableElement.prototype,
+	      {
+	        attachedCallback: {value: initialize},
+
+	        attributeChangedCallback: {value: function(attr, old, value) {
+	          switch (attr) {
+	            case 'orient':
+	              this.update();
+	          }
+	        }},
+
+	        update: {value: update},
+
+	        orient: {
+	          get: function() {
+	            return this.getAttribute('orient');
+	          },
+	          set: function(value) {
+	            if (value !== this.orient) {
+	              this.setAttribute('orient', value);
+	            }
+	          }
+	        }
+	      }
+	    )
+	  });
+
+	})(this);
+
+
+/***/ },
+
+/***/ 25:
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  exports.EITIDataMap = document.registerElement('data-map', {
+	    prototype: Object.create(
+	      HTMLElement.prototype,
+	      {
+	        attachedCallback: {value: function() {
+	          this.update();
+	        }},
+
+	        update: {value: function() {
+	          var type = this.getAttribute('scale-type') || 'quantize';
+	          var scheme = this.getAttribute('color-scheme') || 'Blues';
+	          var steps = this.getAttribute('steps') || 5;
+	          var colors = colorbrewer[scheme][steps];
+	          if (!colors) {
+	            return console.error(
+	              'bad # of steps (%d) for color scheme:', steps, scheme
+	            );
+	          }
+
+	          var marks = d3.select(this)
+	            .selectAll('svg [data-value]')
+	            .datum(function() {
+	              return +this.getAttribute('data-value') || 0;
+	            });
+
+	          var domain = this.hasAttribute('domain')
+	            ? JSON.parse(this.getAttribute('domain'))
+	            : d3.extent(marks.data());
+
+	          if (domain[0] > 0) {
+	            domain[0] = 0;
+	          } else if (domain[0] < 0) {
+	            domain[1] = Math.max(0, domain[1]);
+	          }
+
+	          // FIXME: do something with divergent scales??
+
+	          var scale = d3.scale[type]()
+	            .domain(domain)
+	            .range(colors);
+
+	          marks.attr('fill', scale);
+	        }}
+	      }
+	    )
+	  });
+
+	})(this);
+
+
+/***/ }
+
+/******/ });

--- a/js/src/narrative.js
+++ b/js/src/narrative.js
@@ -2,7 +2,7 @@
   'use strict';
 
   require('./../components/sticky-nav.js');
-  exports.OpenListNav = require('./../components/open-list-nav.js');
+  var OpenListNav = require('./../components/open-list-nav.js');
 
   // exporting instance of OpenListNav because openListNav is
   // referenced in the markup:

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -6,7 +6,8 @@
 
   require('./../components/aria-tabs.js');
   require('./../components/sticky-nav.js');
-  exports.OpenListNav = require('./../components/open-list-nav.js');
+
+  var OpenListNav = require('./../components/open-list-nav.js');
 
   // exporting instance of OpenListNav because openListNav is
   // referenced in the markup:

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -1,0 +1,17 @@
+(function(exports) {
+  'use strict';
+
+  require('./../components/bar-chart-table.js');
+  require('./../components/data-map.js');
+
+  require('./../components/aria-tabs.js');
+  require('./../components/sticky-nav.js');
+  exports.OpenListNav = require('./../components/open-list-nav.js');
+
+  // exporting instance of OpenListNav because openListNav is
+  // referenced in the markup:
+  // _includes/hash_selecor.html
+  exports.openListNav = new OpenListNav();
+
+})(window);
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ var config = {
     'narrative.min': './js/src/narrative.js',
     'explore.min': './js/src/explore.js',
     'homepage.min': './js/src/homepage.js',
+    'state-pages.min': './js/src/state-pages.js',
   },
 
   output: {


### PR DESCRIPTION
Fixes issue(s) #1433

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-pages-tables/)


Changes proposed in this pull request:

- makes a new js file [`src/state-pages.js`](https://github.com/18F/doi-extractives-data/pull/1449/files#diff-fbca2654d407c04806d7604120796e80R5) to house all state-pages specific js code. cc/ @shawnbot would you do this differently?
- slightly modified styling on existing homepage table
- added tabs to revenue table on state page
- adds image of process table
- adds stylized table header `arrow_box` is what @meiqimichelle and I are calling it.