### PR TITLE
Updates open/close behaviors for glossary terms

### DIFF
--- a/_sass/components/_glossary.scss
+++ b/_sass/components/_glossary.scss
@@ -33,6 +33,7 @@ $term-width-max: 220px;
 
 .glossary-term {
   color: $white;
+  cursor: pointer;
   display: inline-block;
   margin: 0;
   max-width: $term-width-max;

--- a/js/components/glossary.js
+++ b/js/components/glossary.js
@@ -60,6 +60,7 @@
     // Bind listeners
     self.$toggle.on('click', this.toggle.bind(this));
     self.$body.on('click', '.toggle', this.toggle.bind(this));
+    self.$body.on('click', '.glossary-term', this.toggleTermFromClick.bind(this) );
     self.$search.on('input', this.handleInput.bind(this));
 
     $(document.body).on('keyup', this.handleKeyup.bind(this));
@@ -141,6 +142,17 @@
     toggle: function() {
       var method = this.isOpen ? this.hide : this.show;
       method.apply(this);
+    },
+
+    toggleTermFromClick: function(event){
+      var $target = $(event.target);
+      var doExpand = $target.parent().attr( 'aria-expanded') === 'true' ? 'false' : 'true';
+
+      $target
+        .siblings( 'p' )
+        .attr('aria-hidden', doExpand )
+        .parent()
+        .attr('aria-expanded', doExpand );
     },
 
     show: function() {

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -100,7 +100,7 @@
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
 	  var d3 = {
-	    version: "3.5.17"
+	    version: "3.5.16"
 	  };
 	  var d3_arraySlice = [].slice, d3_array = function(list) {
 	    return d3_arraySlice.call(list);
@@ -3625,7 +3625,7 @@
 	        λ0 = λ, sinφ0 = sinφ, cosφ0 = cosφ, point0 = point;
 	      }
 	    }
-	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ winding & 1;
+	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ winding & 1;
 	  }
 	  function d3_geo_clipCircle(radius) {
 	    var cr = Math.cos(radius), smallRadius = cr > 0, notHemisphere = abs(cr) > ε, interpolate = d3_geo_circleInterpolate(radius, 6 * d3_radians);
@@ -9842,112 +9842,87 @@
 /* 7 */
 /***/ function(module, exports, __webpack_require__) {
 
-	(function (global, factory) {
-	   true ? module.exports = factory() :
-	  typeof define === 'function' && define.amd ? define('queue', factory) :
-	  (global.queue = factory());
-	}(this, function () { 'use strict';
-
+	var __WEBPACK_AMD_DEFINE_RESULT__;(function() {
 	  var slice = [].slice;
 
-	  function noop() {}
-
-	  var noabort = {};
-	  var success = [null];
-	  function newQueue(concurrency) {
-	    if (!(concurrency >= 1)) throw new Error;
-
+	  function queue(parallelism) {
 	    var q,
 	        tasks = [],
-	        results = [],
-	        waiting = 0,
-	        active = 0,
-	        ended = 0,
-	        starting, // inside a synchronous task callback?
-	        error,
-	        callback = noop,
-	        callbackAll = true;
+	        started = 0, // number of tasks that have been started (and perhaps finished)
+	        active = 0, // number of tasks currently being executed (started but not finished)
+	        remaining = 0, // number of tasks not yet finished
+	        popping, // inside a synchronous task callback?
+	        error = null,
+	        await = noop,
+	        all;
 
-	    function start() {
-	      if (starting) return; // let the current task complete
-	      while (starting = waiting && active < concurrency) {
-	        var i = ended + active,
+	    if (!parallelism) parallelism = Infinity;
+
+	    function pop() {
+	      while (popping = started < tasks.length && active < parallelism) {
+	        var i = started++,
 	            t = tasks[i],
-	            j = t.length - 1,
-	            c = t[j];
-	        t[j] = end(i);
-	        --waiting, ++active, tasks[i] = c.apply(null, t) || noabort;
+	            a = slice.call(t, 1);
+	        a.push(callback(i));
+	        ++active;
+	        t[0].apply(null, a);
 	      }
 	    }
 
-	    function end(i) {
+	    function callback(i) {
 	      return function(e, r) {
-	        if (!tasks[i]) throw new Error; // detect multiple callbacks
-	        --active, ++ended, tasks[i] = null;
-	        if (error != null) return; // only report the first error
+	        --active;
+	        if (error != null) return;
 	        if (e != null) {
-	          abort(e);
+	          error = e; // ignore new tasks and squelch active callbacks
+	          started = remaining = NaN; // stop queued tasks from starting
+	          notify();
 	        } else {
-	          results[i] = r;
-	          if (waiting) start();
-	          else if (!active) notify();
+	          tasks[i] = r;
+	          if (--remaining) popping || pop();
+	          else notify();
 	        }
 	      };
 	    }
 
-	    function abort(e) {
-	      error = e; // ignore new tasks and squelch active callbacks
-	      waiting = NaN; // stop queued tasks from starting
-	      notify();
-	    }
-
 	    function notify() {
-	      if (error != null) callback(error);
-	      else if (callbackAll) callback(null, results);
-	      else callback.apply(null, success.concat(results));
+	      if (error != null) await(error);
+	      else if (all) await(error, tasks);
+	      else await.apply(null, [error].concat(tasks));
 	    }
 
 	    return q = {
-	      defer: function(f) {
-	        if (callback !== noop) throw new Error;
-	        var t = slice.call(arguments, 1);
-	        t.push(f);
-	        ++waiting, tasks.push(t);
-	        start();
-	        return q;
-	      },
-	      abort: function() {
-	        if (error == null) {
-	          var i = ended + active, t;
-	          while (--i >= 0) (t = tasks[i]) && t.abort && t.abort();
-	          abort(new Error("abort"));
+	      defer: function() {
+	        if (!error) {
+	          tasks.push(arguments);
+	          ++remaining;
+	          pop();
 	        }
 	        return q;
 	      },
 	      await: function(f) {
-	        if (callback !== noop) throw new Error;
-	        callback = f, callbackAll = false;
-	        if (!waiting && !active) notify();
+	        await = f;
+	        all = false;
+	        if (!remaining) notify();
 	        return q;
 	      },
 	      awaitAll: function(f) {
-	        if (callback !== noop) throw new Error;
-	        callback = f, callbackAll = true;
-	        if (!waiting && !active) notify();
+	        await = f;
+	        all = true;
+	        if (!remaining) notify();
 	        return q;
 	      }
 	    };
 	  }
 
-	  function queue(concurrency) {
-	    return newQueue(arguments.length ? +concurrency : Infinity);
-	  }
+	  function noop() {}
 
-	  queue.version = "1.2.1";
+	  queue.version = "1.0.7";
+	  if (true) !(__WEBPACK_AMD_DEFINE_RESULT__ = function() { return queue; }.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+	  else if (typeof module === "object" && module.exports) module.exports = queue;
+	  else this.queue = queue;
+	})();
 
-	  return queue;
-
-	}));
 
 /***/ },
 /* 8 */
@@ -10822,7 +10797,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
-	 * jQuery JavaScript Library v1.12.4
+	 * jQuery JavaScript Library v1.12.3
 	 * http://jquery.com/
 	 *
 	 * Includes Sizzle.js
@@ -10832,7 +10807,7 @@
 	 * Released under the MIT license
 	 * http://jquery.org/license
 	 *
-	 * Date: 2016-05-20T17:17Z
+	 * Date: 2016-04-05T19:16Z
 	 */
 
 	(function( global, factory ) {
@@ -10888,7 +10863,7 @@
 
 
 	var
-		version = "1.12.4",
+		version = "1.12.3",
 
 		// Define a local copy of jQuery
 		jQuery = function( selector, context ) {
@@ -17495,7 +17470,6 @@
 			if ( reliableHiddenOffsetsVal ) {
 				div.style.display = "";
 				div.innerHTML = "<table><tr><td></td><td>t</td></tr></table>";
-				div.childNodes[ 0 ].style.borderCollapse = "separate";
 				contents = div.getElementsByTagName( "td" );
 				contents[ 0 ].style.cssText = "margin:0;border:0;padding:0;display:none";
 				reliableHiddenOffsetsVal = contents[ 0 ].offsetHeight === 0;
@@ -17819,6 +17793,19 @@
 			styles = getStyles( elem ),
 			isBorderBox = support.boxSizing &&
 				jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
+
+		// Support: IE11 only
+		// In IE 11 fullscreen elements inside of an iframe have
+		// 100x too small dimensions (gh-1764).
+		if ( document.msFullscreenElement && window.top !== window ) {
+
+			// Support: IE11 only
+			// Running getBoundingClientRect on a disconnected node
+			// in IE throws an error.
+			if ( elem.getClientRects().length ) {
+				val = Math.round( elem.getBoundingClientRect()[ name ] * 100 );
+			}
+		}
 
 		// some non-html elements return undefined for offsetWidth, so check for null/undefined
 		// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
@@ -20810,11 +20797,6 @@
 	}
 
 	function filterHidden( elem ) {
-
-		// Disconnected elements are considered hidden
-		if ( !jQuery.contains( elem.ownerDocument || document, elem ) ) {
-			return true;
-		}
 		while ( elem && elem.nodeType === 1 ) {
 			if ( getDisplay( elem ) === "none" || elem.type === "hidden" ) {
 				return true;

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -100,7 +100,7 @@
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
 	  var d3 = {
-	    version: "3.5.16"
+	    version: "3.5.17"
 	  };
 	  var d3_arraySlice = [].slice, d3_array = function(list) {
 	    return d3_arraySlice.call(list);
@@ -3625,7 +3625,7 @@
 	        λ0 = λ, sinφ0 = sinφ, cosφ0 = cosφ, point0 = point;
 	      }
 	    }
-	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ winding & 1;
+	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ winding & 1;
 	  }
 	  function d3_geo_clipCircle(radius) {
 	    var cr = Math.cos(radius), smallRadius = cr > 0, notHemisphere = abs(cr) > ε, interpolate = d3_geo_circleInterpolate(radius, 6 * d3_radians);
@@ -9842,87 +9842,112 @@
 /* 7 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var __WEBPACK_AMD_DEFINE_RESULT__;(function() {
+	(function (global, factory) {
+	   true ? module.exports = factory() :
+	  typeof define === 'function' && define.amd ? define('queue', factory) :
+	  (global.queue = factory());
+	}(this, function () { 'use strict';
+
 	  var slice = [].slice;
 
-	  function queue(parallelism) {
+	  function noop() {}
+
+	  var noabort = {};
+	  var success = [null];
+	  function newQueue(concurrency) {
+	    if (!(concurrency >= 1)) throw new Error;
+
 	    var q,
 	        tasks = [],
-	        started = 0, // number of tasks that have been started (and perhaps finished)
-	        active = 0, // number of tasks currently being executed (started but not finished)
-	        remaining = 0, // number of tasks not yet finished
-	        popping, // inside a synchronous task callback?
-	        error = null,
-	        await = noop,
-	        all;
+	        results = [],
+	        waiting = 0,
+	        active = 0,
+	        ended = 0,
+	        starting, // inside a synchronous task callback?
+	        error,
+	        callback = noop,
+	        callbackAll = true;
 
-	    if (!parallelism) parallelism = Infinity;
-
-	    function pop() {
-	      while (popping = started < tasks.length && active < parallelism) {
-	        var i = started++,
+	    function start() {
+	      if (starting) return; // let the current task complete
+	      while (starting = waiting && active < concurrency) {
+	        var i = ended + active,
 	            t = tasks[i],
-	            a = slice.call(t, 1);
-	        a.push(callback(i));
-	        ++active;
-	        t[0].apply(null, a);
+	            j = t.length - 1,
+	            c = t[j];
+	        t[j] = end(i);
+	        --waiting, ++active, tasks[i] = c.apply(null, t) || noabort;
 	      }
 	    }
 
-	    function callback(i) {
+	    function end(i) {
 	      return function(e, r) {
-	        --active;
-	        if (error != null) return;
+	        if (!tasks[i]) throw new Error; // detect multiple callbacks
+	        --active, ++ended, tasks[i] = null;
+	        if (error != null) return; // only report the first error
 	        if (e != null) {
-	          error = e; // ignore new tasks and squelch active callbacks
-	          started = remaining = NaN; // stop queued tasks from starting
-	          notify();
+	          abort(e);
 	        } else {
-	          tasks[i] = r;
-	          if (--remaining) popping || pop();
-	          else notify();
+	          results[i] = r;
+	          if (waiting) start();
+	          else if (!active) notify();
 	        }
 	      };
 	    }
 
+	    function abort(e) {
+	      error = e; // ignore new tasks and squelch active callbacks
+	      waiting = NaN; // stop queued tasks from starting
+	      notify();
+	    }
+
 	    function notify() {
-	      if (error != null) await(error);
-	      else if (all) await(error, tasks);
-	      else await.apply(null, [error].concat(tasks));
+	      if (error != null) callback(error);
+	      else if (callbackAll) callback(null, results);
+	      else callback.apply(null, success.concat(results));
 	    }
 
 	    return q = {
-	      defer: function() {
-	        if (!error) {
-	          tasks.push(arguments);
-	          ++remaining;
-	          pop();
+	      defer: function(f) {
+	        if (callback !== noop) throw new Error;
+	        var t = slice.call(arguments, 1);
+	        t.push(f);
+	        ++waiting, tasks.push(t);
+	        start();
+	        return q;
+	      },
+	      abort: function() {
+	        if (error == null) {
+	          var i = ended + active, t;
+	          while (--i >= 0) (t = tasks[i]) && t.abort && t.abort();
+	          abort(new Error("abort"));
 	        }
 	        return q;
 	      },
 	      await: function(f) {
-	        await = f;
-	        all = false;
-	        if (!remaining) notify();
+	        if (callback !== noop) throw new Error;
+	        callback = f, callbackAll = false;
+	        if (!waiting && !active) notify();
 	        return q;
 	      },
 	      awaitAll: function(f) {
-	        await = f;
-	        all = true;
-	        if (!remaining) notify();
+	        if (callback !== noop) throw new Error;
+	        callback = f, callbackAll = true;
+	        if (!waiting && !active) notify();
 	        return q;
 	      }
 	    };
 	  }
 
-	  function noop() {}
+	  function queue(concurrency) {
+	    return newQueue(arguments.length ? +concurrency : Infinity);
+	  }
 
-	  queue.version = "1.0.7";
-	  if (true) !(__WEBPACK_AMD_DEFINE_RESULT__ = function() { return queue; }.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-	  else if (typeof module === "object" && module.exports) module.exports = queue;
-	  else this.queue = queue;
-	})();
+	  queue.version = "1.2.1";
 
+	  return queue;
+
+	}));
 
 /***/ },
 /* 8 */
@@ -10797,7 +10822,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
-	 * jQuery JavaScript Library v1.12.3
+	 * jQuery JavaScript Library v1.12.4
 	 * http://jquery.com/
 	 *
 	 * Includes Sizzle.js
@@ -10807,7 +10832,7 @@
 	 * Released under the MIT license
 	 * http://jquery.org/license
 	 *
-	 * Date: 2016-04-05T19:16Z
+	 * Date: 2016-05-20T17:17Z
 	 */
 
 	(function( global, factory ) {
@@ -10863,7 +10888,7 @@
 
 
 	var
-		version = "1.12.3",
+		version = "1.12.4",
 
 		// Define a local copy of jQuery
 		jQuery = function( selector, context ) {
@@ -17470,6 +17495,7 @@
 			if ( reliableHiddenOffsetsVal ) {
 				div.style.display = "";
 				div.innerHTML = "<table><tr><td></td><td>t</td></tr></table>";
+				div.childNodes[ 0 ].style.borderCollapse = "separate";
 				contents = div.getElementsByTagName( "td" );
 				contents[ 0 ].style.cssText = "margin:0;border:0;padding:0;display:none";
 				reliableHiddenOffsetsVal = contents[ 0 ].offsetHeight === 0;
@@ -17793,19 +17819,6 @@
 			styles = getStyles( elem ),
 			isBorderBox = support.boxSizing &&
 				jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
-
-		// Support: IE11 only
-		// In IE 11 fullscreen elements inside of an iframe have
-		// 100x too small dimensions (gh-1764).
-		if ( document.msFullscreenElement && window.top !== window ) {
-
-			// Support: IE11 only
-			// Running getBoundingClientRect on a disconnected node
-			// in IE throws an error.
-			if ( elem.getClientRects().length ) {
-				val = Math.round( elem.getBoundingClientRect()[ name ] * 100 );
-			}
-		}
 
 		// some non-html elements return undefined for offsetWidth, so check for null/undefined
 		// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
@@ -20797,6 +20810,11 @@
 	}
 
 	function filterHidden( elem ) {
+
+		// Disconnected elements are considered hidden
+		if ( !jQuery.contains( elem.ownerDocument || document, elem ) ) {
+			return true;
+		}
 		while ( elem && elem.nodeType === 1 ) {
 			if ( getDisplay( elem ) === "none" || elem.type === "hidden" ) {
 				return true;
@@ -25124,6 +25142,7 @@
 	    // Bind listeners
 	    self.$toggle.on('click', this.toggle.bind(this));
 	    self.$body.on('click', '.toggle', this.toggle.bind(this));
+	    self.$body.on('click', '.glossary-term', this.toggleTermFromClick.bind(this) );
 	    self.$search.on('input', this.handleInput.bind(this));
 
 	    $(document.body).on('keyup', this.handleKeyup.bind(this));
@@ -25205,6 +25224,17 @@
 	    toggle: function() {
 	      var method = this.isOpen ? this.hide : this.show;
 	      method.apply(this);
+	    },
+
+	    toggleTermFromClick: function(event){
+	      var $target = $(event.target);
+	      var doExpand = $target.parent().attr( 'aria-expanded') === 'true' ? 'false' : 'true';
+
+	      $target
+	        .siblings( 'p' )
+	        .attr('aria-hidden', doExpand )
+	        .parent()
+	        .attr('aria-expanded', doExpand );
 	    },
 
 	    show: function() {


### PR DESCRIPTION
Closes #1563

Previously, when opening the gallery and reading through the list of
terms, one had to click on the chevron next to a term itself in order
to open or close the definition.

This patch allows for performing the same action but also through
clicking on the term itself, expanding the click area and making for
what I feel is a more expected behavior.

**New Behavior**
_See #1563 for video of old/existing behavior_
![glossary-does-toggle-on-click](https://cloud.githubusercontent.com/assets/5431237/16548912/3e3d0da6-414d-11e6-9dec-a8ac5d622e4c.gif)


**Caveats**
 - I'm not familiar with the codebase, so while this seems to _work_, I
   don't know if it's _right_ for the project.

 - I wasn't sure if I needed to submit the changes to the minified code 
   in this PR. There are some big changes that I didn't introduce into the
   minified version that nonetheless came over in rebuilding it. Maybe
   these are related to node versions? Maybe a previous commit didn't
   update the minified copies?

 - The actual work seems like it's happening inside of the `List()`
   which made it more difficult to figure out. This is also why I'm not
   convinced that I made the right changes in the right places.

 - There are lingering issues with the cursor: should it be a pointer
   when hovering over the glossary terms?

Thanks!