### PR TITLE
Restructured state profile

### DIFF
--- a/_includes/location/key-all-production.html
+++ b/_includes/location/key-all-production.html
@@ -7,7 +7,7 @@
   <p>{{ include.location_name }} leads the nation in production of these resources:</p>
     <ul>
     {% for product in top_all_products %}
-    <li><a href="#all-production-{{ product.product | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }} percent of U.S. production</li>
+    <li><a href="#all-production-{{ product.product | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }}% of U.S. production</li>
       {% if forloop.index == include.top %}{% break %}{% endif %}
     {% endfor %}
     </ul>

--- a/_includes/location/key-exports.html
+++ b/_includes/location/key-exports.html
@@ -1,12 +1,14 @@
 {% assign exports = site.data.state_exports[include.location_id].commodities %}
 {% assign exports_total = exports.All[include.year].dollars %}
-{% assign exports_commodities_num = exports | size | minus: 2 %}
+{% assign exports_commodities_num = exports | size %}
 
 {% if exports_commodities_num > 0 %}
-  In {{ include.year }}, 
-  {{ exports_commodities_num }} extractive industries 
-  product{{ exports_commodities_num | plural }} ranked among the top 25 exports from {{ include.location_name }}, generating
-  <a href="#exports">${{ exports.All[include.year].dollars | intcomma }}</a>
-  in export revenue, or
-  {{ exports.All[include.year].percent | percent }} percent of all export revenue.
+	<p>In {{ include.year }}, 
+	{{ exports_commodities_num }} extractive industries 
+	product{{ exports_commodities_num | plural }} ranked among the top 25 exports from {{ state_name }}, generating
+	${{ exports_total | intcomma }}
+	in export revenue, or
+	{{ exports.All[include.year].percent | percent }}% of all export revenue.</p>
+{% else %}
+	<p>In {{ year }}, extractive industries products did not rank among the top 25 exports from {{ state_name }}.</p>
 {% endif %}

--- a/_includes/location/key-federal-production.html
+++ b/_includes/location/key-federal-production.html
@@ -19,5 +19,5 @@
     {% endif %}
   {% endif %}
 {% else %}
-  We have no record of federal production in {{ include.location_name }} in {{ include.year }}.
+  No natural resources were produced on federal land in {{  state_name }} in {{ year }}.
 {% endif %}

--- a/_includes/location/key-gdp.html
+++ b/_includes/location/key-gdp.html
@@ -3,11 +3,11 @@
 
 {% if gdp_dollars > 0 %}
   Extractive industries accounted for
-  <a href="#gdp">{{ gdp[include.year].percent | percent }} percent</a>
-  of {{ include.location_name }}'s gross domestic product (GDP) in {{ include.year }}.
+  <a href="#gdp">{{ gdp[include.year].percent | percent }}%
+  of {{ include.location_name }}'s gross domestic product</a> (GDP) in {{ include.year }}.
   <!-- ${{ gdp_dollars | intcomma }} -->
 {% else %}
-  The extractives industry did not have any effect on GDP in
+  The extractives industry did not have any effect on gross domestic product (GDP) in
   {{ include.location_name }} in {{ include.year }}.
 {% endif %}
 

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -4,11 +4,7 @@
 
   <h2>Natural resource production in {{ state_name }}</h2>
 
-  <h3>Production in all of {{ state_name }}</h3>
-
-  <p>The federal government collects data about all energy-related natural resources produced in each state on all lands, including federal, state, and privately owned property. (For coal, there is also data about mining in each county.)</p>
-
-  <p>In some cases, the specific amount of a resource produced in a state or county is withheld to protect trade secrets.</p>
+  <p>The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>
 
   <div class="chart-list">
 
@@ -55,5 +51,6 @@
     </section>
   {% endfor %}
 
+  <p><a href="{{ site.baseurl }}/downloads/#production-all">Data about energy production on all land comes from the Energy Information Administration.</a></p>
   </div>
 </section>

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -2,13 +2,14 @@
 
 <section id="exports" class="economic exports">
 
-  <h2>Exports</h2>
+  <h3>Exports</h3>
 
   <div class="chart-list has-intro">
 
-  {% if export_commodities %}
     <div class="chart-list-intro">
-      <p>{{ exports_summary | strip_html }}</p>
+
+      {% include location/key-exports.html %}
+    
     </div>
 
     {% for commodity in export_commodities %}
@@ -50,9 +51,7 @@
         </section><!-- /.chart-item -->
       {% endif %}
     {% endfor %}
-  {% else %}
-    <p>In {{ year }}, extractive industries products did not rank among the top 25 exports from {{ state_name }}.</p>
-  {% endif %}
+
   </div><!-- /.chart-list -->
 
   <p><a href="{{ site.baseurl }}/downloads/#exports">Exports data comes from the U.S. Census Bureau</a>.</p>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -1,16 +1,20 @@
 {% assign federal_products = site.data.state_federal_production[state_id].products %}
+{% assign federal_products_num = federal_products | size %}
 
 <section id="federal-production" class="federal production">
 
-  <h3>Natural resource production on federal land</h2>
+  <h3>Production on federal land in {{ state_name }}</h2>
 
-  <p>When companies extract natural resources on federal land, they report how much of each resource was extracted in each county.</p>
-  <p>In a few cases, usually where one company is extracting a resource in a county, production data is withheld to ensure there are no violations of the Trade Secrets Act.</p>
+  {% include location/section-ownership.html %}
 
   <section class="county-map-table">
 
-    <h3>Products</h3>
-
+    <h4>Natural resources extracted on federal land</h4>
+    
+    {% if federal_products_num == 0 %}
+      <p>No natural resources were produced on federal land in {{  state_name }} in {{ year }}.</p>
+    {% endif %}
+  
     <div class="chart-list">
 
     {% for product in federal_products %}

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -2,14 +2,14 @@
 
 <section id="gdp" class="economic gdp">
 
-  <h2>Gross Domestic Product (GDP)</h2>
+  <h3>Gross Domestic Product (GDP)</h3>
 
   <div class="chart-list has-intro">
 
     <div class="chart-list-intro">
       <p>Extractive industries accounted for
         {% if gdp[year].dollars %}
-          {{ gdp[year].percent | percent }} percent (or
+          {{ gdp[year].percent | percent }}% (or
           ${{ gdp[year].dollars | intcomma }}) of {{ state_name }}'s GDP in {{ year }}.
         {% else %}
           The extractives industry did not contribute to {{ state_name }}'s GDP in {{ year }}.

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -6,16 +6,17 @@
 
 <section id="employment" class="economic employment">
 
-  <h2>Employment</h2>
+  <h3>Employment</h3>
 
   <div class="chart-list">
 
     <div class="chart-list-intro">
-      <p>One measure of the role of extractive industries is how many people are employed in jobs related to natural resource extraction. In {{ state_name }}, in {{ year }},
+      <p>In {{ year }},
         {% if jobs_count %}
           there were
           {{ jobs_count | intcomma }}
-          jobs in the extractive industries, which represented
+          jobs in extractive industries in 
+          {{ state_name }}, or
           {{ jobs_percent | percent }}% of state-wide employment.
         {% else %}
           there were no jobs in the extractive industries.
@@ -27,7 +28,7 @@
     {% for _metric in _metrics %}
     <section class="chart-item">
 
-      <h3 class="chart-title">Extractives employment ({{ _metric }})</h3>
+      <h3 class="chart-title">Number of jobs in extractive industries</h3>
 
       <figure class="chart">
         <eiti-line-chart

--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -1,13 +1,8 @@
 <section id="overview">
 
-<!-- <p>USEITI reporting includes data about extractive industries in each state. This page summarizes information from the USEITI reporting process about natural resources in {{ state_name }} and what role extractive industries play in the state economy.</p> -->
-
-<!-- <p>The USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state, so this page also includes state legal and fiscal information.</p>
-<p>To learn more about communities in {{ state_name }} with significant extractive activity, see case studies.</p>
-<p>{{ state_name }} has opted into USEITI sub-national reporting, so this page also includes information about extractive industries activity on state-owned land.</p> -->
-
   <section class="panel-gray container-outer">
 
+    <!-- Includes the GDP percentage, then outputs employment percentage if it's over 2%. If the state leads US production for any commodities, those commodities are listed along with percentage of US production. -->
     <p>
       {%
         include location/key-gdp.html
@@ -32,25 +27,18 @@
       %}
     </p>
 
+    <!-- Sets up the federal-land focus of USEITI data, specifies what percentage of land is federally owned, and outputs the total revenue from federal land. -->
     <p>
-      USEITI focuses on <!-- has the most --> data about natural resource extraction on federal land, which represents {{ site.data.land_stats[state_id].federal_percent | percent }} percent of all land in {{ state_name }}. 
+      USEITI focuses on data about natural resource extraction on {{ "federal land" | term }}, which represents {{ site.data.land_stats[state_id].federal_percent | percent }}% of all land in {{ state_name }}. 
       {%
         include location/key-revenue.html
         location_id=state_id
         location_name=state_name
         year=year
         top=top_products
-      %}</p>
-
-    <!--
-      {% capture disbursements_summary %}
-      {%
-        include location/key-disbursements.html
-        location_id=state_id
-        location_name=state_name
-        year=year
       %}
-      {% endcapture %}{{ disbursements_summary }}
-    -->
+    </p>
+
   </section>
+
 </section>

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -1,13 +1,11 @@
 {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
 {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ state_id }}.svg{% endcapture %}
-<section id="ownership" data-nav-header="ownership" class="container-outer land-ownership">
-
-  <h3>Land ownership</h3>
 
   <section class="text-container">
     <p><strong>In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government.</strong></p>
 
-    <p>When companies extract natural resources on federal land, they pay royalties, rents, bonuses, and other fees — much like they would to any landowner. Companies also report more data about their activities on government-owned land than on private land. Learn more about <a href="{{ site.baseurl }}/how-it-works/ownership/">natural resources and land ownership in the U.S.</a></p>
+    <p>When companies extract natural resources on federal land, they pay royalties, rents, bonuses, and other fees — much like they would to any landowner.</p>
+    <p>Companies also report more data about what resources are extracted on government-owned land than on private land. Learn more about <a href="{{ site.baseurl }}/how-it-works/ownership/">natural resources and land ownership</a> in the U.S.</p>
   </section>
 
   <aside class="map-container">
@@ -50,4 +48,3 @@
 
 
   </aside>
-</section>

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -1,6 +1,7 @@
 {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
 {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ state_id }}.svg{% endcapture %}
 
+<section class="container-outer land-ownership">
   <section class="text-container">
     <p><strong>In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government.</strong></p>
 
@@ -48,3 +49,4 @@
 
 
   </aside>
+</section>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -8,82 +8,63 @@
 
   <h2>Revenue</h2>
 
-  <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called ‘revenue’ because they represent revenue to the American public.</p>
+  <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
 
   <h3 id="federal-revenue">Revenue from federal land</h3>
 
-  <section class="row-container">
-    <section class="text-container">
+  <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
-      <p>When companies want to extract natural resources on federal land, they pay fees depending on where they are in the process of using the land.</p>
+<!--   <aside class="container-half county-map-table">
 
-      <p>Laws and policies govern how rights are awarded to companies and what fees they pay to the government in order to extract natural resources on federal land. The specifics of the process depend on the kind of resource, and often affect how much revenue the federal government ultimately collects.</p>
-
-      <p>For details, read more about the different processes for awarding rights and extracting resources: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
-    </section>
-
-    <aside class="map-container">
-      <figure>
-        <data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
-          {% assign county_revenue = site.data.county_revenue[state_id] %}
-          {% capture caption %}County extractives revenue (dollars, {{ year }}){% endcapture %}
-          {% capture value_key %}revenue.{{ year }}{% endcapture %}
-
-          {%
-            include county-map.html
-            state=state_id
-            counties=county_revenue
-            value=value_key
-            steps=steps
-            inherit_width=true
-            caption=caption
-          %}
-        </data-map>
-      </figure>
-    </aside>
-  </section>
-
-  <section id="fee-summaries" class="container-outer">
-    <div>
-      <p>The federal government collects different fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected for each kind of resource during each phase of production.</p>
-
-      <!-- <p><strong>In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose).</strong></p> -->
-    </div>
-
-    <div class="tab-interface">
-      <ul class="eiti-tabs info-tabs" role="tablist">
-        <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" aria-selected="true">Commodity Revenues</a></li>
-        <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" class="link-charlie">The story behind the numbers</a></li>
-      </ul>
-
-      <article class="eiti-tab-panel" id="revenues" role="tabpanel">
+    <figure>
+      <data-map color-scheme="Blues" steps="9">
+        {% assign county_revenue = site.data.county_revenue[state_id] %}
+        {% capture value_key %}revenue.{{ year }}{% endcapture %}
         {%
-          include location/revenue-type-table.html
-          id='revenue-types'
-          location_id=state_id
-          location_name=state_name
-          year=year
+          include county-map.html
+          state=state_id
+          counties=county_revenue
+          value=value_key
         %}
-      </article>
+      </data-map>
+      <figcaption>Revenue from extraction on federal land by county (dollars, {{ year }})</figcaption>
+    </figure>
+  </aside> -->
 
-      <article class="eiti-tab-panel" id="story" role="tabpanel" aria-hidden="true">
-        {%
-          include location/revenue-process-table.html
-          id='revenue-process'
-          location_id=state_id
-          location_name=state_name
-          year=year
-        %}
-      </article>
-    </div>
-  </section>
+  <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
 
-  <p><em>* Companies may not know whether they’ll produce oil or gas until they explore the land, so fees are not differentiated by product until production begins.</em></p>
+  <div id="fee-summaries" class="tab-interface">
+    <ul class="eiti-tabs info-tabs" role="tablist">
+      <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" aria-selected="true">Commodity Revenues</a></li>
+      <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" class="link-charlie">The story behind the numbers</a></li>
+    </ul>
+
+    <article class="eiti-tab-panel" id="revenues" role="tabpanel">
+      {%
+        include location/revenue-type-table.html
+        id='revenue-types'
+        location_id=state_id
+        location_name=state_name
+        year=year
+      %}
+    </article>
+
+    <article class="eiti-tab-panel" id="story" role="tabpanel" aria-hidden="true">
+      {%
+        include location/revenue-process-table.html
+        id='revenue-process'
+        location_id=state_id
+        location_name=state_name
+        year=year
+      %}
+    </article>
+  </div>
 
   <section id="commodities-revenue" class="chart-list has-intro">
 
-    <h4>Revenue from extraction on federal land in {{ state_name }} over time</h3>
-    <p class="chart-list-intro">In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government, and companies that extract natural resources on federal land pay fees to the federal government. This chart shows how much federal revenue was collected each year in {{ state_name }}.</p>
+    <h4>Revenue from resources extracted on federal land in {{ state_name }}</h4>
+
+    <p class="chart-list-intro">In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}.</p>
 
     {% for commodity in revenue_commodities %}
       {% assign revenue = commodity[1][year].revenue %}
@@ -136,12 +117,11 @@
 </section>
 
 <section id="state-local-revenue" class="state revenue">
-  <h3 >Revenue from state land</h3>
-  <p>Natural resource extraction on land owned by the state of {{ state_name }} is governed by <a href="{{ site.baseurl }}/how-it-works/state-laws-and-regulations/#role-of-state-government-agencies/</a>">state laws and regulations</a>.</p>
-  <p>We don't have detailed data about state revenue from natural resource extraction on land owned by the state. To learn more about regulations and state revenues in {{ state_name }}, see <a href="{{ site.baseurl }}/how-it-works/state-legal-fiscal-info/">state legal and fiscal information</a>.</p>
+  <h3>Revenue from extraction on state land</h3>
+  <p>We don't have detailed data about state revenue from natural resource extraction on land owned by the state of {{ state_name }}. To learn more about regulations and state revenues in {{ state_name }}, see <a href="{{ site.baseurl }}/how-it-works/state-legal-fiscal-info/">state legal and fiscal information</a>.</p>
 </section>
 
 <section id="private-revenue" class="private-lands revenue">
-  <h3>Revenue from private land</h3>
+  <h3>Revenue from extraction on private land</h3>
   <p>Companies that extract natural resources on private land must pay income taxes, like any other company. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
 </section>

--- a/_includes/location/section-state-production.html
+++ b/_includes/location/section-state-production.html
@@ -1,10 +1,10 @@
 <section id="state-local-production" class="state production">
-  <h3>Natural resource production on state land</h3>
+  <h3>Production on state land</h3>
   <p>Natural resource extraction on land owned by the State of {{ state_name }} is governed by <a href="{{ site.baseurl }}/how-it-works/state-laws-and-regulations/#role-of-state-government-agencies/</a>">state laws and regulations</a>.</p>
   <p>We don't have detailed data about natural resource extraction on land owned by the state.</p>
 </section>
 
 <section id="private-land-production" class="production">
-  <h3>Natural resource production on private land</h3>
+  <h3>Production on private land</h3>
   <p>We don't have detailed data about natural resource extraction on land owned by individuals or corporations.</p>
 </section>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -3,40 +3,35 @@ layout: default
 nav_items:
   - name: overview
     title: Overview
-  - name: ownership
-    title: Land ownership
-  - name: revenue
-    title: Revenue
-    subnav_items:
-      - name: federal-revenue
-        title: Federal land
-      - name: fee-summaries
-        title: Fee summaries
-      - name: commodities-revenue
-        title: Commodities
-      - name: state-local-revenue
-        title: State land
-      - name: private-revenue
-        title: Private land
   - name: production
     title: Production
     subnav_items:
-      - name: all-production
-        title: Entire state
       - name: federal-production
         title: Federal land
       - name: state-local-production
         title: State land
       - name: private-land-production
         title: Private land
-  - name: gdp
-    title: Economic impact
-  - name: employment
-    title: Employment
-  - name: exports
-    title: Exports
+  - name: revenue
+    title: Revenue
+    subnav_items:
+      - name: federal-revenue
+        title: Federal land
+      - name: state-local-revenue
+        title: State land
+      - name: private-revenue
+        title: Private land
   - name: disbursements
     title: Disbursements
+  - name: economic-impact
+    title: Economic impact
+    subnav_items:
+    - name: gdp
+      title: GDP
+    - name: employment
+      title: Jobs
+    - name: exports
+      title: Exports
 ---
 
 {% assign state_name = page.title %}
@@ -59,11 +54,8 @@ nav_items:
 
     {% include location/section-overview.html %}
 
-    {% include location/section-ownership.html %}
-
-    {% include location/section-revenue.html %}
-
     <!-- {% include location/section-process.html %} -->
+
     <section id="production">
       {% include location/section-all-production.html %}
 
@@ -72,13 +64,20 @@ nav_items:
       {% include location/section-state-production.html %}
     </section>
 
-    {% include location/section-gdp.html %}
-
-    {% include location/section-jobs.html %}
-
-    {% include location/section-exports.html %}
+    {% include location/section-revenue.html %}
 
     {% include location/section-disbursements.html %}
+
+    <section id="economic-impact">
+    <h2>Economic Impact</h2>
+
+      {% include location/section-gdp.html %}
+
+      {% include location/section-jobs.html %}
+
+      {% include location/section-exports.html %}
+    </section>
+
 
     <!-- XXX setting display: none on this prevents the mask from working -->
     <svg width="0" height="0">


### PR DESCRIPTION
Addresses issue #1514.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-hierarchy-revision/)

Changes proposed in this pull request:

- Demoted ownership info to the beginning of federal production
- Re-ordered sections to move from Production --> Revenue --> Disbursements
- Created a parent nav item for all economic impact measures
- Various and sundry edits to content
- Removed several headers and changed the header level of several others
- Began using `%` instead of `percent` for clarity and scan-ability

This might be a slightly messy one — sorry about that! Also, the exports summary is acting up, and my attempts at troubleshooting have been largely fruitless. 😕 

/cc @meiqimichelle @gemfarmer 

