### PR TITLE
added links to each data and documentation page or section

### DIFF
--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -51,6 +51,10 @@
     </section>
   {% endfor %}
 
-  <p><a href="{{ site.baseurl }}/downloads/#production-all">Data about energy production on all land comes from the Energy Information Administration.</a></p>
   </div>
+
+  <a href="{{site.baseurl}}/downloads/#production-all">
+      <icon class="fa fa-file-text-o u-padding-right"></icon>Data about energy production on all lands and waters comes from the Energy Information Administration
+  </a>
+
 </section>

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -10,4 +10,8 @@
     %}
   {% endif %}
 
+  <a href="{{site.baseurl}}/downloads/disbursements/">
+	<icon class="fa fa-file-text-o u-padding-right"></icon>Disbursements data comes from the Office of Natural Resources Revenue
+  </a>
+
 </section>

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -54,5 +54,8 @@
 
   </div><!-- /.chart-list -->
 
-  <p><a href="{{ site.baseurl }}/downloads/#exports">Exports data comes from the U.S. Census Bureau</a>.</p>
+  <a href="{{site.baseurl}}/downloads/#exports">
+    <icon class="fa fa-file-text-o u-padding-right"></icon>Exports data comes from the U.S. Census Bureau
+  </a>
+
 </section>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -121,4 +121,9 @@
     </div><!-- /.chart-list -->
 
   </section>
+
+  <a href="{{site.baseurl}}/downloads/federal-production/">
+    <icon class="fa fa-file-text-o u-padding-right"></icon>Federal production data comes from the Office of Natural Resources Revenue
+  </a>
+
 </section>

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -60,4 +60,8 @@
 
   </div><!-- /.chart-list.has-intro -->
 
+  <a href="{{site.baseurl}}/downloads/#gdp">
+    <icon class="fa fa-file-text-o u-padding-right"></icon>GDP data comes from the U.S. Bureau of Economic Analysis
+  </a>
+
 </section>

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -113,4 +113,8 @@
 
   </div><!-- /.chart-list -->
 
+
+  <a href="{{site.baseurl}}/downloads/#jobs">
+    <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
+  </a>
 </section>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -114,6 +114,10 @@
     </section>
   {% endfor %}
 
+  <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
+    <icon class="fa fa-file-text-o u-padding-right"></icon>Federal revenue data comes from the Office of Natural Resources Revenue
+  </a>
+
 </section>
 
 <section id="state-local-revenue" class="state revenue">


### PR DESCRIPTION
Fixes issue(s) #1515 .

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-data-links/)

Changes proposed in this pull request:

- Added links to each section of the page, so users can get from the state profile to the appropriate data and documentation
- Wrote data/docs links as statements about where the data is coming from
- Used markup/icons from the old explore data pages

/cc @meiqimichelle 
