### PR TITLE
add circle.yml to dev

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+## Customize the test machine
+machine:
+  # Version of ruby to use
+  ruby:
+    version:
+      2.2.3
+
+## Customize dependencies
+dependencies:
+  pre:
+    - gem install jekyll -v '3.0.0.pre.beta9'
+    - bundle install
+    - bundle exec jekyll build
+
+## Customize test commands
+test:
+  pre:
+    # - npm run test-html
+    - npm run test


### PR DESCRIPTION
Fixes issue(s) #1566 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/circle-to-dev/)

Changes proposed in this pull request:

- adds circle.yml to dev with correct jekyll version
- should no longer create Circle CI error on dev unless there is an error

/cc @meiqimichelle 

