### PR TITLE
State exports summary

### DIFF
--- a/_includes/location/key-exports.html
+++ b/_includes/location/key-exports.html
@@ -3,14 +3,10 @@
 {% assign exports_commodities_num = exports | size | minus: 2 %}
 
 {% if exports_commodities_num > 0 %}
-  {{ include.location_name }} exported
-  {{ exports_commodities_num }} extractives
-  product{{ exports_commodities_num | plural }} in {{ include.year }},
-  generating
+  In {{ include.year }}, 
+  {{ exports_commodities_num }} extractive industries 
+  product{{ exports_commodities_num | plural }} ranked among the top 25 exports from {{ include.location_name }}, generating
   <a href="#exports">${{ exports.All[include.year].dollars | intcomma }}</a>
   in export revenue, or
-  {{ exports.All[include.year].percent | percent }}%.
-{% else %}
-  Extractive industries did not account for any of
-  {{ include.location_name }}'s top 25 exports in {{ include.year }}.
+  {{ exports.All[include.year].percent | percent }} percent of all export revenue.
 {% endif %}

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -6,6 +6,7 @@
 
   <div class="chart-list has-intro">
 
+  {% if export_commodities %}
     <div class="chart-list-intro">
       <p>{{ exports_summary | strip_html }}</p>
     </div>
@@ -43,10 +44,12 @@
           percent=false
         %}
       </div>
-
     </section><!-- /.chart-item -->
     {% endfor %}
-
+  {% else %}
+    <p>In {{ year }}, extractive industries products did not rank among the top 25 exports from {{ state_name }}.</p>
+  {% endif %}
   </div><!-- /.chart-list -->
 
+  <p><a href="{{ site.baseurl }}/downloads/#exports">Exports data comes from the U.S. Census Bureau</a>.</p>
 </section>


### PR DESCRIPTION
Goes to issue #1376. I also added a comment on #1503, because these numbers seem awfully high.

Changes proposed in this pull request:

- Revises exports summary sentence to explain the top-25 situation better
- Adds an if statement so it only displays charts if there are extractives products in the top 25
- Adds a link to the data (we'll need to do this for more sections, this is just the first)

/cc @meiqimichelle @gemfarmer @shawnbot 
