### PR TITLE
Intro revision and other content refinements

### DIFF
--- a/_includes/location/key-all-production.html
+++ b/_includes/location/key-all-production.html
@@ -7,7 +7,7 @@
     <p>{{ include.location_name }} leads the nation in production of these resources:</p>
       <ul>
       {% for product in top_all_products %}
-        {% if product.rank < 3 %}
+        {% if product.rank < 2 %}
           <li><a href="#all-production-{{ product.product | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }} percent of U.S. production</li>
         {% endif %}
       {% if forloop.index == include.top %}{% break %}{% endif %}

--- a/_includes/location/key-all-production.html
+++ b/_includes/location/key-all-production.html
@@ -2,16 +2,16 @@
 {% assign all_products_num = all_products | size %}
 
 {% if include.top %}
-    {% assign top_all_products = site.data.top_state_products[include.location_id].all_production[include.year] %}
-    {% if top_all_products %}
-    <p>{{ include.location_name }} leads the nation in production of these resources:</p>
-      <ul>
-      {% for product in top_all_products %}
-        {% if product.rank < 2 %}
-          <li><a href="#all-production-{{ product.product | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }} percent of U.S. production</li>
-        {% endif %}
-      {% if forloop.index == include.top %}{% break %}{% endif %}
-      {% endfor %}
-      </ul>
-    {% endif %}
+  {% assign top_all_products = site.data.top_state_products[include.location_id].all_production[include.year] %}
+  {% if top_all_products %}
+  <p>{{ include.location_name }} leads the nation in production of these resources:</p>
+    <ul>
+    {% for product in top_all_products %}
+      {% if product.rank < 2 %}
+        <li><a href="#all-production-{{ product.product | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }} percent of U.S. production</li>
+      {% endif %}
+    {% if forloop.index == include.top %}{% break %}{% endif %}
+    {% endfor %}
+    </ul>
   {% endif %}
+{% endif %}

--- a/_includes/location/key-all-production.html
+++ b/_includes/location/key-all-production.html
@@ -1,24 +1,17 @@
 {% assign all_products = site.data.state_all_production[include.location_id].products %}
 {% assign all_products_num = all_products | size %}
 
-{% if all_products_num > 0 %}
-  {{ include.location_name }} produced
-  <a href="#all-production">{{ all_products | size }} product{{ all_products | size | plural }}</a>
-  on all lands and waters in {{ include.year }}.
-  {% if include.top %}
+{% if include.top %}
     {% assign top_all_products = site.data.top_state_products[include.location_id].all_production[include.year] %}
     {% if top_all_products %}
-    These are some of the most notable:
-    <ul class="top-products list-bullet">
+    <p>{{ include.location_name }} leads the nation in production of these resources:</p>
+      <ul>
       {% for product in top_all_products %}
-      <li><a href="#all-production-{{ product.product | slugify }}">{{ product.product }}</a>:
-        #{{ product.rank }} ({{ product.percent | floor }}%)</li>
+        {% if product.rank < 3 %}
+          <li><a href="#all-production-{{ product.product | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }} percent of U.S. production</li>
+        {% endif %}
       {% if forloop.index == include.top %}{% break %}{% endif %}
       {% endfor %}
-    </ul>
+      </ul>
     {% endif %}
   {% endif %}
-{% else %}
-  We have no record of production on all lands and waters in {{ include.location_name }} in {{ include.year }}.
-{% endif %}
-

--- a/_includes/location/key-all-production.html
+++ b/_includes/location/key-all-production.html
@@ -2,15 +2,13 @@
 {% assign all_products_num = all_products | size %}
 
 {% if include.top %}
-  {% assign top_all_products = site.data.top_state_products[include.location_id].all_production[include.year] %}
-  {% if top_all_products %}
+  {% assign top_all_products = site.data.top_state_products[include.location_id].all_production[include.year] | where: 'rank', 1 %}
+  {% if top_all_products.size > 0 %}
   <p>{{ include.location_name }} leads the nation in production of these resources:</p>
     <ul>
     {% for product in top_all_products %}
-      {% if product.rank < 2 %}
-        <li><a href="#all-production-{{ product.product | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }} percent of U.S. production</li>
-      {% endif %}
-    {% if forloop.index == include.top %}{% break %}{% endif %}
+    <li><a href="#all-production-{{ product.product | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }} percent of U.S. production</li>
+      {% if forloop.index == include.top %}{% break %}{% endif %}
     {% endfor %}
     </ul>
   {% endif %}

--- a/_includes/location/key-gdp.html
+++ b/_includes/location/key-gdp.html
@@ -2,10 +2,10 @@
 {% assign gdp_dollars = gdp[include.year].dollars %}
 
 {% if gdp_dollars > 0 %}
-  The extractives industry contributed
-  <a href="#gdp">${{ gdp_dollars | intcomma }}</a>
-  toward {{ include.location_name }}'s GDP in {{ include.year }}, or
-  {{ gdp[include.year].percent | percent }}%.
+  Extractive industries accounted for
+  <a href="#gdp">{{ gdp[include.year].percent | percent }} percent</a>
+  of {{ include.location_name }}'s gross domestic product (GDP) in {{ include.year }}.
+  <!-- ${{ gdp_dollars | intcomma }} -->
 {% else %}
   The extractives industry did not have any effect on GDP in
   {{ include.location_name }} in {{ include.year }}.

--- a/_includes/location/key-jobs.html
+++ b/_includes/location/key-jobs.html
@@ -1,11 +1,11 @@
 {% assign jobs = site.data.state_jobs[include.location_id] %}
 {% assign jobs_count = jobs[include.year].count %}
-{% if jobs_count %}
-  The extractives industry created
-  <a href="#employment">{{ jobs_count | intcomma }} jobs</a>
-  on average in {{ include.location_name }} in {{ include.year }},
-  or {{ jobs[year].percent | percent }}% of state-wide employment.
-{% else %}
-  The extractives industry did not create any jobs in
-  {{ include.location_name }} in {{ include.year }}.
+{% assign jobs_percent = jobs[include.year].percent %}
+
+{% if jobs_percent > 2 %}
+  Jobs in the extractive industries made up 
+  <a href="#employment">{{ jobs_percent | percent }} 
+  percent</a> 
+  of statewide employment in 
+  {{ include.year }}.
 {% endif %}

--- a/_includes/location/key-revenue.html
+++ b/_includes/location/key-revenue.html
@@ -1,12 +1,18 @@
 {% assign revenue_commodities = site.data.state_revenues[include.location_id].commodities %}
 {% assign revenue_total = revenue_commodities.All[include.year].revenue %}
 
-{% if revenue_total %}
-  {{ include.location_name }} generated
-  <strong>${{ revenue_total | intcomma }} in federal revenue</strong>
-  from
-  <a href="#revenue">{{ revenue_commodities | size }} commodit{{ revenue_commodities | size | plural: 'ies', 'y' }}</a>
-  in {{ include.year }}.
+
+In {{ include.year }},
+natural resource extraction on federal land in
+{{ include.location_name }} generated 
+  {% if revenue_total %}
+    <a href="#revenue">${{ revenue_total | intcomma }} in federal revenue</a>.
+  {% else %}
+    no federal revenue.
+  {% endif %}
+
+
+<!-- {% if revenue_total %}
   {% if include.top %}
     {% assign top_revenue_products = site.data.top_state_products[include.location_id].revenue[include.year] %}
     {% if top_revenue_products %}
@@ -23,4 +29,4 @@
   {% endif %}
 {% else %}
   {{ include.location_name }} generated no federal revenue in {{ include.year }}.
-{% endif %}
+{% endif %} -->

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -36,7 +36,7 @@
       <p>
         {% if volume %}{{ volume | intcomma }} {{ units }} of
         {% else %}No{% endif %}
-        {{ product[0] | downcase }} was extracted in {{ state_name }} in {{ year }}.
+        {{ product_name | downcase }} was extracted in {{ state_name }} in {{ year }}.
       </p>
       <h4>
         <button is="aria-toggle"

--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -1,84 +1,56 @@
 <section id="overview" data-nav-header="overview">
 
-  <p>USEITI reporting includes data about extractive industries in each state. This page summarizes information from the USEITI reporting process about natural resources in {{ state_name }} and what role extractive industries play in the state economy.</p>
+<!-- <p>USEITI reporting includes data about extractive industries in each state. This page summarizes information from the USEITI reporting process about natural resources in {{ state_name }} and what role extractive industries play in the state economy.</p> -->
 
-<!--   <p>The USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state, so this page also includes state legal and fiscal information.</p>
-  <p>To learn more about communities in {{ state_name }} with significant extractive activity, see case studies.</p>
-  <p>{{ state_name }} has opted into USEITI sub-national reporting, so this page also includes information about extractive industries activity on state-owned land.</p> -->
+<!-- <p>The USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state, so this page also includes state legal and fiscal information.</p>
+<p>To learn more about communities in {{ state_name }} with significant extractive activity, see case studies.</p>
+<p>{{ state_name }} has opted into USEITI sub-national reporting, so this page also includes information about extractive industries activity on state-owned land.</p> -->
 
-<!--   <section class="panel-gray container-outer">
+  <section class="panel-gray container-outer">
 
-    <p>{%
+    <p>
+      {%
         include location/key-gdp.html
         location_id=state_id
         location_name=state_name
         year=year
-      %}</p>
+      %}
 
-    <hr/>
-
-    <ul class="list-bullet key-facts">
-
-      <li class="revenue">{%
-        include location/key-revenue.html
+      {%
+        include location/key-jobs.html
         location_id=state_id
         location_name=state_name
         year=year
-        top=top_products
-      %}</li>
+      %}
 
-      <li class="production all-production">{%
+      {%
         include location/key-all-production.html
         location_id=state_id
         location_name=state_name
         year=year
         top=top_products
-      %}</li>
+      %}
+    </p>
 
-      <li class="production federal-production">{%
-        include location/key-federal-production.html
+    <p>
+      USEITI focuses on <!-- has the most --> data about natural resource extraction on federal land, which represents {{ site.data.land_stats[state_id].federal_percent | percent }} percent of all land in {{ state_name }}. 
+      {%
+        include location/key-revenue.html
         location_id=state_id
         location_name=state_name
         year=year
         top=top_products
-      %}</li>
+      %}</p>
 
-      <li class="employment">{%
-        include location/key-jobs.html
+    <!--
+      {% capture disbursements_summary %}
+      {%
+        include location/key-disbursements.html
         location_id=state_id
         location_name=state_name
         year=year
-      %}</li>
-
-      <li class="gdp">{%
-        include location/key-gdp.html
-        location_id=state_id
-        location_name=state_name
-        year=year
-      %}</li>
-
-      <li class="exports">
-        {% capture exports_summary %}
-        {%
-          include location/key-exports.html
-          location_id=state_id
-          location_name=state_name
-          year=year
-        %}
-        {% endcapture %}{{ exports_summary }}
-      </li>
-
-      <li class="disbursements">
-        {% capture disbursements_summary %}
-        {%
-          include location/key-disbursements.html
-          location_id=state_id
-          location_name=state_name
-          year=year
-        %}
-        {% endcapture %}{{ disbursements_summary }}
-      </li>
-
-    </ul>
-  </section> -->
+      %}
+      {% endcapture %}{{ disbursements_summary }}
+    -->
+  </section>
 </section>

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -2,10 +2,10 @@
 {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ state_id }}.svg{% endcapture %}
 <section id="ownership" data-nav-header="ownership" class="container-outer">
   
-  <h2>Land ownership</h2>
+  <h3>Land ownership</h3>
 
   <section class="container-half">
-    <h3>In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government.</h3>
+    <strong>In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government.</strong>
 
     <p>When companies extract natural resources on federal land, they pay royalties, rents, bonuses, and other fees — much like they would to any landowner. Companies also report more data about their activities on government-owned land than on private land. Learn more about <a href="{{ site.baseurl }}/how-it-works/ownership/">natural resources and land ownership in the U.S.</a></p>
   </section>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -75,7 +75,7 @@
 
   <section id="revenue-commodities" class="chart-list has-intro">
 
-    <h4>Revenue from extraction on federal land in Utah over time</h3>
+    <h4>Revenue from extraction on federal land in {{ state_name }} over time</h3>
     <p class="chart-list-intro">In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government, and companies that extract natural resources on federal land pay fees to the federal government. This chart shows how much federal revenue was collected each year in {{ state_name }}.</p>
 
     {% for commodity in revenue_commodities %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -4,15 +4,15 @@ nav_items:
   - name: overview
     title: Overview
   - name: ownership
-    title: Land Ownership
+    title: Land ownership
   - name: revenue
     title: Revenue
   - name: all-production
     title: Production
+  - name: gdp
+    title: Economic impact
   - name: employment
     title: Employment
-  - name: gdp
-    title: GDP
   - name: exports
     title: Exports
   - name: disbursements
@@ -50,9 +50,9 @@ nav_items:
 
     {% include location/section-state-production.html %}
 
-    {% include location/section-jobs.html %}
-
     {% include location/section-gdp.html %}
+
+    {% include location/section-jobs.html %}
 
     {% include location/section-exports.html %}
 

--- a/_plugins/data.rb
+++ b/_plugins/data.rb
@@ -49,27 +49,6 @@ module EITI
       (start..finish).to_a
     end
 
-    # filter a list of objects by whether a key is above or below a value:
-    #
-    # threshold([...], 'foo', '>', 10) # or 'gt'
-    # threshold([...], 'foo', '<', 10) # or 'lt'
-    # threshold([...], 'foo', '>=', 10) # or 'gte'
-    # threshold([...], 'foo', '<=', 10) # or 'lte'
-    def threshold(list, key, op, value=nil)
-      if not list.is_a? Array
-        return []
-      elsif op == '<' or op == 'lt'
-        return list.select { |d| d[key] < value }
-      elsif op == '<=' or op == 'lte'
-        return list.select { |d| d[key] <= value }
-      elsif op == '>' or op == 'gt'
-        return list.select { |d| d[key] > value }
-      elsif op == '>=' or op == 'gte'
-        return list.select { |d| d[key] >= value }
-      end
-      list.select { |d| d[key] >= op }
-    end
-
     def to_f(x)
       (x.is_a? Array) ? x.map(&:to_f) : x.to_f
     end

--- a/_plugins/data.rb
+++ b/_plugins/data.rb
@@ -49,6 +49,27 @@ module EITI
       (start..finish).to_a
     end
 
+    # filter a list of objects by whether a key is above or below a value:
+    #
+    # threshold([...], 'foo', '>', 10) # or 'gt'
+    # threshold([...], 'foo', '<', 10) # or 'lt'
+    # threshold([...], 'foo', '>=', 10) # or 'gte'
+    # threshold([...], 'foo', '<=', 10) # or 'lte'
+    def threshold(list, key, op, value=nil)
+      if not list.is_a? Array
+        return []
+      elsif op == '<' or op == 'lt'
+        return list.select { |d| d[key] < value }
+      elsif op == '<=' or op == 'lte'
+        return list.select { |d| d[key] <= value }
+      elsif op == '>' or op == 'gt'
+        return list.select { |d| d[key] > value }
+      elsif op == '>=' or op == 'gte'
+        return list.select { |d| d[key] >= value }
+      end
+      list.select { |d| d[key] >= op }
+    end
+
     def to_f(x)
       (x.is_a? Array) ? x.map(&:to_f) : x.to_f
     end


### PR DESCRIPTION
Progress on issue #1465 🎉 

Changes proposed in this pull request:

- Brings back "key facts", but in simplified sentence form. Hopefully this will help users see quickly what's interesting about extractives in each state, or at least get a sense of the overall scale.
- Fixes a stray "Utah" so that the appropriate state displays instead.
- Change "GDP" in the nav to "economic impact", in hopes of reducing acronyms
- Tidies up a few product names to remove duplication of units
- Downgrades the header level of Land Ownership to avoid confusion (this may need further adjustment, but it's a start)

@shawnbot — tagging you so you can remove the key facts intro sentence for states without products in the #1 spot. (See West Virginia for an example.)

/cc @meiqimichelle: thoughts?! Does this make sense? Do we need more intro/boilerplate here, or do you think it's working in this super-concise version?