### PR TITLE
State page style

### DIFF
--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -24,16 +24,16 @@
       <h3 class="chart-title">{{ product_name }}</h3>
 
       <figure class="chart">
+        <figcaption id="all-production-figures-{{ product_slug }}">
+          <span class="eiti-bar-chart-x-value">{{ year }}</span>
+          <span class="eiti-bar-chart-y-value" data-format="," data-units="{{ short_units }}">{{ volume | default: 0 | intcomma }}</span>
+        </figcaption>
         <eiti-bar-chart
           aria-controls="all-production-figures-{{ product_slug }}"
           data='{% include location/line-chart-data.json values=production_values key="volume" %}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
-        <figcaption id="all-production-figures-{{ product_slug }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value" data-format="," data-units="{{ short_units }}">{{ volume | default: 0 | intcomma }}</span>
-        </figcaption>
       </figure>
       <p class="chart-list_caption">
         {% if volume %}{{ volume | intcomma }} {{ long_units | term }} of

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -9,7 +9,7 @@
     <div class="chart-list-intro">
 
       {% include location/key-exports.html %}
-    
+
     </div>
 
     {% for commodity in export_commodities %}
@@ -22,18 +22,19 @@
           <h3 class="chart-title">{{ commodity[0] }}</h3>
 
           <figure class="chart chart-{{ _metric }}">
-            <eiti-bar-chart
-              aria-controls="exports-figures-{{ commodity_slug }}"
-              data='{% include location/line-chart-data.json values=exports key="dollars" %}'
-              data-x-range="{{ year_range }}"
-              selected="{{ year }}">
-            </eiti-bar-chart>
             <figcaption id="exports-figures-{{ commodity_slug }}">
               <span class="eiti-bar-chart-x-value">{{ year }}</span>
               <span class="eiti-bar-chart-y-value" data-format="$,">
                 ${{ exports[year].dollars | intcomma }}
               </span>
             </figcaption>
+            <eiti-bar-chart
+              aria-controls="exports-figures-{{ commodity_slug }}"
+              data='{% include location/line-chart-data.json values=exports key="dollars" %}'
+              data-x-range="{{ year_range }}"
+              selected="{{ year }}">
+            </eiti-bar-chart>
+
           </figure>
 
           <h4>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -40,32 +40,21 @@
 
           <div class="chart-container">
 
-            <div class="text-container">
-              <p>
-                {% if volume %}
-                  {{ volume | intcomma }} {{ long_units | term }}
-                  of {{ product_name | downcase | suffix:units_suffix }} were
-                {% else %}
-                  No {{ product_name | downcase | suffix:units_suffix }} was
-                {% endif %}
-                produced on federal land in {{ state_name }} in {{ year }}.
-              </p>
-            </div>
-
             {% if volume %}
               <figure class="chart">
+                <figcaption id="federal-production-figures-{{ product_slug }}">
+                    <span class="eiti-bar-chart-x-value">{{ year }}</span>
+                    <span class="eiti-bar-chart-y-value"
+                          data-format=","
+                          data-units="{{ short_units }}">{{ volume | default: 0 | intcomma }}</span>
+                </figcaption>
                 <eiti-bar-chart
                   aria-controls="federal-production-figures-{{ product_slug }}"
                   data='{% include location/line-chart-data.json values=production_values key="volume" %}'
                   data-x-range="{{ year_range }}"
                   x-value="{{ year }}">
                 </eiti-bar-chart>
-                <figcaption id="federal-production-figures-{{ product_slug }}">
-                  <span class="eiti-bar-chart-x-value">{{ year }}</span>
-                  <span class="eiti-bar-chart-y-value"
-                        data-format=","
-                        data-units="{{ short_units }}">{{ volume | default: 0 | intcomma }}</span>
-                </figcaption>
+
               </figure>
 
               <!-- <h4>
@@ -83,6 +72,17 @@
                 %}
               </div> -->
             {% endif %}
+            <div class="text-container">
+              <p>
+                {% if volume %}
+                  {{ volume | intcomma }} {{ long_units | term }}
+                  of {{ product_name | downcase | suffix:units_suffix }} were
+                {% else %}
+                  No {{ product_name | downcase | suffix:units_suffix }} was
+                {% endif %}
+                produced on federal land in {{ state_name }} in {{ year }}.
+              </p>
+            </div>
           </div><!-- /.chart-container -->
 
           {% if volume %}

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -23,12 +23,6 @@
       <h3 class="chart-title">GDP ({{ _metric }})</h3>
 
       <figure class="chart chart-{{ _metric }}">
-        <eiti-bar-chart
-          aria-controls="gdp-figures-{{ _metric }}"
-          data='{% include location/line-chart-data.json values=gdp key=_metric %}'
-          data-x-range="{{ year_range }}"
-          x-value="{{ year }}">
-        </eiti-bar-chart>
         <figcaption id="gdp-figures-{{ _metric }}">
           <span class="eiti-bar-chart-x-value">{{ year }}</span>
           {% assign _format = ',' %}
@@ -45,6 +39,13 @@
             {% endif %}
           </span>
         </figcaption>
+        <eiti-bar-chart
+          aria-controls="gdp-figures-{{ _metric }}"
+          data='{% include location/line-chart-data.json values=gdp key=_metric %}'
+          data-x-range="{{ year_range }}"
+          x-value="{{ year }}">
+        </eiti-bar-chart>
+
       </figure>
 
       {% if forloop.last %}

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -35,12 +35,6 @@
       <h3 class="chart-title">Number of jobs in extractives</h3>
 
       <figure class="chart">
-        <eiti-bar-chart
-          aria-controls="jobs-figures-{{ _metric }}"
-          data='{% include location/line-chart-data.json values=jobs key=_metric %}'
-          data-x-range="{{ year_range }}"
-          x-value="{{ year }}">
-        </eiti-bar-chart>
         <figcaption id="jobs-figures-{{ _metric }}">
           <span class="eiti-bar-chart-x-value">{{ year }}</span>
           <span class="eiti-bar-chart-y-value"
@@ -56,6 +50,13 @@
             {% endif %}
           </span>
         </figcaption>
+        <eiti-bar-chart
+          aria-controls="jobs-figures-{{ _metric }}"
+          data='{% include location/line-chart-data.json values=jobs key=_metric %}'
+          data-x-range="{{ year_range }}"
+          x-value="{{ year }}">
+        </eiti-bar-chart>
+
       </figure>
 
       {% if forloop.last %}
@@ -116,14 +117,11 @@
     </div><!-- /.row-container -->
 
   </div><!-- /.chart-list -->
+
   <div class="chart-list">
     <div class="chart-list-intro">
 
       <p><strong>Self-employment data</strong> describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.</p>
-
-      <a href="{{site.baseurl}}/downloads/#jobs">
-        <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
-      </a>
 
     </div>
 
@@ -134,12 +132,6 @@
       <h3 class="chart-title">Number of self-employment jobs in extractives</h3>
 
       <figure class="chart">
-        <eiti-bar-chart
-          aria-controls="self-employment-figures-{{ _metric }}"
-          data='{% include location/line-chart-data.json values=self_employment_jobs key=_metric %}'
-          data-x-range="{{ year_range }}"
-          x-value="{{ year }}">
-        </eiti-bar-chart>
         <figcaption id="self-employment-figures-{{ _metric }}">
           <span class="eiti-bar-chart-x-value">{{ year }}</span>
           <span class="eiti-bar-chart-y-value"
@@ -155,10 +147,20 @@
             {% endif %}
           </span>
         </figcaption>
+        <eiti-bar-chart
+          aria-controls="self-employment-figures-{{ _metric }}"
+          data='{% include location/line-chart-data.json values=self_employment_jobs key=_metric %}'
+          data-x-range="{{ year_range }}"
+          x-value="{{ year }}">
+        </eiti-bar-chart>
+
       </figure>
 
     </section><!-- /.chart-item -->
     {% endfor %}
-  </div>
+  </div><!-- /.chart-list -->
+  <a href="{{site.baseurl}}/downloads/#jobs">
+    <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
+  </a>
 
 </section>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -78,16 +78,17 @@
 
       <figure class="chart">
         {% assign annual_revenue = commodity[1] %}
+        <figcaption id="revenue-figures-{{ commodity_slug }}">
+          <span class="eiti-bar-chart-x-value">{{ year }}</span>
+          <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span>
+        </figcaption>
         <eiti-bar-chart
           data='{% include location/line-chart-data.json values=annual_revenue key="revenue" %}'
           aria-controls="revenue-figures-{{ commodity_slug }}"
           x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
-        <figcaption id="revenue-figures-{{ commodity_slug }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span>
-        </figcaption>
+
       </figure>
       <p class="chart-list_caption">
         In {{ year }},

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -89,6 +89,10 @@ $base-padding-large: 1.875em; //30px
 $base-padding-extra: 3.125em; //50px
 $base-padding-jumbo: 3.8em;
 
+// Padding on rem scale
+$standard-padding: 1.25rem;
+$standard-padding-large: 5rem;
+
 // Link Colors
 $base-link-color: $dark-gray;
 

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -69,6 +69,7 @@ $green-sea: #b1d39c;
 $green-dark: #657c60;
 $chart-green: #a5d78a;
 $green-darkest: #2f4d26;
+$green-dark-chart: #587f4c;
 
 // v2 - deprecate
 $putty: #f4f4f4;
@@ -91,7 +92,11 @@ $base-padding-jumbo: 3.8em;
 
 // Padding on rem scale
 $standard-padding: 1.25rem;
-$standard-padding-large: 5rem;
+$standard-padding-lite: $standard-padding / 3;
+$standard-padding-large: 1.875rem; //30px
+$standard-padding-extra: 3.125rem; //50px
+$standard-padding-jumbo: 3.8rem;
+$standard-padding-fluffed: 5rem;
 
 // Link Colors
 $base-link-color: $dark-gray;

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -11,9 +11,12 @@
   }
 
   .chart-title {
+    @include heading(para-lg);
+
     border-bottom: 1px solid $mid-gray;
     font-size: inherit;
     font-weight: $weight-book;
+    letter-spacing: 1px;
     margin-bottom: $base-padding;
     text-transform: uppercase;
   }

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -8,14 +8,14 @@
 
   h2 {
     border-top: 6px solid $light-green;
-    padding-top: $standard-padding-fluffed;
     padding-bottom: $standard-padding;
+    padding-top: $standard-padding-fluffed;
   }
 
   h3:not(.chart-title) {
     border-top: 2px solid $light-green;
-    padding-top: $standard-padding-fluffed;
     padding-bottom: $standard-padding;
+    padding-top: $standard-padding-fluffed;
   }
 
   h4 {

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -1,26 +1,29 @@
 .layout-state-pages {
+  padding-bottom: $standard-padding-fluffed;
 
-  section + section {
-    padding-top: $base-padding-extra;
-    padding-top: $standard-padding-large;
+  section + section,
+  h2 + section {
+    padding-top: $standard-padding-fluffed;
   }
 
   h2 {
     border-top: 6px solid $light-green;
-    padding-top: $base-padding;
-    padding-top: $standard-padding;
+    padding-top: $standard-padding-fluffed;
+    padding-bottom: $standard-padding;
   }
 
   h3:not(.chart-title) {
     border-top: 2px solid $light-green;
-    padding-top: $base-padding-large;
-    padding-top: $standard-padding-large;
+    padding-top: $standard-padding-fluffed;
+    padding-bottom: $standard-padding;
+  }
+
+  h4 {
+    padding-bottom: $standard-padding;
   }
 
   hr {
     border-top: 1px solid $neutral-gray;
-    margin-bottom: $base-padding;
-    margin-top: $base-padding;
     margin-bottom: $standard-padding;
     margin-top: $standard-padding;
   }
@@ -28,8 +31,6 @@
   p + [class*='panel-'],
   section + [class*='panel-'],
   h3 + [class*='panel-'] {
-    margin-bottom: $base-padding;
-    margin-top: $base-padding;
     margin-bottom: $standard-padding;
     margin-top: $standard-padding;
   }
@@ -50,9 +51,7 @@
   }
 
   .tab-interface {
-    margin-bottom: $base-padding-extra;
-    margin-top: $base-padding-extra;
-    margin-bottom: $standard-padding-large;
-    margin-top: $standard-padding-large;
+    margin-bottom: $standard-padding-fluffed;
+    margin-top: $standard-padding-fluffed;
   }
 }

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -2,17 +2,27 @@
 
   section + section {
     padding-top: $base-padding-extra;
+    padding-top: $standard-padding-large;
   }
 
   h2 {
-    border-top: 1px solid $mid-light-gray;
+    border-top: 6px solid $light-green;
     padding-top: $base-padding;
+    padding-top: $standard-padding;
+  }
+
+  h3:not(.chart-title) {
+    border-top: 2px solid $light-green;
+    padding-top: $base-padding-large;
+    padding-top: $standard-padding-large;
   }
 
   hr {
     border-top: 1px solid $neutral-gray;
     margin-bottom: $base-padding;
     margin-top: $base-padding;
+    margin-bottom: $standard-padding;
+    margin-top: $standard-padding;
   }
 
   p + [class*='panel-'],
@@ -20,6 +30,8 @@
   h3 + [class*='panel-'] {
     margin-bottom: $base-padding;
     margin-top: $base-padding;
+    margin-bottom: $standard-padding;
+    margin-top: $standard-padding;
   }
 
   figure {
@@ -40,5 +52,7 @@
   .tab-interface {
     margin-bottom: $base-padding-extra;
     margin-top: $base-padding-extra;
+    margin-bottom: $standard-padding-large;
+    margin-top: $standard-padding-large;
   }
 }

--- a/_sass/components/_eiti-bar-chart.scss
+++ b/_sass/components/_eiti-bar-chart.scss
@@ -8,7 +8,7 @@ eiti-bar-chart {
     font-size: inherit;
     font-weight: $weight-light;
     height: auto;
-    opacity: 0.75;
+    opacity: 0.85;
     transition: opacity 0.5s;
     width: 100%;
   }
@@ -22,7 +22,7 @@ eiti-bar-chart {
   }
 
   .bar-value {
-    fill: $neutral-gray;
+    fill: $mid-light-gray;
     pointer-events: none;
     transition: fill 0.1s;
   }
@@ -59,6 +59,7 @@ eiti-bar-chart {
   .bar-selected .bar-value,
   .tick-selected text {
     fill: $green-dark;
+    fill: $green-dark-chart;
     font-weight: $weight-bold;
   }
 }
@@ -66,4 +67,5 @@ eiti-bar-chart {
 .eiti-bar-chart-x-value,
 .eiti-bar-chart-y-value {
   color: $green-dark;
+  color: $green-dark-chart;
 }

--- a/_sass/components/_eiti-bar-chart.scss
+++ b/_sass/components/_eiti-bar-chart.scss
@@ -58,7 +58,6 @@ eiti-bar-chart {
 
   .bar-selected .bar-value,
   .tick-selected text {
-    fill: $green-dark;
     fill: $green-dark-chart;
     font-weight: $weight-bold;
   }
@@ -66,6 +65,5 @@ eiti-bar-chart {
 
 .eiti-bar-chart-x-value,
 .eiti-bar-chart-y-value {
-  color: $green-dark;
   color: $green-dark-chart;
 }

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -15,6 +15,7 @@
   }
 
   a {
+    font-weight: $weight-bold;
     padding: $base-padding-lite;
     text-decoration: none;
 

--- a/_sass/mixins/_tabs.scss
+++ b/_sass/mixins/_tabs.scss
@@ -1,5 +1,4 @@
 @mixin active-tab($color:'') {
-  font-weight: $weight-bold;
   text-decoration: none;
 
   @if $color == 'info' {

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -8,7 +8,7 @@
 
   // global dimensions
   var width = 300;
-  var height = 100;
+  var height = 150;
 
   var textMargin = 18;
   var baseMargin = 2;

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12204,7 +12204,7 @@
 
 	  // global dimensions
 	  var width = 300;
-	  var height = 100;
+	  var height = 150;
 
 	  var textMargin = 18;
 	  var baseMargin = 2;


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-page-style/)

Changes proposed in this pull request:

- moved the year and value `figcaption` above the bar charts in all instances
- changed height and color of bars
- changed layout spacing to rem from em. variables.scss now has a separate `$standard-padding` variable featuring my homage d'eric ronne: `$standard-padding-fluffed`

/cc @ericronne 
