### PR TITLE
sorted out some section heirarchy issues and revised content

### DIFF
--- a/_includes/location/revenue-type-row-oilgas.html
+++ b/_includes/location/revenue-type-row-oilgas.html
@@ -7,7 +7,7 @@
   %}
   <th scope="row" rowspan="2" data-value="{{ total }}">
     <a href="#revenue-{{ commodity_name | slugify }}">
-      <strong>Oil &amp; Gas</strong><br>
+      <strong>Oil &amp; Gas </strong><br>
     </a>
     <strong>${{ total | intcomma }}</strong>
   </th>

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -4,10 +4,11 @@
 
   <h2>Natural resource production in {{ state_name }}</h2>
 
-  <p>The federal government collects data about all energy-related natural resources produced in each state on all lands, including federal, state, and privately owned property. (For coal, there is also data about mining in each county.)</p>
-  <p>In some cases, the specific amount of a resource produced in a state or county is withheld to protect trade secrets.</p>
-
   <h3>Production in all of {{ state_name }}</h3>
+
+  <p>The federal government collects data about all energy-related natural resources produced in each state on all lands, including federal, state, and privately owned property. (For coal, there is also data about mining in each county.)</p>
+  
+  <p>In some cases, the specific amount of a resource produced in a state or county is withheld to protect trade secrets.</p>
 
   <div class="chart-list">
 

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -40,7 +40,7 @@
         {%
           include location/display-exports.html
           values=exports
-          percent=true
+          percent=false
         %}
       </div>
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -2,7 +2,7 @@
 
 <section id="federal-production" class="federal production">
 
-  <h2>Natural resource production on federal land</h2>
+  <h3>Natural resource production on federal land</h2>
 
   <p>When companies extract natural resources on federal land, they report how much of each resource was extracted in each county.</p>
   <p>In a few cases, usually where one company is extracting a resource in a county, production data is withheld to ensure there are no violations of the Trade Secrets Act.</p>

--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -1,6 +1,10 @@
 <section id="overview" data-nav-header="overview">
 
-  <p>The United States is large enough that data about extractive industries is often most meaningful at the state or local level. Each state has different natural resources, land ownership, and local laws and regulations. This page summarizes USEITI information about the state of {{ state_name }}.</p>
+  <p>USEITI reporting includes data about extractive industries in each state. This page summarizes information from the USEITI reporting process about natural resources in {{ state_name }} and what role extractive industries play in the state economy.</p>
+
+<!--   <p>The USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state, so this page also includes state legal and fiscal information.</p>
+  <p>To learn more about communities in {{ state_name }} with significant extractive activity, see case studies.</p>
+  <p>{{ state_name }} has opted into USEITI sub-national reporting, so this page also includes information about extractive industries activity on state-owned land.</p> -->
 
 <!--   <section class="panel-gray container-outer">
 

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -7,16 +7,17 @@
 
   <h2>Revenue</h2>
 
-  <p>When companies want to extract natural resources on federal land, they pay fees depending on where they are in the process of using the land. For instance, a company might pay for the right to explore for resources, pay rent while exploring the land, and then pay a percentage of production value once they start producing resources on the land.</p>
+  <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called ‘revenue’ because they represent revenue to the American public.</p>
+
+  <h3>Revenue from federal land</h3>
 
   <section class="container-half">
 
-    <h3>Revenue from federal land</h3>
+    <p>When companies want to extract natural resources on federal land, they pay fees depending on where they are in the process of using the land.</p>
 
-    <p>{{ site.data.land_stats[state_id].federal_percent | percent }} percent of land in {{ state_name }} is owned by the federal government.</p>
+    <p>Laws and policies govern how rights are awarded to companies and what fees they pay to the government in order to extract natural resources on federal land. The specifics of the process depend on the kind of resource, and often affect how much revenue the federal government ultimately collects.</p>
 
-    <p>In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose).</p>
-
+    <p>For details, read more about the different processes for awarding rights and extracting resources: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
   </section>
 
   <aside class="container-half county-map-table">
@@ -38,14 +39,9 @@
 
   <section>
     <div>
-      <h3>Revenues during phases of production on federal lands</h3>
-      <p>Laws and policies govern how rights are awarded to companies and what fees they pay to the government in order to extract natural resources on federal land. The specifics of the process depend on the kind of resource, and often affect how much revenue the federal government ultimately collects.</p>
+      <p>The federal government collects different fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected for each kind of resource during each phase of production.</p>
 
-      <p>For details, read more about the different processes for awarding rights and extracting resources: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
-
-      <p>At each phase of natural resource extraction, the federal government collects different fees. This chart shows how much federal revenue was collected for each kind of resource during each phase of production.</p>
-
-      <p>PUT THIS IN THE CHART: Companies may not know whether they’ll produce oil or gas until they explore the land, so fees are not differentiated by product until production begins.</p>
+      <!-- <p><strong>In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose).</strong></p> -->
     </div>
   </section>
 
@@ -75,12 +71,12 @@
       %}
     </article>
   </div>
+  <p><em>* Companies may not know whether they’ll produce oil or gas until they explore the land, so fees are not differentiated by product until production begins.</em></p>
 
   <section id="revenue-commodities" class="chart-list has-intro">
 
-    <h3>Revenue from extraction on federal land over time</h3>
-
-    <p class="chart-list-intro">At each phase of natural resource extraction, the federal government collects different fees. This chart shows how much federal revenue was collected for each kind of resource during each phase of production.</p>
+    <h4>Revenue from extraction on federal land in Utah over time</h3>
+    <p class="chart-list-intro">In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government, and companies that extract natural resources on federal land pay fees to the federal government. This chart shows how much federal revenue was collected each year in {{ state_name }}.</p>
 
     {% for commodity in revenue_commodities %}
       {% assign revenue = commodity[1][year].revenue %}

--- a/_includes/location/section-state-production.html
+++ b/_includes/location/section-state-production.html
@@ -3,3 +3,8 @@
   <p>Natural resource extraction on land owned by the State of {{ state_name }} is governed by <a href="{{ site.baseurl }}/how-it-works/state-laws-and-regulations/#role-of-state-government-agencies/</a>">state laws and regulations</a>.</p>
   <p>We don't have detailed data about natural resource extraction on land owned by the state.</p>
 </section>
+
+<section id="private-land-production" class="production">
+  <h3>Natural resource production on private land</h3>
+  <p>We don't have detailed data about natural resource extraction on land owned by individuals or corporations.</p>
+</section>


### PR DESCRIPTION
Changes proposed in this pull request:

- De-dupes some section headers in revenue, and makes that content more concise.
- Removes percentages from exports because they were percentages of _top 25 exports only_, which was confusing.
- Added a brief placeholder for private-lands production info (or lack thereof).

/cc @meiqimichelle @gemfarmer 

