### PR TITLE
Sidenav with submenu

### DIFF
--- a/_case-studies/boone-logan-and-mingo.md
+++ b/_case-studies/boone-logan-and-mingo.md
@@ -7,7 +7,7 @@ resource: coal
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -30,11 +30,11 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 Coal has driven economic development across Boone, Logan, and Mingo counties for many decades. In 1742, Explorer John Peter Salley first discovered bituminous coal in what would later become Boone County. Although forest extraction was the first major industry in the region, large-scale coal mining began in Boone County in the 1880s. The arrival of the Norfolk & Western Railroad in the 1890s and the Chesapeake & Ohio Railroad soon thereafter launched a coal extraction boom in all three counties. The early decades of the twentieth century marked a period of frenzied development in these counties. In the decades that followed, coal continued to drive the counties’ economies, but population numbers declined as mechanization and a shift to greater surface mining reduced the need for labor.[^3]
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 In 2013, 37 underground mines and 31 surface mines were operating across the three counties.[^4] In all three counties, the top ten landowners own at least 50% of private land.[^5] Notable operations include Boone County’s Twilight Mountaintop Removal Surface Mine (2.5 million tons in 2013) and Hobet 21 Surface Mine (2.3 million tons in 2013).[^6] [^7]
 
@@ -42,25 +42,25 @@ Cumulatively, mines in Boone, Logan, and Mingo counties produced 32.7 million to
 
 <img src="{{ site.baseurl }}/img/counties/wv-production.png" alt="Coal Production: Boone, Logan, and Mingo Counties from 2004-2013" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 Coal extraction has provided employment in these communities for the past century, but employment is declining in tandem with the region’s dropping production levels and the industry’s increased mechanization. In 2013, the combined population of the three counties was 88,211.[^10] That year, 3,427 people were employed at underground mines and 1,601 people were employed at surface mines across the three counties.[^11] This translates to 19% of the total employed population, or 6% of the total population. These numbers marked a 20% drop in the sector’s employment since 2007.[^12] The following graph illustrates changes in mining employment across these three counties from 2004 through 2013, compared with employment in all other industries.[^13] [^14]
 
 <img src="{{ site.baseurl }}/img/counties/wv-wage.png" alt="Boone, Logan, and Mingo Counties Mining Industry vs. All Other Industries Wage and Salary Employment from 2004–2013" class="case_studies_content-graph">
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 West Virginia levies three primary state tax mechanisms to collect coal revenue and distribute it to counties. The most significant of these mechanisms is the Coal Severance Tax, which amounts to 5% of the sale price of mined coal.[^15] 75% of net proceeds from this tax are distributed to coal-producing counties, while the remaining 25% is divided amongst all counties and municipalities in the state.[^16] In 2013, Boone, Logan, and Mingo counties received $7.7 million out of a total $32.5 million collected by the state from this tax.[^17]
 
 Boone, Logan, and Mingo also benefit from the Coal County Reallocation Severance Tax (an additional coal severance tax specifically for the counties in which the coal was located at the time it was extracted) and the Waste Coal Tax (a severance tax on coal produced from refuse, gob piles, and slurry ponds). Boone, Logan, and Mingo counties received more than $1.2 million out of a total $4.5 million disbursed across all counties from the Coal County Reallocation Severance Tax in 2013.[^18] Logan and Mingo counties received additional revenue in the tens of thousands of dollars from the Waste Coal Tax.[^19]
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 The West Virginia Department of Transportation (DOT) consists of three operating sections, including the Coal Resource Transportation System (CRTS). The CRTS manages, among other items, the permit system for coal haulers that would like to use designated CRTS roads. As of 2003, coal haulers must purchase a permit that allows for a gross vehicle weight of up to 120,000 pounds depending on their truck configuration.[^20] Fees collected through that permitting process are used by the Commission of Highways to match funds provided by coal companies and other parties for repairs and improvements to CRTS roads and bridges. Exact information on how much money the state collects and spends on industry-related transportation maintenance and repairs was not found in publicly available government sources.
 
 The West Virginia Office of Miners’ Health, Safety, and Training (WVOMHST) is the lead state agency for incidents involving coal mine emergencies. In 2013, the state agency’s expenditures totaled $15,346,893.[^21] Of that total, $12.8 million came from a general revenue fund, $2.2 million from industry fees, and the remainder from consolidated federal funds.[^22] The West Virginia Emergency Operations Plan sheds light on various WVOMHST tasks, including coordinating all rescue-related activities, maintaining the Mine and Industrial Accident Emergency Operations Center, and keeping the coal mine emergency contact list current.[^23] Publicly available government documents do not clarify how much Boone, Logan, and Mingo counties spend on coal mine-related emergency services.
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 
@@ -96,7 +96,7 @@ The table below highlights the data sources used to compile this narrative, as w
   </tbody>
 </table>
 
-<h2 class="case_studies_content-heading">Notes</h2>
+## Notes
 
 [^1]: U.S. Energy Information Administration, [What is the Role of Coal in the United States?](http://www.eia.gov/energy_in_brief/article/role_coal_us.cfm), 2014
 [^2]: U.S. Energy Information Administration, [Recoverable Coal Reserves and Average Recoverable Percentage at Producing Mines by State (PDF)](http://www.eia.gov/coal/annual/pdf/table14.pdf), 2013 and 2012

--- a/_case-studies/campbell.md
+++ b/_case-studies/campbell.md
@@ -7,7 +7,7 @@ resource: coal
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,13 +28,13 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 Campbell County’s geographic position atop the Powder River Basin came with such plentiful coal deposits that early cattle ranchers in the area could dig their own coal.[^4] Significant mining operations in the region began in the early twentieth century with the Peerless and Wyodak Mines near the city of Gillette. Further coal development and the discovery of oil spurred population growth in the county throughout the decades that followed.
 
 Most Campbell County coal is sub-bituminous, meaning it contains 35% to 45% carbon. Although sub-bituminous coal has the second lowest energy content of the four main types of coal, it is often found in thick deposits near the surface, which results in lower mining costs.[^5] The low sulfur content of the coal in Campbell County deposits became an advantage in the market after the 1990 revision of the Clean Air Act, which required reduced sulfur emissions from coal-fired power plants.[^6] Today, the Powder River Basin is estimated to have 25 billion tons of economically recoverable coal resources.[^7]
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 In 2013, Campbell County produced 343 million tons of coal, accounting for 88% of the state’s total production.[^8] Wyoming coal mines operate largely on federal lands managed by the Bureau of Land Management under the U.S. Department of the Interior.[^9] In fact, Wyoming is the site of more coal mining on federal and Indian lands than any other state in the country, constituting 80% of the total coal production on federal and Indian lands in the fiscal year ending in 2014.[^10] [^11]
 
@@ -42,13 +42,13 @@ Production levels fluctuated between 2004 and 2013. For instance, 2013’s level
 
 <img src="{{ site.baseurl }}/img/counties/wy-production.png" alt="Campbell County Coal Production 2004–2013" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 The coal mining industry provides employment for 5,195 workers in Campbell County (out of a total population of 48,176), representing approximately 11% of county residents and 24% of total employment.[^13] The chart below shows the county employment trend in the broader mining industry from 2004 through 2013, including mining and mining-support activities.[^14]
 
 <img src="{{ site.baseurl }}/img/counties/wy-wage.png" alt="Campbell County Mining Industry vs. All Other Industries Wage and Salary Employment 2004–2013" class="case_studies_content-graph">
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 With $120 million in total government revenue for 2014, Campbell County is the most revenue rich county in Wyoming.[^15] [^16] [^17] Its wealth is largely due to the revenue brought in from coal extraction. In 2013, Campbell County valued its own coal production at $3.5 billion.[^18] The State of Wyoming applies a 7% severance tax on the value of extracted surface coal.[^19] Between 2011 and 2012, Wyoming collected $587 million in severance tax revenue from coal production.[^20]
 
@@ -58,13 +58,13 @@ Campbell County further generates coal-related revenue through a gross products 
 
 Local communities in Wyoming also benefit from federal mineral royalties and coal lease bonuses. Between 2011 and 2012, the state received $850 million in coal-related royalties and bonuses.[^25] This revenue helped fund public programs such as the state’s school foundation, highway fund, city budgets, and the University of Wyoming. The exact distribution formulas for these funds among the various public programs is outlined in the state’s Mineral Revenue Report.[^26]
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 Campbell County and the Wyoming Department of Transportation (DOT) published the Campbell County Coal Belt Transportation Study in 2010.[^27] The report documents recommendations for roadway network improvements in the near and long term, discusses coal industry impacts to the system, and identifies funding options. While Campbell County is expected to be the primary funding source for new transportation improvements, the study includes a wide variety of collaborative funding efforts, including the Bureau of Land Management’s Abandoned Mine Lands program funds, road impact fees, a sinking fund account, and direct state and federal appropriations.[^28] The study estimates that it would require $43.9 million in investment in county roads between 2010 and 2015 to support coal extraction.[^29]
 
 No publicly available government data discussing the emergency services, {{ "reclamation" | term }}, or water-infrastructure costs of coal mining in Campbell County was found.
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/default.md
+++ b/_case-studies/default.md
@@ -3,13 +3,13 @@ title: Overview | Case Studies
 layout: content
 permalink: /case-studies/
 nav_items:
-  - name: intro
+  - name: overview
     title: Top
-  - name: revenue
+  - name: revenue-sustainability
     title: Revenue sustainability
   - name: county-revenue
     title: Revenue
-  - name: county-costs
+  - name: costs
     title: Costs
   - name: data
     title: Data
@@ -25,11 +25,11 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="intro" class="case_studies_content-heading" data-nav-header="intro">Overview</a></h2>
+## Overview
 
 While extractive industries made up 2.6% of the U.S. GDP in 2013, they play a much larger role in some local communities. For example, extractive industries make up more than a third of Wyoming’s GDP.[^1] At the county level, certain communities may be even more economically dependent on extractive industries.
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue sustainability</a></h2>
+## Revenue sustainability
 
 Local governments and communities must consider the many ways natural resource management and extraction can affect their fiscal health. One of the most significant considerations is the sustainability of revenues local governments receive due to natural resource extraction. Multiple EITI guiding principles reference revenue sustainability as a critical factor in making natural resource wealth &ldquo;an engine for sustainable economic growth.&rdquo;[^2] However, when it comes to managing this critical factor, there are two challenges localities need to address:
 
@@ -39,7 +39,7 @@ Local governments and communities must consider the many ways natural resource m
 
 These revenue sustainability considerations are magnified at the local level. A significant influx or loss of natural resource revenue can have a material impact, positive or negative, on the quality and variety of services that a local government can provide its residents. To achieve sustainable economic prosperity, local governments must consider how they can best use natural resource revenue to promote long-term growth and investment in their communities, and how to ensure that the financial benefits of extraction outweigh the costs in the short- and long-term.
 
-<h2><a name="county-revenue" class="case_studies_content-heading" data-nav-header="county-revenue">Revenue</a></h2>
+## Revenue
 
 At the county level, revenue received from extractive activities takes many forms. For example, some payments originate from taxes on land ownership, while others are based on ownership of the natural resource itself. There are also different methods of valuation ranging from payments at the point-of-sale, to annual taxes, to those based on an estimated value of the natural resource. The four most common types of revenue examined include: property taxes, sales and use taxes, state transfer payments, and additional production taxes.
 
@@ -48,7 +48,7 @@ At the county level, revenue received from extractive activities takes many form
 * **State transfer payments:** Revenue transferred to the county by the state, from sources such as **severance taxes** (paid by extractive industries to the state based on the volume or value of the resources extracted) and **lease payments** (such as bonuses, rents, and royalties, paid by extractive industries to a public land and mineral owner, which might be the federal government or the state).
 * **County production taxes:** Severance taxes or other payments paid by extractive industries to the county based on the volume or value of resources extracted, or per lease terms if the county is the landowner.
 
-<h2><a name="county-costs" class="case_studies_content-heading" data-nav-header="county-costs">Costs</a></h2>
+## Costs
 
 Local governments often make financial investments in their communities to support extractive industries. Costs vary based on the size of the community, the state of its current infrastructure, and the type of natural resources extracted. In some circumstances, these costs are outweighed by the influx of revenue, while in other cases costs can result in net negative fiscal effects on local governments.[^3] Given these possibilities and considerations, these case studies focus on four types of fiscal costs at the local level:
 
@@ -59,7 +59,7 @@ Local governments often make financial investments in their communities to suppo
 
 There are additional fiscal benefits and burdens associated with extractive activities beyond those addressed here. For example, a local government may receive in-kind revenue from extractive industries, such as payment for a new public road that company employees will use to access work sites. Another fiscal cost might be additional government staff for managing public services that support extractive activities. While all are worthy of careful consideration by local communities and governments, these case studies focus on the revenue and costs defined above.
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data</a></h2>
+## Data
 
 We used a range of information publicly available online to compile the case studies, including government databases, documents, and reports, as well as information produced by councils of governments. The case studies integrate data and analysis already reported elsewhere by government bodies. Local data sources were prioritized, and data was collected and presented at the most granular level available. We used state information when county information was not available.
 

--- a/_case-studies/desoto.md
+++ b/_case-studies/desoto.md
@@ -7,7 +7,7 @@ resource: gas
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -29,11 +29,11 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 The Haynesville sedimentary rock formation rests 10,000 feet to 13,000 feet below the surface of northwestern Louisiana, eastern Texas, and southwestern Arkansas. DeSoto Parish, home to 27,112 residents, sits at the center of the Haynesville Shale. In the early 2000s, DeSoto Parish’s economy consisted primarily of cattle and dairy farming, and forest extraction. However, DeSoto’s economy transformed when the Chesapeake Energy Corporation drilled the first exploratory well in the Haynesville Shale in 2007, setting off a natural gas boom in the parish in 2008.[^1]
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 From 2007 to 2011, natural gas production quadrupled in northern Louisiana, where DeSoto Parish is located.[^2] More recently, declining natural gas prices have resulted in lower production numbers. In 2013, northern Louisiana produced a total of 1,858,222,187 thousand cubic feet (or Mcf) of natural gas.[^3]
 
@@ -41,13 +41,13 @@ In 2013, the U.S. Energy Information Administration estimated that there were 16
 
 <img src="{{ site.baseurl }}/img/counties/la-production.png" alt="Northern Louisiana Natural Gas Production" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 Out of DeSoto’s nearly 28,000 residents, 548 people (about 2%) are employed in mining-support activities, which include oil and gas extraction.[^5] [^6] Of this group, 271 people are employed specifically in support activities for oil and gas extraction.[^7] Employment data for the complete oil and gas industry in the parish is unavailable. The chart below shows the increase in employment in broader extractive industries — specifically mining, quarrying, and oil and gas extraction — in DeSoto Parish between 2004 and 2013.[^8]
 
 <img src="{{ site.baseurl }}/img/counties/la-wage.png" alt="DeSoto Parish Mining, Quarrying, and Oil and Gas Extraction Industries vs. All Other Industries Wage and Salary Employment 2004–2013" class="case_studies_content-graph">
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 The Haynesville Shale natural gas boom has increased revenue for the State of Louisiana and DeSoto Parish through state severance taxes and royalties, parish property taxes, and sales and use taxes.
 
@@ -61,7 +61,7 @@ The DeSoto Parish School Board reports receiving the largest percentage of its a
 
 Property taxes also contribute substantially to the school board’s revenue, funding employee salaries, operations, and debt service payments on capital bonds for the local education system.[^20] The DeSoto Parish School Board estimated that 26.8% of the school budget would come from property taxes, and 49.1% would come from sales and use taxes in FY 2012–2013.[^21] State tax documents do not specify what percentage of property taxes comes from the gas industry.
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 Since 2008, Louisiana has invested $1.1 billion in transportation projects in the seven parishes located in the northwest region of the state, including DeSoto Parish.[^22] While Louisiana’s latest comprehensive state transportation plan acknowledges that the state must pay adequate attention to the transportation needs of the rapidly expanding oil and gas industry, it does not specify the types or costs of projects supported.[^23]
 
@@ -69,7 +69,7 @@ Louisiana completed a Hydraulic Fracturing State Review in March 2011, which exp
 
 The DeSoto Parish Emergency Medical Services (EMS) Department formed in 2001, funded by a four percent {{ "millage tax" | term_end }}.[^25] Since then, the DeSoto EMS Department has worked closely with gas companies on safety measures, including answering numerous calls related to gas-well site incidents. The parish is not bearing the full burden of these incidents; the parish has received donations from private companies to offset equipment costs. The frequency and value of the donations is not published.
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/elko-and-eureka.md
+++ b/_case-studies/elko-and-eureka.md
@@ -7,7 +7,7 @@ resource: gold
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,13 +28,13 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 Mineral mining in Nevada began shortly after the onset of the California Gold Rush in 1849. The 1859 discovery of the Comstock Lode silver deposit in the Virginia Range of western Nevada was the first major discovery of silver ore in the country.[^4] All told, the Great Basin geological region, which covers most of Nevada and crosses into Oregon, Utah, and California, has a total resource potential that exceeds 3,200 {{ "metric tons" | term:"metric ton"}} (100,000,000 ounces) of gold.[^5]
 
 In 1962, Newmont Mining Corporation discovered large deposits of gold ore along the Carlin Trend, a mineral-rich belt stretching 40 miles across Elko and Eureka counties that soon became one of the largest gold-producing regions in the world. This discovery marked the beginning of a robust gold-mining industry in the region: As of 2012, 87% of Nevada’s total historical gold output had been generated since the Carlin Trend discovery.[^6]
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 Nevada is in the midst of the biggest gold boom in U.S. history, which began in 1981 and has produced over 240 million ounces, often from public lands. This surge in production is largely the result of discovering sediment-hosted deposits that contain microscopic gold particles.[^7] These deposits occur when gold is deposited quickly and disseminated into the surrounding rock.
 
@@ -42,15 +42,15 @@ The two major gold-mining companies driving this development are Newmont Mining 
 
 <img src="{{ site.baseurl }}/img/counties/nv-production.png" alt="Elko and Eureka Counties Gold Production 2008–2012" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 In these two counties, gold-mining operations employed approximately 10% of the total population in 2012, or 5,196 workers and 1,121 contractors within a two-county population of 52,957. Gold-mining employment represented 26% of total employment in the counties in 2012.[^10]
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 Gold mining is a key driver of funding for local governments across the state. In addition to various property and sales taxes, counties receive annual revenue from the gold industry, largely from the state’s Net Proceeds of Minerals Tax. This tax is considered to be an ad valorem property tax assessed on minerals produced in the state, applied at a rate of 5% on royalties and all other net proceeds exceeding $4 million. In 2012, Nevada counties received $117 million in revenue from the Net Proceeds of Minerals Tax.[^11] Of that, Elko and Eureka received $31 million to spend on public services and infrastructure.[^12]
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 A number of state-level resources shed light on Elko and Eureka counties’ transportation systems, {{ "reclamation" | term }} procedures, and emergency services. While these government publications discuss costs to the state government, they do not specify the fiscal costs of gold extraction to Elko and Eureka county governments.
 
@@ -59,7 +59,7 @@ A number of state-level resources shed light on Elko and Eureka counties’ tran
 	<li><a href="http://ndep.nv.gov/bmrr/cost.htm">Nevada Bureau of Mining Regulation & Reclamation Cost Estimator</a></li>
 </ul>
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/greenlee.md
+++ b/_case-studies/greenlee.md
@@ -7,7 +7,7 @@ resource: copper
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,21 +28,21 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 Greenlee County has a long history of copper mining dating back to the mineral’s discovery in the area during the 1870s. Initial recovery operations drew prospectors to the towns of Clifton, Morenci, and Metcalf, where underground mining methods targeted high-grade copper ores. In the 1920s, the Phelps Dodge Corporation (now Freeport-McMoRan Inc.) became the single owner of mining operations in the jurisdiction and discovered huge reserves of low-grade ores in the area. However, when the price of copper collapsed during the Great Depression, mining in the region temporarily halted between 1932 and 1937, until Phelps Dodge Corporation converted its underground mining operations to open-pit methods that could profitably harvest lower-grade ores.[^3] The modern Morenci Mine was thus established and has been a significant economic driver in the county ever since.
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 The largest-producing copper mine in North America is the privately owned Morenci Mine, located in Greenlee County. In 2012, the Morenci Mine produced 537 million pounds of recoverable copper.[^4] This amount reflects a 22% decrease in production from its output five years prior as a result of the 2008 global recession and associated price drop.[^5] [^6] However, production increased 19% between 2010 and 2011, reflecting a healthy rebound in production in conjunction with rising copper prices. Moreover, in 2012 the Morenci Mine maintained a total output capacity of 420,000 metric tons of copper-molybdenum ore — an amount greater than the combined output capacity of the next three largest copper mines in the state.[^7]
 
 <img src="{{ site.baseurl }}/img/counties/az-production.png" alt="Morencini Copper Production vs. Average Price from 2007-2012" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 Copper production employed 10,637 workers in Arizona in 2011, comprising less than 1% of statewide private-sector employment (out of 1,992,727 total workers).[^8] [^9] In Greenlee County, the ebbs and flows of employment mirror trends in the copper industry. County unemployment reached 18% in 2009 at the height of the recession before falling to around 7% in 2013, as global demand and prices stabilized.[^10] Freeport-McMoRan Inc. owns and operates Greenlee County’s Morenci Mine, after merging with Phelps Dodge Corporation in 2007, and serves as the key copper-mining employer. In 2011, mining activities in the county employed approximately 2,296 workers out of a population of 8,594.[^11]
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 State revenue from copper extraction is directed back to Greenlee County primarily through the state’s severance tax. Arizona levies this tax on metal minerals (including copper) set at 2.5% on 50% of the difference between the gross value of production and the production costs. While 47.6% of this revenue goes to the state’s General Fund, the other 52.4% is distributed to cities and counties.[^12]
 
@@ -50,11 +50,11 @@ Arizona also collects a Transaction Privilege Tax for the right to do business i
 
 In 2012, Greenlee County received $4,376,829 in transaction privilege and severance tax disbursements.[^14] In publicly available documents, the Arizona Department of Revenue reports this revenue as one sum, and does not specify what percentage of the tax stems from copper mining. Greenlee County also collected $2,763,245 in local property taxes levied for general purposes, public health services, and flood control (out of a total $17.1 million in county revenue) in 2012.[^15] While some portion of property taxes stems from copper mining, the percentage is not specified in publicly available data.
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 Copper mining activity is a key consideration in Greenlee County road planning.[^16] No additional publicly available government sources delineating specific fiscal costs of copper mining in Greenlee County were found.
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/humbolt-and-lander.md
+++ b/_case-studies/humbolt-and-lander.md
@@ -7,7 +7,7 @@ resource: gold
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,13 +28,13 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 Mineral mining in Nevada began shortly after the onset of the California Gold Rush in 1849. The 1859 discovery of the Comstock Lode silver deposit in the Virginia Range of western Nevada was the first major discovery of silver ore in the country.[^4] All told, the Great Basin geological region, which covers most of Nevada and crosses into Oregon, Utah, and California, has a total {{ "resource potential" | term:"mineral resource potential" }} that exceeds 3,200 {{ "metric tons" | term:"metric ton" }} (100,000,000 ounces) of gold.[^5]
 
 The major gold mines in Humboldt and Lander counties represent more recent production operations. The counties’ two largest mines, the Twin Creeks Mine in Humboldt and the Pipeline/Cortez Hills Mine in Lander, did not start producing gold until the early 1990s. These mines are now two of the largest gold producers in the state.
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 Nevada is currently experiencing the biggest gold boom in U.S. history, which began in 1981 and has produced over 240 million ounces, often from public lands.[^6] This surge in production is largely the result of discovering deposits that contain microscopic gold particles.[^7] These deposits occur when gold is deposited quickly and disseminated into the surrounding rock.
 
@@ -42,15 +42,15 @@ The two major gold-mining companies behind this development are Newmont Mining C
 
 <img src="{{ site.baseurl }}/img/counties/nv-humboldt-production.png" alt="Humboldt and Lander Counties Gold Production from 2008–2012" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 In 2012, gold extraction provided jobs for 3,704 workers and 2,156 contractors, which represented 25% of the entire county population of 22,981, and 58% of total employment in the two counties.[^10] [^11]
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 Gold-mining serves as a key driver of funding for local governments across the state. In addition to various property and sales taxes, counties receive annual revenue from the gold industry, largely from the state’s Net Proceeds of Minerals Tax. This tax is considered to be an ad valorem property tax assessed on minerals produced in the state, applied at a rate of 5% on royalties and all other net proceeds exceeding $4 million. In FY 2012, Nevada counties received $117 million in revenue from minerals taxes.[^12] [^13] Of that total, $71 million went to these two counties.[^14]
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 A number of state-level resources, which are listed below, shed light on Humboldt and Lander County transportation systems, {{ "reclamation" | term }} procedures, and emergency services. While these government publications discuss costs to the state government, they do not specify the fiscal costs of gold extraction to Humboldt and Lander county governments.
 
@@ -59,7 +59,7 @@ A number of state-level resources, which are listed below, shed light on Humbold
 	<li><a href="http://ndep.nv.gov/bmrr/cost.htm">Nevada Bureau of Mining Regulation & Reclamation Cost Estimator</a></li>
 </ul>
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/kern.md
+++ b/_case-studies/kern.md
@@ -7,7 +7,7 @@ resource: oil
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,13 +28,13 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 Companies began extracting oil at a commercial level in California in the 1850s, inspired by the oil rush in Pennsylvania and a growing market for oil-fueled lighting. In the 1860s, production began in Kern County, where extractors dug holes into oil seeps to remove the fuel. Near the turn of the century, extraction in the county shifted toward commercial drilling, in part because of the 1890 discovery of the Midway-Sunset field, which is still the largest-producing oil field in California today.[^1]
 
 During the beginning of the twentieth century, many other large oil discoveries occurred in Kern County, and continued at a lesser pace through the 1970s. As discoveries of new fields ended in the 1970s, refined steam-injection techniques helped producers extract the substantial heavy oil — a more difficult and costly type of oil to extract and transport — from known Kern County fields.[^2]
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 In terms of oil production, Kern County has long been a leader both nationally and within California. Kern County produced 141,040,000 {{ "oil barrels" | term:"barrel" }} (bbls) in 2013.[^3] In 2012, the largest-producing oil fields in the state were privately owned oil fields in Kern County, including the Midway-Sunset field (29.3 m bbls), the Kern River Field (26.2 m bbls), and the Belridge South Field (23.6 m bbls).[^4] As of 2009, the two top oil-producing companies in California, excluding offshore production, were Chevron Corporation and Aera Energy LLC, both of which have operations in Kern County.[^5]
 
@@ -42,13 +42,13 @@ Since peaking in 1985, California’s oil production has trended downward; Kern 
 
 <img src="{{ site.baseurl }}/img/counties/ca-production.png" alt="Kern County Oil Production from 2004–2013" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 In 2013, oil and gas extraction employed over 10,000 of Kern County’s 865,923 residents, or between 1% to 2% of the population and 3.3% of total employment.[^8] [^9] In particular, 3,309 people were employed in oil and gas extraction, and 8,039 in support activities (1,748 in drilling for oil and gas, and 6,289 in support activities for oil and gas operations).[^10] Although oil production in the county has decreased, oil and gas industry employment increased from 2010 to 2013, because of the introduction of {{ "hydraulic fracturing" | term }} methods used to extract natural gas.
 
 <img src="{{ site.baseurl }}/img/counties/ca-wage.png" alt="Kern County Oil and Gas Industry vs. All Other Industries Wage and Salary Employment from 2004–2013" class="case_studies_content-graph">
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 California does not levy a statewide severance tax on oil and gas production, but counties in the state collect ad valorem or property taxes on oil and gas resources and equipment owned in their jurisdictions. The state does levy an annual assessment on oil and gas production to fund the Department of Conservation’s Oil, Gas, and Geothermal Resources Division. The division oversees the drilling, operation, maintenance, and plugging and abandonment of oil, natural gas, and geothermal wells.[^11]
 
@@ -56,7 +56,7 @@ Like other counties in the state, Kern County collects property taxes for oil an
 
 According to the Kern County Treasurer-Tax Collector, the top payer of property taxes in the county in FY 2014–2015 was Chevron Corporation. The company received a bill for more than $90 million in taxes, or 9.39% of the county’s $964 million in total property taxes owed. All of the top ten property tax payers were associated with either the extractive or energy sectors, and they received bills for a combined $323 million, or 33.5% of total property taxes due to the county.[^14]
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 A number of resources shed light on Kern County’s transportation systems, water infrastructure, {{ "reclamation" | term }} procedures, and emergency services. However, these government publications do not explicitly discuss the fiscal costs of oil extraction to the Kern County government.
 
@@ -67,7 +67,7 @@ A number of resources shed light on Kern County’s transportation systems, wate
 	<li><a href="http://www.co.kern.ca.us/CAO/policy/16.pdf">Kern County Policy and Administrative Procedures Manual: Emergency Preparedness (PDF)</a></li>
 </ul>
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/marquette.md
+++ b/_case-studies/marquette.md
@@ -7,7 +7,7 @@ resource: iron
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,13 +28,13 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 Marquette County generated 20% of the national iron output in 2012.[^1] This iron ore is located in the Marquette Iron Range, a narrow basin of iron formations running approximately 33 miles through the towns of Negaunee and Ishpeming. Discovered in 1844, this range houses Michigan’s oldest iron-mining operations; the Jackson Mining Company began extraction here in 1848. In the following decades, the development of critical infrastructure — including roads, railroads, and a canal connecting Lake Superior and Lake Huron — spurred additional mining activity. It was iron mining that originally drew settlers to the area.
 
 Although increased production costs and a diversified global supply of iron drove down output in the first half of the twentieth century, the development of new technology in the 1950s made it economically feasible to produce lower-grade taconite, which increased output.[^2]
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 Today’s iron mining along the Marquette Iron Range is centered on the Empire and Tilden Mines, operated by Cliffs Natural Resources Inc. In 2012, these two mines generated a combined 10.8 million {{ "metric tons" | term:"metric ton" }} of usable iron ore, which produced a total of 6.6 million metric tons of iron.[^3] Marquette County’s usable iron ore output had remained relatively constant over the preceding ten years, averaging 12 million metric tons out of a total annual capacity of 13 million metric tons.[^4] As shown in the chart below, the 2009 economic crisis drove down iron-ore production, but it rebounded the following year.
 
@@ -42,19 +42,19 @@ Major corporate landowners own a significant portion of the land used for natura
 
 <img src="{{ site.baseurl }}/img/counties/mi-production.png" alt="Marquette County Crude vs. Usable Iron Production from 2003–2012" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 According to the Bureau of Labor Statistics (BLS), total private sector employment in Marquette County stood at 27,195 in 2012.[^6] The iron-mining industry employed 1,500 individuals (6% of total employment). Iron-ore reserve estimates project a thirty-year supply at Tilden Mine, suggesting continued employment opportunities for the near future.[^7] Empire Mine production, on the other hand, was slated to halt in 2014 until a partnership agreement with ArcelorMittal USA Inc. extended the mine’s operations (and employment potential) through 2016.[^8]
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 The State of Michigan assesses mining operations under the same state and local taxes as other commercial ventures in the state (for example, sales, use, and property taxes). However, the state does collect a specific tax on low-grade iron ore at a rate of 1.1% of the value per gross ton produced.[^9] In 2013, Marquette County collected $3,049,250 from that tax, comprising 12.8% of the total $23,834,433 General Fund operating budget for that year.[^10] The low-grade iron ore tax revenue constituted an increase of $767,000 from 2012.[^11] These funds supported public services, such as law enforcement, health care, childcare, aging services, and the county’s international airport.[^12]
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 Public sources specifying the fiscal costs of iron-ore mining in Marquette County were not found.
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/north-slope.md
+++ b/_case-studies/north-slope.md
@@ -7,7 +7,7 @@ resource: oil
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,23 +28,23 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 The North Slope Borough is the country’s largest organized local jurisdiction, spanning more than 94,000 miles north of the Arctic Circle. Its 9,686 residents, most of whom are Inupiat Alaskan Natives, are spread across eight separate communities.[^6] The northern coast of Alaska was documented as a potential oil-producing region as early as 1900. However, the borough’s government was not formally incorporated until 1972, soon after the discovery of oil at Prudhoe Bay, the largest single oil field in North America.[^7]
 
 Oil production increased dramatically in 1977 with the opening of the Alaska Pipeline, which provided an economically viable way to transport large amounts of crude oil from the North Slope to market. In 1994, ARCO identified another significant deposit at the Alpine Field, located on state land east of the Colville River and extending into the federally administered National Petroleum Reserve of Alaska. The North Slope’s Prudhoe Bay, Alpine Field, and Kuparuk River constitute the majority of the state of Alaska’s oil production. Today, the borough’s oil reserve base is extensive, with approximately six billion barrels of proved oil.[^8]
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 In 2013, the North Slope Borough produced 182.5 million bbl of oil on both state-owned and federal land.[^9] Since production at Prudhoe Bay commenced, all of the North Slope’s extraction has taken place in the northern portion of the Colville-Canning province, administered by either the Alaska Department of Natural Resources or the Bureau of Land Management. While three major companies account for most production, North Slope exploration and extraction has diversified, with 63 current lease holders from seven countries.[^10] Annual oil production in the borough peaked in 1988 (at 722 million bbl) and has steadily declined since.[^11]
 
 <img src="{{ site.baseurl }}/img/counties/ak-production.png" alt="Oil Production in North Slope" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 The oil industry is a key driver of jobs throughout the borough. In 2013, oil and gas extraction provided 1,768 jobs on the North Slope, accounting for 12.5% of total employment (14,199).[^12] [^13] The North Slope Borough’s population is less than 10,000, so many private jobs are filled by nonresidents. In 2013, nonresidents accounted for 33.6% of oil industry workers in Alaska, up from 31.6% in 2012.[^14] The North Slope Borough government itself remains the largest employer of local residents, along with the Arctic Slope Regional Corporation, school district, and local Native corporations.[^15]
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenues</a></h2>
+## Revenues
 
 Given the North Slope’s relative geographic isolation, oil revenue is critical for supporting local schools, health centers, fire stations, water and sanitation facilities, and infrastructure. In 2013, the North Slope government received $470 million in revenue. Of that revenue, the borough received $332 million from local property taxes, 98% of which was levied on oil- and gas-related properties.[^16]
 
@@ -57,7 +57,7 @@ At the state level, the Alaska government collects oil-related revenue for the b
 
 Alaskan residents also receive annual dividend payments from the state’s Permanent Fund, based on a five-year average of the fund’s performance. The state established the Permanent Fund in 1976, as construction of the Alaska Pipeline concluded. Twenty-five percent of revenue from mineral leases on state-owned lands and from federal mineral revenue-sharing payments go into the Permanent Fund for investment. In 2013 each Alaskan resident received $900 as a result of this payout.[^19]
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 Oil extraction also incurs certain fiscal costs. Oil exploration and development on the North Slope require infrastructure, including airports, docks, pads and roads, ports, production-related facilities, pipelines, and gravel islands.[^20] The North Slope Borough is responsible for maintaining approximately 100 miles of roads, as well as boat ramps, boat landings, port facilities, nine public airports, and thousands of miles of winter trails and roads.[^21]
 
@@ -69,7 +69,7 @@ The state also spends public dollars on {{ "reclamation" | term }} services, inc
 
 The North Slope Borough often responds to, and pays for, emergency services on oilfield roads, such as Kuparuk Oilfield roads.[^27] The Alaska state government also invests a significant amount of tax dollars to prevent and respond to oil and hazardous substance emergencies in the state. For example, the Office of Management and Budget appropriated $750,000 toward oil and hazardous substance first-responder equipment and preparedness in 2013.[^28]
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights the data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/pima.md
+++ b/_case-studies/pima.md
@@ -7,7 +7,7 @@ resource: copper
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,21 +28,21 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 In Pima County, much like nearby Greenlee County, copper mining began in the 1870s. Mining activity in Pima County flourished in the late nineteeth century, particularly as the arrival of the Southern Pacific Railroad brought increased commerce and traffic to the region. The copper-mining industry followed a series of boom-and-bust cycles throughout the following decades, with particular spikes during the two world wars, when demand soared. Today, copper output in Pima County is driven by operations at three open-pit mines: Sierrita, Mission Complex, and Silver Bell.
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 In 2012, the combined copper production from Pima County’s three major mines totaled 152,700 metric tons.[^3] [^4] [^5] This output constituted 13% of national production for that year.[^6] Freeport-McMoRan Inc. manages the Sierrita mine, the top-producing operation in the county, while ASARCO LLC owns both the Mission Complex and Silver Bell mines.[^7]
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 Copper mining makes up a relatively small portion of Pima County’s overall employment, largely as a result of the Tucson metropolitan area’s more diversified economy and workforce. Of Pima County’s total 2012 employment of 346,828, copper mining and related activities account for less than 1% (1,745 workers).[^8] The county cites a 58% growth in employment in this sector compared to 2004 levels.[^9] Data for mining and support activities for the entire mining industry shows an overall increase in employment in Pima County from 2004 through 2013.[^10] [^11]
 
 <img src="{{ site.baseurl }}/img/counties/az-wage.png" alt="Mining Industry vs. All Other Industries Wage and Salary Pima County Employment from 2004–2013" class="case_studies_content-graph">
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 State revenue from copper extraction is directed back to Pima County primarily through the state’s severance tax. Arizona levies this tax on metal minerals (including copper) set at 2.5% on 50% of the difference between the gross value of production and the production costs. While 47.6% of this revenue goes to the state’s General Fund, the other 52.4% is distributed to cities and counties.[^12] In 2013, $21 million was distributed to all cities and counties in Arizona from the severance tax on metals.[^13] Arizona also collects a Transaction Privilege Tax, although this tax does not apply to copper revenue.[^14]
 
@@ -50,11 +50,11 @@ Pima County derives revenue from copper mining within its borders. However, in o
 
 ASARCO LLC also pays royalties to both the State of Arizona and the Tohono O’odham Nation as part of the leasing agreement to operate the Mission Mine, which is located on both state-owned and Indian land.
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 publicly available government sources specifying the fiscal costs of copper mining in Pima County were not found.
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/st-louis.md
+++ b/_case-studies/st-louis.md
@@ -7,7 +7,7 @@ resource: iron
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,11 +28,11 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 All iron mining in St. Louis County takes place along the Mesabi Iron Range. The Mesabi Range is a narrow, 120-mile-long iron deposit stretching from Babbitt to Grand Rapids that has shaped the economic development of the region throughout the past century. Iron ore was first discovered in the Mesabi Range in 1866; extractive operations began in the 1890s, and focused on exploiting the rich reserves of high-grade natural ore that could be easily processed into steel. After extracting approximately 2.5 billion tons of this natural ore, the industry had largely exhausted the supply by the 1950s, and companies began mining a lower-grade iron ore alternative: taconite. Taconite mining targets chert-magnetite ores that are processed and upgraded into higher-grade iron pellets to feed steel mill blast furnaces. To date, the industry has produced approximately 1.6 billion tons of these iron pellets from Mesabi Range ore.[^2]
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 In 2012, St. Louis County's eight iron mines produced 41.7 million metric tons of ore. Production rates were relatively constant throughout the preceding ten years, averaging 37.8 million metric tons with a compound annual growth rate of 2%.[^3] [^4] As shown in the chart, iron production in St. Louis County drives the majority of national iron production. The abnormally low production rate in 2009 was broadly the result of the global economic recession and weak demand from Chinese steel mills.
 
@@ -40,11 +40,11 @@ In Minnesota, the state government is the largest owner of mineral rights. It ow
 
 <img src="{{ site.baseurl }}/img/counties/mn-production.png" alt="Iron Ore Production from 2003 - 2012" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 The iron industry employs thousands of people in St. Louis County. The three major companies that operate the county’s iron mines and processing facilities are Cliffs Natural Resources, ArcelorMittal USA Inc., and the United States Steel Corporation. The eight mines in St. Louis County operated by these and other companies provided 3,970 jobs in 2012, comprising 4% of the county’s total 93,615 employment.[^7] [^8]
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 Annually, the iron ore industry in Minnesota takes in more than $3 billion in sales revenue.[^9] Various state and county tax mechanisms funnel a portion of these dollars back into the counties. The Taconite Production Tax, which is levied on concentrates or pellets produced by taconite companies, is the largest tax paid by the mining industry in Minnesota. Counties receive 26.05 cents per ton of iron ore from the Taconite Production Tax; in 2012, this amounted to $11.6 million for St. Louis County out of the $102 million collected from this tax across the state.[^10]
 
@@ -52,7 +52,7 @@ The production tax is distributed to a variety of recipients for public use, inc
 
 St. Louis County also collects revenue from various ad valorem and property taxes, including the tax on unmined taconite ($265,107 in 2013) and the ad valorem tax on taconite railroads ($2,981 in 2013).[^12] Taken together with the Taconite Production Tax, this revenue is important for the county’s schools, infrastructure, and public services.
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 Mining operations in Minnesota rely heavily on the state’s multimodal transportation system, which includes trucks, trains, ports, and barges: for instance, taconite makes up more than half the tonnage moved by rail across the state. However, keeping the railroads running requires significant financial investment. The Minnesota Department of Transportation (DOT) projects that it will need between $125 million and $433 million from Minnesota state and local governments throughout the next 20 years to fulfill the freight-rail-improvement component of its State Rail Plan.[^14] The state does not itemize how much of that money, if any, is specified for rail improvements that support the mining industry.
 
@@ -60,7 +60,7 @@ The Port of Duluth/Superior is the busiest port on the Great Lakes, and handles 
 
 In Minnesota, the Department of Natural Resources (DNR) has the authority to regulate the {{ "reclamation" | term }} of lands subject to metallic mining operations. The finances for any publicly funded reclamation activities come from a variety of sources, including the General Fund, annual fees directly from the permit holders, application and supplemental fees for permits, and industry and other governmental agencies.[^17] In FY 2012–2013, the Minnesota DNR Resources Land and Minerals Program spent $4.4 million, or 6% of its budget, on mine land reclamation.[^18] Generally, the mining-operation permit holder bears the cost of reclamation, except in cases in which the mine is abandoned and there is no party under legal obligation to reclaim the site, or the mine operator is fiscally insolvent.
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_case-studies/tarrant-and-johnson.md
+++ b/_case-studies/tarrant-and-johnson.md
@@ -7,7 +7,7 @@ resource: gas
 nav_items:
   - name: intro
     title: Top
-  - name: geology
+  - name: geology-and-history
     title: Geology and history
   - name: production
     title: Production
@@ -17,7 +17,7 @@ nav_items:
     title: Revenue
   - name: costs
     title: Costs
-  - name: data
+  - name: data-availability
     title: Data
 selector: list
 ---
@@ -28,25 +28,25 @@ selector: list
 
 {% include case-studies/_maps.html screen="mobile" %}
 
-<h2><a name="geology" class="case_studies_content-heading" data-nav-header="geology">Geology and history</a></h2>
+## Geology and history
 
 The Barnett Shale reserve spans approximately 5,000 square miles of sedimentary clay and quartz rock, with much of the productive portion of the rock located beneath Tarrant and Johnson counties. With an estimated 43 trillion cubic feet of {{ "proved reserves" | term:"proved reserves"}} of natural gas, the Barnett Shale is one of the largest onshore natural gas formations in the country.[^2]
 
 For many years, the Barnett Shale acted as an important sealing cap rock for conventional oil and gas development, but was not regarded as a legitimate source for economically viable drilling. However, technological advances in the 1980s allowed Mitchell Energy to drill its first well, and drilling activity increased with rising gas prices in the 1990s. Specifically, horizontal drilling and {{ "hydraulic fracturing" | term:"hydraulic fracturing" }} techniques allowed producers to access more natural gas from relatively thin shale deposits. The number of horizontal wells in the Barnett Shale grew from approximately 400 in 2004 to 10,860 in 2011.[^3] [^4]
 
-<h2><a name="production" class="case_studies_content-heading" data-nav-header="production">Production</a></h2>
+## Production
 
 In 2013, Tarrant and Johnson counties produced a combined 1.16 trillion cubic feet of natural gas from state-owned lands, constituting a significant portion of Texas’s total 7.73 trillion cubic feet output.[^5] [^6] [^7] Almost all other drilling in the state occurs on private lands, as only 1.8% of the acreage in Texas is federal land.[^8] The 2013 output was particularly remarkable given that only ten years prior, the two counties were producing just 7% of this amount.[^9] [^10] However, production began to drop in 2013 with falling natural gas prices and strong global supplies.
 
 <img src="{{ site.baseurl }}/img/counties/tx-production.png" alt="Tarrant and Johnson Counties Natural Gas Production on State-Owned Lands 2004 – 2013" class="case_studies_content-graph">
 
-<h2><a name="employment" class="case_studies_content-heading" data-nav-header="employment">Employment</a></h2>
+## Employment
 
 The boom in natural gas production in the Barnett Shale over the past decade increased employment in this sector. Based on data from the U.S. Census Bureau, the number of residents employed in the oil and gas industries has more than quadrupled in the past decade.[^11] In 2013, the oil and gas industry (including extraction, drilling, and support services) employed an estimated 7,371 residents, or less than 1% of the two counties’ total employment of 849,624 and less than 0.01% of the two counties’ total population of 2.07 million.[^12]
 
 <img src="{{ site.baseurl }}/img/counties/tx-employment.png" alt="Tarrant and Johnson Counties Oil and Gas Industry Employment Trend 2004 - 2013" class="case_studies_content-graph">
 
-<h2><a name="revenue" class="case_studies_content-heading" data-nav-header="revenue">Revenue</a></h2>
+## Revenue
 
 The State of Texas levies a Natural Gas Production Tax at 7.5% of the market value of the gas, but with the various allowable exemptions and reductions, the effective tax rate hovers below 2%.[^13] In 2013, the state government collected $1.5 billion from this tax, earmarking 25% for investment in the Permanent School Fund (PSF), and directing the rest to the state’s Economic Stabilization Fund.[^14] The interest earned on the PSF investments is distributed by the State Board of Education to every school district on a per-pupil basis.[^15]
 
@@ -54,7 +54,7 @@ The state also collects royalties from the natural gas produced on state-owned l
 
 Tarrant and Johnson counties derive additional revenue from extractive industries through local property and mineral taxes. In Tarrant County, thousands of homeowners own very small interests in gas units located under large residential developments.[^17] The value of all real property in a given county is assessed by the County Appraisal District, and property taxes are levied based on applicable mill rates for the locality. Property tax revenue for Tarrant and Johnson counties from all sources, not just natural gas property, totaled $367 million in 2013, which constituted a 48% increase from 2004. In its 2012 annual report, the Tarrant County Auditor’s Office cited the development of Barnett Shale gas resources as a factor in providing significant employment and business opportunities, which helped to offset the reduction in other property values and provided additional taxable value.[^18] [^19]
 
-<h2><a name="costs" class="case_studies_content-heading" data-nav-header="costs">Costs</a></h2>
+## Costs
 
 Texas leaves the siting and permitting for natural gas development to its municipalities, and while benefits accrue to these communities, extraction does come with costs. During well construction and drilling, heavy truck traffic causes wear on roads and bridges that can significantly reduce their service life. This problem is particularly pronounced on roadways that were not originally designed to support industrial traffic. According to the Texas Department of Transportation (DOT), the volume of truck traffic required to bring one gas well into production is equivalent to the impact of approximately eight million cars; truck traffic required to maintain that well is equivalent to another two million cars. Constructing such a well reduces highway service life by as much as 53%.[^20]
 
@@ -62,7 +62,7 @@ In its 2012 State Water Report, the Texas Water Development Board recommended $4
 
 The Texas Railroad Commission requires operators to remove water from extraction pits and refill them with sediment within set time frames, as well as completing the appropriate paperwork for any dry or inactive wells that will remain offline for more than a year.[^23] However, in cases where operators do not comply, Texas relies on its Oil and Gas Regulation Cleanup Fund to reclaim oil and gas wells.[^24] In FY 2013, the fund paid $54,263,532 for well plugging, site reclamation, monitoring and inspections, oil and gas permitting, and administration, and set aside an additional $22,277,506 in encumbrances for these activities.[^25] [^26] A combination of industry permitting fees, production taxes, enforcement penalties, reimbursements, proceeds from the sale of salvaged equipment and hydrocarbons, and federal money from the Coastal Impact Assistance Program finance the fund.[^27]
 
-<h2><a name="data" class="case_studies_content-heading" data-nav-header="data">Data availability</a></h2>
+## Data availability
 
 The table below highlights data sources used to compile this narrative, as well as any gaps in publicly available data.
 

--- a/_how-it-works/laws-and-regulations/federal-laws.md
+++ b/_how-it-works/laws-and-regulations/federal-laws.md
@@ -26,8 +26,7 @@ selector: hash
 
 {% include selector.html %}
 
-
-<h2 id="fiscal-regime" data-nav-header="fiscal-regime">Fiscal regime</h2>
+## Fiscal regime
 
 The following table lists the laws that provide the backbone of the fiscal regime for the extractive industries, as well as the relevant lands and natural resources to which they apply.
 
@@ -148,7 +147,7 @@ The following table lists the laws that provide the backbone of the fiscal regim
   </tr>
 </table>
 
-<h2 id="fees-and-fines" data-nav-header="fees-and-fines">Fees and fines for extractive industries companies</h2>
+<h2 id="fees-and-fines">Fees and fines for extractive industries companies</h2>
 
 There are other laws governing natural resources and extractive companies’ operations. Some of these laws require companies to pay fees. Violating some of these laws can also result in companies paying fines.
 
@@ -203,7 +202,7 @@ There are other laws governing natural resources and extractive companies’ ope
   </tr>
 </table>
 
-<h2 id="other-laws" data-nav-header="other-laws">Other laws</h2>
+## Other laws
 
 There are many other laws with which extractive industries companies must comply. DOI, EPA, the National Oceanic and Atmospheric Administration (NOAA), and other federal agencies’ websites contain more comprehensive lists of laws they enforce:
 
@@ -216,7 +215,7 @@ There are many other laws with which extractive industries companies must comply
 * [NOAA](http://www.nmfs.noaa.gov/ole/about/what_we_do/laws.html)
 
 
-<h2 id="regulations" data-nav-header="regulations">Regulations</h2>
+## Regulations
 
 Federal agencies, such as DOI and relevant bureaus, implement these laws by developing and enforcing regulations and rules. These key regulations relate to natural resource extraction, particularly on federal and Indian lands:
 

--- a/_how-it-works/laws-and-regulations/federal-reforms.md
+++ b/_how-it-works/laws-and-regulations/federal-reforms.md
@@ -27,7 +27,7 @@ selector: hash
 
 {% include selector.html %}
 
-<h2 id="deepwater-horizon-oil-spill" data-nav-header="deepwater-horizon-oil-spill">Reforms following the Deepwater Horizon oil spill</h2>
+<h2 id="deepwater-horizon-oil-spill">Reforms following the Deepwater Horizon oil spill</h2>
 
 In the aftermath of the [Deep Water Horizon oil spill](http://www.gpo.gov/fdsys/pkg/GPO-OILCOMMISSION/pdf/GPO-OILCOMMISSION.pdf) in the Gulf of Mexico in 2010, the federal government overhauled the oversight of DOI’s leasing, regulation, and collection of revenue for oil and gas extraction on the Outer Continental Shelf. DOI’s post Deepwater Horizon reorganization separated and established [independent oversight for offshore leasing](http://www.boem.gov/Reforms-since-the-Deepwater-Horizon-Tragedy/) (i.e., BOEM), offshore safety and environmental enforcement (i.e., BSEE), and the collection and accountability of the revenue generated from natural resource development on federal and Indian lands through the creation of the Office of Natural Resources Revenue (i.e., ONRR).
 
@@ -41,7 +41,7 @@ When the Secretary of the Interior announced the creation of ONRR in May 2010 an
 
 While the federal government made regulatory reforms following the spill, Congress did not change any laws related to offshore fossil fuel management in response to the accident.
 
-<h2 id="oig-reports" data-nav-header="oig-reports">Office of Inspector General (OIG) reports</h2>
+<h2 id="oig-reports">Office of Inspector General (OIG) reports</h2>
 
 [DOI’s OIG](https://www.doioig.gov/sites/doioig.gov/files/99-I-387.pdf) is responsible for the independent oversight and promotion of excellence, integrity, and accountability within the programs, operations, and management of DOI. OIG also identifies and prevents fraud, waste, and mismanagement within the agency. In recent years, OIG has published numerous reports related to DOI revenue from natural resource extraction, including:
 
@@ -52,7 +52,7 @@ While the federal government made regulatory reforms following the spill, Congre
 * May 2010: <a [Minerals Management Service: Royalty-In-Kind Program’s Oil Volume Verification Process](https://www.doioig.gov/sites/doioig.gov/files/2010-I-0021.pdf). OIG found several areas where the Royalty-In-Kind Program could be improved to ensure proper accounting of royalties that are paid in oil and gas volumes to the federal government, rather than in dollars.
 
 
-<h2 id="gao-reports" data-nav-header="gao-reports">Government Accountability Office (GAO) reports</h2>
+<h2 id="gao-reports">Government Accountability Office (GAO) reports</h2>
 
 The GAO is an independent, nonpartisan agency that investigates how the federal government spends taxpayer funds, including those for natural resource management on federal and Indian lands. GAO publishes its reports on the [GAO Summary Page](http://www.gao.gov/key_issues/oil_and_natural_gas/issue_summary). Some recent GAO findings related to natural resource extraction include:
 
@@ -62,7 +62,7 @@ The GAO is an independent, nonpartisan agency that investigates how the federal 
 * March 1989: [The Mining Law of 1872 Needs Revision(http://archive.gao.gov/d15t6/138159.pdf). This report critiques the foundational mining law on three major points: that the law’s annual work requirements need to be replaced, that the law forces the federal government to sell valuable land at nominal prices, and that the patent provision runs counter to other natural resource policies.
 
 
-<h2 id="proposed-rules" data-nav-header="proposed-rules">Proposed rules</h2>
+## Proposed rules
 
 Per the Administrative Procedures Act, agencies propose rules to implement federal laws. The public has an opportunity to comment on all proposed rules before an agency finalizes any regulations. Recently, DOI bureaus and offices proposed new rules intended to go into effect in 2015, including:
 
@@ -74,7 +74,7 @@ Per the Administrative Procedures Act, agencies propose rules to implement feder
 
 For more details, search the [Federal Registrar for DOI proposed rules](https://www.federalregister.gov/articles/search?conditions%5Bpublication_date%5D%5Bis%5D=11%2F04%2F2015&conditions%5Bterm%5D=Department+of+the+Interior&conditions%5Btype%5D%5B%5D=PRORULE).
 
-<h2 id="dodd-frank" data-nav-header="dodd-frank">The 2010 Dodd-Frank Act</h2>
+<h2 id="dodd-frank">The 2010 Dodd-Frank Act</h2>
 
 In 2010, the U.S. enacted the [Dodd-Frank Wall Street Reform and Consumer Protection Act](http://www.gpo.gov/fdsys/pkg/PLAW-111publ203/pdf/PLAW-111publ203.pdf) (124 Stat. 1376) to improve transparency and accountability across the financial system. Section 1504 of the act requires extractive industries companies registered with the Securities and Exchange Commission (SEC) to separately disclose information about payments to governments around the world in an interactive data format.
 

--- a/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
@@ -12,7 +12,7 @@ nav_items:
     title: State leasing programs
   - name: state-extractive-industries-revenue
     title: Extractive industries revenue
-  - name: revenue-disbursements
+  - name: state-revenue-disbursements
     title: Revenue disbursements
   - name: natural-resource-trust-funds
     title: Natural resource trust funds
@@ -48,7 +48,7 @@ While all 50 states have some natural resource extraction activity, the 2015 USE
 
 See [State Legal and Fiscal Information]({{site.baseurl}}/how-it-works/state-legal-fiscal-info/) for more details about the individual states’ laws and statutes.
 
-<h2 id="role-of-state-government-agencies" data-nav-header="role-of-state-government-agencies">Role of state government agencies</h2>
+## Role of state government agencies
 
 State government agencies create regulations and rules related to natural resource extraction based on applicable state laws and statutes (federal laws and regulations apply to all states and localities). Specifically, state government agencies manage state-owned land and natural resources, including leasing natural resources for extraction; enforce regulations and rules related to natural resource extraction; and collect, manage, and disburse revenue from natural resource extraction.
 
@@ -61,11 +61,11 @@ Each state has unique agencies that fulfill these functions. For example:
 
 Local government agencies also play a role in natural resource extraction. In particular, county departments of revenue collect, manage, and disburse local revenue from extractive industries activities.
 
-<h2 id="state-leasing-programs" data-nav-header="state-leasing-programs">State leasing programs</h2>
+## State leasing programs
 
 State ownership of land constitutes [almost 9% of total land area](http://www.nrcm.org/documents/publiclandownership.pdf) in the U.S. Each state has its own process for leasing natural resources on state-owned lands, and different oversight procedures for when companies explore for, develop, and produce natural resources and when companies decommission projects and reclaim sites. For example, in the State of Alaska, the director of the Division of Oil and Gas at the Department of Natural Resources must establish in writing that the state’s interests will be optimized before any leasing action can occur. Known as a “best-interest finding,” the director weighs the costs and benefits of the leasing action, including potential effects on natural, historical, and cultural resources, as well as on local communities and fish and wildlife populations. The director also considers public comments.
 
-<h2 id="state-extractive-industries-revenue" data-nav-header="state-extractive-industries-revenue">State extractive industries revenue</h2>
+## State extractive industries revenue
 
 The revenue a state receives from extractive activities varies by the local legal and fiscal framework, and by the types of resources and land owners involved. At a high level, many states receive the following revenue:
 
@@ -112,7 +112,7 @@ As an example, <a href="http://revenue.wyo.gov/mineral-tax-division/severance-ta
 
 State royalty rates vary. [Louisiana royalty rates](http://app1.lla.state.la.us/PublicReports.nsf/DB918AD8E33411F286257B490074B82A/$FILE/00031C97.pdf) average 21.9%, and can reach as high as 61.6%. California has a [minimum royalty rate](http://www.leginfo.ca.gov/cgi-bin/displaycode?section=prc&group=06001-07000&file=6826-6836) of 16 and 2/3% that can rise up to a maximum percentage outlined in the invitation to bid for a lease, and paid on the average production of oil per well, per day under the lease.
 
-<h2 id="revenue-disbursements" data-nav-header="revenue-disbursements">State revenue disbursements</h2>
+## State revenue disbursements
 
 Each individual state determines how to disburse revenue from extractive industries’ activities. To illustrate, North Dakota, one of the leading oil and gas producing states in the country, levies an Oil and Gas Production Tax at close to 1 cent per Mcf of gas, and at 5% of the gross production value of oil. 20% of the money collected from this tax is distributed to various state funds, while 80% flows to counties, cities, schools, and townships.
 
@@ -127,7 +127,7 @@ North Dakota also sets an [Oil Extraction Tax](http://www.nd.gov/tax/misc/faq/oi
 
 In comparison, Alaska, another leading oil and gas producer, levies its own Oil and Gas Production Tax at 35% of the net value. Most of the revenue derived from the Oil and Gas Production Tax is deposited in the state’s General Fund for government operations and basic services. Payments resulting from an assessment or litigation are deposited into the [Constitutional Budget Reserve Fund](http://www.tax.alaska.gov/programs/documentviewer/viewer.aspx?1139r), which covers the state’s short-term deficits.
 
-<h2 id="natural-resource-trust-funds" data-nav-header="natural-resource-trust-funds">Natural resource trust funds</h2>
+## Natural resource trust funds
 
 Many states choose to establish permanent mineral trust funds through legislation. These funds allow states to invest and hold revenue from natural resource extraction over time. Permanent mineral trust funds can help governments dependent on revenue from natural resources smooth revenue and investments across boom and bust cycles.
 

--- a/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
+++ b/_how-it-works/laws-and-regulations/state-legal-fiscal-info.md
@@ -6,41 +6,41 @@ nav_description: Jump to a state
 nav_items:
   - name: introduction
     title: Top
-  - name: ak
+  - name: alaska
     title: Alaska
-  - name: az
+  - name: arizona
     title: Arizona
-  - name: ca
+  - name: california
     title: California
-  - name: co
+  - name: colorado
     title: Colorado
-  - name: il
+  - name: illinois
     title: Illinois
-  - name: ky
+  - name: kentucky
     title: Kentucky
-  - name: la
+  - name: louisiana
     title: Louisiana
-  - name: mn
+  - name: minnesota
     title: Minnesota
-  - name: mt
+  - name: montana
     title: Montana
-  - name: nv
+  - name: nevada
     title: Nevada
-  - name: nm
+  - name: new-mexico
     title: New Mexico
-  - name: nd
+  - name: north-dakota
     title: North Dakota
-  - name: ok
+  - name: oklahoma
     title: Oklahoma
-  - name: pa
+  - name: pennsylvania
     title: Pennsylvania
-  - name: tx
+  - name: texas
     title: Texas
-  - name: ut
+  - name: utah
     title: Utah
-  - name: wv
+  - name: west-virginia
     title: West Virginia
-  - name: wy
+  - name: wyoming
     title: Wyoming
 breadcrumb:
   - title: How it works
@@ -53,7 +53,7 @@ selector: hash
 
 {% include selector.html %}
 
-<h2 id="ak" data-nav-header="ak">Alaska</h2>
+## Alaska
 
 The Division of Oil and Gas within the Alaska Department of Natural Resources is responsible for leasing state lands for oil, gas, and geothermal extraction. Its major functions include evaluating oil and gas resources, fielding and issuing exploration permits, conducting royalty audits, and negotiating contracts. The website for the Alaska Department of Natural Resources has significant information regarding statutes and regulations, leasing on state lands, and historical revenue collection and distribution information, as well as production data, for oil and gas. Additional information about statutes and regulations and leasing on state lands is available for mining from the Division of Land and Water. The Alaska Department of Revenue’s Tax Division collects state taxes, including the Oil and Gas Production Tax and Oil and Gas Property Tax, and administers tax laws. The website contains information about taxes collected and revenue sources and forecasts.
 
@@ -71,7 +71,7 @@ Learn more about natural resource regulation, production, and revenue in Alaska:
   - [Tax Division reports](http://www.tax.alaska.gov/programs/reports.aspx)
   - [Revenue sources and forecast information](http://www.tax.alaska.gov/programs/sourcebook/index.aspx)
 
-<h2 id="az" data-nav-header="az">Arizona</h2>
+## Arizona
 
 The Minerals Section within the Arizona State Land Department oversees mining activities on state-trust lands by issuing permits and leases. The Minerals Section’s website contains information about the energy, mineral, and other management programs. The Arizona Department of Mines and Mineral Resources’ information is now available on the Geological Survey Mineral Resources’ webpage, where information on mineral rights, production levels, and laws and regulations can be found. The Office of the Arizona State Treasurer’s website allows visitors to create customized reports on revenue distribution.
 
@@ -82,7 +82,7 @@ Learn more about natural resource regulation, production, and revenue in Arizona
   - [Laws and Regulations: Mineral Rights in Arizona](http://repository.azgs.az.gov/sites/default/files/dlio/files/nid1639/lawregs9thed5thprintverforprintingaugust2014.pdf), 9th edition
 * [Arizona State Treasurer revenue distribution reports](http://www.aztreasury.gov/local-govt/revenue-distributions/)
 
-<h2 id="ca" data-nav-header="ca">California</h2>
+## California
 
 The California Department of Conservation includes both the State Mining and Geology Board and the Division of Oil, Gas, and Geothermal Resources. The board oversees mineral resource extraction, reclaiming mine lands, and preparing geologic hazard information. The division regulates the drilling, operation, maintenance, plugging, and abandonment of oil, natural gas, and geothermal wells. Department of Conservation websites provide information on regulation, production, and programs for oil, gas, geothermal, and mining. The California Natural Resources Agency’s website has information regarding California’s renewable energy programs and goals.
 
@@ -97,7 +97,7 @@ Learn more about natural resource regulation, production, and revenue in Califor
   - [California Geological Survey](http://www.conservation.ca.gov/cgs/Pages/Index.aspx)
 * California Natural Resources Agency, [information on renewable energy programs](http://resources.ca.gov/developing_renewable_energy_sources/)
 
-<h2 id="co" data-nav-header="co">Colorado</h2>
+## Colorado
 
 The Oil and Gas Conservation Commission of the state’s Department of Natural Resources oversees the development of Colorado’s oil and gas natural resources. Its website provides relevant regulatory information, monthly resource production data, quarterly levy data, and information on drilling permits. The Colorado State Land Board manages assets held in public trust for Colorado public schools and institutions, including state lands used for natural resource extraction. The Division of Reclamation Mining and Safety protects miners, the public, and the environment from current and past mining operations. The Colorado Department of Revenue collects and disburses revenue for the state; annual reports provide details on these activities.
 
@@ -116,7 +116,7 @@ Learn more about natural resource regulation, production, and revenue in Colorad
 * [Colorado Department of Revenue Annual Report](https://www.colorado.gov/pacific/revenue/annual-report)
 * [Energy / Mineral Impact Assistance Fund supported by state severance taxes](https://www.colorado.gov/pacific/dola/energymineral-impact-assistance-fund-eiaf)
 
-<h2 id="il" data-nav-header="il">Illinois</h2>
+## Illinois
 
 The Department of Natural Resources Office of Mines and Minerals regulates natural resource exploration and development throughout the state. The Office is comprised of four divisions: Land Reclamation; Abandoned Mine Lands; Blasting, Explosives, and Aggregates; and Mine Safety and Training. The Office of Oil and Gas Resource Management is the regulatory authority responsible for permitting, drilling, operating, and plugging oil and gas production wells.
 
@@ -129,7 +129,7 @@ Learn more about natural resource regulation, production, and revenue in Illinoi
   - [Coal production maps and data](http://isgs.illinois.edu/research/coal/maps)
 * [State of Illinois Comprehensive Annual Financial Report Archive](http://www.ioc.state.il.us/index.cfm/resources/reports/cafr/)
 
-<h2 id="ky" data-nav-header="ky">Kentucky</h2>
+## Kentucky
 
 The Department for Natural Resources Division of Oil and Gas regulates the oil and gas industry in the state to protect mineral owners’ rights and the sustainability of the environment. The department’s divisions of Mine Permits, Mine Reclamation and Enforcement, and Mine Safety each execute different statutory responsibilities for mineral extraction oversight. Kentucky’s Energy and Environment Cabinet established the Department for Energy Development and Independence to develop and employ sustainable energy strategies for the state.
 
@@ -147,7 +147,7 @@ Learn more about natural resource regulation, production, and revenue in Kentuck
   - [Coal production](http://kgs.uky.edu/kgsweb/DataSearching/Coal/Production/prodsearch.asp)
 * [Kentucky Finance and Administration Cabinet Comprehensive Annual Financial Report Archive](http://finance.ky.gov/services/statewideacct/Pages/ReportsandPublications.aspx)
 
-<h2 id="la" data-nav-header="la">Louisiana</h2>
+## Louisiana
 
 The Office of Mineral Resources within the Department of Natural Resources manages natural resource extraction throughout the state and receives revenue from royalties, bonuses, rents, interest, and fees for leases for state-owned lands. The Office of Conservation and Office of Coastal Management within the department also oversee Louisiana’s oil and gas resources. The State Energy Office helps maximize Louisiana's energy potential by exploring all energy sources.
 
@@ -160,7 +160,7 @@ Learn more about natural resource production, revenue, and regulation in Louisia
   - [Royalties, rents, bonuses, and severance tax revenue](http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=212)
 * [Office of State Register Administrative Code for natural resources](http://www.doa.la.gov/Pages/osr/lac/LAC-43.aspx)
 
-<h2 id="mn" data-nav-header="mn">Minnesota</h2>
+## Minnesota
 
 The Division of Lands and Minerals within Minnesota’s Department of Natural Resources manages the state's mineral resources and mine development on state-owned lands to generate revenue for the state's School and University Trust Funds, local communities, and General Fund. The division ensures full reclamation of extractive sites and maintains comprehensive mineral land records.
 
@@ -171,7 +171,7 @@ Learn more about natural resource production and revenue in Minnesota:
   - [Minerals data](http://minarchive.dnr.state.mn.us/)
 * [Minnesota Comprehensive Annual Financial Report Archive](http://mn.gov/mmb/accounting/reports/comprehensive-annual.jsp)
 
-<h2 id="mt" data-nav-header="mt">Montana</h2>
+## Montana
 
 Within Montana’s Department of Resources and Natural Conservation, the Trust Lands Management Division oversees 5.2 million acres of state land and manages all energy resource leasing. The Minerals Management Bureau manages and issues leases and permits for oil, gas, coal, and other natural resources on state lands. The Montana Board of Oil and Gas protects citizens and the environment from the negative effects of oil and gas extraction by issuing permits, inspecting wells, and conducting environmental remediation programs.
 
@@ -184,7 +184,7 @@ Learn more about natural resource regulation, production, and revenue in Montana
   - [Wells, production, and leases data](http://bogc.dnrc.mt.gov/WebApps/DataMiner/)
 * [Montana Department of Revenue Tax Related Reports](https://revenue.mt.gov/home/publications)
 
-<h2 id="nv" data-nav-header="nv">Nevada</h2>
+## Nevada
 
 The Bureau of Mining Regulation and Reclamation within the Department of Conservation and Natural Resources oversees all mining activities in the state of Nevada. The division focuses on regulation (ensuring statutory compliance), closure (confirming stabilization of all applicable mine components), and reclamation (issuing reclamation permits to all large-scale operators).
 
@@ -197,7 +197,7 @@ Learn more about natural resource regulation, production, and revenue in Nevada:
   - [Minerals and energy data](http://www.nbmg.unr.edu/Minerals&Energy/index.html)
 * [Nevada State Controller Comprehensive Annual Financial Report Archive](http://controller.nv.gov/FinancialReports/CAFR_Download_Page.html)
 
-<h2 id="nm" data-nav-header="nm">New Mexico</h2>
+## New Mexico
 
 The New Mexico Mining and Minerals Division enforces laws and regulations related to mine safety and reclamation of abandoned mines. The division collects production and employment data on active mining operations through its Mine Registration and Reporting Program. It also uses a Geographic Information System (GIS) to locate and track mining activities in the state, available for public use on the division’s website. The Oil Conservation Division regulates oil, gas, and geothermal activity in New Mexico. It gathers well production data, issues permits for new wells, enforces statutes and rules, and ensures abandoned wells are properly plugged and the land is restored.
 
@@ -211,7 +211,7 @@ Learn more about natural resource regulation, production, and revenue in New Mex
   - [Oil and gas production data](http://www.emnrd.state.nm.us/OCD/statistics.html)
 * [New Mexico Department of Finance and Administration Comprehensive Annual Financial Report Archive](http://nmdfa.state.nm.us/New_Mexico_CAFR.aspx)
 
-<h2 id="nd" data-nav-header="nd">North Dakota</h2>
+## North Dakota
 
 North Dakota’s Department of Mineral Resources Oil and Gas Division regulates the drilling and production of oil and gas in the state. In addition to its regulatory oversight function, the Oil and Gas Division manages permitting and maintains production and well data. Data pertaining to mineral extraction is housed by the state’s Geological Survey.
 
@@ -225,7 +225,7 @@ Learn more about natural resource regulation, production, and revenue in North D
   - [Revenue distribution (including Oil and Gas Gross Production, Oil Extraction, Coal Severance, and other taxes associated with resource extraction)](http://www.nd.gov/treasurer/revenue-distribution/)
   - [Oil and gas revenue distribution](http://www.nd.gov/treasurer/how-is-oil-and-gas-tax-revenue-distributed/)
 
-<h2 id="ok" data-nav-header="ok">Oklahoma</h2>
+## Oklahoma
 
 The Oklahoma Commissioners of the Land Office manages state lands, including oil and gas leasing to generate revenue that supports the state’s common schools and higher education institutions. The Oklahoma Department of Mines regulates the coal and nonfuel mineral production, enforcing a variety of federal and state programs for safety, health, and land reclamation. The department also issues permits for all mining operations.
 
@@ -239,8 +239,7 @@ Learn more about natural resource regulation, production, and revenue in Oklahom
   - [Department of Mines Annual Reports](http://www.ok.gov/mines/Annual_Reports/)
 * [Oklahoma Office of Management and Enterprise Services Comprehensive Annual Financial Report](http://www.ok.gov/OSF/documents/cafr14.pdf)
 
-
-<h2 id="pa" data-nav-header="pa">Pennsylvania</h2>
+## Pennsylvania
 
 The Department of Environmental Protection, including the Bureau of Mining Programs and the Office of Oil and Gas Management, manages programs that ensure the safe and responsible exploration, development, and recovery of extractive resources. These programs include permitting and inspection, regulatory oversight, and training.
 
@@ -256,7 +255,7 @@ Learn more about natural resource regulation, production, and revenue in Pennsyl
   - [Mineral resources](http://dcnr.state.pa.us/topogeo/econresource/mineral_industries/index.htm)
   - [Coal resources](http://dcnr.state.pa.us/topogeo/econresource/coal/index.htm)
 
-<h2 id="tx" data-nav-header="tx">Texas</h2>
+## Texas
 
 The Railroad Commission of Texas is statutorily responsible for regulating the exploration and production of the state’s natural resources: oil, natural gas, minerals (particularly lignite and coal), and alternative fuels. The commission oversees natural resource extraction along with land reclamation and environmental protection. The commission also oversees safety and compliance related to the state’s extensive oil and gas pipeline infrastructure.
 
@@ -267,7 +266,7 @@ Learn more about natural resource regulation, production, and revenue in Texas:
   - [Regulations for commodity extraction](http://www.rrc.state.tx.us/legal/rules/current-rules/)
 * [Historical state net tax revenue by source](http://www.texastransparency.org/State_Finance/Budget_Finance/Reports/Revenue_by_Source/revenue_hist.php)
 
-<h2 id="ut" data-nav-header="ut">Utah</h2>
+## Utah
 
 The Division of Oil, Gas, and Mining within Utah’s Department of Natural Resources is responsible for developing natural resources for the economic benefit of the public while preserving the state’s natural environment. The division maintains four core programs, each with specific oversight functions: the Coal Program, the Mineral Mining Program, the Oil and Gas Program, and the Abandoned Mine Reclamation Program.
 
@@ -284,7 +283,7 @@ Learn more about natural resource regulation, production, and revenue in Utah:
 * [Utah Geological Survey](http://geology.utah.gov/)
 * [Utah Department of Administrative Services Division of Finance Comprehensive Annual Financial Report Archive](http://finance.utah.gov/cafr.html)
 
-<h2 id="wv" data-nav-header="wv">West Virginia</h2>
+## West Virginia
 
 The West Virginia Department of Environmental Protection oversees natural resource extraction in West Virginia. The department’s Office of Oil and Gas is responsible for monitoring and regulating all actions related to the exploration, drilling, storage, and production of oil and natural gas. The Division of Mining and Reclamation manages compliance, reclamation, permitting, and communications between the public and industry.
 
@@ -299,7 +298,7 @@ Learn more about natural resource revenue, regulation, and production in West Vi
 * [West Virginia Geological and Economic Survey](http://www.wvcommerce.org/business/businessassistance/expandingorrelocating/businesstaxes.aspx)
 * [West Virginia Department of Administration, Division of Finance Comprehensive Annual Financial Report Archive](http://www.finance.wv.gov/FARS/CAFR/Pages/default.aspx)
 
-<h2 id="wy" data-nav-header="wy">Wyoming</h2>
+## Wyoming
 
 The Wyoming Office of State Lands and Investments manages resource extraction on state land held in public trust. The revenue from energy and mineral resource leasing helps fund public education and essential institutions in the state.
 

--- a/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
@@ -27,13 +27,13 @@ selector: hash
 
 The federal government formally recognizes 566 Indian tribes and 325 Indian reservations that cover [56 million acres of land](http://www.blm.gov/public_land_statistics/pls13/pls2013.pdf). This land is held in trust by DOI and has [significant natural resource extraction potential](http://www.resourcegovernance.org/sites/default/files/RWI_Native_American_Lands_2011.pdf), containing up to 30% of U.S. coal reserves west of the Mississippi, 50% of potential uranium reserves, and 20% of known oil and gas reserves. Extracting natural resources on Indian land and distributing the associated revenue involves a unique set of processes and stakeholders.
 
-<h2 id="federal-obligations" data-nav-header="federal-obligations">Federal obligations</h2>
+## Federal obligations
 
 The basis of the regulatory relationship between Indian tribes and the federal government was established in the Commerce Clause of the U.S. Constitution (Article 1, Section 8, Clause 3). This relationship, as it pertains to land use and ownership, was clarified in the 1830s. In a series of Supreme Court decisions known as the Marshall Trilogy, former Supreme Court Justice John Marshall established several important principles of Indian law.
 
 One was the federal Indian trust responsibility, whereby the government charged itself with “[moral obligations of the highest responsibility and trust](http://www.bia.gov/FAQs/index.htm)” toward Indian tribes. In this capacity, the U.S. Government maintains fiduciary responsibility to protect tribal assets and resources and serves as a trustee for Indian lands. Another was the principle that tribes are sovereign, which is inherent to them as the original governing bodies of what is now the United States, and that sovereignty can only be diminished by Congress.
 
-<h2 id="leasing-process" data-nav-header="leasing-process">Leasing process</h2>
+## Leasing process
 
 Today, there are [two major types of Indian-owned land](http://teeic.indianaffairs.gov/triballand/):
 
@@ -46,11 +46,11 @@ ONRR collects royalties from extractive companies and reviews monthly revenue an
 
 The Office of the Special Trustee for American Indians (OST) receives the payments and information from ONRR and [disburses 100% of the funds to the owner of the land](http://www.onrr.gov/IndianServices/pdfdocs/FrequentlyAskedQuestion.pdf), whether that is an individual or a tribe.
 
-<h2 id="production-and-revenue" data-nav-header="production-and-revenue">Indian land production and revenue</h2>
+## Indian land production and revenue
 
 Natural resources are increasingly a key source of income for many American Indian tribes. In FY 2013, ONRR and OST disbursed [$933 million to American Indian tribes and allottees](http://statistics.onrr.gov/ReportTool.aspx), an increase of more than 171% from 10 years prior.
 
-<h3 id="fy-2013-production-and-revenue" data-nav-header="fy-2013-production-and-revenue">FY 2013 production and revenue</h3>
+### FY 2013 production and revenue
 
 <table class="article_table">
   <tr>

--- a/_how-it-works/natural-resources/ownership.md
+++ b/_how-it-works/natural-resources/ownership.md
@@ -35,11 +35,11 @@ selector: hash
 
 There are four main types of land owners: citizens and corporations; the federal government; state and local governments; and Indian tribes and individuals. There are two types of owners for submerged lands under the ocean: states and the federal government.
 
-<h3 id="private-lands" data-nav-header="private-lands">Private lands</h3>
+### Private lands
 
 Private lands are owned by private citizens or corporations.
 
-<h3 id="federal-lands" data-nav-header="federal-lands">Federal lands</h3>
+### Federal lands
 
 [Federal lands](http://fas.org/sgp/crs/misc/R42346.pdf) are owned by or under jurisdiction of the federal government, including:
 
@@ -49,7 +49,7 @@ Private lands are owned by private citizens or corporations.
 * Military acquired lands purchased by the federal government under military acquisition laws
 * [Outer Continental Shelf](http://www.boem.gov/OCS-Lands-Act-History/) submerged lands located farther than three miles off a state’s coastline, or three marine leagues into the Gulf of Mexico off of Texas and Western Florida
 
-<h3 id="state-and-local-lands" data-nav-header="state-and-local-lands">State and local lands</h3>
+### State and local lands
 
 State and local lands are owned by state or local governments, including:
 
@@ -57,7 +57,7 @@ State and local lands are owned by state or local governments, including:
 * [State submerged lands](http://www.boem.gov/uploadedfiles/submergedla.pdf) under the ocean stretching from a state’s coast to three miles out into the ocean, or in the case of Texas and western Florida, from the coast out to three marine leagues into the Gulf of Mexico
 * Lands owned by a local government, such as a county
 
-<h3 id="indian-lands" data-nav-header="indian-lands">Indian lands</h3>
+### Indian lands
 
 Indian lands are owned by Native Americans, and include:
 
@@ -71,7 +71,7 @@ Private individuals and corporations, as well as federal, state, local, and trib
 
 Natural resource ownership has historical roots in the 19th century, when the federal government passed homestead and development acts to encourage settlement in the West. These acts, along with the General Mining Law of 1872, allowed for federal public domain lands, and the natural resources within them, to pass to private ownership. Starting in the 20th century, the U.S. passed legislation that began to withdraw both specific natural resources and eventually public domain lands from settlement and other development, preserving these lands and natural resources in federal ownership today.
 
-<h3 id="split-ownership" data-nav-header="split-ownership">Split ownership</h3>
+### Split ownership
 
 Sometimes the land’s surface owner is different from the owner of the minerals in the ground below. The party that owns the land’s surface has {{ "surface rights" | term_end }}, while the party that owns the natural resources in the ground has {{ "subsurface rights" | term_end }}. When ownership is divided in this way, it is referred to as a [split estate](http://www.blm.gov/wo/st/en/prog/energy/oil_and_gas/best_management_practices/split_estate.html). There are 57 million acres of land in the U.S. where the federal government owns oil, gas, coal, and other minerals below the surface, but another party, mostly citizens or corporations, owns the surface land above. Land and mineral ownership can become quite complicated. Often, a combination of private landholders, the federal government, a state government, or Indian tribes own the span of a single mine or field.
 

--- a/_how-it-works/natural-resources/production.md
+++ b/_how-it-works/natural-resources/production.md
@@ -49,11 +49,11 @@ Fossil fuels are our main source of electricity, and the primary fuel for poweri
 
 Besides creating energy, these natural resources are also used to make many products. For example, manufacturers use oil to make asphalt and coal to make steel. Through natural processes over hundreds of millions of years, plant and animal matter becomes energy resources in the form of oil, gas, and coal. While fossil fuels are abundant, they are not renewable.
 
-<h3 id="oil" data-nav-header="oil">Oil</h3>
+### Oil
 
 Oil forms in underground reservoirs on land and under the ocean. Crude oil occurs naturally, while petroleum products (e.g., jet fuel, diesel fuel, and heating oil) come from refining and otherwise processing crude oil and other liquids. Petroleum is a broad term that can mean both crude oil and {{ "petroleum products" | term_end }}. In 2013, [five states](http://www.eia.gov/todayinenergy/detail.cfm?id=15631) — Texas, North Dakota, California, Alaska, and Oklahoma — and federal submerged lands in the Gulf of Mexico supplied more than 80% of the {{ "crude oil" | term }} produced here.
 
-<h3 id="gas" data-nav-header="gas">Gas</h3>
+### Gas
 
 Gas, also called natural gas, forms underground on land and offshore in beds under the ocean. There are two types of natural gas: dry and wet. Dry natural gas is mostly methane. Wet natural gas contains a small amount of methane, as well as other liquid hydrocarbons — such as ethane, propane, and butane — and nonhydrocarbon gases. Wet natural gas is the source of natural gas liquids. Once wet natural gas is extracted from the ground, natural gas liquids are separated from the gas stream close to the well or at a gas processing plant. This leaves both dry gas and natural gas liquids such as ethane, propane, and butane.
 
@@ -74,7 +74,7 @@ In addition to these shale formations, the Green River Formation, which is locat
 * [Offshore exploration and development plans](http://www.data.boem.gov/homepg/data_center/plans/plans/master.asp)
 
 
-<h3 id="coal" data-nav-header="coal">Coal</h3>
+### Coal
 
 Coal forms in the ground in coal seams or beds. Miners extract coal through surface and subsurface mining. In surface mining, the coal is close to the surface. Miners remove the “overburden,” or the soil and rock covering the coal, before mining it. In subsurface mining, the coal is farther down in the earth. Through passages that go into the earth, miners remove the coal from [underground rooms or long coal seams](http://teeic.indianaffairs.gov/er/coal/restech/tech/index.htm). In 2013, the U.S. was the world’s second largest coal producer after China.
 
@@ -96,7 +96,7 @@ There are three common types of reserves, or the amount of a particular natural 
 
 Renewable energy resources include geothermal, solar, wind, biomass, and hydrokinetic energy, all of which constitute growing sources of environmentally sustainable energy to meet the country’s electricity needs. Renewable energy sources comprised about [10% of total U.S. energy consumption in 2013](http://www.eia.gov/totalenergy/data/monthly/archive/00351405.pdf).
 
-<h3 id="geothermal-energy" data-nav-header="geothermal-energy">Geothermal energy</h3>
+### Geothermal energy
 
 Geothermal energy comes from the earth’s heat, which is captured as steam or hot water and converted into energy. Most geothermal resources are found along the boundaries of tectonic plates and manifest themselves as volcanoes, hot springs, or geysers. California produces more geothermal energy than any other state, accounting for more than [75% of the country’s total geothermal output in 2013](http://www.eia.gov/todayinenergy/detail.cfm?id=17871).
 
@@ -104,7 +104,7 @@ Many sites for potential geothermal development are on federal land; currently, 
 
 See where [geothermal energy production happens](http://www.nrel.gov/gis/images/geothermal_resource2009-final.jpg).
 
-<h3 id="solar-energy" data-nav-header="solar-energy">Solar energy</h3>
+### Solar energy
 
 Solar energy can be generated in two ways: by converting solar radiation into heat and electricity via photovoltaic panels or by using the sun’s radiation to heat a fluid and produce steam for a power generator. California leads the country in producing solar energy, followed by New Jersey. As of 2014, California is the first state to receive [5% or more of its electricity from solar energy sources](http://www.eia.gov/todayinenergy/detail.cfm?id=20492).
 
@@ -112,7 +112,7 @@ The solar industry has experienced rapid growth in the past decade due to govern
 
 See [areas of the U.S. with solar energy potential](http://energy.gov/maps/solar-energy-potential).
 
-<h3 id="wind-power" data-nav-header="wind-power">Wind power</h3>
+### Wind power
 
 Wind power takes advantage of daily wind cycles to rotate wind turbines, which can be clustered together on wind farms. In 2013, wind power accounted for more than [4% of total U.S. energy production](http://www.energy.gov/sites/prod/files/wind_vision_highlights.pdf), with more than 61 gigawatts (GW) installed across 39 states. Texas (12.3 GW), California (5.8 GW), and Iowa (5.2 GW) are the leading producers.
 
@@ -120,25 +120,25 @@ No offshore wind projects have been completed to date. [The National Renewable E
 
 See a map of [current wind power capacity](http://apps2.eere.energy.gov/wind/windexchange/wind_installed_capacity.asp), [potential onshore power](http://apps2.eere.energy.gov/wind/windexchange/wind_maps.asp), and [potential offshore power](http://apps2.eere.energy.gov/wind/windexchange/windmaps/offshore.asp).
 
-<h2>Nonenergy minerals</h2>
+## Nonenergy minerals
 
 Nonenergy minerals include base and precious metals, industrial metals, and gemstones, amongst others. The 2015 USEITI Report focuses on nonenergy minerals, specifically gold, copper, and iron. In 2013, these minerals accounted for most of the valuable metal produced in the United States: [gold, copper, and iron made up 32%, 29%, and 17%, respectively, of $32 billion worth of metal extracted](http://minerals.usgs.gov/minerals/pubs/mcs/2014/mcs2014.pdf).
 
 The 2013 estimated exploration budget for nonenergy minerals decreased by 38% from 2012, dropping from $1.7 billion to $1 billion. Continued uncertainty about the U.S. and European economies, as well as weakened demand from China, either depressed or maintained prices for nonenergy minerals. Noteworthy exploration sites for nonenergy minerals are located in [Alaska, Idaho, Nevada, and Wyoming](http://minerals.usgs.gov/minerals/mflow/exploration-2013.pdf), more than half of which are for gold and silver.
 
-<h3 id="gold" data-nav-header="gold">Gold</h3>
+### Gold
 
 Gold can be found in both loose materials and hard rocks. Miners extract gold from placer mines using sluicing, dredging, jigging, and amalgamation devices that separate the gold from water, silt, rock, and other compounds. Lode mining, both open pit and underground, extracts gold embedded within rock walls. Once mined, gold is used to make jewelry, electronics, dental treatments, and other products.
 
 In 2013, the majority of U.S. gold came from [Nevada (172,000 kilograms) and Alaska (30,600 kilograms)](http://minerals.usgs.gov/minerals/pubs/commodity/gold/mis-201311_12-gold.pdf). In Nevada, recent exploration for gold resulted in discoveries along the Carlin and Battle Mountain-Eureka (Cortez) trends in Eureka and Elko Counties, as well as in the [Pequop Mountains in Elko County](http://pubs.nbmg.unr.edu/The-NV-mineral-industry-2011-p/mi2011.htm). Alaska continues to be a prominent site for gold exploration, although exploration spending in the state in 2013 made up less than [half the peak expenditure in 2011](http://minerals.er.usgs.gov/minerals/mflow/exploration-2014.pdf). Half of the estimated 2013 total $1 billion budget for nonenergy mineral exploration was for gold.
 
-<h3 id="copper" data-nav-header="copper">Copper</h3>
+### Copper
 
 Copper is found in hard rocks in the form of copper ore. Miners extract copper from open pit and underground mines through traditional quarrying to separate the copper from rock, or leaching which involves treating the ore with diluted sulfuric acid. Once produced, copper has a variety of uses, including as a building material, as an effective conductor of electricity, and within the health care sector.
 
 In 2013, Arizona accounted for the most copper production out of all U.S. states with [795,000 metric tons](http://minerals.usgs.gov/minerals/pubs/commodity/copper/mis-201401-coppe.pdf). In terms of exploration, an estimated [36% of the 2013 total $1 billion](http://minerals.usgs.gov/minerals/mflow/exploration-2013.pdf) U.S. budget for nonenergy mineral exploration was for base metals, primarily copper.
 
-<h3 id="iron" data-nav-header="iron">Iron</h3>
+### Iron
 
 Iron is found in underground rocks. Miners extract iron by drilling holes in the ground in carefully engineered patterns and blasting out rocks with explosives. Next, miners crush the rocks and separate out the iron ore from other materials. Almost all iron is used to make steel, which in turn is used to make buildings, infrastructure, machines, and vehicles.
 

--- a/_how-it-works/natural-resources/revenues.md
+++ b/_how-it-works/natural-resources/revenues.md
@@ -30,7 +30,7 @@ selector: hash
 
 {% include selector.html %}
 
-<h2 id="federal-lands-and-waters" data-nav-header="federal-lands-and-waters">Payments to extract natural resources from federal land and waters</h2>
+<h2 id="federal-lands-and-waters">Payments to extract natural resources from federal land and waters</h2>
 
 When companies extract natural resources on federal onshore lands and the Outer Continental Shelf, they pay revenue to the Department of the Interior (DOI).
 
@@ -40,9 +40,9 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
 
 <img src="{{site.baseurl}}/img/revenue-streams-chart.png" alt="Select federal revenue streams and statutory and regulatory rates" class="article_img-100 u-margin-top">
 
-<h2 id="all-lands-and-waters" data-nav-header="all-lands-and-waters">Payments to extract natural resources from any land or water in the U.S.</h2>
+<h2 id="all-lands-and-waters">Payments to extract natural resources from any land or water in the U.S.</h2>
 
-<h3 id="corporate-income-tax" data-nav-header="corporate-income-tax">Corporate income taxes</h3>
+### Corporate income taxes
 
 Corporations operating in the extractive industries pay taxes to the IRS on their income. These companies pay federal corporate income taxes regardless of whether they extract natural resources from federal, state, or privately held lands, so long as they have a liability. These companies also pay taxes on income from extracting natural resources and processing them into other products and commodities. There are different types of companies operating in these industries, with different ownership structures, and as a result, they are treated as different taxpayers:
 
@@ -54,7 +54,7 @@ Corporations operating in the extractive industries pay taxes to the IRS on thei
 
 Only income taxes from C-corporations are included in the 2015 USEITI Report.
 
-<h3 id="revenue-policy-provisions" data-nav-header="revenue-policy-provisions">Revenue policy provisions</h3>
+### Revenue policy provisions
 
 While royalty rates can reach as high as 18.75%, and the federal corporate income tax rate can reach as high as 35% depending on company income, companies may pay less. Revenue policy provisions, including royalty relief and tax expenditures, can result in smaller revenue and tax payments to the federal government to promote other policy goals.
 
@@ -69,7 +69,7 @@ To incentivize companies to produce additional oil and gas on certain leases on 
 
 In some situations, if oil and gas prices rise above certain thresholds, lease holders that previously gained royalty relief must start paying royalties at the regular rate again.
 
-<h3 id="tax-expenditures" data-nav-header="tax-expenditures">Tax expenditures</h3>
+### Tax expenditures
 
 Tax expenditures are [defined in the law](https://www.treasury.gov/resource-center/tax-policy/Documents/Tax-Expenditures-FY2017-Revised.pdf) as “revenue losses attributable to provisions of the federal tax laws which allow a special exclusion, exemption, or deduction from gross income or which provide a special credit, a preferential rate of tax, or a deferral of tax liability.” These exceptions may be viewed as alternatives to other policy instruments, such as spending or regulatory programs.
 
@@ -84,7 +84,7 @@ The federal budget also includes annual estimates of the net revenue effects of 
 
 ## After a payment, what happens to the revenue?
 
-<h3 id="federal-budget-process" data-nav-header="federal-budget-process">Federal budget process</h3>
+### Federal budget process
 
 Once revenue is collected by the federal government, it passes through a series of budgetary gateways before ultimately funding public services and community development. These gateways are described below, and you can [explore disbursement data here]({{ site.baseurl }}/explore/disbursements/).
 

--- a/_includes/case-studies/_nav-list.html
+++ b/_includes/case-studies/_nav-list.html
@@ -13,6 +13,14 @@
       {% else %}
         <a href="#{{item.name}}" class="sticky_nav-nav_item" data-nav-item="{{item.name}}">{{item.title}}</a>
       {% endif %}
+
+      {% if item.subnav_items %}
+        <ul>
+          {% for subnav_item in item.subnav_items %}
+            <a href="#{{subnav_item.name}}" class="sticky_nav-nav_item" data-nav-item="{{subnav_item.name}}">{{subnav_item.title}}</a>
+          {% endfor %}
+        </ul>
+      {% endif %}
     {% endfor %}
   {% endif %}
 </ul>

--- a/_includes/case-studies/_nav-list.html
+++ b/_includes/case-studies/_nav-list.html
@@ -17,7 +17,7 @@
       {% if item.subnav_items %}
         <ul>
           {% for subnav_item in item.subnav_items %}
-            <a href="#{{subnav_item.name}}" class="sticky_nav-nav_item" data-nav-item="{{subnav_item.name}}">{{subnav_item.title}}</a>
+            <a href="#{{subnav_item.name}}" class="sticky_nav-nav_item sticky_nav-nav_item-sub" data-nav-item="{{subnav_item.name}}">{{subnav_item.title}}</a>
           {% endfor %}
         </ul>
       {% endif %}

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -1,13 +1,13 @@
 {% assign all_products = site.data.state_all_production[state_id].products %}
 
-<section id="all-production" class="all-lands production" data-nav-header="all-production">
+<section id="all-production" class="all-lands production">
 
   <h2>Natural resource production in {{ state_name }}</h2>
 
   <h3>Production in all of {{ state_name }}</h3>
 
   <p>The federal government collects data about all energy-related natural resources produced in each state on all lands, including federal, state, and privately owned property. (For coal, there is also data about mining in each county.)</p>
-  
+
   <p>In some cases, the specific amount of a resource produced in a state or county is withheld to protect trade secrets.</p>
 
   <div class="chart-list">

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -1,4 +1,4 @@
-<section id="disbursements" class="disbursements" data-nav-header="disbursements">
+<section id="disbursements" class="disbursements">
   <h2>Disbursements</h2>
   <p>{{ disbursements_summary | strip_html }}</p>
 

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -1,6 +1,6 @@
 {% assign export_commodities = site.data.state_exports[state_id].commodities %}
 
-<section id="exports" class="economic exports" data-nav-header="exports">
+<section id="exports" class="economic exports">
 
   <h2>Exports</h2>
 

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -1,6 +1,6 @@
 {% assign gdp = site.data.state_gdp[state_id] %}
 
-<section id="gdp" class="economic gdp" data-nav-header="gdp">
+<section id="gdp" class="economic gdp">
 
   <h2>Gross Domestic Product (GDP)</h2>
 

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -4,7 +4,7 @@
 {% assign jobs_count = jobs[year].count | default: 0 %}
 {% assign jobs_percent = jobs[year].percent | default: 0 %}
 
-<section id="employment" class="economic employment" data-nav-header="employment">
+<section id="employment" class="economic employment">
 
   <h2>Employment</h2>
 

--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -1,4 +1,4 @@
-<section id="overview" data-nav-header="overview">
+<section id="overview">
 
   <p>USEITI reporting includes data about extractive industries in each state. This page summarizes information from the USEITI reporting process about natural resources in {{ state_name }} and what role extractive industries play in the state economy.</p>
 

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -1,7 +1,7 @@
 {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
 {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ state_id }}.svg{% endcapture %}
-<section id="ownership" data-nav-header="ownership" class="container-outer">
-  
+<section id="ownership" class="container-outer">
+
   <h2>Land ownership</h2>
 
   <section class="container-half">

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -1,6 +1,6 @@
 {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
 {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ state_id }}.svg{% endcapture %}
-<section id="ownership" class="container-outer">
+<section id="ownership" class="container-outer land-ownership">
 
   <h2>Land ownership</h2>
 

--- a/_includes/location/section-process.html
+++ b/_includes/location/section-process.html
@@ -1,4 +1,4 @@
-<section id="process" data-nav-header="process">
+<section id="process">
   <h2>Process</h2>
   <p>Laws and policies govern how rights are awarded to companies and what fees they pay to the government in order to extract natural resources on federal land. The specifics of the process depend on the kind of resource, and often affect how much revenue the federal government ultimately collects.</p>
 

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -3,7 +3,7 @@
 
 {% capture year_range %}[2006, 2015]{% endcapture %}
 
-<section id="revenue" class="federal revenue" data-nav-header="revenue">
+<section id="revenue" class="federal revenue">
 
   <h2>Revenue</h2>
 

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -9,7 +9,7 @@
 
   <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called ‘revenue’ because they represent revenue to the American public.</p>
 
-  <h3>Revenue from federal land</h3>
+  <h3 id="federal-revenue">Revenue from federal land</h3>
 
   <section class="container-half">
 
@@ -45,7 +45,7 @@
     </div>
   </section>
 
-  <div class="tab-interface">
+  <div id="fee-summaries" class="tab-interface">
     <ul class="eiti-tabs info-tabs" role="tablist">
       <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" aria-selected="true">Commodity Revenues</a></li>
       <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" class="link-charlie">The story behind the numbers</a></li>
@@ -73,7 +73,7 @@
   </div>
   <p><em>* Companies may not know whether they’ll produce oil or gas until they explore the land, so fees are not differentiated by product until production begins.</em></p>
 
-  <section id="revenue-commodities" class="chart-list has-intro">
+  <section id="commodities-revenue" class="chart-list has-intro">
 
     <h4>Revenue from extraction on federal land in Utah over time</h3>
     <p class="chart-list-intro">In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government, and companies that extract natural resources on federal land pay fees to the federal government. This chart shows how much federal revenue was collected each year in {{ state_name }}.</p>
@@ -130,12 +130,12 @@
 </section>
 
 <section id="state-local-revenue" class="state revenue">
-  <h3>Revenue from state land</h3>
+  <h3 >Revenue from state land</h3>
   <p>Natural resource extraction on land owned by the state of {{ state_name }} is governed by <a href="{{ site.baseurl }}/how-it-works/state-laws-and-regulations/#role-of-state-government-agencies/</a>">state laws and regulations</a>.</p>
   <p>We don't have detailed data about state revenue from natural resource extraction on land owned by the state. To learn more about regulations and state revenues in {{ state_name }}, see <a href="{{ site.baseurl }}/how-it-works/state-legal-fiscal-info/">state legal and fiscal information</a>.</p>
 </section>
 
-<section id="" class="private-lands revenue">
+<section id="private-revenue" class="private-lands revenue">
   <h3>Revenue from private land</h3>
   <p>Companies that extract natural resources on private land must pay income taxes, like any other company. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
 </section>

--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -32,9 +32,9 @@ layout: default
     {% if page.title_display %}
       {% if page.nav_items %}
         {% if page.selector == 'hash' %}
-          <h1 id="{{nav_slug}}" data-nav-header="{{nav_slug}}">{{page.title_display}}</h1>
+          <h1 id="{{nav_slug}}">{{page.title_display}}</h1>
         {% elsif page.selector == 'list' %}
-          <h1><a name="{{nav_slug}}" class="case_studies_content-heading" data-nav-header="{{nav_slug}}">{{ page.title_display }}</a></h1>
+          <h1 id="{{nav_slug}}">{{ page.title_display }}</a></h1>
         {% endif %}
       {% else %}
         <h1>{{page.title_display}}</h1>
@@ -42,17 +42,14 @@ layout: default
     {% elsif page.title %}
       {% if page.nav_items %}
         {% if page.selector == 'hash' %}
-          <h1 id="{{nav_slug}}" data-nav-header="{{nav_slug}}">{{page.title_display}}</h1>
+          <h1 id="{{nav_slug}}">{{page.title_display}}</h1>
         {% elsif page.selector == 'list' %}
-          <h1><a name="{{nav_slug}}" class="case_studies_content-heading" data-nav-header="{{nav_slug}}">{{ page.title_display }}</a></h1>
+          <h1 id="{{nav_slug}}">{{ page.title_display }}</a></h1>
         {% endif %}
       {% else %}
         <h1>{{page.title}}</h1>
       {% endif %}
     {% endif %}
-
-
-
 
 
     {{ content | markdownify }}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -8,15 +8,25 @@ nav_items:
   - name: revenue
     title: Revenue
     subnav_items:
-      - name: revenue-commodities
+      - name: federal-revenue
+        title: Federal land
+      - name: fee-summaries
+        title: Fee summaries
+      - name: commodities-revenue
         title: Commodities
+      - name: state-local-revenue
+        title: State land
+      - name: private-revenue
+        title: Private land
   - name: production
     title: Production
     subnav_items:
       - name: all-production
-        title: All lands
+        title: Entire state
+      - name: federal-production
+        title: Federal land
       - name: state-local-production
-        title: State local
+        title: State land
       - name: private-land-production
         title: Private land
   - name: employment

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -7,8 +7,18 @@ nav_items:
     title: Land Ownership
   - name: revenue
     title: Revenue
-  - name: all-production
+    subnav_items:
+      - name: revenue-commodities
+        title: Revenue commodities
+  - name: production
     title: Production
+    subnav_items:
+      - name: all-production
+        title: All lands production
+      - name: state-local-production
+        title: State local production
+      - name: private-land-production
+        title: Private land production
   - name: employment
     title: Employment
   - name: gdp
@@ -43,12 +53,13 @@ nav_items:
     {% include location/section-revenue.html %}
 
     <!-- {% include location/section-process.html %} -->
+    <section id="production">
+      {% include location/section-all-production.html %}
 
-    {% include location/section-all-production.html %}
+      {% include location/section-federal-production.html %}
 
-    {% include location/section-federal-production.html %}
-
-    {% include location/section-state-production.html %}
+      {% include location/section-state-production.html %}
+    </section>
 
     {% include location/section-jobs.html %}
 

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -9,16 +9,16 @@ nav_items:
     title: Revenue
     subnav_items:
       - name: revenue-commodities
-        title: Revenue commodities
+        title: Commodities
   - name: production
     title: Production
     subnav_items:
       - name: all-production
-        title: All lands production
+        title: All lands
       - name: state-local-production
-        title: State local production
+        title: State local
       - name: private-land-production
-        title: Private land production
+        title: Private land
   - name: employment
     title: Employment
   - name: gdp

--- a/_sass/blocks/case-studies/_content.scss
+++ b/_sass/blocks/case-studies/_content.scss
@@ -24,14 +24,6 @@
 
 }
 
-.case_studies_content-heading {
-  color: $dark-gray;
-
-  &:hover {
-    text-decoration: none;
-  }
-}
-
 .case_studies-maps {
   display: block;
 

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -26,7 +26,7 @@
     margin-top: 0;
   }
 
-  section[data-nav-header='ownership'] {
+  section.ownership {
     h2 {
       border-top: none;
       margin-top: 0;

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -26,7 +26,7 @@
     margin-top: 0;
   }
 
-  section.ownership {
+  .land-ownership {
     h2 {
       border-top: none;
       margin-top: 0;

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -35,6 +35,14 @@
   }
 }
 
+.sticky_nav-nav_item + ul {
+  display: none;
+}
+
+.sticky_nav-nav_item[data-active=true] + ul {
+  display: inline-block;
+}
+
 .sticky_nav-nav_item-sub {
   border-left: 3px solid $neutral-gray;
 }

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -29,18 +29,18 @@
   margin-bottom: 0;
   padding: $base-padding-lite;
 
+  + ul {
+    display: none;
+  }
+
   &[data-active=true] {
     color: $dark-gray;
     font-weight: $weight-book;
+
+    + ul {
+      display: inline-block;
+    }
   }
-}
-
-.sticky_nav-nav_item + ul {
-  display: none;
-}
-
-.sticky_nav-nav_item[data-active=true] + ul {
-  display: inline-block;
 }
 
 .sticky_nav-nav_item-sub {

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -34,3 +34,7 @@
     font-weight: $weight-book;
   }
 }
+
+.sticky_nav-nav_item-sub {
+  border-left: 3px solid $neutral-gray;
+}

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -13,7 +13,7 @@
       // init OpenListNav Properties
       this.active = this.stripHash(window.location.hash) || 'intro';
       this.navItems = document.querySelectorAll('[data-nav-item]');
-      this.navSelect = $('[data-nav-options]');
+      this.navSelect = document.querySelectorAll('[data-nav-options]');
       this.navIsSelect = !!this.navSelect.length;
       // initialize at maximum value
       this.defaultTop = 1e8;
@@ -129,6 +129,7 @@
         window.addEventListener('scroll', function() {
           self.updateScrollTop();
           // TODO: throttle
+          console.log('detect')
           self.detectNavChange();
         });
 
@@ -146,31 +147,52 @@
       detectNavChange: function(){
 
         var self = this;
-        var newName;
 
         // initialize nav status as not updated
         var updated = false;
 
-        Array.prototype.forEach.call(this.navItems, function(item){
-          var header = document.getElementById(item.dataset.navItem);
+        console.log(this.navSelect)
+        console.log(this.navItems)
+        console.log('-------------')
+        var items = this.navIsSelect
+          ? this.navSelect
+          : this.navItems;
 
-          var isActiveElement = self.isActiveElement(header);
+        Array.prototype.forEach.call(items, function(item){
+          var parentName,
+            newName,
+            header,
+            isActiveElement;
 
-          if (isActiveElement && !self.navIsSelect) {
-            newName = header.id;
+          var updated = false;
 
-            if (item.classList.contains(self.subnavItemClass)) {
-              var parentName = item.parentElement.previousElementSibling
-              .getAttribute('data-nav-item');
+          if (!self.navIsSelect) {
+            header = document.getElementById(item.dataset.navItem);
+
+            isActiveElement = self.isActiveElement(header);
+
+            if (isActiveElement) {
+              newName = header.id;
+
+              if (item.classList.contains(self.subnavItemClass)) {
+                parentName = item.parentElement.previousElementSibling
+                .getAttribute('data-nav-item');
+              }
+
+              self.update(null, newName, parentName);
+
             }
-
-            self.update(null, newName, parentName);
-
-          } else if (isActiveElement && self.navIsSelect && !updated) {
-            newName = header.name || header.id;
-            self.updateSelectField(newName);
-            updated = true;
+          } else if (self.navIsSelect) {
+            Array.prototype.forEach.call(items, function(item){
+              if (isActiveElement && self.navIsSelect && !updated) {
+                newName = header.name || header.id;
+                console.log(newName)
+                self.updateSelectField(newName);
+                updated = true;
+              }
+            });
           }
+
         });
 
         this.resetTop();

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -106,7 +106,8 @@
         // initialize nav status as not updated
         var updated = false;
 
-         Array.prototype.forEach.call(this.navHeaders, function(header){
+         Array.prototype.forEach.call(this.navItems, function(header){
+          console.log(header)
            var inViewPort = isElementInViewport(header);
            if (inViewPort && !self.navIsSelect && !updated) {
               var newName = header.name || header.id;

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -48,8 +48,10 @@
 
         var elementInViewport = rect.bottom > 0 &&
             rect.right > 0 &&
-            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
-            rect.top < (window.innerHeight || document.documentElement.clientHeight);
+            rect.left < (window.innerWidth ||
+                         document.documentElement.clientWidth) &&
+            rect.top < (window.innerHeight ||
+                        document.documentElement.clientHeight);
 
         var elTop = Math.abs(rect.top);
 

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -7,14 +7,7 @@
           || document.body).scrollTop;
     }
 
-    function isElementInViewport(el) {
-      var rect = el.getBoundingClientRect();
 
-      return rect.bottom > 0 &&
-          rect.right > 0 &&
-          rect.left < (window.innerWidth || document. documentElement.clientWidth) &&
-          rect.top < (window.innerHeight || document. documentElement.clientHeight);
-    }
 
     exports.OpenListNav = function() {
       // init OpenListNav Properties
@@ -23,6 +16,9 @@
       this.navSelect = $('[data-nav-options]');
       this.navIsSelect = !!this.navSelect.length;
       this.navHeaders = document.querySelectorAll('[data-nav-header]');
+      // initialize at maximum value
+      this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
+      this.closestToMid = this.defaultMid;
       this.scrollTop = {
         current: getScrollTop(),
         prev: getScrollTop(),
@@ -39,6 +35,37 @@
         this.scrollTop.direction = (this.scrollTop.current >= this.scrollTop.prev)
           ? 'down'
           : 'up';
+      },
+
+      isActiveElement: function(el) {
+        var rect = el.getBoundingClientRect();
+
+
+
+        var elementInViewport = rect.bottom > 0 &&
+            rect.right > 0 &&
+            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
+            rect.top < (window.innerHeight || document.documentElement.clientHeight);
+
+        if (elementInViewport) {
+          console.log(el.id, rect)
+          console.log('mid', this.closestToMid)
+          console.log('top', Math.abs(rect.top))
+        }
+
+        if (elementInViewport && (Math.abs(rect.top) < this.closestToMid)) {
+          this.closestToMid = Math.abs(rect.top);
+          console.log('chosen----------')
+          // console.log(this.closestToMid)
+          return true;
+        } else {
+          return false;
+        }
+
+      },
+
+      resetMid: function(){
+        this.closestToMid = this.defaultMid;
       },
 
       removeActive: function(){
@@ -60,6 +87,7 @@
       },
 
       update: function(el, name){
+        this.resetMid();
         this.removeActive();
         this.addActive(el, name);
       },
@@ -106,18 +134,21 @@
         // initialize nav status as not updated
         var updated = false;
 
-         Array.prototype.forEach.call(this.navItems, function(header){
-          console.log(header)
-           var inViewPort = isElementInViewport(header);
-           if (inViewPort && !self.navIsSelect && !updated) {
+        Array.prototype.forEach.call(this.navItems, function(item){
+          var header = document.getElementById(item.dataset.navItem);
+
+          var isActiveElement = self.isActiveElement(header);
+
+          if (isActiveElement && !self.navIsSelect && !updated) {
               var newName = header.name || header.id;
               self.update(null, newName);
-              updated = true;
-           } else if(inViewPort && self.navIsSelect && !updated) {
-             var newName = header.name || header.id;
+              // updated = true;
+
+          } else if (isActiveElement && self.navIsSelect && !updated) {
+            var newName = header.name || header.id;
             self.updateSelectField(newName);
-             updated = true;
-           }
+            updated = true;
+          }
         });
       }
     };

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -17,8 +17,10 @@
       this.navIsSelect = !!this.navSelect.length;
       this.navHeaders = document.querySelectorAll('[data-nav-header]');
       // initialize at maximum value
-      this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
+      // this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
+      this.defaultMid = window.innerHeight || document.documentElement.clientHeight;
       this.closestToMid = this.defaultMid;
+      this.viewportElements = 0;
       this.scrollTop = {
         current: getScrollTop(),
         prev: getScrollTop(),
@@ -40,23 +42,32 @@
       isActiveElement: function(el) {
         var rect = el.getBoundingClientRect();
 
-
-
         var elementInViewport = rect.bottom > 0 &&
             rect.right > 0 &&
             rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
             rect.top < (window.innerHeight || document.documentElement.clientHeight);
 
+        var elMid = Math.abs( rect.top + (Math.abs( rect.top - rect.bottom ) / 2) );
+        var elTop = Math.abs(rect.top)
+
         if (elementInViewport) {
           console.log(el.id, rect)
           console.log('mid', this.closestToMid)
           console.log('top', Math.abs(rect.top))
+          console.log('rect mid', elMid)
         }
 
-        if (elementInViewport && (Math.abs(rect.top) < this.closestToMid)) {
-          this.closestToMid = Math.abs(rect.top);
-          console.log('chosen----------')
+
+
+        if (elementInViewport && (elTop < this.closestToMid) ) {
+          this.closestToMid = elTop;
+          this.viewportElements++;
+          console.log('---------- chosen ----------')
           // console.log(this.closestToMid)
+          return true;
+        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToMid) ) {
+          console.log('-------------- only one -------------')
+          this.viewportElements++;
           return true;
         } else {
           return false;
@@ -66,6 +77,7 @@
 
       resetMid: function(){
         this.closestToMid = this.defaultMid;
+        this.viewportElements = 0;
       },
 
       removeActive: function(){
@@ -87,7 +99,7 @@
       },
 
       update: function(el, name){
-        this.resetMid();
+        // this.resetMid();
         this.removeActive();
         this.addActive(el, name);
       },
@@ -150,6 +162,9 @@
             updated = true;
           }
         });
+
+        // this.viewportElements = 0;
+        this.resetMid();
       }
     };
 

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -11,12 +11,12 @@
 
     exports.OpenListNav = function() {
       // init OpenListNav Properties
-      this.active = window.location.hash || '#intro';
+      this.active = this.stripHash(window.location.hash) || 'intro';
       this.navItems = document.querySelectorAll('[data-nav-item]');
       this.navSelect = $('[data-nav-options]');
       this.navIsSelect = !!this.navSelect.length;
       // initialize at maximum value
-      this.defaultTop = window.innerHeight || document.documentElement.clientHeight;
+      this.defaultTop = 1e8;
       this.closestToTop = this.defaultTop;
       this.viewportElements = 0;
       this.subnavItemClass = 'sticky_nav-nav_item-sub';
@@ -67,6 +67,12 @@
         return status;
       },
 
+      stripHash: function (str) {
+        return str.charAt(0) === '#'
+          ? str.slice(1, str.length)
+          : str;
+      },
+
       resetTop: function(){
         this.closestToTop = this.defaultTop;
         this.viewportElements = 0;
@@ -83,14 +89,14 @@
         if (!el){
           el = document.querySelector('[data-nav-item="' + name + '"]');
           parent = document.querySelector('[data-nav-item="' + parent + '"]');
-          this.active = name;
+          this.active = this.stripHash(name);
           el.setAttribute('data-active', true);
           if (parent) {
             parent.setAttribute('data-active', true);
           }
 
         } else {
-          this.active = el.getAttribute('data-nav-item');
+          this.active = this.stripHash(el.getAttribute('data-nav-item'));
           el.setAttribute('data-active', true);
           if (parent) {
             parent.setAttribute('data-active', true);
@@ -140,8 +146,7 @@
       detectNavChange: function(){
 
         var self = this;
-        var parentName,
-          newName;
+        var newName;
 
         // initialize nav status as not updated
         var updated = false;
@@ -155,8 +160,8 @@
             newName = header.id;
 
             if (item.classList.contains(self.subnavItemClass)) {
-              parentName = item.parentElement.previousElementSibling
-                .getAttribute('data-nav-item');
+              var parentName = item.parentElement.previousElementSibling
+              .getAttribute('data-nav-item');
             }
 
             self.update(null, newName, parentName);

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -15,11 +15,9 @@
       this.navItems = document.querySelectorAll('[data-nav-item]');
       this.navSelect = $('[data-nav-options]');
       this.navIsSelect = !!this.navSelect.length;
-      this.navHeaders = document.querySelectorAll('[data-nav-header]');
       // initialize at maximum value
-      // this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
-      this.defaultMid = window.innerHeight || document.documentElement.clientHeight;
-      this.closestToMid = this.defaultMid;
+      this.defaultTop = window.innerHeight || document.documentElement.clientHeight;
+      this.closestToTop = this.defaultTop;
       this.viewportElements = 0;
       this.scrollTop = {
         current: getScrollTop(),
@@ -40,6 +38,7 @@
       },
 
       isActiveElement: function(el) {
+        var status = false;
         var rect = el.getBoundingClientRect();
 
         var elementInViewport = rect.bottom > 0 &&
@@ -47,36 +46,22 @@
             rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
             rect.top < (window.innerHeight || document.documentElement.clientHeight);
 
-        var elMid = Math.abs( rect.top + (Math.abs( rect.top - rect.bottom ) / 2) );
-        var elTop = Math.abs(rect.top)
+        var elTop = Math.abs(rect.top);
 
-        if (elementInViewport) {
-          console.log(el.id, rect)
-          console.log('mid', this.closestToMid)
-          console.log('top', Math.abs(rect.top))
-          console.log('rect mid', elMid)
+        if (elementInViewport && (elTop < this.closestToTop) ) {
+          this.closestToTop = elTop;
+          this.viewportElements++;
+          status = true;
+        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToTop) ) {
+          this.viewportElements++;
+          status = true;
         }
 
-
-
-        if (elementInViewport && (elTop < this.closestToMid) ) {
-          this.closestToMid = elTop;
-          this.viewportElements++;
-          console.log('---------- chosen ----------')
-          // console.log(this.closestToMid)
-          return true;
-        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToMid) ) {
-          console.log('-------------- only one -------------')
-          this.viewportElements++;
-          return true;
-        } else {
-          return false;
-        }
-
+        return status;
       },
 
-      resetMid: function(){
-        this.closestToMid = this.defaultMid;
+      resetTop: function(){
+        this.closestToTop = this.defaultTop;
         this.viewportElements = 0;
       },
 
@@ -99,7 +84,6 @@
       },
 
       update: function(el, name){
-        // this.resetMid();
         this.removeActive();
         this.addActive(el, name);
       },
@@ -163,8 +147,7 @@
           }
         });
 
-        // this.viewportElements = 0;
-        this.resetMid();
+        this.resetTop();
       }
     };
 

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -38,6 +38,10 @@
       },
 
       isActiveElement: function(el) {
+        if (!el) {
+          return;
+        }
+
         var status = false;
         var rect = el.getBoundingClientRect();
 

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -19,6 +19,7 @@
       this.defaultTop = window.innerHeight || document.documentElement.clientHeight;
       this.closestToTop = this.defaultTop;
       this.viewportElements = 0;
+      this.subnavItemClass = 'sticky_nav-nav_item-sub';
       this.scrollTop = {
         current: getScrollTop(),
         prev: getScrollTop(),
@@ -56,7 +57,9 @@
           this.closestToTop = elTop;
           this.viewportElements++;
           status = true;
-        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToTop) ) {
+        } else if (elementInViewport &&
+                  (this.viewportElements < 1) &&
+                  (elTop >= this.closestToTop) ) {
           this.viewportElements++;
           status = true;
         }
@@ -76,20 +79,28 @@
         }
       },
 
-      addActive: function(el, name){
+      addActive: function(el, name, parent){
         if (!el){
           el = document.querySelector('[data-nav-item="' + name + '"]');
+          parent = document.querySelector('[data-nav-item="' + parent + '"]');
           this.active = name;
           el.setAttribute('data-active', true);
+          if (parent) {
+            parent.setAttribute('data-active', true);
+          }
+
         } else {
           this.active = el.getAttribute('data-nav-item');
           el.setAttribute('data-active', true);
+          if (parent) {
+            parent.setAttribute('data-active', true);
+          }
         }
       },
 
-      update: function(el, name){
+      update: function(el, name, parent){
         this.removeActive();
-        this.addActive(el, name);
+        this.addActive(el, name, parent);
       },
 
       updateSelectField: function(newValue) {
@@ -126,10 +137,11 @@
         window.location.hash = selector.value;
       },
 
-
       detectNavChange: function(){
 
         var self = this;
+        var parentName,
+          newName;
 
         // initialize nav status as not updated
         var updated = false;
@@ -139,13 +151,18 @@
 
           var isActiveElement = self.isActiveElement(header);
 
-          if (isActiveElement && !self.navIsSelect && !updated) {
-              var newName = header.name || header.id;
-              self.update(null, newName);
-              // updated = true;
+          if (isActiveElement && !self.navIsSelect) {
+            newName = header.id;
+
+            if (item.classList.contains(self.subnavItemClass)) {
+              parentName = item.parentElement.previousElementSibling
+                .getAttribute('data-nav-item');
+            }
+
+            self.update(null, newName, parentName);
 
           } else if (isActiveElement && self.navIsSelect && !updated) {
-            var newName = header.name || header.id;
+            newName = header.name || header.id;
             self.updateSelectField(newName);
             updated = true;
           }

--- a/js/components/open-list-nav.js
+++ b/js/components/open-list-nav.js
@@ -13,7 +13,7 @@
       // init OpenListNav Properties
       this.active = this.stripHash(window.location.hash) || 'intro';
       this.navItems = document.querySelectorAll('[data-nav-item]');
-      this.navSelect = document.querySelectorAll('[data-nav-options]');
+      this.navSelect = $('[data-nav-options]');
       this.navIsSelect = !!this.navSelect.length;
       // initialize at maximum value
       this.defaultTop = 1e8;
@@ -129,7 +129,6 @@
         window.addEventListener('scroll', function() {
           self.updateScrollTop();
           // TODO: throttle
-          console.log('detect')
           self.detectNavChange();
         });
 
@@ -148,12 +147,6 @@
 
         var self = this;
 
-        // initialize nav status as not updated
-        var updated = false;
-
-        console.log(this.navSelect)
-        console.log(this.navItems)
-        console.log('-------------')
         var items = this.navIsSelect
           ? this.navSelect
           : this.navItems;
@@ -163,8 +156,6 @@
             newName,
             header,
             isActiveElement;
-
-          var updated = false;
 
           if (!self.navIsSelect) {
             header = document.getElementById(item.dataset.navItem);
@@ -183,12 +174,14 @@
 
             }
           } else if (self.navIsSelect) {
-            Array.prototype.forEach.call(items, function(item){
-              if (isActiveElement && self.navIsSelect && !updated) {
-                newName = header.name || header.id;
-                console.log(newName)
+            Array.prototype.forEach.call(item, function(option){
+
+              header = document.getElementById(option.value);
+              isActiveElement = self.isActiveElement(header);
+
+              if (isActiveElement && self.navIsSelect) {
+                newName = option.value;
                 self.updateSelectField(newName);
-                updated = true;
               }
             });
           }

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -345,8 +345,10 @@
 
 	        var elementInViewport = rect.bottom > 0 &&
 	            rect.right > 0 &&
-	            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
-	            rect.top < (window.innerHeight || document.documentElement.clientHeight);
+	            rect.left < (window.innerWidth ||
+	                         document.documentElement.clientWidth) &&
+	            rect.top < (window.innerHeight ||
+	                        document.documentElement.clientHeight);
 
 	        var elTop = Math.abs(rect.top);
 

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -308,12 +308,12 @@
 
 	    exports.OpenListNav = function() {
 	      // init OpenListNav Properties
-	      this.active = window.location.hash || '#intro';
+	      this.active = this.stripHash(window.location.hash) || 'intro';
 	      this.navItems = document.querySelectorAll('[data-nav-item]');
 	      this.navSelect = $('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
 	      // initialize at maximum value
-	      this.defaultTop = window.innerHeight || document.documentElement.clientHeight;
+	      this.defaultTop = 1e8;
 	      this.closestToTop = this.defaultTop;
 	      this.viewportElements = 0;
 	      this.subnavItemClass = 'sticky_nav-nav_item-sub';
@@ -364,6 +364,12 @@
 	        return status;
 	      },
 
+	      stripHash: function (str) {
+	        return str.charAt(0) === '#'
+	          ? str.slice(1, str.length)
+	          : str;
+	      },
+
 	      resetTop: function(){
 	        this.closestToTop = this.defaultTop;
 	        this.viewportElements = 0;
@@ -380,14 +386,14 @@
 	        if (!el){
 	          el = document.querySelector('[data-nav-item="' + name + '"]');
 	          parent = document.querySelector('[data-nav-item="' + parent + '"]');
-	          this.active = name;
+	          this.active = this.stripHash(name);
 	          el.setAttribute('data-active', true);
 	          if (parent) {
 	            parent.setAttribute('data-active', true);
 	          }
 
 	        } else {
-	          this.active = el.getAttribute('data-nav-item');
+	          this.active = this.stripHash(el.getAttribute('data-nav-item'));
 	          el.setAttribute('data-active', true);
 	          if (parent) {
 	            parent.setAttribute('data-active', true);
@@ -437,8 +443,7 @@
 	      detectNavChange: function(){
 
 	        var self = this;
-	        var parentName,
-	          newName;
+	        var newName;
 
 	        // initialize nav status as not updated
 	        var updated = false;
@@ -452,8 +457,8 @@
 	            newName = header.id;
 
 	            if (item.classList.contains(self.subnavItemClass)) {
-	              parentName = item.parentElement.previousElementSibling
-	                .getAttribute('data-nav-item');
+	              var parentName = item.parentElement.previousElementSibling
+	              .getAttribute('data-nav-item');
 	            }
 
 	            self.update(null, newName, parentName);

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -310,7 +310,7 @@
 	      // init OpenListNav Properties
 	      this.active = this.stripHash(window.location.hash) || 'intro';
 	      this.navItems = document.querySelectorAll('[data-nav-item]');
-	      this.navSelect = $('[data-nav-options]');
+	      this.navSelect = document.querySelectorAll('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
 	      // initialize at maximum value
 	      this.defaultTop = 1e8;
@@ -426,6 +426,7 @@
 	        window.addEventListener('scroll', function() {
 	          self.updateScrollTop();
 	          // TODO: throttle
+	          console.log('detect')
 	          self.detectNavChange();
 	        });
 
@@ -443,31 +444,52 @@
 	      detectNavChange: function(){
 
 	        var self = this;
-	        var newName;
 
 	        // initialize nav status as not updated
 	        var updated = false;
 
-	        Array.prototype.forEach.call(this.navItems, function(item){
-	          var header = document.getElementById(item.dataset.navItem);
+	        console.log(this.navSelect)
+	        console.log(this.navItems)
+	        console.log('-------------')
+	        var items = this.navIsSelect
+	          ? this.navSelect
+	          : this.navItems;
 
-	          var isActiveElement = self.isActiveElement(header);
+	        Array.prototype.forEach.call(items, function(item){
+	          var parentName,
+	            newName,
+	            header,
+	            isActiveElement;
 
-	          if (isActiveElement && !self.navIsSelect) {
-	            newName = header.id;
+	          var updated = false;
 
-	            if (item.classList.contains(self.subnavItemClass)) {
-	              var parentName = item.parentElement.previousElementSibling
-	              .getAttribute('data-nav-item');
+	          if (!self.navIsSelect) {
+	            header = document.getElementById(item.dataset.navItem);
+
+	            isActiveElement = self.isActiveElement(header);
+
+	            if (isActiveElement) {
+	              newName = header.id;
+
+	              if (item.classList.contains(self.subnavItemClass)) {
+	                parentName = item.parentElement.previousElementSibling
+	                .getAttribute('data-nav-item');
+	              }
+
+	              self.update(null, newName, parentName);
+
 	            }
-
-	            self.update(null, newName, parentName);
-
-	          } else if (isActiveElement && self.navIsSelect && !updated) {
-	            newName = header.name || header.id;
-	            self.updateSelectField(newName);
-	            updated = true;
+	          } else if (self.navIsSelect) {
+	            Array.prototype.forEach.call(items, function(item){
+	              if (isActiveElement && self.navIsSelect && !updated) {
+	                newName = header.name || header.id;
+	                console.log(newName)
+	                self.updateSelectField(newName);
+	                updated = true;
+	              }
+	            });
 	          }
+
 	        });
 
 	        this.resetTop();

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -316,6 +316,7 @@
 	      this.defaultTop = window.innerHeight || document.documentElement.clientHeight;
 	      this.closestToTop = this.defaultTop;
 	      this.viewportElements = 0;
+	      this.subnavItemClass = 'sticky_nav-nav_item-sub';
 	      this.scrollTop = {
 	        current: getScrollTop(),
 	        prev: getScrollTop(),
@@ -353,7 +354,9 @@
 	          this.closestToTop = elTop;
 	          this.viewportElements++;
 	          status = true;
-	        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToTop) ) {
+	        } else if (elementInViewport &&
+	                  (this.viewportElements < 1) &&
+	                  (elTop >= this.closestToTop) ) {
 	          this.viewportElements++;
 	          status = true;
 	        }
@@ -373,20 +376,28 @@
 	        }
 	      },
 
-	      addActive: function(el, name){
+	      addActive: function(el, name, parent){
 	        if (!el){
 	          el = document.querySelector('[data-nav-item="' + name + '"]');
+	          parent = document.querySelector('[data-nav-item="' + parent + '"]');
 	          this.active = name;
 	          el.setAttribute('data-active', true);
+	          if (parent) {
+	            parent.setAttribute('data-active', true);
+	          }
+
 	        } else {
 	          this.active = el.getAttribute('data-nav-item');
 	          el.setAttribute('data-active', true);
+	          if (parent) {
+	            parent.setAttribute('data-active', true);
+	          }
 	        }
 	      },
 
-	      update: function(el, name){
+	      update: function(el, name, parent){
 	        this.removeActive();
-	        this.addActive(el, name);
+	        this.addActive(el, name, parent);
 	      },
 
 	      updateSelectField: function(newValue) {
@@ -423,10 +434,11 @@
 	        window.location.hash = selector.value;
 	      },
 
-
 	      detectNavChange: function(){
 
 	        var self = this;
+	        var parentName,
+	          newName;
 
 	        // initialize nav status as not updated
 	        var updated = false;
@@ -436,13 +448,18 @@
 
 	          var isActiveElement = self.isActiveElement(header);
 
-	          if (isActiveElement && !self.navIsSelect && !updated) {
-	              var newName = header.name || header.id;
-	              self.update(null, newName);
-	              // updated = true;
+	          if (isActiveElement && !self.navIsSelect) {
+	            newName = header.id;
+
+	            if (item.classList.contains(self.subnavItemClass)) {
+	              parentName = item.parentElement.previousElementSibling
+	                .getAttribute('data-nav-item');
+	            }
+
+	            self.update(null, newName, parentName);
 
 	          } else if (isActiveElement && self.navIsSelect && !updated) {
-	            var newName = header.name || header.id;
+	            newName = header.name || header.id;
 	            self.updateSelectField(newName);
 	            updated = true;
 	          }

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -49,7 +49,7 @@
 	  'use strict';
 
 	  __webpack_require__(1);
-	  var OpenListNav = __webpack_require__(22);
+	  var OpenListNav = __webpack_require__(23);
 
 	  // exporting instance of OpenListNav because openListNav is
 	  // referenced in the markup:
@@ -292,7 +292,7 @@
 
 /***/ },
 
-/***/ 22:
+/***/ 23:
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -304,14 +304,7 @@
 	          || document.body).scrollTop;
 	    }
 
-	    function isElementInViewport(el) {
-	      var rect = el.getBoundingClientRect();
 
-	      return rect.bottom > 0 &&
-	          rect.right > 0 &&
-	          rect.left < (window.innerWidth || document. documentElement.clientWidth) &&
-	          rect.top < (window.innerHeight || document. documentElement.clientHeight);
-	    }
 
 	    exports.OpenListNav = function() {
 	      // init OpenListNav Properties
@@ -320,6 +313,9 @@
 	      this.navSelect = $('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
 	      this.navHeaders = document.querySelectorAll('[data-nav-header]');
+	      // initialize at maximum value
+	      this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
+	      this.closestToMid = this.defaultMid;
 	      this.scrollTop = {
 	        current: getScrollTop(),
 	        prev: getScrollTop(),
@@ -336,6 +332,37 @@
 	        this.scrollTop.direction = (this.scrollTop.current >= this.scrollTop.prev)
 	          ? 'down'
 	          : 'up';
+	      },
+
+	      isActiveElement: function(el) {
+	        var rect = el.getBoundingClientRect();
+
+
+
+	        var elementInViewport = rect.bottom > 0 &&
+	            rect.right > 0 &&
+	            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
+	            rect.top < (window.innerHeight || document.documentElement.clientHeight);
+
+	        if (elementInViewport) {
+	          console.log(el.id, rect)
+	          console.log('mid', this.closestToMid)
+	          console.log('top', Math.abs(rect.top))
+	        }
+
+	        if (elementInViewport && (Math.abs(rect.top) < this.closestToMid)) {
+	          this.closestToMid = Math.abs(rect.top);
+	          console.log('chosen----------')
+	          // console.log(this.closestToMid)
+	          return true;
+	        } else {
+	          return false;
+	        }
+
+	      },
+
+	      resetMid: function(){
+	        this.closestToMid = this.defaultMid;
 	      },
 
 	      removeActive: function(){
@@ -357,6 +384,7 @@
 	      },
 
 	      update: function(el, name){
+	        this.resetMid();
 	        this.removeActive();
 	        this.addActive(el, name);
 	      },
@@ -403,18 +431,21 @@
 	        // initialize nav status as not updated
 	        var updated = false;
 
-	         Array.prototype.forEach.call(this.navItems, function(header){
-	          console.log(header)
-	           var inViewPort = isElementInViewport(header);
-	           if (inViewPort && !self.navIsSelect && !updated) {
+	        Array.prototype.forEach.call(this.navItems, function(item){
+	          var header = document.getElementById(item.dataset.navItem);
+
+	          var isActiveElement = self.isActiveElement(header);
+
+	          if (isActiveElement && !self.navIsSelect && !updated) {
 	              var newName = header.name || header.id;
 	              self.update(null, newName);
-	              updated = true;
-	           } else if(inViewPort && self.navIsSelect && !updated) {
-	             var newName = header.name || header.id;
+	              // updated = true;
+
+	          } else if (isActiveElement && self.navIsSelect && !updated) {
+	            var newName = header.name || header.id;
 	            self.updateSelectField(newName);
-	             updated = true;
-	           }
+	            updated = true;
+	          }
 	        });
 	      }
 	    };

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -314,8 +314,10 @@
 	      this.navIsSelect = !!this.navSelect.length;
 	      this.navHeaders = document.querySelectorAll('[data-nav-header]');
 	      // initialize at maximum value
-	      this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
+	      // this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
+	      this.defaultMid = window.innerHeight || document.documentElement.clientHeight;
 	      this.closestToMid = this.defaultMid;
+	      this.viewportElements = 0;
 	      this.scrollTop = {
 	        current: getScrollTop(),
 	        prev: getScrollTop(),
@@ -337,23 +339,32 @@
 	      isActiveElement: function(el) {
 	        var rect = el.getBoundingClientRect();
 
-
-
 	        var elementInViewport = rect.bottom > 0 &&
 	            rect.right > 0 &&
 	            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
 	            rect.top < (window.innerHeight || document.documentElement.clientHeight);
 
+	        var elMid = Math.abs( rect.top + (Math.abs( rect.top - rect.bottom ) / 2) );
+	        var elTop = Math.abs(rect.top)
+
 	        if (elementInViewport) {
 	          console.log(el.id, rect)
 	          console.log('mid', this.closestToMid)
 	          console.log('top', Math.abs(rect.top))
+	          console.log('rect mid', elMid)
 	        }
 
-	        if (elementInViewport && (Math.abs(rect.top) < this.closestToMid)) {
-	          this.closestToMid = Math.abs(rect.top);
-	          console.log('chosen----------')
+
+
+	        if (elementInViewport && (elTop < this.closestToMid) ) {
+	          this.closestToMid = elTop;
+	          this.viewportElements++;
+	          console.log('---------- chosen ----------')
 	          // console.log(this.closestToMid)
+	          return true;
+	        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToMid) ) {
+	          console.log('-------------- only one -------------')
+	          this.viewportElements++;
 	          return true;
 	        } else {
 	          return false;
@@ -363,6 +374,7 @@
 
 	      resetMid: function(){
 	        this.closestToMid = this.defaultMid;
+	        this.viewportElements = 0;
 	      },
 
 	      removeActive: function(){
@@ -384,7 +396,7 @@
 	      },
 
 	      update: function(el, name){
-	        this.resetMid();
+	        // this.resetMid();
 	        this.removeActive();
 	        this.addActive(el, name);
 	      },
@@ -447,6 +459,9 @@
 	            updated = true;
 	          }
 	        });
+
+	        // this.viewportElements = 0;
+	        this.resetMid();
 	      }
 	    };
 

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -49,7 +49,7 @@
 	  'use strict';
 
 	  __webpack_require__(1);
-	  var OpenListNav = __webpack_require__(23);
+	  var OpenListNav = __webpack_require__(22);
 
 	  // exporting instance of OpenListNav because openListNav is
 	  // referenced in the markup:
@@ -292,7 +292,7 @@
 
 /***/ },
 
-/***/ 23:
+/***/ 22:
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -403,7 +403,8 @@
 	        // initialize nav status as not updated
 	        var updated = false;
 
-	         Array.prototype.forEach.call(this.navHeaders, function(header){
+	         Array.prototype.forEach.call(this.navItems, function(header){
+	          console.log(header)
 	           var inViewPort = isElementInViewport(header);
 	           if (inViewPort && !self.navIsSelect && !updated) {
 	              var newName = header.name || header.id;

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -335,6 +335,10 @@
 	      },
 
 	      isActiveElement: function(el) {
+	        if (!el) {
+	          return;
+	        }
+
 	        var status = false;
 	        var rect = el.getBoundingClientRect();
 

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -310,7 +310,7 @@
 	      // init OpenListNav Properties
 	      this.active = this.stripHash(window.location.hash) || 'intro';
 	      this.navItems = document.querySelectorAll('[data-nav-item]');
-	      this.navSelect = document.querySelectorAll('[data-nav-options]');
+	      this.navSelect = $('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
 	      // initialize at maximum value
 	      this.defaultTop = 1e8;
@@ -426,7 +426,6 @@
 	        window.addEventListener('scroll', function() {
 	          self.updateScrollTop();
 	          // TODO: throttle
-	          console.log('detect')
 	          self.detectNavChange();
 	        });
 
@@ -445,12 +444,6 @@
 
 	        var self = this;
 
-	        // initialize nav status as not updated
-	        var updated = false;
-
-	        console.log(this.navSelect)
-	        console.log(this.navItems)
-	        console.log('-------------')
 	        var items = this.navIsSelect
 	          ? this.navSelect
 	          : this.navItems;
@@ -460,8 +453,6 @@
 	            newName,
 	            header,
 	            isActiveElement;
-
-	          var updated = false;
 
 	          if (!self.navIsSelect) {
 	            header = document.getElementById(item.dataset.navItem);
@@ -480,12 +471,14 @@
 
 	            }
 	          } else if (self.navIsSelect) {
-	            Array.prototype.forEach.call(items, function(item){
-	              if (isActiveElement && self.navIsSelect && !updated) {
-	                newName = header.name || header.id;
-	                console.log(newName)
+	            Array.prototype.forEach.call(item, function(option){
+
+	              header = document.getElementById(option.value);
+	              isActiveElement = self.isActiveElement(header);
+
+	              if (isActiveElement && self.navIsSelect) {
+	                newName = option.value;
 	                self.updateSelectField(newName);
-	                updated = true;
 	              }
 	            });
 	          }

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -312,11 +312,9 @@
 	      this.navItems = document.querySelectorAll('[data-nav-item]');
 	      this.navSelect = $('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
-	      this.navHeaders = document.querySelectorAll('[data-nav-header]');
 	      // initialize at maximum value
-	      // this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
-	      this.defaultMid = window.innerHeight || document.documentElement.clientHeight;
-	      this.closestToMid = this.defaultMid;
+	      this.defaultTop = window.innerHeight || document.documentElement.clientHeight;
+	      this.closestToTop = this.defaultTop;
 	      this.viewportElements = 0;
 	      this.scrollTop = {
 	        current: getScrollTop(),
@@ -337,6 +335,7 @@
 	      },
 
 	      isActiveElement: function(el) {
+	        var status = false;
 	        var rect = el.getBoundingClientRect();
 
 	        var elementInViewport = rect.bottom > 0 &&
@@ -344,36 +343,22 @@
 	            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
 	            rect.top < (window.innerHeight || document.documentElement.clientHeight);
 
-	        var elMid = Math.abs( rect.top + (Math.abs( rect.top - rect.bottom ) / 2) );
-	        var elTop = Math.abs(rect.top)
+	        var elTop = Math.abs(rect.top);
 
-	        if (elementInViewport) {
-	          console.log(el.id, rect)
-	          console.log('mid', this.closestToMid)
-	          console.log('top', Math.abs(rect.top))
-	          console.log('rect mid', elMid)
+	        if (elementInViewport && (elTop < this.closestToTop) ) {
+	          this.closestToTop = elTop;
+	          this.viewportElements++;
+	          status = true;
+	        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToTop) ) {
+	          this.viewportElements++;
+	          status = true;
 	        }
 
-
-
-	        if (elementInViewport && (elTop < this.closestToMid) ) {
-	          this.closestToMid = elTop;
-	          this.viewportElements++;
-	          console.log('---------- chosen ----------')
-	          // console.log(this.closestToMid)
-	          return true;
-	        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToMid) ) {
-	          console.log('-------------- only one -------------')
-	          this.viewportElements++;
-	          return true;
-	        } else {
-	          return false;
-	        }
-
+	        return status;
 	      },
 
-	      resetMid: function(){
-	        this.closestToMid = this.defaultMid;
+	      resetTop: function(){
+	        this.closestToTop = this.defaultTop;
 	        this.viewportElements = 0;
 	      },
 
@@ -396,7 +381,6 @@
 	      },
 
 	      update: function(el, name){
-	        // this.resetMid();
 	        this.removeActive();
 	        this.addActive(el, name);
 	      },
@@ -460,8 +444,7 @@
 	          }
 	        });
 
-	        // this.viewportElements = 0;
-	        this.resetMid();
+	        this.resetTop();
 	      }
 	    };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -497,6 +497,10 @@
 	      },
 
 	      isActiveElement: function(el) {
+	        if (!el) {
+	          return;
+	        }
+
 	        var status = false;
 	        var rect = el.getBoundingClientRect();
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -507,8 +507,10 @@
 
 	        var elementInViewport = rect.bottom > 0 &&
 	            rect.right > 0 &&
-	            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
-	            rect.top < (window.innerHeight || document.documentElement.clientHeight);
+	            rect.left < (window.innerWidth ||
+	                         document.documentElement.clientWidth) &&
+	            rect.top < (window.innerHeight ||
+	                        document.documentElement.clientHeight);
 
 	        var elTop = Math.abs(rect.top);
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -470,12 +470,12 @@
 
 	    exports.OpenListNav = function() {
 	      // init OpenListNav Properties
-	      this.active = window.location.hash || '#intro';
+	      this.active = this.stripHash(window.location.hash) || 'intro';
 	      this.navItems = document.querySelectorAll('[data-nav-item]');
 	      this.navSelect = $('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
 	      // initialize at maximum value
-	      this.defaultTop = window.innerHeight || document.documentElement.clientHeight;
+	      this.defaultTop = 1e8;
 	      this.closestToTop = this.defaultTop;
 	      this.viewportElements = 0;
 	      this.subnavItemClass = 'sticky_nav-nav_item-sub';
@@ -526,6 +526,12 @@
 	        return status;
 	      },
 
+	      stripHash: function (str) {
+	        return str.charAt(0) === '#'
+	          ? str.slice(1, str.length)
+	          : str;
+	      },
+
 	      resetTop: function(){
 	        this.closestToTop = this.defaultTop;
 	        this.viewportElements = 0;
@@ -542,14 +548,14 @@
 	        if (!el){
 	          el = document.querySelector('[data-nav-item="' + name + '"]');
 	          parent = document.querySelector('[data-nav-item="' + parent + '"]');
-	          this.active = name;
+	          this.active = this.stripHash(name);
 	          el.setAttribute('data-active', true);
 	          if (parent) {
 	            parent.setAttribute('data-active', true);
 	          }
 
 	        } else {
-	          this.active = el.getAttribute('data-nav-item');
+	          this.active = this.stripHash(el.getAttribute('data-nav-item'));
 	          el.setAttribute('data-active', true);
 	          if (parent) {
 	            parent.setAttribute('data-active', true);
@@ -599,8 +605,7 @@
 	      detectNavChange: function(){
 
 	        var self = this;
-	        var parentName,
-	          newName;
+	        var newName;
 
 	        // initialize nav status as not updated
 	        var updated = false;
@@ -614,8 +619,8 @@
 	            newName = header.id;
 
 	            if (item.classList.contains(self.subnavItemClass)) {
-	              parentName = item.parentElement.previousElementSibling
-	                .getAttribute('data-nav-item');
+	              var parentName = item.parentElement.previousElementSibling
+	              .getAttribute('data-nav-item');
 	            }
 
 	            self.update(null, newName, parentName);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -472,7 +472,7 @@
 	      // init OpenListNav Properties
 	      this.active = this.stripHash(window.location.hash) || 'intro';
 	      this.navItems = document.querySelectorAll('[data-nav-item]');
-	      this.navSelect = $('[data-nav-options]');
+	      this.navSelect = document.querySelectorAll('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
 	      // initialize at maximum value
 	      this.defaultTop = 1e8;
@@ -588,6 +588,7 @@
 	        window.addEventListener('scroll', function() {
 	          self.updateScrollTop();
 	          // TODO: throttle
+	          console.log('detect')
 	          self.detectNavChange();
 	        });
 
@@ -605,31 +606,52 @@
 	      detectNavChange: function(){
 
 	        var self = this;
-	        var newName;
 
 	        // initialize nav status as not updated
 	        var updated = false;
 
-	        Array.prototype.forEach.call(this.navItems, function(item){
-	          var header = document.getElementById(item.dataset.navItem);
+	        console.log(this.navSelect)
+	        console.log(this.navItems)
+	        console.log('-------------')
+	        var items = this.navIsSelect
+	          ? this.navSelect
+	          : this.navItems;
 
-	          var isActiveElement = self.isActiveElement(header);
+	        Array.prototype.forEach.call(items, function(item){
+	          var parentName,
+	            newName,
+	            header,
+	            isActiveElement;
 
-	          if (isActiveElement && !self.navIsSelect) {
-	            newName = header.id;
+	          var updated = false;
 
-	            if (item.classList.contains(self.subnavItemClass)) {
-	              var parentName = item.parentElement.previousElementSibling
-	              .getAttribute('data-nav-item');
+	          if (!self.navIsSelect) {
+	            header = document.getElementById(item.dataset.navItem);
+
+	            isActiveElement = self.isActiveElement(header);
+
+	            if (isActiveElement) {
+	              newName = header.id;
+
+	              if (item.classList.contains(self.subnavItemClass)) {
+	                parentName = item.parentElement.previousElementSibling
+	                .getAttribute('data-nav-item');
+	              }
+
+	              self.update(null, newName, parentName);
+
 	            }
-
-	            self.update(null, newName, parentName);
-
-	          } else if (isActiveElement && self.navIsSelect && !updated) {
-	            newName = header.name || header.id;
-	            self.updateSelectField(newName);
-	            updated = true;
+	          } else if (self.navIsSelect) {
+	            Array.prototype.forEach.call(items, function(item){
+	              if (isActiveElement && self.navIsSelect && !updated) {
+	                newName = header.name || header.id;
+	                console.log(newName)
+	                self.updateSelectField(newName);
+	                updated = true;
+	              }
+	            });
 	          }
+
 	        });
 
 	        this.resetTop();

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -466,14 +466,7 @@
 	          || document.body).scrollTop;
 	    }
 
-	    function isElementInViewport(el) {
-	      var rect = el.getBoundingClientRect();
 
-	      return rect.bottom > 0 &&
-	          rect.right > 0 &&
-	          rect.left < (window.innerWidth || document. documentElement.clientWidth) &&
-	          rect.top < (window.innerHeight || document. documentElement.clientHeight);
-	    }
 
 	    exports.OpenListNav = function() {
 	      // init OpenListNav Properties
@@ -482,6 +475,9 @@
 	      this.navSelect = $('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
 	      this.navHeaders = document.querySelectorAll('[data-nav-header]');
+	      // initialize at maximum value
+	      this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
+	      this.closestToMid = this.defaultMid;
 	      this.scrollTop = {
 	        current: getScrollTop(),
 	        prev: getScrollTop(),
@@ -498,6 +494,37 @@
 	        this.scrollTop.direction = (this.scrollTop.current >= this.scrollTop.prev)
 	          ? 'down'
 	          : 'up';
+	      },
+
+	      isActiveElement: function(el) {
+	        var rect = el.getBoundingClientRect();
+
+
+
+	        var elementInViewport = rect.bottom > 0 &&
+	            rect.right > 0 &&
+	            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
+	            rect.top < (window.innerHeight || document.documentElement.clientHeight);
+
+	        if (elementInViewport) {
+	          console.log(el.id, rect)
+	          console.log('mid', this.closestToMid)
+	          console.log('top', Math.abs(rect.top))
+	        }
+
+	        if (elementInViewport && (Math.abs(rect.top) < this.closestToMid)) {
+	          this.closestToMid = Math.abs(rect.top);
+	          console.log('chosen----------')
+	          // console.log(this.closestToMid)
+	          return true;
+	        } else {
+	          return false;
+	        }
+
+	      },
+
+	      resetMid: function(){
+	        this.closestToMid = this.defaultMid;
 	      },
 
 	      removeActive: function(){
@@ -519,6 +546,7 @@
 	      },
 
 	      update: function(el, name){
+	        this.resetMid();
 	        this.removeActive();
 	        this.addActive(el, name);
 	      },
@@ -565,17 +593,21 @@
 	        // initialize nav status as not updated
 	        var updated = false;
 
-	         Array.prototype.forEach.call(this.navHeaders, function(header){
-	           var inViewPort = isElementInViewport(header);
-	           if (inViewPort && !self.navIsSelect && !updated) {
+	        Array.prototype.forEach.call(this.navItems, function(item){
+	          var header = document.getElementById(item.dataset.navItem);
+
+	          var isActiveElement = self.isActiveElement(header);
+
+	          if (isActiveElement && !self.navIsSelect && !updated) {
 	              var newName = header.name || header.id;
 	              self.update(null, newName);
-	              updated = true;
-	           } else if(inViewPort && self.navIsSelect && !updated) {
-	             var newName = header.name || header.id;
+	              // updated = true;
+
+	          } else if (isActiveElement && self.navIsSelect && !updated) {
+	            var newName = header.name || header.id;
 	            self.updateSelectField(newName);
-	             updated = true;
-	           }
+	            updated = true;
+	          }
 	        });
 	      }
 	    };

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -476,8 +476,10 @@
 	      this.navIsSelect = !!this.navSelect.length;
 	      this.navHeaders = document.querySelectorAll('[data-nav-header]');
 	      // initialize at maximum value
-	      this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
+	      // this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
+	      this.defaultMid = window.innerHeight || document.documentElement.clientHeight;
 	      this.closestToMid = this.defaultMid;
+	      this.viewportElements = 0;
 	      this.scrollTop = {
 	        current: getScrollTop(),
 	        prev: getScrollTop(),
@@ -499,23 +501,32 @@
 	      isActiveElement: function(el) {
 	        var rect = el.getBoundingClientRect();
 
-
-
 	        var elementInViewport = rect.bottom > 0 &&
 	            rect.right > 0 &&
 	            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
 	            rect.top < (window.innerHeight || document.documentElement.clientHeight);
 
+	        var elMid = Math.abs( rect.top + (Math.abs( rect.top - rect.bottom ) / 2) );
+	        var elTop = Math.abs(rect.top)
+
 	        if (elementInViewport) {
 	          console.log(el.id, rect)
 	          console.log('mid', this.closestToMid)
 	          console.log('top', Math.abs(rect.top))
+	          console.log('rect mid', elMid)
 	        }
 
-	        if (elementInViewport && (Math.abs(rect.top) < this.closestToMid)) {
-	          this.closestToMid = Math.abs(rect.top);
-	          console.log('chosen----------')
+
+
+	        if (elementInViewport && (elTop < this.closestToMid) ) {
+	          this.closestToMid = elTop;
+	          this.viewportElements++;
+	          console.log('---------- chosen ----------')
 	          // console.log(this.closestToMid)
+	          return true;
+	        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToMid) ) {
+	          console.log('-------------- only one -------------')
+	          this.viewportElements++;
 	          return true;
 	        } else {
 	          return false;
@@ -525,6 +536,7 @@
 
 	      resetMid: function(){
 	        this.closestToMid = this.defaultMid;
+	        this.viewportElements = 0;
 	      },
 
 	      removeActive: function(){
@@ -546,7 +558,7 @@
 	      },
 
 	      update: function(el, name){
-	        this.resetMid();
+	        // this.resetMid();
 	        this.removeActive();
 	        this.addActive(el, name);
 	      },
@@ -609,6 +621,9 @@
 	            updated = true;
 	          }
 	        });
+
+	        // this.viewportElements = 0;
+	        this.resetMid();
 	      }
 	    };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -478,6 +478,7 @@
 	      this.defaultTop = window.innerHeight || document.documentElement.clientHeight;
 	      this.closestToTop = this.defaultTop;
 	      this.viewportElements = 0;
+	      this.subnavItemClass = 'sticky_nav-nav_item-sub';
 	      this.scrollTop = {
 	        current: getScrollTop(),
 	        prev: getScrollTop(),
@@ -515,7 +516,9 @@
 	          this.closestToTop = elTop;
 	          this.viewportElements++;
 	          status = true;
-	        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToTop) ) {
+	        } else if (elementInViewport &&
+	                  (this.viewportElements < 1) &&
+	                  (elTop >= this.closestToTop) ) {
 	          this.viewportElements++;
 	          status = true;
 	        }
@@ -535,20 +538,28 @@
 	        }
 	      },
 
-	      addActive: function(el, name){
+	      addActive: function(el, name, parent){
 	        if (!el){
 	          el = document.querySelector('[data-nav-item="' + name + '"]');
+	          parent = document.querySelector('[data-nav-item="' + parent + '"]');
 	          this.active = name;
 	          el.setAttribute('data-active', true);
+	          if (parent) {
+	            parent.setAttribute('data-active', true);
+	          }
+
 	        } else {
 	          this.active = el.getAttribute('data-nav-item');
 	          el.setAttribute('data-active', true);
+	          if (parent) {
+	            parent.setAttribute('data-active', true);
+	          }
 	        }
 	      },
 
-	      update: function(el, name){
+	      update: function(el, name, parent){
 	        this.removeActive();
-	        this.addActive(el, name);
+	        this.addActive(el, name, parent);
 	      },
 
 	      updateSelectField: function(newValue) {
@@ -585,10 +596,11 @@
 	        window.location.hash = selector.value;
 	      },
 
-
 	      detectNavChange: function(){
 
 	        var self = this;
+	        var parentName,
+	          newName;
 
 	        // initialize nav status as not updated
 	        var updated = false;
@@ -598,13 +610,18 @@
 
 	          var isActiveElement = self.isActiveElement(header);
 
-	          if (isActiveElement && !self.navIsSelect && !updated) {
-	              var newName = header.name || header.id;
-	              self.update(null, newName);
-	              // updated = true;
+	          if (isActiveElement && !self.navIsSelect) {
+	            newName = header.id;
+
+	            if (item.classList.contains(self.subnavItemClass)) {
+	              parentName = item.parentElement.previousElementSibling
+	                .getAttribute('data-nav-item');
+	            }
+
+	            self.update(null, newName, parentName);
 
 	          } else if (isActiveElement && self.navIsSelect && !updated) {
-	            var newName = header.name || header.id;
+	            newName = header.name || header.id;
 	            self.updateSelectField(newName);
 	            updated = true;
 	          }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -472,7 +472,7 @@
 	      // init OpenListNav Properties
 	      this.active = this.stripHash(window.location.hash) || 'intro';
 	      this.navItems = document.querySelectorAll('[data-nav-item]');
-	      this.navSelect = document.querySelectorAll('[data-nav-options]');
+	      this.navSelect = $('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
 	      // initialize at maximum value
 	      this.defaultTop = 1e8;
@@ -588,7 +588,6 @@
 	        window.addEventListener('scroll', function() {
 	          self.updateScrollTop();
 	          // TODO: throttle
-	          console.log('detect')
 	          self.detectNavChange();
 	        });
 
@@ -607,12 +606,6 @@
 
 	        var self = this;
 
-	        // initialize nav status as not updated
-	        var updated = false;
-
-	        console.log(this.navSelect)
-	        console.log(this.navItems)
-	        console.log('-------------')
 	        var items = this.navIsSelect
 	          ? this.navSelect
 	          : this.navItems;
@@ -622,8 +615,6 @@
 	            newName,
 	            header,
 	            isActiveElement;
-
-	          var updated = false;
 
 	          if (!self.navIsSelect) {
 	            header = document.getElementById(item.dataset.navItem);
@@ -642,12 +633,14 @@
 
 	            }
 	          } else if (self.navIsSelect) {
-	            Array.prototype.forEach.call(items, function(item){
-	              if (isActiveElement && self.navIsSelect && !updated) {
-	                newName = header.name || header.id;
-	                console.log(newName)
+	            Array.prototype.forEach.call(item, function(option){
+
+	              header = document.getElementById(option.value);
+	              isActiveElement = self.isActiveElement(header);
+
+	              if (isActiveElement && self.navIsSelect) {
+	                newName = option.value;
 	                self.updateSelectField(newName);
-	                updated = true;
 	              }
 	            });
 	          }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -474,11 +474,9 @@
 	      this.navItems = document.querySelectorAll('[data-nav-item]');
 	      this.navSelect = $('[data-nav-options]');
 	      this.navIsSelect = !!this.navSelect.length;
-	      this.navHeaders = document.querySelectorAll('[data-nav-header]');
 	      // initialize at maximum value
-	      // this.defaultMid = (window.innerHeight || document.documentElement.clientHeight) / 2;
-	      this.defaultMid = window.innerHeight || document.documentElement.clientHeight;
-	      this.closestToMid = this.defaultMid;
+	      this.defaultTop = window.innerHeight || document.documentElement.clientHeight;
+	      this.closestToTop = this.defaultTop;
 	      this.viewportElements = 0;
 	      this.scrollTop = {
 	        current: getScrollTop(),
@@ -499,6 +497,7 @@
 	      },
 
 	      isActiveElement: function(el) {
+	        var status = false;
 	        var rect = el.getBoundingClientRect();
 
 	        var elementInViewport = rect.bottom > 0 &&
@@ -506,36 +505,22 @@
 	            rect.left < (window.innerWidth || document.documentElement.clientWidth) &&
 	            rect.top < (window.innerHeight || document.documentElement.clientHeight);
 
-	        var elMid = Math.abs( rect.top + (Math.abs( rect.top - rect.bottom ) / 2) );
-	        var elTop = Math.abs(rect.top)
+	        var elTop = Math.abs(rect.top);
 
-	        if (elementInViewport) {
-	          console.log(el.id, rect)
-	          console.log('mid', this.closestToMid)
-	          console.log('top', Math.abs(rect.top))
-	          console.log('rect mid', elMid)
+	        if (elementInViewport && (elTop < this.closestToTop) ) {
+	          this.closestToTop = elTop;
+	          this.viewportElements++;
+	          status = true;
+	        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToTop) ) {
+	          this.viewportElements++;
+	          status = true;
 	        }
 
-
-
-	        if (elementInViewport && (elTop < this.closestToMid) ) {
-	          this.closestToMid = elTop;
-	          this.viewportElements++;
-	          console.log('---------- chosen ----------')
-	          // console.log(this.closestToMid)
-	          return true;
-	        } else if (elementInViewport && (this.viewportElements < 1) && (elTop >= this.closestToMid) ) {
-	          console.log('-------------- only one -------------')
-	          this.viewportElements++;
-	          return true;
-	        } else {
-	          return false;
-	        }
-
+	        return status;
 	      },
 
-	      resetMid: function(){
-	        this.closestToMid = this.defaultMid;
+	      resetTop: function(){
+	        this.closestToTop = this.defaultTop;
 	        this.viewportElements = 0;
 	      },
 
@@ -558,7 +543,6 @@
 	      },
 
 	      update: function(el, name){
-	        // this.resetMid();
 	        this.removeActive();
 	        this.addActive(el, name);
 	      },
@@ -622,8 +606,7 @@
 	          }
 	        });
 
-	        // this.viewportElements = 0;
-	        this.resetMid();
+	        this.resetTop();
 	      }
 	    };
 


### PR DESCRIPTION
Fixes issue(s) #1432 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/sticky-nav-submenu/)

TODO:
- [x] highlight parent menu item when any child is active
- [x] add all submenu items
- [x] ensure that `select` style navs still work properly

Changes proposed in this pull request:

- adds the ability to add subnav items on the sticky menu
- refines the function that determines the "active" nav item
- highlights parent menu item when any child is active
- adds submenu items from mock
- simplifies the syntax and applies markdown where possible. @coreycaitlin, I made changes so that any header can become a nav item if its title is referenced in snake case in the `nav_items` front matter.

So  `## Example header` can be referenced like so in the yaml:

```
nav_items:
  - name: example-header
    title: Example header
```

Longer, more unwieldy titles should probably still be referenced using an id. So the above front matter would need a real html header:

```
<h2 id="example-header>
  Example header that is super long and annoying to look at
</h2>
```



/cc relevant people
