### PR TITLE
Megachart stacked bars

### DIFF
--- a/_includes/location/revenue-type-row-oilgas.html
+++ b/_includes/location/revenue-type-row-oilgas.html
@@ -20,24 +20,24 @@
   <td data-value="{{
     revenue_types.Oil.Royalties[include.year] | default: 0
   }}">
-    <a href="#revenue-oil"><strong>Oil</strong></a>
+    <span class="tester" data-value="{{
+    revenue_types.Gas.Royalties[include.year] | default: 0
+  }}"></span>
+
     <span class="text">
+    <a href="#revenue-oil"><strong>Oil</strong></a>
     ${{
       revenue_types.Oil.Royalties[include.year]
       | default: 0
       | intcomma
     }}</span>
+
+    <span class="text">
+    <a href="#revenue-gas"><strong>Gas</strong></a>
+    ${{ revenue_types.Gas.Royalties[include.year] | default: 0 | intcomma }}</span>
+
   </td>
   <td rowspan="2" data-value="{{
     values['Other Revenues'][include.year] | default: 0
   }}"><span class="text">${{ values['Other Revenues'][include.year] | default: 0 | intcomma }}</span></td>
-</tr>
-<tr>
-  <td data-value="{{
-    revenue_types.Gas.Royalties[include.year] | default: 0
-  }}">
-    <a href="#revenue-gas"><strong>Gas</strong></a>
-    <span class="text">
-    ${{ revenue_types.Gas.Royalties[include.year] | default: 0 | intcomma }}</span>
-  </td>
 </tr>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -68,6 +68,7 @@ $green-mint: #d2e2cc;
 $green-sea: #b1d39c;
 $green-dark: #657c60;
 $chart-green: #a5d78a;
+$green-darkest: #2f4d26;
 
 // v2 - deprecate
 $putty: #f4f4f4;

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -35,6 +35,11 @@
       background: $green-dark;
     }
 
+    .bar .bar .bar {
+      background: $green-darkest;
+      border-right: 1px solid $neutral-gray;
+    }
+
     &:not([data-value="0"]) {
       .bar {
         min-width: 1px;

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -29,15 +29,15 @@
       background: $mid-gray;
       display: block;
       height: 1em;
-    }
 
-    .bar .bar {
-      background: $green-dark;
-    }
+      .bar {
+        background: $green-dark;
 
-    .bar .bar .bar {
-      background: $green-darkest;
-      border-right: 1px solid $neutral-gray;
+        .bar {
+          background: $green-darkest;
+          border-right: 1px solid $neutral-gray;
+        }
+      }
     }
 
     &:not([data-value="0"]) {

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -2,6 +2,9 @@
 
   var initialize = function() {
     this._cells = [].slice.call(this.querySelectorAll('tr > [data-value]'));
+    this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
+    this._cells = this._cells.concat(this.nested_cells)
+
     this.update();
   };
 
@@ -79,7 +82,11 @@
         if (!cell) {
           console.warn('no cell @', i);
           return;
+        } else if (cell.parentNode.hasAttribute('data-value')) {
+          console.warn('cell is child', i);
         }
+
+        var childCell = cell.querySelector('[data-value]');
 
         // TODO only do this if autolabel="true"?
         if (cell.childNodes.length === 1 && cell.firstChild.nodeType === Node.TEXT_NODE) {
@@ -93,6 +100,7 @@
             span.appendChild(text);
           }
         }
+
 
         var barExtent = cell.querySelector('.bar');
         if (barExtent) {
@@ -111,9 +119,28 @@
           }
         }
 
+        if (childCell) {
+          var childBar = document.createElement('div');
+          childBar.className = 'bar';
+          bar.appendChild(childBar);
+        }
+
         var value = +cell.dataset.value;
         var size = width(value);
-        bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
+
+        if (childCell) {
+          var childValue = +childCell.dataset.value;
+          size = width(value) + width(childValue);
+          var diff = childValue - value;
+          var largerSize = diff > 0
+            ? width(childValue) / (size / 100)
+            : width(value) / (size / 100);
+          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
+          childBar.style.setProperty(sizeProperty, Math.abs(largerSize) + '%');
+        } else {
+          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
+        }
+
         if (offset) {
           bar.style.setProperty(offsetProperty, offset(value) + '%');
         } else {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11084,6 +11084,9 @@
 
 	  var initialize = function() {
 	    this._cells = [].slice.call(this.querySelectorAll('tr > [data-value]'));
+	    this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
+	    this._cells = this._cells.concat(this.nested_cells)
+
 	    this.update();
 	  };
 
@@ -11161,7 +11164,11 @@
 	        if (!cell) {
 	          console.warn('no cell @', i);
 	          return;
+	        } else if (cell.parentNode.hasAttribute('data-value')) {
+	          console.warn('cell is child', i);
 	        }
+
+	        var childCell = cell.querySelector('[data-value]');
 
 	        // TODO only do this if autolabel="true"?
 	        if (cell.childNodes.length === 1 && cell.firstChild.nodeType === Node.TEXT_NODE) {
@@ -11175,6 +11182,7 @@
 	            span.appendChild(text);
 	          }
 	        }
+
 
 	        var barExtent = cell.querySelector('.bar');
 	        if (barExtent) {
@@ -11193,9 +11201,28 @@
 	          }
 	        }
 
+	        if (childCell) {
+	          var childBar = document.createElement('div');
+	          childBar.className = 'bar';
+	          bar.appendChild(childBar);
+	        }
+
 	        var value = +cell.dataset.value;
 	        var size = width(value);
-	        bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
+
+	        if (childCell) {
+	          var childValue = +childCell.dataset.value;
+	          size = width(value) + width(childValue);
+	          var diff = childValue - value;
+	          var largerSize = diff > 0
+	            ? width(childValue) / (size / 100)
+	            : width(value) / (size / 100);
+	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
+	          childBar.style.setProperty(sizeProperty, Math.abs(largerSize) + '%');
+	        } else {
+	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
+	        }
+
 	        if (offset) {
 	          bar.style.setProperty(offsetProperty, offset(value) + '%');
 	        } else {


### PR DESCRIPTION
Fixes issue(s) #1459 

Working from [this mock](https://gsa.invisionapp.com/share/827QI8DGR#/screens/168829790)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/megachart-tidy/states/UT/#fee-summaries)

Changes proposed in this pull request:

updates the js/scss to handle the single instance where there are nested bars. @shawnbot, I realize that his is a pretty porous way to go about this – it is pretty much set up to handle the oil gas double bar, and cases _exactly_ like it, and that's it.

/cc @meiqimichelle @shawnbot 

