### PR TITLE
State pages: new layout, year selectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,9 @@ data/national_federal_production.yml:
 		  product, product_name, units, year, \
 		  ROUND(volume) AS volume \
 		FROM federal_national_production \
+		WHERE \
+			volume != 0 AND \
+			volume IS NOT NULL \
 		ORDER BY \
 			product, product_name, units, year" \
 	  | $(nestly) --if ndjson \

--- a/_data/national_federal_production.yml
+++ b/_data/national_federal_production.yml
@@ -36,14 +36,6 @@ US:
           volume: 376686236
         '2014':
           volume: 375266659
-    Coal Bed Methane (mcf):
-      name: Coal Bed Methane
-      units: mcf
-      volume:
-        '2009':
-          volume: 0
-        '2011':
-          volume: 0
     Condensate (bbl):
       name: Condensate
       units: bbl

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -36,7 +36,17 @@
         {% assign value = county[1] | get: keys %}
         {% if value != nil %}
         <g class="county feature"
-          data-value='{{ value | default: 0 | jsonify }}'>
+          data-value='{{ value | default: 0 | jsonify }}'
+          {% if include.years %}
+            {% assign year_values = county[1] | get: include.years %}
+            {% if include.years_property %}
+              data-year-values='{ {% for year_value in year_values %}
+              "{{ year_value[0] }}": {{ year_value[1] | get: include.years_property | jsonify }}{% unless forloop.last %},{% endunless %}
+              {% endfor %} }'
+            {% else %}
+              data-year-values='{{ year_values | jsonify }}'
+            {% endif %}
+          {% endif %} >
           <title>{{ county[1].name }}</title>
           <use xlink:href="{{ state_svg }}#county-{{ fips }}"></use>
         </g>

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -40,12 +40,9 @@
           {% if include.years %}
             {% assign year_values = county[1] | get: include.years %}
             {% if include.years_property %}
-              data-year-values='{ {% for year_value in year_values %}
-              "{{ year_value[0] }}": {{ year_value[1] | get: include.years_property | jsonify }}{% unless forloop.last %},{% endunless %}
-              {% endfor %} }'
-            {% else %}
-              data-year-values='{{ year_values | jsonify }}'
+              {% assign year_values = year_values | map_hash: include.years_property %}
             {% endif %}
+            data-year-values='{{ year_values | jsonify }}'
           {% endif %} >
           <title>{{ county[1].name }}</title>
           <use xlink:href="{{ state_svg }}#county-{{ fips }}"></use>

--- a/_includes/location/key-exports.html
+++ b/_includes/location/key-exports.html
@@ -3,12 +3,12 @@
 {% assign exports_commodities_num = exports | size %}
 
 {% if exports_commodities_num > 0 %}
-	<p>In {{ include.year }}, 
-	{{ exports_commodities_num }} extractive industries 
+	In {{ include.year }},
+	{{ exports_commodities_num }} extractive industries
 	product{{ exports_commodities_num | plural }} ranked among the top 25 exports from {{ state_name }}, generating
 	${{ exports_total | intcomma }}
 	in export revenue, or
-	{{ exports.All[include.year].percent | percent }}% of all export revenue.</p>
+	{{ exports.All[include.year].percent | percent }}% of all export revenue.
 {% else %}
-	<p>In {{ year }}, extractive industries products did not rank among the top 25 exports from {{ state_name }}.</p>
+	In {{ year }}, extractive industries products did not rank among the top 25 exports from {{ state_name }}.
 {% endif %}

--- a/_includes/location/line-chart-data.json
+++ b/_includes/location/line-chart-data.json
@@ -1,3 +1,1 @@
-{ {% for entry in include.values %}
-  "{{ entry[0] }}": {{ entry[1] | get: include.key | default: 0 | jsonify }}{% unless forloop.last %},{% endunless %}
-{% endfor %} }
+{{ include.values | map_hash: include.key | jsonify }}

--- a/_includes/location/line-chart-data.json
+++ b/_includes/location/line-chart-data.json
@@ -1,1 +1,0 @@
-{{ include.values | map_hash: include.key | jsonify }}

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -2,6 +2,8 @@
 
 {% assign units_map = site.data.production_units %}
 
+{% capture year_range %}[2004, 2013]{% endcapture %}
+
 <section id="all-production" class="all-lands production">
 
   <h2>Natural resource production in {{ state_name }}</h2>

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -1,12 +1,18 @@
 {% assign all_products = site.data.national_all_production[state_id].products %}
 {% assign units_map = site.data.production_units %}
 {% assign year_range = '[2004, 2013]' %}
+{% assign year_list = year_range | to_list %}
 
-<section id="all-production" class="all-lands production">
+<section id="all-production" is="year-switcher-section" class="all-lands production">
 
   <h2>Natural resource production in {{ state_name }}</h2>
 
-  <p>The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>
+  <div class="chart-selector-wrapper">
+
+    {% include year-selector.html year_range=year_range %}
+
+    <p class="chart-description">The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>
+  </div>
 
   <div class="chart-list">
 
@@ -25,22 +31,19 @@
       <h3 class="chart-title">{{ product_name }}</h3>
 
       <figure class="chart">
+        <figcaption id="all-production-figures-{{ product_slug }}">
+          <span class="eiti-bar-chart-y-value" data-format=","">{{ volume | default: 0 | intcomma }}</span>
+          {{ long_units | term }} of
+          {{ product_name | downcase | suffix:units_suffix }} was extracted in {{ state_name }} in
+          <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+        </figcaption>
         <eiti-bar-chart
           aria-controls="all-production-figures-{{ product_slug }}"
           data='{{ production_values | map_hash: "volume" | jsonify }}'
           x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
-        <figcaption id="all-production-figures-{{ product_slug }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value" data-format="," data-units="{{ short_units }}">{{ volume | default: 0 | intcomma }}</span>
-        </figcaption>
       </figure>
-      <p class="chart-list_caption">
-        {% if volume %}{{ volume | intcomma }} {{ long_units | term }} of
-        {% else %}No{% endif %}
-        {{ product_name | downcase | suffix:units_suffix }} was extracted in {{ state_name }} in {{ year }}.
-      </p>
       <!-- <h4>
         <button is="aria-toggle"
           aria-controls="all-production-detail-{{ product_slug }}">&plus; Historical details</button>

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -29,7 +29,7 @@
       <figure class="chart">
         <eiti-bar-chart
           aria-controls="all-production-figures-{{ product_slug }}"
-          data='{% include location/line-chart-data.json values=production_values key="volume" %}'
+          data='{{ production_values | map_hash: "volume" | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>

--- a/_includes/location/national-exports.html
+++ b/_includes/location/national-exports.html
@@ -24,7 +24,7 @@
           <figure class="chart chart-{{ _metric }}">
             <eiti-bar-chart
               aria-controls="exports-figures-{{ commodity_slug }}"
-              data='{% include location/line-chart-data.json values=exports key="dollars" %}'
+              data='{{ exports | map_hash: "dollars" | jsonify }}'
               data-x-range="{{ year_range }}"
               selected="{{ year }}">
             </eiti-bar-chart>

--- a/_includes/location/national-exports.html
+++ b/_includes/location/national-exports.html
@@ -1,42 +1,52 @@
 {% assign export_commodities = site.data.national_exports[state_id].commodities %}
 
-<section id="exports" class="economic exports">
+{% assign year_range = '[2011, 2014]' %}
+
+<section id="exports" is="year-switcher-section" class="economic exports">
 
   <h3>Exports</h3>
 
-  <div class="chart-list has-intro">
+  <div class="chart-list">
 
-    <div class="chart-list-intro">
+    <div class="chart-selector-wrapper">
 
-      {% include location/key-exports.html %}
+      {% include year-selector.html year_range=year_range %}
 
+      <p class="chart-description">
+        {% include location/key-exports.html %}
+      </p>
     </div>
+
+    {% assign _format = '$,' %}
+    {% assign _metric = 'dollars' %}
 
     {% for commodity in export_commodities %}
       {% assign exports = commodity[1] %}
       {% assign commodity_slug = commodity[0] | slugify %}
 
       {% if commodity[0] != "Total" and commodity[0] != "All" %}
-        <section id="exports-{{ commodity_slug }}" class="chart-item">
+        <section class="chart-item">
 
           <h3 class="chart-title">{{ commodity[0] }}</h3>
 
           <figure class="chart chart-{{ _metric }}">
-            <eiti-bar-chart
-              aria-controls="exports-figures-{{ commodity_slug }}"
-              data='{{ exports | map_hash: "dollars" | jsonify }}'
-              data-x-range="{{ year_range }}"
-              selected="{{ year }}">
-            </eiti-bar-chart>
             <figcaption id="exports-figures-{{ commodity_slug }}">
-              <span class="eiti-bar-chart-x-value">{{ year }}</span>
-              <span class="eiti-bar-chart-y-value" data-format="$,">
+              <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">
                 ${{ exports[year].dollars | intcomma }}
               </span>
+              of {{ commodity[0] }} was exported from {{ state_name }}
+              in <span class="eiti-bar-chart-x-value">{{ year }}</span>.
             </figcaption>
+            <eiti-bar-chart
+              aria-controls="exports-figures-{{ commodity_slug }}"
+              data='{{ exports | map_hash: _metric | jsonify }}'
+              data-x-range="{{ year_range }}"
+              x-value="{{ year }}">
+            </eiti-bar-chart>
+
           </figure>
 
-          <h4>
+        <!--   <h4>
             <button is="aria-toggle" aria-controls="exports-detail-{{ commodity_slug }}">
               &plus; Details
             </button>
@@ -47,7 +57,7 @@
               values=exports
               percent=false
             %}
-          </div>
+          </div> -->
 
         </section><!-- /.chart-item -->
       {% endif %}

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -1,22 +1,35 @@
-
 {% assign federal_products = site.data.national_federal_production[state_id].products %}
+{% assign year_range = '[2005, 2014]' %}
 
 {% assign federal_products_num = federal_products | size %}
 {% assign units_map = site.data.production_units %}
 
-<section id="federal-production" class="federal production">
+<section id="federal-production" is="year-switcher-section" class="federal production">
 
   <h3>Land ownership</h2>
 
   {% include location/national-ownership.html %}
 
-  <section class="county-map-table">
+  <section class="county-map-table" is="year-switcher-section">
 
-    <h4>Natural resources extracted on federal land</h4>
+    <h3>Natural resources extracted on federal land</h3>
 
     {% if federal_products_num == 0 %}
       <p>No natural resources were produced on federal land in {{  state_name }} in {{ year }}.</p>
     {% endif %}
+
+    <div class="chart-selector-wrapper">
+
+      {% include year-selector.html year_range=year_range %}
+
+      <p class="chart-description">
+        {% if federal_products_num == 0 %}
+          No natural resources were produced on federal land in {{  state_name }} in {{ year }}.
+        {% else %}
+          Is there some kind of summary sentence that would be good here? The year selector would update all references to year in the federal production section.
+        {% endif %}
+      </p>
+    </div>
 
     <div class="chart-list">
 
@@ -31,51 +44,45 @@
       {% assign units_suffix = units_map[units].suffix | default '' %}
       {% assign units_title = units_map[units].title %}
 
-      <section id="federal-production-{{ product_slug }}" class="product chart-item full-width">
+      <section id="national-federal-production-{{ product_slug }}" class="product chart-item">
 
         <h4 class="chart-title">
           {{ product_name }}
           {% if units_title %} ({{ units_title }}){% endif %}
         </h4>
 
-        <div class="row-container">
+        <figure class="chart">
+          <figcaption id="national-federal-production-figures-{{ product_slug }}">
+          <span class="eiti-bar-chart-y-value"
+                  data-format=",">{{ volume | default: 0 | intcomma }}</span>
+          {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
+          produced on federal land in {{ state_name }} in
+          <span class="eiti-bar-chart-x-value">{{ year }}</span>.
 
-          <div class="chart-container">
+          </figcaption>
+          <eiti-bar-chart
+            aria-controls="national-federal-production-figures-{{ product_slug }}"
+            data='{{ production_values | map_hash: "volume" | jsonify }}'
+            x-range="{{ year_range }}"
+            x-value="{{ year }}">
+          </eiti-bar-chart>
 
-            <div class="text-container">
-              <p>
-                {% if volume %}
-                  {{ volume | intcomma }} {{ long_units | term }}
-                  of {{ product_name | downcase | suffix:units_suffix }} were
-                {% else %}
-                  No {{ product_name | downcase | suffix:units_suffix }} was
-                {% endif %}
-                produced on federal land in {{ state_name }} in {{ year }}.
-              </p>
-            </div>
+        </figure>
 
-            {% if volume %}
-              <figure class="chart">
-                <eiti-bar-chart
-                  aria-controls="federal-production-figures-{{ product_slug }}"
-                  data='{{ production_values | map_hash: "volume" | jsonify }}'
-                  data-x-range="{{ year_range }}"
-                  x-value="{{ year }}">
-                </eiti-bar-chart>
-                <figcaption id="federal-production-figures-{{ product_slug }}">
-                  <span class="eiti-bar-chart-x-value">{{ year }}</span>
-                  <span class="eiti-bar-chart-y-value"
-                        data-format=","
-                        data-units="{{ short_units }}">{{ volume | default: 0 | intcomma }}</span>
-                </figcaption>
-              </figure>
-
-            {% endif %}
-          </div><!-- /.chart-container -->
-
-
-        </div><!-- /.row-container -->
-
+        <!-- <h4>
+          <button is="aria-toggle"
+            aria-controls="national-federal-production-{{ product_slug }}-years">&plus; Details</button>
+        </h4>
+        <div id="national-federal-production-{{ product_slug }}-years" aria-hidden="true">
+          {%
+            include location/display-production.html
+            units=units
+            year=year
+            values=production_values
+            percent=true
+            rank=true
+          %}
+        </div> -->
       </section>
     {% endfor %}
 

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -6,7 +6,7 @@
 
 <section id="federal-production" class="federal production">
 
-  <h3>Production on federal land in {{ state_name }}</h2>
+  <h3>Land ownership</h2>
 
   {% include location/national-ownership.html %}
 

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -58,7 +58,7 @@
               <figure class="chart">
                 <eiti-bar-chart
                   aria-controls="federal-production-figures-{{ product_slug }}"
-                  data='{% include location/line-chart-data.json values=production_values key="volume" %}'
+                  data='{{ production_values | map_hash: "volume" | jsonify }}'
                   data-x-range="{{ year_range }}"
                   x-value="{{ year }}">
                 </eiti-bar-chart>

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -25,7 +25,7 @@
       <figure class="chart chart-{{ _metric }}">
         <eiti-bar-chart
           aria-controls="gdp-figures-{{ _metric }}"
-          data='{% include location/line-chart-data.json values=gdp key=_metric %}'
+          data='{{ gdp | map_hash: _metric | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -1,42 +1,37 @@
 {% assign gdp = site.data.national_gdp[state_id] %}
 
-<section id="gdp" class="economic gdp">
+{% assign year_range = '[2004, 2013]' %}
+
+<section id="gdp" is="year-switcher-section" class="economic gdp">
 
   <h3>Gross Domestic Product (GDP)</h3>
 
-  <div class="chart-list has-intro">
+  <div class="chart-selector-wrapper">
 
-    <div class="chart-list-intro">
-      <p>Extractive industries accounted for
-        {% if gdp[year].dollars %}
-          {{ gdp[year].percent | percent }}% (or
-          ${{ gdp[year].dollars | intcomma }}) of {{ state_name }}'s GDP in {{ year }}.
-        {% else %}
-          The extractives industry did not contribute to {{ state_name }}'s GDP in {{ year }}.
-        {% endif %}
-      </p>
-    </div>
+    {% include year-selector.html year_range=year_range %}
+
+    <p class="chart-description">
+      A revolutionary description of GDP from extractives could go here. The selector should change only the GDP section
+    </p>
+  </div><!-- .chart-selector-wrapper -->
+
+  <div class="chart-list">
 
     {% assign _metrics = 'dollars' | split: ' ' %}
     {% for _metric in _metrics %}
+      {% assign _format = ',' %}
+      {% if _metric == 'dollars' %}
+        {% assign _format = '$,' %}
+      {% elsif _metric == 'percent' %}
+        {% assign _format = '%' %}
+      {% endif %}
+
     <section class="chart-item">
       <h3 class="chart-title">GDP ({{ _metric }})</h3>
 
       <figure class="chart chart-{{ _metric }}">
-        <eiti-bar-chart
-          aria-controls="gdp-figures-{{ _metric }}"
-          data='{{ gdp | map_hash: _metric | jsonify }}'
-          data-x-range="{{ year_range }}"
-          x-value="{{ year }}">
-        </eiti-bar-chart>
         <figcaption id="gdp-figures-{{ _metric }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          {% assign _format = ',' %}
-          {% if _metric == 'dollars' %}
-            {% assign _format = '$,' %}
-          {% elsif _metric == 'percent' %}
-            {% assign _format = '%' %}
-          {% endif %}
+          Extractive industries accounted for
           <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">
             {% if _metric == 'dollars' %}
               ${{ gdp[year].dollars | intcomma }}
@@ -44,7 +39,16 @@
               {{ gdp[year].percent | percent }}%
             {% endif %}
           </span>
+          of {{ state_name }}'s GDP in
+          <span class="eiti-bar-chart-x-value">{{ year }}</span>.
         </figcaption>
+        <eiti-bar-chart
+          aria-controls="gdp-figures-{{ _metric }}"
+          data='{{ gdp | map_hash: _metric | jsonify }}'
+          data-x-range="{{ year_range }}"
+          x-value="{{ year }}">
+        </eiti-bar-chart>
+
       </figure>
 
       {% if forloop.last %}

--- a/_includes/location/national-jobs.html
+++ b/_includes/location/national-jobs.html
@@ -36,7 +36,7 @@
       <figure class="chart">
         <eiti-bar-chart
           aria-controls="jobs-figures-{{ _metric }}"
-          data='{% include location/line-chart-data.json values=jobs key=_metric %}'
+          data='{{ jobs | map_hash: _metric | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
@@ -97,7 +97,7 @@
       <figure class="chart">
         <eiti-bar-chart
           aria-controls="self-employment-figures-{{ _metric }}"
-          data='{% include location/line-chart-data.json values=self_employment_jobs key=_metric %}'
+          data='{{ self_employment_jobs | map_hash: _metric | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>

--- a/_includes/location/national-jobs.html
+++ b/_includes/location/national-jobs.html
@@ -5,121 +5,118 @@
 {% assign jobs_count = jobs[year].count | default: 0 %}
 {% assign jobs_percent = jobs[year].percent | default: 0 %}
 
+{% assign year_range = '[2004, 2013]' %}
+
+
 <section id="employment" class="economic employment">
 
-  <h3>Employment</h3>
+  <h3>Wage and salary jobs</h3>
 
-  <div class="chart-list">
+  <section is="year-switcher-section" class="chart-list">
 
-    <div class="chart-list-intro">
-      <p>Two kinds of data help represent the economic role of extractive industries in {{ state_name }}.</p>
-      <p><strong>Wage and salary data</strong> describes the number of people employed in natural resource extraction that receive wages or salaries from companies.</p>
-      <p>In {{ year }},
-        {% if jobs_count %}
-          there were
-          {{ jobs_count | intcomma }}
-          jobs in extractive industries that paid a wage or salary in
-          {{ state_name }}, or
-          {{ jobs_percent | percent }}% of state-wide employment.
-        {% else %}
-          there were no wage or salary jobs in the extractive industries.
-        {% endif %}
-      </p>
-    </div>
+    <div class="chart-selector-wrapper">
+
+      {% include year-selector.html year_range=year_range %}
+
+      <div class="chart-description">
+        <p>Two kinds of data help represent the economic role of extractive industries in {{ state_name }}.</p>
+        <p><strong>Wage and salary data</strong> describes the number of people employed in natural resource extraction that receive wages or salaries from companies.</p>
+      </div>
+    </div><!-- .chart-selector-wrapper -->
+
 
     {% assign _metrics = 'count' | split: ' ' %}
     {% for _metric in _metrics %}
-    <section class="chart-item">
-
-      <h3 class="chart-title">Number of jobs in extractives</h3>
+    <section class="chart-item"
+      <h3 class="chart-title">Wage and salary jobs</h3>
 
       <figure class="chart">
+        <figcaption id="jobs-figures-{{ _metric }}">
+          In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+          there were
+          <span class="eiti-bar-chart-y-value" data-format=",">
+            {{ jobs[year].jobs | intcomma }}
+          </span>
+          jobs in extractive industries that paid a wage or salary in
+          {{ state_name }}.
+        </figcaption>
         <eiti-bar-chart
           aria-controls="jobs-figures-{{ _metric }}"
           data='{{ jobs | map_hash: _metric | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
-        <figcaption id="jobs-figures-{{ _metric }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value"
-            {% if _metric == 'count' %}
-              data-format=","
-            {% elsif _metric == 'percent' %}
-              data-format="%"
-            {% endif %}>
-            {% if _metric == 'count' %}
-              {{ jobs[year].jobs | intcomma }}
-            {% elsif _metric == 'percent' %}
-              {{ jobs[year].percent | percent }}%
-            {% endif %}
-          </span>
-        </figcaption>
-      </figure>
+      </figure><!-- /.chart -->
 
-      {% if forloop.last %}
-      <h4>
-        <button is="aria-toggle"
-          aria-controls="employment-detail-{{ _metric }}">&plus; Detail</button>
-      </h4>
-      <div id="employment-detail-{{ _metric }}" aria-hidden="true">
-        {%
-          include location/display-jobs.html
-          values=jobs
-          percent=true
-        %}
-      </div>
-      {% endif %}
-
+        {% if forloop.last %}
+        <!-- <h4>
+          <button is="aria-toggle"
+            aria-controls="employment-detail-{{ _metric }}">&plus; Detail</button>
+        </h4>
+        <div id="employment-detail-{{ _metric }}" aria-hidden="true">
+          {%
+            include location/display-jobs.html
+            values=jobs
+            percent=true
+          %}
+        </div> -->
+        {% endif %}
     </section><!-- /.chart-item -->
-    {% endfor %}
+      {% endfor %}
+  </section><!-- /.chart-list -->
 
-  </div><!-- /.chart-list.has-intro -->
+  <p>
+    <a href="{{site.baseurl}}/downloads/#jobs">
+      <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
+    </a>
+  </p>
 
 
-  <div class="chart-list">
-    <div class="chart-list-intro">
+  <h3>Self-employment jobs</h3>
 
-      <p><strong>Self-employment data</strong> describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.</p>
+  <section class="chart-list" is="year-switcher-section">
+    <div class="chart-selector-wrapper">
 
-      <a href="{{site.baseurl}}/downloads/#jobs">
-        <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
-      </a>
+      {% include year-selector.html year_range=year_range %}
 
-    </div>
+      <p class="chart-description">
+        <strong>Self-employment data</strong> describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.
+      </p>
+    </div><!-- .chart-selector-wrapper -->
 
     {% assign _metrics = 'count' | split: ' ' %}
     {% for _metric in _metrics %}
     <section class="chart-item">
 
-      <h3 class="chart-title">Number of self-employment jobs in extractives</h3>
+      <h3 class="chart-title">Self-employment jobs</h3>
 
       <figure class="chart">
+        <figcaption id="self-employment-figures-{{ _metric }}">
+          In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+          there were
+          <span class="eiti-bar-chart-y-value" data-format=",">
+            {{ self_employment_jobs[year].jobs | intcomma }}
+          </span>
+          self-employed extractive industries professionals in
+          {{ state_name }}.
+        </figcaption>
         <eiti-bar-chart
           aria-controls="self-employment-figures-{{ _metric }}"
           data='{{ self_employment_jobs | map_hash: _metric | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
-        <figcaption id="self-employment-figures-{{ _metric }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value"
-            {% if _metric == 'count' %}
-              data-format=","
-            {% elsif _metric == 'percent' %}
-              data-format="%"
-            {% endif %}>
-            {% if _metric == 'count' %}
-              {{ self_employment_jobs[year].jobs | intcomma }}
-            {% elsif _metric == 'percent' %}
-              {{ self_employment_jobs[year].percent | percent }}%
-            {% endif %}
-          </span>
-        </figcaption>
+
       </figure>
 
     </section><!-- /.chart-item -->
     {% endfor %}
-  </div>
+  </section><!-- /.chart-list -->
+
+  <p>
+    <a href="{{site.baseurl}}/downloads/#jobs">
+      <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
+    </a>
+  </p>
 
 </section>

--- a/_includes/location/national-ownership.html
+++ b/_includes/location/national-ownership.html
@@ -9,15 +9,15 @@
   </section>
 
   <aside class="map-container">
-    <figure is="data-map" color-scheme="Reds" steps="9">
-        {%
-          include state-map.html
-          states=site.data.state_revenues
-          value='products.All.2013.revenue'
-          href='%/'
-          ownership=true
-        %}
-    </figure>
+    <eiti-data-map color-scheme="Reds" steps="9">
+      {%
+        include state-map.html
+        states=site.data.state_revenues
+        value='products.All.2013.revenue'
+        href='%/'
+        ownership=true
+      %}
+    </eiti-data-map>
     <aside class="legend-container">
       <h5>Land ownership</h5>
 

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -3,89 +3,133 @@
 {% assign units = '$' %}
 {% assign year_range = '[2006, 2015]' %}
 
-<section id="revenue" class="federal revenue">
+<section id="revenue" is="year-switcher-section" class="federal revenue">
 
   <h2>Revenue</h2>
 
-  <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
-
-  <h3 id="federal-revenue">Revenue from federal land</h3>
-
-  <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
+  <p class="full-width-text">Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
 
 
-  <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
+  <h3>Revenue from federal land</h3>
 
-  <div id="fee-summaries" class="tab-interface">
-    <ul class="eiti-tabs info-tabs" role="tablist">
-      <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" aria-selected="true">Federal revenue by phase ({{ year }})</a></li>
-      <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" class="link-charlie">Revenue details by phase</a></li>
-    </ul>
+  <section id="federal-revenue">
 
-    <article class="eiti-tab-panel" id="revenues" role="tabpanel">
-      {%
-        include location/revenue-type-table.html
-        id='revenue-types'
-        location_id=state_id
-        location_name=state_name
-        year=year
-      %}
-    </article>
+    <p class="full-width-text">Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
-    <article class="eiti-tab-panel" id="story" role="tabpanel" aria-hidden="true">
-      {%
-        include location/revenue-process-table.html
-        id='revenue-process'
-        location_id=state_id
-        location_name=state_name
-        year=year
-      %}
-    </article>
-  </div>
+<!--   <aside class="container-half county-map-table">
 
-  <section id="commodities-revenue" class="chart-list has-intro">
+    <figure>
+      <eiti-data-map color-scheme="Blues" steps="9">
+        {% assign county_revenue = site.data.county_revenue[state_id] %}
+        {% capture value_key %}revenue.{{ year }}{% endcapture %}
+        {%
+          include county-map.html
+          state=state_id
+          counties=county_revenue
+          value=value_key
+        %}
+      </eiti-data-map>
+      <figcaption>Revenue from extraction on federal land by county (dollars, {{ year }})</figcaption>
+    </figure>
+  </aside> -->
 
-    <h4>Revenue from resources extracted on federal land in {{ state_name }}</h4>
+    <p class="full-width-text">The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
 
-    <p class="chart-list-intro">In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/"><icon class="fa fa-file-text-o u-padding-right"></icon>Federal revenue data comes from the Office of Natural Resources Revenue
-    </a></p>
+    <div id="fee-summaries" class="tab-interface">
+      <ul class="eiti-tabs info-tabs" role="tablist">
+        <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" aria-selected="true">Federal revenue by phase ({{ year }})</a></li>
+        <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" class="link-charlie">Revenue details by phase</a></li>
+      </ul>
 
-    {% for commodity in revenue_commodities %}
-      {% assign revenue = commodity[1][year].revenue %}
-      {% assign commodity_name = commodity[0] | lookup: commodity_names %}
-      {% assign commodity_slug = commodity[0] | slugify %}
+      <article class="eiti-tab-panel" id="revenues" role="tabpanel">
+        {%
+          include location/revenue-type-table.html
+          id='revenue-types'
+          location_id=state_id
+          location_name=state_name
+          year=year
+        %}
+      </article>
 
-    <section id="revenue-{{ commodity_slug }}" class="chart-item">
+      <article class="eiti-tab-panel" id="story" role="tabpanel" aria-hidden="true">
+        {%
+          include location/revenue-process-table.html
+          id='revenue-process'
+          location_id=state_id
+          location_name=state_name
+          year=year
+        %}
+      </article>
+    </div>
 
-      <h3 class="chart-title">{{ commodity_name }}</h3>
+    <section class="chart-list">
 
-      <figure class="chart">
-        {% assign annual_revenue = commodity[1] %}
-        <eiti-bar-chart
-          data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
-          aria-controls="revenue-figures-{{ commodity_slug }}"
-          x-range="{{ year_range }}"
-          x-value="{{ year }}">
-        </eiti-bar-chart>
-        <figcaption id="revenue-figures-{{ commodity_slug }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span>
-        </figcaption>
-      </figure>
-      <p class="chart-list_caption">
-        In {{ year }},
-          {% if revenue %}
-            companies paid the federal government ${{ revenue | intcomma }} to extract
-          {% else %}
-            the federal government did not collect any revenue from extraction of
-          {% endif %}
-          {{ commodity_name | downcase }} on federal land in {{ state_name }}.
-      </p>
+      <h4>Revenue from resources extracted on federal land in {{ state_name }}</h4>
+
+      <div class="chart-selector-wrapper">
+
+        {% include year-selector.html year_range=year_range %}
+
+        <p class="chart-description">
+          In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}.
+        </p>
+      </div>
+
+
+      {% for commodity in revenue_commodities %}
+        {% assign revenue = commodity[1][year].revenue %}
+        {% assign commodity_name = commodity[0] | lookup: commodity_names %}
+        {% assign commodity_slug = commodity[0] | slugify %}
+
+        <section id="revenue-{{ commodity_slug }}" class="chart-item">
+
+          <h3 class="chart-title">{{ commodity_name }}</h3>
+
+          <figure class="chart">
+            {% assign annual_revenue = commodity[1] %}
+            <figcaption id="revenue-figures-{{ commodity_slug }}">
+              In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+                companies paid the federal government <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span> to extract
+              {{ commodity_name | downcase }} on federal land in {{ state_name }}.
+
+            </figcaption>
+            <eiti-bar-chart
+              data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
+              aria-controls="revenue-figures-{{ commodity_slug }}"
+              x-range="{{ year_range }}"
+              x-value="{{ year }}">
+            </eiti-bar-chart>
+
+          </figure>
+
+          <!-- <h4>
+            <button is="aria-toggle"
+              aria-controls="revenue-detail-{{ commodity_slug }}">&plus; Details</button>
+          </h4>
+          <div id="revenue-detail-{{ commodity_slug }}" aria-hidden="true">
+            {% assign revenue_values = commodity[1] %}
+            {%
+              include location/display-revenue.html
+              year=year
+              values=revenue_values
+              percent=false
+              rank=false
+            %}
+          </div> -->
+
+        </section>
+
+      {% endfor %}
 
     </section>
+    <!-- .chart-list -->
 
-  {% endfor %}
+    <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/"><icon class="fa fa-file-text-o u-padding-right"></icon>Federal revenue data comes from the Office of Natural Resources Revenue</a>
+  </section>
+  <!-- #federal-revenue -->
 
+  <section id="private-revenue" class="private-lands revenue">
+    <h3>Revenue from extraction on private land</h3>
+    <p class="full-width-text">Companies that extract natural resources on private land must pay income taxes, like any other company. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
+  </section>
 </section>
-
-

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -63,7 +63,7 @@
       <figure class="chart">
         {% assign annual_revenue = commodity[1] %}
         <eiti-bar-chart
-          data='{% include location/line-chart-data.json values=annual_revenue key="revenue" %}'
+          data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
           aria-controls="revenue-figures-{{ commodity_slug }}"
           x-range="{{ year_range }}"
           x-value="{{ year }}">

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -2,11 +2,22 @@
 
 {% assign units_map = site.data.production_units %}
 
+{% capture year_range %}[2004, 2013]{% endcapture %}
+
+{% assign year_list = year_range | to_list %}
+
 <section id="all-production" class="all-lands production">
 
   <h2>Natural resource production in {{ state_name }}</h2>
 
-  <p>The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>
+  <div class="chart-selector-wrapper">
+    <select class="chart-selector selector-all-production">
+      {% for _year in year_list %}
+        <option value="{{ _year }}" {% if year == _year %}selected{% endif %}>{{ _year }}</option>
+      {% endfor %}
+    </select>
+    <p>The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>
+  </div>
 
   <div class="chart-list">
 

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -46,7 +46,7 @@
         </figcaption>
         <eiti-bar-chart
           aria-controls="all-production-figures-{{ product_slug }}"
-          data='{% include location/line-chart-data.json values=production_values key="volume" %}'
+          data='{{ production_values | map_hash: "volume" | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -26,8 +26,10 @@
 
       <figure class="chart">
         <figcaption id="all-production-figures-{{ product_slug }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value" data-format="," data-units="{{ short_units }}">{{ volume | default: 0 | intcomma }}</span>
+          <span class="eiti-bar-chart-y-value" data-format=","">{{ volume | default: 0 | intcomma }}</span>
+          {{ long_units | term }} of
+          {{ product_name | downcase | suffix:units_suffix }} was extracted in {{ state_name }} in
+          <span class="eiti-bar-chart-x-value">{{ year }}</span>.
         </figcaption>
         <eiti-bar-chart
           aria-controls="all-production-figures-{{ product_slug }}"
@@ -36,11 +38,6 @@
           x-value="{{ year }}">
         </eiti-bar-chart>
       </figure>
-      <p class="chart-list_caption">
-        {% if volume %}{{ volume | intcomma }} {{ long_units | term }} of
-        {% else %}No{% endif %}
-        {{ product_name | downcase | suffix:units_suffix }} was extracted in {{ state_name }} in {{ year }}.
-      </p>
       <!-- <h4>
         <button is="aria-toggle"
           aria-controls="all-production-detail-{{ product_slug }}">&plus; Historical details</button>

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -18,7 +18,7 @@
         <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
       {% endfor %}
     </select>
-    <p>The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>
+    <p class="chart-description">The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>
   </div>
 
   <div class="chart-list">

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -6,11 +6,11 @@
 
 {% assign year_list = year_range | to_list %}
 
-<section id="all-production" class="all-lands production">
+<section id="all-production" is="year-switcher-section" class="all-lands production">
 
   <h2>Natural resource production in {{ state_name }}</h2>
 
-  <div class="chart-selector-wrapper">
+  <div class="chart-selector-wrapper" aria-controls="all-production">
 
     <select class="chart-selector selector-all-production">
       {% for _year in year_list %}

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -10,14 +10,10 @@
 
   <h2>Natural resource production in {{ state_name }}</h2>
 
-  <div class="chart-selector-wrapper" aria-controls="all-production">
+  <div class="chart-selector-wrapper">
 
-    <select class="chart-selector selector-all-production">
-      {% for _year in year_list %}
-        {% assign __year = year | to_i %}
-        <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
-      {% endfor %}
-    </select>
+    {% include year-selector.html year_range=year_range %}
+
     <p class="chart-description">The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>
   </div>
 

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -26,19 +26,19 @@
     {% assign long_units = units_map[units].long | default 'units' %}
     {% assign units_suffix = units_map[units].suffix | default '' %}
 
-    <section id="all-production-{{ product_slug }}" class="chart-item">
+    <section id="national-all-production-{{ product_slug }}" class="chart-item">
 
       <h3 class="chart-title">{{ product_name }}</h3>
 
       <figure class="chart">
-        <figcaption id="all-production-figures-{{ product_slug }}">
+        <figcaption id="national-all-production-figures-{{ product_slug }}">
           <span class="eiti-bar-chart-y-value" data-format=","">{{ volume | default: 0 | intcomma }}</span>
           {{ long_units | term }} of
           {{ product_name | downcase | suffix:units_suffix }} was extracted in {{ state_name }} in
           <span class="eiti-bar-chart-x-value">{{ year }}</span>.
         </figcaption>
         <eiti-bar-chart
-          aria-controls="all-production-figures-{{ product_slug }}"
+          aria-controls="national-all-production-figures-{{ product_slug }}"
           data='{{ production_values | map_hash: "volume" | jsonify }}'
           x-range="{{ year_range }}"
           x-value="{{ year }}">

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -11,9 +11,11 @@
   <h2>Natural resource production in {{ state_name }}</h2>
 
   <div class="chart-selector-wrapper">
+
     <select class="chart-selector selector-all-production">
       {% for _year in year_list %}
-        <option value="{{ _year }}" {% if year == _year %}selected{% endif %}>{{ _year }}</option>
+        {% assign __year = year | to_i %}
+        <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
       {% endfor %}
     </select>
     <p>The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -7,34 +7,35 @@
   <div class="chart-list has-intro">
 
     <div class="chart-list-intro">
-
       {% include location/key-exports.html %}
-
     </div>
+
+    {% assign _format = '$,' %}
+    {% assign _metric = 'dollars' %}
 
     {% for commodity in export_commodities %}
       {% assign exports = commodity[1] %}
       {% assign commodity_slug = commodity[0] | slugify %}
 
       {% if commodity[0] != "Total" and commodity[0] != "All" %}
-        <section id="exports-{{ commodity_slug }}" class="chart-item">
+        <section class="chart-item">
 
           <h3 class="chart-title">{{ commodity[0] }}</h3>
 
           <figure class="chart chart-{{ _metric }}">
             <figcaption id="exports-figures-{{ commodity_slug }}">
-              In <span class="eiti-bar-chart-x-value">{{ year }}</span>
               {{ state_name }} exported
-              <span class="eiti-bar-chart-y-value" data-format="$,">
+              <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">
                 ${{ exports[year].dollars | intcomma }}
               </span>
-              of {{ commodity[0] }}.
+              of {{ commodity[0] }}
+              in <span class="eiti-bar-chart-x-value">{{ year }}</span>.
             </figcaption>
             <eiti-bar-chart
               aria-controls="exports-figures-{{ commodity_slug }}"
-              data='{% include location/line-chart-data.json values=exports key="dollars" %}'
+              data='{% include location/line-chart-data.json values=exports key=_metric %}'
               data-x-range="{{ year_range }}"
-              selected="{{ year }}">
+              x-value="{{ year }}">
             </eiti-bar-chart>
 
           </figure>

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -1,13 +1,20 @@
 {% assign export_commodities = site.data.state_exports[state_id].commodities %}
 
+{% capture year_range %}[2011, 2014]{% endcapture %}
+
 <section id="exports" is="year-switcher-section" class="economic exports">
 
   <h3>Exports</h3>
 
-  <div class="chart-list has-intro">
+  <div class="chart-list">
 
-    <div class="chart-list-intro">
-      {% include location/key-exports.html %}
+    <div class="chart-selector-wrapper">
+
+      {% include year-selector.html year_range=year_range %}
+
+      <p class="chart-description">
+        {% include location/key-exports.html %}
+      </p>
     </div>
 
     {% assign _format = '$,' %}
@@ -39,7 +46,7 @@
 
           </figure>
 
-          <h4>
+        <!--   <h4>
             <button is="aria-toggle" aria-controls="exports-detail-{{ commodity_slug }}">
               &plus; Details
             </button>
@@ -50,7 +57,7 @@
               values=exports
               percent=false
             %}
-          </div>
+          </div> -->
 
         </section><!-- /.chart-item -->
       {% endif %}

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -32,7 +32,7 @@
             </figcaption>
             <eiti-bar-chart
               aria-controls="exports-figures-{{ commodity_slug }}"
-              data='{% include location/line-chart-data.json values=exports key=_metric %}'
+              data='{{ exports | map_hash: _metric | jsonify }}'
               data-x-range="{{ year_range }}"
               x-value="{{ year }}">
             </eiti-bar-chart>

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -24,11 +24,10 @@
 
           <figure class="chart chart-{{ _metric }}">
             <figcaption id="exports-figures-{{ commodity_slug }}">
-              {{ state_name }} exported
               <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">
                 ${{ exports[year].dollars | intcomma }}
               </span>
-              of {{ commodity[0] }}
+              of {{ commodity[0] }} was exported from {{ state_name }}
               in <span class="eiti-bar-chart-x-value">{{ year }}</span>.
             </figcaption>
             <eiti-bar-chart

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -1,6 +1,6 @@
 {% assign export_commodities = site.data.state_exports[state_id].commodities %}
 
-<section id="exports" class="economic exports">
+<section id="exports" is="year-switcher-section" class="economic exports">
 
   <h3>Exports</h3>
 

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -23,10 +23,12 @@
 
           <figure class="chart chart-{{ _metric }}">
             <figcaption id="exports-figures-{{ commodity_slug }}">
-              <span class="eiti-bar-chart-x-value">{{ year }}</span>
+              In <span class="eiti-bar-chart-x-value">{{ year }}</span>
+              {{ state_name }} exported
               <span class="eiti-bar-chart-y-value" data-format="$,">
                 ${{ exports[year].dollars | intcomma }}
               </span>
+              of {{ commodity[0] }}.
             </figcaption>
             <eiti-bar-chart
               aria-controls="exports-figures-{{ commodity_slug }}"

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -9,7 +9,7 @@
 
 <section id="federal-production" class="federal production">
 
-  <h3>Production on federal land in {{ state_name }}</h2>
+  <h3>Land ownership</h2>
 
   {% include location/section-ownership.html %}
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -15,7 +15,7 @@
 
   <section class="county-map-table">
 
-    <h4>Natural resources extracted on federal land</h4>
+    <h3>Natural resources extracted on federal land</h3>
 
     {% if federal_products_num == 0 %}
       <p>No natural resources were produced on federal land in {{  state_name }} in {{ year }}.</p>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -97,7 +97,7 @@
                 {% assign _width ='inherit' %}
                 {% capture caption %}County production for {{ product_name }} in {{ year }}{% endcapture %}
 
-                <data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
+                <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
                   {% assign federal_county_production = site.data.federal_county_production[state_id] %}
 
                   {%
@@ -111,7 +111,7 @@
                     caption=caption
                     toggle=toggle
                   %}
-                </data-map>
+                </eiti-data-map>
 
               </figure>
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -13,13 +13,20 @@
 
   {% include location/section-ownership.html %}
 
-  <section class="county-map-table">
+  <section class="county-map-table" is="year-switcher-section">
 
     <h3>Natural resources extracted on federal land</h3>
 
     {% if federal_products_num == 0 %}
       <p>No natural resources were produced on federal land in {{  state_name }} in {{ year }}.</p>
     {% endif %}
+
+    <select class="chart-selector selector-all-production">
+      {% for _year in year_list %}
+        {% assign __year = year | to_i %}
+        <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
+      {% endfor %}
+    </select>
 
     <div class="chart-list">
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -7,6 +7,8 @@
 {% assign federal_products_num = federal_products | size %}
 {% assign units_map = site.data.production_units %}
 
+{% capture year_range %}[2005, 2014]{% endcapture %}
+
 <section id="federal-production" is="year-switcher-section" class="federal production">
 
   <h3>Land ownership</h2>
@@ -21,12 +23,18 @@
       <p>No natural resources were produced on federal land in {{  state_name }} in {{ year }}.</p>
     {% endif %}
 
-    <select class="chart-selector selector-all-production">
-      {% for _year in year_list %}
-        {% assign __year = year | to_i %}
-        <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
-      {% endfor %}
-    </select>
+    <div class="chart-selector-wrapper">
+
+      {% include year-selector.html year_range=year_range %}
+
+      <p class="chart-description">
+        {% if federal_products_num == 0 %}
+          No natural resources were produced on federal land in {{  state_name }} in {{ year }}.
+        {% else %}
+          Is there some kind of summary sentence that would be good here? The year selector would update all references to year in the federal production section.
+        {% endif %}
+      </p>
+    </div>
 
     <div class="chart-list">
 
@@ -43,92 +51,94 @@
 
       <section id="federal-production-{{ product_slug }}" class="product chart-item full-width">
 
-        <h4 class="chart-title">
-          {{ product_name }}
-          {% if units_title %} ({{ units_title }}){% endif %}
-        </h4>
-
         <div class="row-container">
 
           <div class="chart-container">
 
-            {% if volume %}
-              <figure class="chart">
-                <figcaption id="federal-production-figures-{{ product_slug }}">
-                <span class="eiti-bar-chart-y-value"
-                        data-format=",">{{ volume | default: 0 | intcomma }}</span>
-                {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
-                produced on federal land in {{ state_name }} in
-                <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+            <h4 class="chart-title">
+              {{ product_name }}
+              {% if units_title %} ({{ units_title }}){% endif %}
+            </h4>
 
-                </figcaption>
-                <eiti-bar-chart
-                  aria-controls="federal-production-figures-{{ product_slug }}"
-                  data='{{ production_values | map_hash: "volume" | jsonify }}'
-                  data-x-range="{{ year_range }}"
-                  x-value="{{ year }}">
-                </eiti-bar-chart>
+            <figure class="chart">
+              <figcaption id="federal-production-figures-{{ product_slug }}">
+              <span class="eiti-bar-chart-y-value"
+                      data-format=",">{{ volume | default: 0 | intcomma }}</span>
+              {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
+              produced on federal land in {{ state_name }} in
+              <span class="eiti-bar-chart-x-value">{{ year }}</span>.
 
-              </figure>
+              </figcaption>
+              <eiti-bar-chart
+                aria-controls="federal-production-figures-{{ product_slug }}"
+                data='{{ production_values | map_hash: "volume" | jsonify }}'
+                data-x-range="{{ year_range }}"
+                x-value="{{ year }}">
+              </eiti-bar-chart>
 
-              <!-- <h4>
-                <button is="aria-toggle"
-                  aria-controls="federal-production-{{ product_slug }}-years">&plus; Details</button>
-              </h4>
-              <div id="federal-production-{{ product_slug }}-years" aria-hidden="true">
-                {%
-                  include location/display-production.html
-                  units=units
-                  year=year
-                  values=production_values
-                  percent=true
-                  rank=true
-                %}
-              </div> -->
-            {% endif %}
+            </figure>
+
+            <!-- <h4>
+              <button is="aria-toggle"
+                aria-controls="federal-production-{{ product_slug }}-years">&plus; Details</button>
+            </h4>
+            <div id="federal-production-{{ product_slug }}-years" aria-hidden="true">
+              {%
+                include location/display-production.html
+                units=units
+                year=year
+                values=production_values
+                percent=true
+                rank=true
+              %}
+            </div> -->
           </div><!-- /.chart-container -->
 
-          {% if volume %}
-            <div class="map-container">
-              {% capture toggle %}federal-production-{{ product_slug }}-counties{% endcapture %}
-              <figure>
-                {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
-                {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
-                {% assign _width ='inherit' %}
-                {% capture caption %}County production for {{ product_name }} in {{ year }}{% endcapture %}
+          <div class="map-container">
 
-                <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
-                  {% assign federal_county_production = site.data.federal_county_production[state_id] %}
-
-                  {%
-                    include county-map.html
-                    state=state_id
-                    counties=federal_county_production
-                    value=value_key
-                    years=years_key
-                    steps=steps
-                    inherit_width=true
-                    caption=caption
-                    toggle=toggle
-                  %}
-                </eiti-data-map>
-
-              </figure>
+            <h4 class="chart-title">
+              By county
+            </h4>
 
 
-              <div id="{{ toggle }}" aria-hidden="true">
+            {% capture toggle %}federal-production-{{ product_slug }}-counties{% endcapture %}
+            <figure>
+              {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
+              {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
+              {% assign _width ='inherit' %}
+              {% capture caption %}County production for {{ product_name }} in {{ year }}{% endcapture %}
+
+              <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
+                {% assign federal_county_production = site.data.federal_county_production[state_id] %}
+
                 {%
-                  include location/display-production.html
-                  units=units
-                  year=year
-                  values=production_values
-                  percent=true
-                  rank=true
+                  include county-map.html
+                  state=state_id
+                  counties=federal_county_production
+                  value=value_key
+                  years=years_key
+                  steps=steps
+                  inherit_width=true
+                  caption=caption
+                  toggle=toggle
                 %}
-              </div>
+              </eiti-data-map>
 
-            </div><!-- /.map-container -->
-          {% endif %}
+            </figure>
+
+
+            <div id="{{ toggle }}" aria-hidden="true">
+              {%
+                include location/display-production.html
+                units=units
+                year=year
+                values=production_values
+                percent=true
+                rank=true
+              %}
+            </div>
+
+          </div><!-- /.map-container -->
 
         </div><!-- /.row-container -->
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -1,10 +1,6 @@
 {% assign federal_products = site.data.state_federal_production[state_id].products %}
 {% assign year_range = '[2005, 2014]' %}
 
-{% if national_page %}
-  {% assign federal_products = site.data.national_federal_production[state_id].products %}
-{% endif %}
-
 {% assign federal_products_num = federal_products | size %}
 {% assign units_map = site.data.production_units %}
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -48,10 +48,12 @@
             {% if volume %}
               <figure class="chart">
                 <figcaption id="federal-production-figures-{{ product_slug }}">
-                    <span class="eiti-bar-chart-x-value">{{ year }}</span>
-                    <span class="eiti-bar-chart-y-value"
-                          data-format=","
-                          data-units="{{ short_units }}">{{ volume | default: 0 | intcomma }}</span>
+                <span class="eiti-bar-chart-y-value"
+                        data-format=",">{{ volume | default: 0 | intcomma }}</span>
+                {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
+                produced on federal land in {{ state_name }} in
+                <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+
                 </figcaption>
                 <eiti-bar-chart
                   aria-controls="federal-production-figures-{{ product_slug }}"
@@ -77,17 +79,6 @@
                 %}
               </div> -->
             {% endif %}
-            <div class="text-container">
-              <p>
-                {% if volume %}
-                  {{ volume | intcomma }} {{ long_units | term }}
-                  of {{ product_name | downcase | suffix:units_suffix }} were
-                {% else %}
-                  No {{ product_name | downcase | suffix:units_suffix }} was
-                {% endif %}
-                produced on federal land in {{ state_name }} in {{ year }}.
-              </p>
-            </div>
           </div><!-- /.chart-container -->
 
           {% if volume %}

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -93,6 +93,7 @@
               {% capture toggle %}federal-production-{{ product_slug }}-counties{% endcapture %}
               <figure>
                 {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
+                {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
                 {% assign _width ='inherit' %}
                 {% capture caption %}County production for {{ product_name }} in {{ year }}{% endcapture %}
 
@@ -104,6 +105,7 @@
                     state=state_id
                     counties=federal_county_production
                     value=value_key
+                    years=years_key
                     steps=steps
                     inherit_width=true
                     caption=caption

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -6,7 +6,7 @@
 
 <section id="federal-production" is="year-switcher-section" class="federal production">
 
-  <h3>Land ownership</h2>
+  <h3>Production on federal land in {{ state_name }}</h2>
 
   {% include location/section-ownership.html %}
 
@@ -26,7 +26,7 @@
         {% if federal_products_num == 0 %}
           No natural resources were produced on federal land in {{  state_name }} in {{ year }}.
         {% else %}
-          Is there some kind of summary sentence that would be good here? The year selector would update all references to year in the federal production section.
+          ONRR collects data about what natural resources are produced on federal land in {{ state_name }}. <a href="{{site.baseurl}}/downloads/federal-production/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
         {% endif %}
       </p>
     </div>
@@ -92,7 +92,7 @@
           <div class="map-container">
 
             <h4 class="chart-title">
-              By county
+              Local production
             </h4>
 
 
@@ -101,7 +101,7 @@
               {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
               {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
               {% assign _width ='inherit' %}
-              {% capture caption %}County production for {{ product_name }} in {{ year }}{% endcapture %}
+              {% capture caption %}Local production of {{ product_name | downcase | suffix:units_suffix }} in {{ year }}{% endcapture %}
 
               <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
                 {% assign federal_county_production = site.data.federal_county_production[state_id] %}
@@ -128,8 +128,8 @@
                 units=units
                 year=year
                 values=production_values
-                percent=true
-                rank=true
+                percent=false
+                rank=false
               %}
             </div>
 
@@ -143,9 +143,5 @@
     </div><!-- /.chart-list -->
 
   </section>
-
-  <a href="{{site.baseurl}}/downloads/federal-production/">
-    <icon class="fa fa-file-text-o u-padding-right"></icon>Federal production data comes from the Office of Natural Resources Revenue
-  </a>
 
 </section>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -7,7 +7,7 @@
 {% assign federal_products_num = federal_products | size %}
 {% assign units_map = site.data.production_units %}
 
-<section id="federal-production" class="federal production">
+<section id="federal-production" is="year-switcher-section" class="federal production">
 
   <h3>Land ownership</h2>
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -64,7 +64,7 @@
                 </figcaption>
                 <eiti-bar-chart
                   aria-controls="federal-production-figures-{{ product_slug }}"
-                  data='{% include location/line-chart-data.json values=production_values key="volume" %}'
+                  data='{{ production_values | map_hash: "volume" | jsonify }}'
                   data-x-range="{{ year_range }}"
                   x-value="{{ year }}">
                 </eiti-bar-chart>

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -1,6 +1,6 @@
 {% assign gdp = site.data.state_gdp[state_id] %}
 
-<section id="gdp" class="economic gdp">
+<section id="gdp" is="year-switcher-section" class="economic gdp">
 
   <h3>Gross Domestic Product (GDP)</h3>
 
@@ -33,7 +33,7 @@
         </figcaption>
         <eiti-bar-chart
           aria-controls="gdp-figures-{{ _metric }}"
-          data='{% include location/line-chart-data.json values=gdp key=_metric %}'
+          data='{{ gdp | map_hash: _metric | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -1,8 +1,19 @@
 {% assign gdp = site.data.state_gdp[state_id] %}
 
+{% capture year_range %}[2004, 2013]{% endcapture %}
+
 <section id="gdp" is="year-switcher-section" class="economic gdp">
 
   <h3>Gross Domestic Product (GDP)</h3>
+
+  <div class="chart-selector-wrapper">
+
+    {% include year-selector.html year_range=year_range %}
+
+    <p class="chart-description">
+      A revolutionary description of GDP from extractives could go here. The selector should change only the GDP section
+    </p>
+  </div><!-- .chart-selector-wrapper -->
 
   <div class="chart-list">
 

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -11,7 +11,7 @@
     {% include year-selector.html year_range=year_range %}
 
     <p class="chart-description">
-      A revolutionary description of GDP from extractives could go here. The selector should change only the GDP section
+      GDP data comes from the U.S. Bureau of Economic Analysis. <a href="{{site.baseurl}}/downloads/#gdp">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
     </p>
   </div><!-- .chart-selector-wrapper -->
 
@@ -71,9 +71,5 @@
     {% endfor %}
 
   </div><!-- /.chart-list.has-intro -->
-
-  <a href="{{site.baseurl}}/downloads/#gdp">
-    <icon class="fa fa-file-text-o u-padding-right"></icon>GDP data comes from the U.S. Bureau of Economic Analysis
-  </a>
 
 </section>

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -4,33 +4,23 @@
 
   <h3>Gross Domestic Product (GDP)</h3>
 
-  <div class="chart-list has-intro">
-
-    <div class="chart-list-intro">
-      <p>Extractive industries accounted for
-        {% if gdp[year].dollars %}
-          {{ gdp[year].percent | percent }}% (or
-          ${{ gdp[year].dollars | intcomma }}) of {{ state_name }}'s GDP in {{ year }}.
-        {% else %}
-          The extractives industry did not contribute to {{ state_name }}'s GDP in {{ year }}.
-        {% endif %}
-      </p>
-    </div>
+  <div class="chart-list">
 
     {% assign _metrics = 'dollars' | split: ' ' %}
     {% for _metric in _metrics %}
+      {% assign _format = ',' %}
+      {% if _metric == 'dollars' %}
+        {% assign _format = '$,' %}
+      {% elsif _metric == 'percent' %}
+        {% assign _format = '%' %}
+      {% endif %}
+
     <section class="chart-item">
       <h3 class="chart-title">GDP ({{ _metric }})</h3>
 
       <figure class="chart chart-{{ _metric }}">
         <figcaption id="gdp-figures-{{ _metric }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          {% assign _format = ',' %}
-          {% if _metric == 'dollars' %}
-            {% assign _format = '$,' %}
-          {% elsif _metric == 'percent' %}
-            {% assign _format = '%' %}
-          {% endif %}
+          Extractive industries accounted for
           <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">
             {% if _metric == 'dollars' %}
               ${{ gdp[year].dollars | intcomma }}
@@ -38,6 +28,8 @@
               {{ gdp[year].percent | percent }}%
             {% endif %}
           </span>
+          of {{ state_name }}'s GDP in
+          <span class="eiti-bar-chart-x-value">{{ year }}</span>.
         </figcaption>
         <eiti-bar-chart
           aria-controls="gdp-figures-{{ _metric }}"

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -6,74 +6,71 @@
 {% assign jobs_count = jobs[year].count | default: 0 %}
 {% assign jobs_percent = jobs[year].percent | default: 0 %}
 
-{% assign year_list = year_range | to_list %}
+{% capture year_range %}[2004, 2013]{% endcapture %}
 
-<section id="employment" is="year-switcher-section" class="economic employment">
 
-  <h3>Employment</h3>
+<section id="employment" class="economic employment">
 
-  <div class="chart-list">
+  <h3>Wage and salary jobs</h3>
 
-    <select class="chart-selector selector-all-production">
-      {% for _year in year_list %}
-        {% assign __year = year | to_i %}
-        <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
-      {% endfor %}
-    </select>
+  <section is="year-switcher-section" class="chart-list">
 
-    <div class="chart-list-intro">
-      <p>Two kinds of data help represent the economic role of extractive industries in {{ state_name }}.</p>
-      <p><strong>Wage and salary data</strong> describes the number of people employed in natural resource extraction that receive wages or salaries from companies.</p>
-    </div>
+    <div class="chart-selector-wrapper">
 
-    {% assign _metrics = 'count' | split: ' ' %}
-    {% for _metric in _metrics %}
-    <section class="chart-item">
+      {% include year-selector.html year_range=year_range %}
 
-      <h3 class="chart-title">Number of jobs in extractives</h3>
-
-      <figure class="chart">
-        <figcaption id="jobs-figures-{{ _metric }}">
-          In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
-          there were
-          <span class="eiti-bar-chart-y-value" data-format=",">
-            {{ jobs[year].jobs | intcomma }}
-          </span>
-          jobs in extractive industries that paid a wage or salary in
-          {{ state_name }}.
-        </figcaption>
-        <eiti-bar-chart
-          aria-controls="jobs-figures-{{ _metric }}"
-          data='{{ jobs | map_hash: _metric | jsonify }}'
-          data-x-range="{{ year_range }}"
-          x-value="{{ year }}">
-        </eiti-bar-chart>
-      </figure><!-- /.chart -->
-
-      {% if forloop.last %}
-      <h4>
-        <button is="aria-toggle"
-          aria-controls="employment-detail-{{ _metric }}">&plus; Detail</button>
-      </h4>
-      <div id="employment-detail-{{ _metric }}" aria-hidden="true">
-        {%
-          include location/display-jobs.html
-          values=jobs
-          percent=true
-        %}
+      <div class="chart-description">
+        <p>Two kinds of data help represent the economic role of extractive industries in {{ state_name }}.</p>
+        <p><strong>Wage and salary data</strong> describes the number of people employed in natural resource extraction that receive wages or salaries from companies.</p>
       </div>
-      {% endif %}
+    </div><!-- .chart-selector-wrapper -->
 
-    </section><!-- /.chart-item -->
-    {% endfor %}
-
-  </div><!-- /.chart-list.has-intro -->
-
-  <div class="chart-list">
-
-    <h3 class="chart-title">County-level employment in extractives</h3>
 
     <div class="row-container">
+
+      <div class="chart-container">
+
+
+        {% assign _metrics = 'count' | split: ' ' %}
+        {% for _metric in _metrics %}
+        <h3 class="chart-title">Wage and salary jobs</h3>
+
+        <figure class="chart">
+          <figcaption id="jobs-figures-{{ _metric }}">
+            In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+            there were
+            <span class="eiti-bar-chart-y-value" data-format=",">
+              {{ jobs[year].jobs | intcomma }}
+            </span>
+            jobs in extractive industries that paid a wage or salary in
+            {{ state_name }}.
+          </figcaption>
+          <eiti-bar-chart
+            aria-controls="jobs-figures-{{ _metric }}"
+            data='{{ jobs | map_hash: _metric | jsonify }}'
+            data-x-range="{{ year_range }}"
+            x-value="{{ year }}">
+          </eiti-bar-chart>
+        </figure><!-- /.chart -->
+
+          {% if forloop.last %}
+          <!-- <h4>
+            <button is="aria-toggle"
+              aria-controls="employment-detail-{{ _metric }}">&plus; Detail</button>
+          </h4>
+          <div id="employment-detail-{{ _metric }}" aria-hidden="true">
+            {%
+              include location/display-jobs.html
+              values=jobs
+              percent=true
+            %}
+          </div> -->
+          {% endif %}
+
+        {% endfor %}
+
+      </div><!-- /.chart-container -->
+
       {% capture toggle %}county-level-employment–{{ state_id }}{% endcapture %}
 
       <div class="map-container">
@@ -96,33 +93,43 @@
             %}
           </eiti-data-map>
         </figure>
+        <div class="table-container" id="{{ toggle }}" aria-hidden="true">
+          {%
+            include location/display-jobs-county.html
+            year=year
+            values=county_jobs
+            percent=true
+          %}
+        </div><!-- /.table-container -->
       </div><!-- /.map-container -->
-
-      <div class="table-container" id="{{ toggle }}" aria-hidden="true">
-        {%
-          include location/display-jobs-county.html
-          year=year
-          values=county_jobs
-          percent=true
-        %}
-      </div><!-- /.table-container -->
-
     </div><!-- /.row-container -->
 
-  </div><!-- /.chart-list -->
+  </section><!-- /.chart-list -->
 
-  <div class="chart-list">
-    <div class="chart-list-intro">
+  <p>
+    <a href="{{site.baseurl}}/downloads/#jobs">
+      <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
+    </a>
+  </p>
 
-      <p><strong>Self-employment data</strong> describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.</p>
 
-    </div>
+  <h3>Self-employment jobs</h3>
+
+  <section class="chart-list" is="year-switcher-section">
+    <div class="chart-selector-wrapper">
+
+      {% include year-selector.html year_range=year_range %}
+
+      <p class="chart-description">
+        <strong>Self-employment data</strong> describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.
+      </p>
+    </div><!-- .chart-selector-wrapper -->
 
     {% assign _metrics = 'count' | split: ' ' %}
     {% for _metric in _metrics %}
     <section class="chart-item">
 
-      <h3 class="chart-title">Number of self-employment jobs in extractives</h3>
+      <h3 class="chart-title">Self-employment jobs</h3>
 
       <figure class="chart">
         <figcaption id="self-employment-figures-{{ _metric }}">
@@ -145,7 +152,7 @@
 
     </section><!-- /.chart-item -->
     {% endfor %}
-  </div><!-- /.chart-list -->
+  </section><!-- /.chart-list -->
 
   <p>
     <a href="{{site.baseurl}}/downloads/#jobs">

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -15,17 +15,6 @@
     <div class="chart-list-intro">
       <p>Two kinds of data help represent the economic role of extractive industries in {{ state_name }}.</p>
       <p><strong>Wage and salary data</strong> describes the number of people employed in natural resource extraction that receive wages or salaries from companies.</p>
-      <p>In {{ year }},
-        {% if jobs_count %}
-          there were
-          {{ jobs_count | intcomma }}
-          jobs in extractive industries that paid a wage or salary in
-          {{ state_name }}, or
-          {{ jobs_percent | percent }}% of state-wide employment.
-        {% else %}
-          there were no wage or salary jobs in the extractive industries.
-        {% endif %}
-      </p>
     </div>
 
     {% assign _metrics = 'count' | split: ' ' %}
@@ -36,19 +25,13 @@
 
       <figure class="chart">
         <figcaption id="jobs-figures-{{ _metric }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value"
-            {% if _metric == 'count' %}
-              data-format=","
-            {% elsif _metric == 'percent' %}
-              data-format="%"
-            {% endif %}>
-            {% if _metric == 'count' %}
-              {{ jobs[year].jobs | intcomma }}
-            {% elsif _metric == 'percent' %}
-              {{ jobs[year].percent | percent }}%
-            {% endif %}
+          In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+          there were
+          <span class="eiti-bar-chart-y-value" data-format=",">
+            {{ jobs[year].jobs | intcomma }}
           </span>
+          jobs in extractive industries that paid a wage or salary in
+          {{ state_name }}.
         </figcaption>
         <eiti-bar-chart
           aria-controls="jobs-figures-{{ _metric }}"
@@ -133,19 +116,13 @@
 
       <figure class="chart">
         <figcaption id="self-employment-figures-{{ _metric }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value"
-            {% if _metric == 'count' %}
-              data-format=","
-            {% elsif _metric == 'percent' %}
-              data-format="%"
-            {% endif %}>
-            {% if _metric == 'count' %}
-              {{ self_employment_jobs[year].jobs | intcomma }}
-            {% elsif _metric == 'percent' %}
-              {{ self_employment_jobs[year].percent | percent }}%
-            {% endif %}
+          In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+          there were
+          <span class="eiti-bar-chart-y-value" data-format=",">
+            {{ self_employment_jobs[year].jobs | intcomma }}
           </span>
+          self-employed extractive industries professionals in
+          {{ state_name }}.
         </figcaption>
         <eiti-bar-chart
           aria-controls="self-employment-figures-{{ _metric }}"

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -6,11 +6,20 @@
 {% assign jobs_count = jobs[year].count | default: 0 %}
 {% assign jobs_percent = jobs[year].percent | default: 0 %}
 
-<section id="employment" class="economic employment">
+{% assign year_list = year_range | to_list %}
+
+<section id="employment" is="year-switcher-section" class="economic employment">
 
   <h3>Employment</h3>
 
   <div class="chart-list">
+
+    <select class="chart-selector selector-all-production">
+      {% for _year in year_list %}
+        {% assign __year = year | to_i %}
+        <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
+      {% endfor %}
+    </select>
 
     <div class="chart-list-intro">
       <p>Two kinds of data help represent the economic role of extractive industries in {{ state_name }}.</p>
@@ -79,6 +88,8 @@
               state=state_id
               counties=county_jobs
               value=value_key
+              years="employment"
+              years_property="count"
               steps=steps
               inherit_width=true
               caption=caption

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -20,8 +20,9 @@
       {% include year-selector.html year_range=year_range %}
 
       <div class="chart-description">
-        <p>Two kinds of data help represent the economic role of extractive industries in {{ state_name }}.</p>
         <p><strong>Wage and salary data</strong> describes the number of people employed in natural resource extraction that receive wages or salaries from companies.</p>
+        <p>In {{ year }}, jobs in the extractive industries that paid a wage or salary made up {{ jobs_percent | percent }} % of statewide employment in {{ state_name }}.</p>
+        <p>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a></p>
       </div>
     </div><!-- .chart-selector-wrapper -->
 
@@ -77,7 +78,7 @@
         <figure class="container">
           <eiti-data-map color-scheme="Reds" steps="{{ steps }}">
             {% capture value_key %}employment.{{ year }}.count{% endcapture %}
-            {% capture caption %}County extractives employment (jobs, {{ year }}){% endcapture %}
+            {% capture caption %}Local employment in extractive industries (jobs, {{ year }}){% endcapture %}
 
             {%
               include county-map.html
@@ -106,39 +107,36 @@
 
   </section><!-- /.chart-list -->
 
-  <p>
-    <a href="{{site.baseurl}}/downloads/#jobs">
-      <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
-    </a>
-  </p>
-
-
-  <h3>Self-employment jobs</h3>
+  <h3 id="self-employment">Self-employment</h3>
 
   <section class="chart-list" is="year-switcher-section">
     <div class="chart-selector-wrapper">
 
       {% include year-selector.html year_range=year_range %}
 
-      <p class="chart-description">
-        <strong>Self-employment data</strong> describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.
-      </p>
+      <div class="chart-description">
+        <p>
+          <strong>Self-employment data</strong> describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.
+        </p>
+        <p>
+          Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+        </p>
+      </div>
     </div><!-- .chart-selector-wrapper -->
 
     {% assign _metrics = 'count' | split: ' ' %}
     {% for _metric in _metrics %}
     <section class="chart-item">
 
-      <h3 class="chart-title">Self-employment jobs</h3>
+      <h3 class="chart-title">Self-employment</h3>
 
       <figure class="chart">
         <figcaption id="self-employment-figures-{{ _metric }}">
           In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
-          there were
           <span class="eiti-bar-chart-y-value" data-format=",">
             {{ self_employment_jobs[year].jobs | intcomma }}
           </span>
-          self-employed extractive industries professionals in
+          of people were self-employed in the extractive industries
           {{ state_name }}.
         </figcaption>
         <eiti-bar-chart
@@ -153,11 +151,5 @@
     </section><!-- /.chart-item -->
     {% endfor %}
   </section><!-- /.chart-list -->
-
-  <p>
-    <a href="{{site.baseurl}}/downloads/#jobs">
-      <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
-    </a>
-  </p>
 
 </section>

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -79,7 +79,7 @@
 
       <div class="map-container">
         <figure class="container">
-          <data-map color-scheme="Reds" steps="{{ steps }}">
+          <eiti-data-map color-scheme="Reds" steps="{{ steps }}">
             {% capture value_key %}employment.{{ year }}.count{% endcapture %}
             {% capture caption %}County extractives employment (jobs, {{ year }}){% endcapture %}
 
@@ -95,7 +95,7 @@
               caption=caption
               toggle=toggle
             %}
-          </data-map>
+          </eiti-data-map>
         </figure>
       </div><!-- /.map-container -->
 

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -44,12 +44,11 @@
         </figcaption>
         <eiti-bar-chart
           aria-controls="jobs-figures-{{ _metric }}"
-          data='{% include location/line-chart-data.json values=jobs key=_metric %}'
+          data='{{ jobs | map_hash: _metric | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
-
-      </figure>
+      </figure><!-- /.chart -->
 
       {% if forloop.last %}
       <h4>
@@ -137,7 +136,7 @@
         </figcaption>
         <eiti-bar-chart
           aria-controls="self-employment-figures-{{ _metric }}"
-          data='{% include location/line-chart-data.json values=self_employment_jobs key=_metric %}'
+          data='{{ self_employment_jobs | map_hash: _metric | jsonify }}'
           data-x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
@@ -147,8 +146,11 @@
     </section><!-- /.chart-item -->
     {% endfor %}
   </div><!-- /.chart-list -->
-  <a href="{{site.baseurl}}/downloads/#jobs">
-    <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
-  </a>
+
+  <p>
+    <a href="{{site.baseurl}}/downloads/#jobs">
+      <icon class="fa fa-file-text-o u-padding-right"></icon>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis
+    </a>
+  </p>
 
 </section>

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -6,7 +6,8 @@
     <p><strong>In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government.</strong></p>
 
     <p>When companies extract natural resources on federal land, they pay royalties, rents, bonuses, and other fees — much like they would to any landowner.</p>
-    <p>Companies also report more data about what resources are extracted on government-owned land than on private land. Learn more about <a href="{{ site.baseurl }}/how-it-works/ownership/">natural resources and land ownership</a> in the U.S.</p>
+
+    <p>Learn more about <a href="{{ site.baseurl }}/how-it-works/ownership/">natural resources and land ownership</a> in the U.S.</p>
   </section>
 
   <aside class="map-container">

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -42,8 +42,6 @@
 
     </figure>
     <aside class="legend-container">
-      <h5>Land ownership</h5>
-
       {% include maps/federal_land_ownership_legend.svg %}
     </aside>
 

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -17,7 +17,7 @@
 <!--   <aside class="container-half county-map-table">
 
     <figure>
-      <data-map color-scheme="Blues" steps="9">
+      <eiti-data-map color-scheme="Blues" steps="9">
         {% assign county_revenue = site.data.county_revenue[state_id] %}
         {% capture value_key %}revenue.{{ year }}{% endcapture %}
         {%
@@ -26,7 +26,7 @@
           counties=county_revenue
           value=value_key
         %}
-      </data-map>
+      </eiti-data-map>
       <figcaption>Revenue from extraction on federal land by county (dollars, {{ year }})</figcaption>
     </figure>
   </aside> -->

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -7,14 +7,14 @@
 
   <h2>Revenue</h2>
 
-  <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
+  <p class="full-width-text">Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
 
 
   <h3>Revenue from federal land</h3>
 
   <section id="federal-revenue">
 
-    <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
+    <p class="full-width-text">Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
 <!--   <aside class="container-half county-map-table">
 
@@ -33,7 +33,7 @@
     </figure>
   </aside> -->
 
-    <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
+    <p class="full-width-text">The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
 
     <div id="fee-summaries" class="tab-interface">
       <ul class="eiti-tabs info-tabs" role="tablist">
@@ -131,16 +131,18 @@
   <section id="state-local-revenue" class="state revenue">
     <h3>Revenue from extraction on state land</h3>
 
-    <p>We don't have detailed data about state revenue from natural resource extraction on land owned by the state of {{ state_name }}.</p>
+    <div class="full-width-text">
+      <p>We don't have detailed data about state revenue from natural resource extraction on land owned by the state of {{ state_name }}.</p>
 
-    <!-- pulls in state fiscal and legal information if the state is one of the MSG-prioritized states -->
-    {% if is_priority_state %}
-      <p>However, the USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern extraction on state land.</p>
-      <p>Learn more about natural resource regulation, production, and revenue in {{ state_name }}:</p>
+      <!-- pulls in state fiscal and legal information if the state is one of the MSG-prioritized states -->
+      {% if is_priority_state %}
+        <p>However, the USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern extraction on state land.</p>
+        <p>Learn more about natural resource regulation, production, and revenue in {{ state_name }}:</p>
 
-      {{ regulations | markdownify }}
+        {{ regulations | markdownify }}
 
-    {% endif %}
+      {% endif %}
+    </div>
   </section>
 
   <section id="private-revenue" class="private-lands revenue">

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -147,6 +147,6 @@
 
   <section id="private-revenue" class="private-lands revenue">
     <h3>Revenue from extraction on private land</h3>
-    <p>Companies that extract natural resources on private land must pay income taxes, like any other company. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
+    <p class="full-width-text">Companies that extract natural resources on private land must pay income taxes, like any other company. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
   </section>
 </section>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -71,7 +71,7 @@
         {% include year-selector.html year_range=year_range %}
 
         <p class="chart-description">
-          In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}.
+          In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
         </p>
       </div>
 
@@ -124,7 +124,6 @@
     </section>
     <!-- .chart-list -->
 
-    <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/"><icon class="fa fa-file-text-o u-padding-right"></icon>Federal revenue data comes from the Office of Natural Resources Revenue</a>
   </section>
   <!-- #federal-revenue -->
 
@@ -147,6 +146,6 @@
 
   <section id="private-revenue" class="private-lands revenue">
     <h3>Revenue from extraction on private land</h3>
-    <p class="full-width-text">Companies that extract natural resources on private land must pay income taxes, like any other company. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
+    <p class="full-width-text">All companies, including those that extract natural resources on private land, must pay state, local, and federal taxes. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
   </section>
 </section>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -4,7 +4,7 @@
 
 {% capture year_range %}[2006, 2015]{% endcapture %}
 
-<section id="revenue" class="federal revenue">
+<section id="revenue" is="year-switcher-section" class="federal revenue">
 
   <h2>Revenue</h2>
 
@@ -85,7 +85,7 @@
 
         </figcaption>
         <eiti-bar-chart
-          data='{% include location/line-chart-data.json values=annual_revenue key="revenue" %}'
+          data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
           aria-controls="revenue-figures-{{ commodity_slug }}"
           x-range="{{ year_range }}"
           x-value="{{ year }}">

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -79,8 +79,10 @@
       <figure class="chart">
         {% assign annual_revenue = commodity[1] %}
         <figcaption id="revenue-figures-{{ commodity_slug }}">
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span>
+          In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+            companies paid the federal government <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span> to extract
+          {{ commodity_name | downcase }} on federal land in {{ state_name }}.
+
         </figcaption>
         <eiti-bar-chart
           data='{% include location/line-chart-data.json values=annual_revenue key="revenue" %}'
@@ -90,15 +92,6 @@
         </eiti-bar-chart>
 
       </figure>
-      <p class="chart-list_caption">
-        In {{ year }},
-          {% if revenue %}
-            companies paid the federal government ${{ revenue | intcomma }} to extract
-          {% else %}
-            the federal government did not collect any revenue from extraction of
-          {% endif %}
-          {{ commodity_name | downcase }} on federal land in {{ state_name }}.
-      </p>
 
       <!-- <h4>
         <button is="aria-toggle"

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -10,9 +10,12 @@
 
   <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
 
-  <h3 id="federal-revenue">Revenue from federal land</h3>
 
-  <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
+  <h3>Revenue from federal land</h3>
+
+  <section id="federal-revenue">
+
+    <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
 <!--   <aside class="container-half county-map-table">
 
@@ -31,105 +34,118 @@
     </figure>
   </aside> -->
 
-  <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
+    <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
 
-  <div id="fee-summaries" class="tab-interface">
-    <ul class="eiti-tabs info-tabs" role="tablist">
-      <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" aria-selected="true">Federal revenue by phase ({{ year }})</a></li>
-      <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" class="link-charlie">Revenue details by phase</a></li>
-    </ul>
+    <div id="fee-summaries" class="tab-interface">
+      <ul class="eiti-tabs info-tabs" role="tablist">
+        <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" aria-selected="true">Federal revenue by phase ({{ year }})</a></li>
+        <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" class="link-charlie">Revenue details by phase</a></li>
+      </ul>
 
-    <article class="eiti-tab-panel" id="revenues" role="tabpanel">
-      {%
-        include location/revenue-type-table.html
-        id='revenue-types'
-        location_id=state_id
-        location_name=state_name
-        year=year
-      %}
-    </article>
-
-    <article class="eiti-tab-panel" id="story" role="tabpanel" aria-hidden="true">
-      {%
-        include location/revenue-process-table.html
-        id='revenue-process'
-        location_id=state_id
-        location_name=state_name
-        year=year
-      %}
-    </article>
-  </div>
-
-  <section id="commodities-revenue" class="chart-list has-intro">
-
-    <h4>Revenue from resources extracted on federal land in {{ state_name }}</h4>
-
-    <p class="chart-list-intro">In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/"><icon class="fa fa-file-text-o u-padding-right"></icon>Federal revenue data comes from the Office of Natural Resources Revenue
-    </a></p>
-
-    {% for commodity in revenue_commodities %}
-      {% assign revenue = commodity[1][year].revenue %}
-      {% assign commodity_name = commodity[0] | lookup: commodity_names %}
-      {% assign commodity_slug = commodity[0] | slugify %}
-
-    <section id="revenue-{{ commodity_slug }}" class="chart-item">
-
-      <h3 class="chart-title">{{ commodity_name }}</h3>
-
-      <figure class="chart">
-        {% assign annual_revenue = commodity[1] %}
-        <figcaption id="revenue-figures-{{ commodity_slug }}">
-          In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
-            companies paid the federal government <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span> to extract
-          {{ commodity_name | downcase }} on federal land in {{ state_name }}.
-
-        </figcaption>
-        <eiti-bar-chart
-          data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
-          aria-controls="revenue-figures-{{ commodity_slug }}"
-          x-range="{{ year_range }}"
-          x-value="{{ year }}">
-        </eiti-bar-chart>
-
-      </figure>
-
-      <!-- <h4>
-        <button is="aria-toggle"
-          aria-controls="revenue-detail-{{ commodity_slug }}">&plus; Details</button>
-      </h4>
-      <div id="revenue-detail-{{ commodity_slug }}" aria-hidden="true">
-        {% assign revenue_values = commodity[1] %}
+      <article class="eiti-tab-panel" id="revenues" role="tabpanel">
         {%
-          include location/display-revenue.html
+          include location/revenue-type-table.html
+          id='revenue-types'
+          location_id=state_id
+          location_name=state_name
           year=year
-          values=revenue_values
-          percent=false
-          rank=false
         %}
-      </div> -->
+      </article>
+
+      <article class="eiti-tab-panel" id="story" role="tabpanel" aria-hidden="true">
+        {%
+          include location/revenue-process-table.html
+          id='revenue-process'
+          location_id=state_id
+          location_name=state_name
+          year=year
+        %}
+      </article>
+    </div>
+
+    <section class="chart-list">
+
+      <h4>Revenue from resources extracted on federal land in {{ state_name }}</h4>
+
+      <div class="chart-selector-wrapper">
+
+        {% include year-selector.html year_range=year_range %}
+
+        <p class="chart-description">
+          In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}.
+        </p>
+      </div>
+
+
+      {% for commodity in revenue_commodities %}
+        {% assign revenue = commodity[1][year].revenue %}
+        {% assign commodity_name = commodity[0] | lookup: commodity_names %}
+        {% assign commodity_slug = commodity[0] | slugify %}
+
+        <section id="revenue-{{ commodity_slug }}" class="chart-item">
+
+          <h3 class="chart-title">{{ commodity_name }}</h3>
+
+          <figure class="chart">
+            {% assign annual_revenue = commodity[1] %}
+            <figcaption id="revenue-figures-{{ commodity_slug }}">
+              In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+                companies paid the federal government <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span> to extract
+              {{ commodity_name | downcase }} on federal land in {{ state_name }}.
+
+            </figcaption>
+            <eiti-bar-chart
+              data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
+              aria-controls="revenue-figures-{{ commodity_slug }}"
+              x-range="{{ year_range }}"
+              x-value="{{ year }}">
+            </eiti-bar-chart>
+
+          </figure>
+
+          <!-- <h4>
+            <button is="aria-toggle"
+              aria-controls="revenue-detail-{{ commodity_slug }}">&plus; Details</button>
+          </h4>
+          <div id="revenue-detail-{{ commodity_slug }}" aria-hidden="true">
+            {% assign revenue_values = commodity[1] %}
+            {%
+              include location/display-revenue.html
+              year=year
+              values=revenue_values
+              percent=false
+              rank=false
+            %}
+          </div> -->
+
+        </section>
+
+      {% endfor %}
 
     </section>
+    <!-- .chart-list -->
 
-  {% endfor %}
+    <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/"><icon class="fa fa-file-text-o u-padding-right"></icon>Federal revenue data comes from the Office of Natural Resources Revenue</a>
+  </section>
+  <!-- #federal-revenue -->
 
-</section>
+  <section id="state-local-revenue" class="state revenue">
+    <h3>Revenue from extraction on state land</h3>
 
-<section id="state-local-revenue" class="state revenue">
-  <h3>Revenue from extraction on state land</h3>
+    <p>We don't have detailed data about state revenue from natural resource extraction on land owned by the state of {{ state_name }}.</p>
 
-  <p>We don't have detailed data about state revenue from natural resource extraction on land owned by the state of {{ state_name }}.</p>
+    <!-- pulls in state fiscal and legal information if the state is one of the MSG-prioritized states -->
+    {% if is_priority_state %}
+      <p>However, the USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern extraction on state land.</p>
+      <p>Learn more about natural resource regulation, production, and revenue in {{ state_name }}:</p>
 
-  <!-- pulls in state fiscal and legal information if the state is one of the MSG-prioritized states -->
-  {% if is_priority_state %}
-    <p>However, the USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern extraction on state land.</p>
-    <p>Learn more about natural resource regulation, production, and revenue in {{ state_name }}:</p>
+      {{ regulations | markdownify }}
 
-    {{ regulations | markdownify }}
+    {% endif %}
+  </section>
 
-  {% endif %}
-</section>
-
-<section id="private-revenue" class="private-lands revenue">
-  <h3>Revenue from extraction on private land</h3>
-  <p>Companies that extract natural resources on private land must pay income taxes, like any other company. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
+  <section id="private-revenue" class="private-lands revenue">
+    <h3>Revenue from extraction on private land</h3>
+    <p>Companies that extract natural resources on private land must pay income taxes, like any other company. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
+  </section>
 </section>

--- a/_includes/location/section-state-production.html
+++ b/_includes/location/section-state-production.html
@@ -1,10 +1,10 @@
 <section id="state-local-production" class="state production">
   <h3>Production on state land</h3>
-  <p>Natural resource extraction on land owned by the State of {{ state_name }} is governed by <a href="{{ site.baseurl }}/how-it-works/state-laws-and-regulations/#role-of-state-government-agencies/</a>">state laws and regulations</a>.</p>
+  <p class="full-width-text">Natural resource extraction on land owned by the State of {{ state_name }} is governed by <a href="{{ site.baseurl }}/how-it-works/state-laws-and-regulations/#role-of-state-government-agencies/</a>">state laws and regulations</a>.</p>
   <p>We don't have detailed data about natural resource extraction on land owned by the state.</p>
 </section>
 
 <section id="private-land-production" class="production">
   <h3>Production on private land</h3>
-  <p>We don't have detailed data about natural resource extraction on land owned by individuals or corporations.</p>
+  <p class="full-width-text">We don't have detailed data about natural resource extraction on land owned by individuals or corporations.</p>
 </section>

--- a/_includes/year-selector.html
+++ b/_includes/year-selector.html
@@ -1,0 +1,14 @@
+{% if include.year_range %}
+	{% assign year_range = include.year_range %}
+{% endif %}
+
+{% if year_range %}
+	{% assign year_list = year_range | to_list %}
+
+	<select class="chart-selector selector-all-production">
+	  {% for _year in year_list %}
+	    {% assign __year = year | to_i %}
+	    <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
+	  {% endfor %}
+	</select>
+{% endif %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -27,7 +27,9 @@ nav_items:
     - name: gdp
       title: GDP
     - name: employment
-      title: Jobs
+      title: Wage and salary jobs
+    - name: self-employment
+      title: Self-employment
     - name: exports
       title: Exports
 ---

--- a/_plugins/data.rb
+++ b/_plugins/data.rb
@@ -29,7 +29,7 @@ module EITI
     # map_hash({'2011' => {'volume' => 100}}, 'volume')
     # > {'2011' => 100}
     def map_hash(data, key)
-      data.to_h().map { |_key, value| [_key, get(value, key)] }.to_h
+      data.to_h.map { |k, v| [k, get(v, key)] }.to_h
     end
 
     # pad the provided string with the provided padding character (or a
@@ -79,31 +79,39 @@ module EITI
         (str.include? term) ? true : nil
       end
     end
+    # takes a range and returns a list of numbers within that range
+    # incrimented by 1
+    # Only accepts an Array. Otherwise returns the range
+    # e.g [0,5] => [0,1,2,3,4,5]
+    # e.g '[0,5]' => '[0,5]'
+    def create_list(range)
+      if range.is_a? Array
+        arr = []
+        min = range[0]
+        max = range[1]
+        (min..max).step(1) do |i|
+          arr.push(i)
+        end
+        arr
+      else
+        range
+      end
+    end
 
-    # takes a domain and returns a list of numbers within that domain
+    # takes a range and returns a list of numbers within that range
     # incrimented by 1
     # e.g '[0,5]' => [0,1,2,3,4,5]
     # e.g [0,5] => [0,1,2,3,4,5]
     # If the input is not a string, it returns the input value
     # e.g 5 => 5
-    def to_list(domain)
-      def create_list(domain)
-        arr = []
-        $i = domain[0]
-        $num = domain[1]
-        for i in $i..$num
-          arr.push(i)
-        end
-        arr
-      end
-
-      if domain.is_a? Array
-        create_list(domain)
-      elsif domain.is_a? String
-        domain = JSON.parse(domain)
-        create_list(domain)
+    def to_list(range)
+      if range.is_a? Array
+        create_list(range)
+      elsif range.is_a? String
+        range = JSON.parse(range)
+        create_list(range)
       else
-        domain
+        range
       end
     end
   end

--- a/_plugins/data.rb
+++ b/_plugins/data.rb
@@ -24,9 +24,12 @@ module EITI
       data
     end
 
-    # "unwrap" values in a 2-level hash
+    # "unwrap" values in a 2-level hash:
+    #
+    # map_hash({'2011' => {'volume' => 100}}, 'volume')
+    # > {'2011' => 100}
     def map_hash(data, key)
-      data.to_h().map { |_key, value| [_key, value[key]] }.to_h
+      data.to_h().map { |_key, value| [_key, get(value, key)] }.to_h
     end
 
     # pad the provided string with the provided padding character (or a
@@ -54,12 +57,19 @@ module EITI
       (start..finish).to_a
     end
 
+    # convert (or map) a value to floats
     def to_f(x)
       (x.is_a? Array) ? x.map(&:to_f) : x.to_f
     end
 
+    # convert (or map) a value to integers
     def to_i(x)
       (x.is_a? Array) ? x.map(&:to_i) : x.to_i
+    end
+
+    # convert (or map) a value to strings
+    def to_s(x)
+      (x.is_a? Array) ? x.map(&:to_s) : x.to_s
     end
 
     # attempts to find a substring

--- a/_plugins/data.rb
+++ b/_plugins/data.rb
@@ -65,6 +65,12 @@ module EITI
       end
     end
 
+    # takes a domain and returns a list of numbers within that domain
+    # incrimented by 1
+    # e.g '[0,5]' => [0,1,2,3,4,5]
+    # e.g [0,5] => [0,1,2,3,4,5]
+    # If the input is not a string, it returns the input value
+    # e.g 5 => 5
     def to_list(domain)
       def create_list(domain)
         arr = []
@@ -81,6 +87,8 @@ module EITI
       elsif domain.is_a? String
         domain = JSON.parse(domain)
         create_list(domain)
+      else
+        domain
       end
     end
   end

--- a/_plugins/data.rb
+++ b/_plugins/data.rb
@@ -24,6 +24,11 @@ module EITI
       data
     end
 
+    # "unwrap" values in a 2-level hash
+    def map_hash(data, key)
+      data.to_h().map { |_key, value| [_key, value[key]] }.to_h
+    end
+
     # pad the provided string with the provided padding character (or a
     # space, by default) if its length is less than a given length
     def pad_left(str, len, pad = " ")

--- a/_plugins/data.rb
+++ b/_plugins/data.rb
@@ -64,6 +64,25 @@ module EITI
         (str.include? term) ? true : nil
       end
     end
+
+    def to_list(domain)
+      def create_list(domain)
+        arr = []
+        $i = domain[0]
+        $num = domain[1]
+        for i in $i..$num
+          arr.push(i)
+        end
+        arr
+      end
+
+      if domain.is_a? Array
+        create_list(domain)
+      elsif domain.is_a? String
+        domain = JSON.parse(domain)
+        create_list(domain)
+      end
+    end
   end
 end
 

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -2,6 +2,13 @@
   @include font-size(0.8);
   @include outer-container();
 
+  display: flex;
+  -ms-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-justify-content: space-between;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
   padding-top: $base-padding-jumbo;
 
   .chart-list_caption {
@@ -17,7 +24,9 @@
     font-size: inherit;
     font-weight: $weight-book;
     letter-spacing: 1px;
+    line-height: $standard-padding;
     margin-bottom: $base-padding;
+    padding-bottom: $base-padding-lite;
     text-transform: uppercase;
   }
 
@@ -28,7 +37,12 @@
   .chart-item {
     @include span-columns(4);
 
+    -ms-flex-direction: column;
+    -webkit-flex-direction: column;
     border-top: none;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: $base-padding;
     margin-top: 0;
     padding-top: 0;
 

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -99,13 +99,18 @@
     background-color: $mid-gray;
     border: 0;
     font-weight: $weight-book;
-
+    margin-right: $standard-padding;
+    margin-top: $standard-padding-lite;
   }
 
-  p {
-    @include span-columns(10);
+  .chart-description {
+    float: left;
+    width: 75%;
+    padding-left: 1.25rem;
+    border-left: 1px solid #ebebeb;
   }
 }
+
 
 
 .row-container {

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -6,9 +6,10 @@
   -ms-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   flex-wrap: wrap;
-  -ms-justify-content: space-between;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
+  -ms-justify-content: flex-start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+
 
   .chart-list_caption {
     @include heading(para-sm);
@@ -86,6 +87,15 @@
     > :last-child {
       text-align: right;
     }
+  }
+
+  eiti-data-map figcaption {
+    min-height: inherit;
+
+    @include heading('para-sm');
+
+    font-weight: $weight-bold;
+    margin: 0;
   }
 }
 

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -38,10 +38,11 @@
   .chart-item {
     @include span-columns(4);
 
-    -ms-flex-direction: column;
-    -webkit-flex-direction: column;
+
     border-top: none;
     display: flex;
+    -ms-flex-direction: column;
+    -webkit-flex-direction: column;
     flex-direction: column;
     margin-bottom: $base-padding;
     margin-top: 0;
@@ -90,12 +91,11 @@
   }
 
   eiti-data-map figcaption {
-    min-height: inherit;
-
     @include heading('para-sm');
 
     font-weight: $weight-bold;
     margin: 0;
+    min-height: inherit;
   }
 }
 
@@ -114,14 +114,12 @@
   }
 
   .chart-description {
+    border-left: 1px solid $mid-gray;
     float: left;
-    width: 75%;
     padding-left: 1.25rem;
-    border-left: 1px solid #ebebeb;
+    width: 75%;
   }
 }
-
-
 
 .row-container {
   @include outer-container();

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -21,6 +21,7 @@
     @include heading(para-lg);
 
     border-bottom: 1px solid $mid-gray;
+    flex: 1 0 auto;
     font-size: inherit;
     font-weight: $weight-book;
     letter-spacing: 1px;
@@ -88,6 +89,24 @@
     }
   }
 }
+
+.chart-selector-wrapper {
+  display: inline-block;
+
+  .chart-selector {
+    @include span-columns(2);
+
+    background-color: $mid-gray;
+    border: 0;
+    font-weight: $weight-book;
+
+  }
+
+  p {
+    @include span-columns(10);
+  }
+}
+
 
 .row-container {
   @include outer-container();

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -25,7 +25,7 @@
     font-weight: $weight-book;
     letter-spacing: 1px;
     line-height: $standard-padding;
-    margin-bottom: $base-padding;
+    margin-bottom: $base-padding-lite;
     padding-bottom: $base-padding-lite;
     text-transform: uppercase;
   }

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -9,7 +9,6 @@
   -ms-justify-content: space-between;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  padding-top: $base-padding-jumbo;
 
   .chart-list_caption {
     @include heading(para-sm);
@@ -92,6 +91,7 @@
 
 .chart-selector-wrapper {
   display: inline-block;
+  margin-bottom: $base-padding-jumbo;
 
   .chart-selector {
     @include span-columns(2);

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -63,14 +63,11 @@
   }
 
   figcaption {
-    display: flex;
-    font-weight: $weight-bold;
-    padding: $base-padding-lite;
+    @include font-size(1);
 
-    > * {
-      flex: 1;
-      width: 50%;
-    }
+    font-weight: $weight-light;
+    min-height: 100px;
+    padding: $base-padding-lite;
 
     > :last-child {
       text-align: right;

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -13,7 +13,8 @@
 
   h3:not(.chart-title) {
     border-bottom: 2px solid $light-green;
-    padding-bottom: $standard-padding;
+    margin-bottom: $standard-padding;
+    padding-bottom: $standard-padding-lite;
   }
 
   h4 {

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -53,4 +53,9 @@
     margin-bottom: $standard-padding-fluffed;
     margin-top: $standard-padding-fluffed;
   }
+
+  .full-width-text {
+    margin-right: 25%;
+    width: 75%;
+  }
 }

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -7,15 +7,13 @@
   }
 
   h2 {
-    border-top: 6px solid $light-green;
-    padding-bottom: $standard-padding;
-    padding-top: $standard-padding-fluffed;
+    border-bottom: 20px solid $light-green;
+    padding-bottom: $standard-padding-lite;
   }
 
   h3:not(.chart-title) {
-    border-top: 2px solid $light-green;
+    border-bottom: 2px solid $light-green;
     padding-bottom: $standard-padding;
-    padding-top: $standard-padding-fluffed;
   }
 
   h4 {

--- a/_sass/components/_eiti-bar-chart.scss
+++ b/_sass/components/_eiti-bar-chart.scss
@@ -65,5 +65,19 @@ eiti-bar-chart {
 
 .eiti-bar-chart-x-value,
 .eiti-bar-chart-y-value {
+  @include font-size(1.1);
+
   color: $green-dark-chart;
+  font-weight: $weight-bold;
+
+}
+
+.x-axis-label {
+  text-transform: uppercase;
+
+  text {
+    @include font-size(1);
+
+    text-anchor: middle;
+  }
 }

--- a/_sass/components/_eiti-bar-chart.scss
+++ b/_sass/components/_eiti-bar-chart.scss
@@ -81,3 +81,7 @@ eiti-bar-chart {
     text-anchor: middle;
   }
 }
+
+.x-axis-baseline line {
+  stroke: $neutral-gray;
+}

--- a/js/components/data-map.js
+++ b/js/components/data-map.js
@@ -10,6 +10,26 @@
       HTMLElement.prototype,
       {
         attachedCallback: {value: function() {
+          this.marks
+            .datum(function() {
+              return +this.getAttribute('data-value') || 0;
+            });
+
+          this.update();
+        }},
+
+        marks: {
+          get: function() {
+            return d3.select(this)
+              .selectAll('svg [data-value]');
+          }
+        },
+
+        setYear: {value: function(year) {
+          this.marks.datum(function() {
+            var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+            return data[year] || 0;
+          });
           this.update();
         }},
 
@@ -27,11 +47,7 @@
             );
           }
 
-          var marks = d3.select(this)
-            .selectAll('svg [data-value]')
-            .datum(function() {
-              return +this.getAttribute('data-value') || 0;
-            });
+          var marks = this.marks;
 
           var domain = this.hasAttribute('domain')
             ? JSON.parse(this.getAttribute('domain'))

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -173,6 +173,13 @@
         return String(x).substr(2);
       });
 
+    svg.append('g')
+      .attr('class', 'x-axis-baseline')
+      .append('line')
+        .attr('x1', 0)
+        .attr('x2', width)
+        .attr('transform', 'translate(' + [0, bottom] + ')');
+
     svg.select('.x-axis')
       .attr('transform', 'translate(' + [0, bottom] + ')')
       .call(axis)
@@ -182,10 +189,10 @@
     svg.append('g')
       .attr('class', 'x-axis-label')
       .append('text')
-      .text(xAxisLabel)
-      .attr('transform', function(d) {
-        return 'translate(' + [labelOffset, xAxisBottom] + ')';
-      });
+        .text(xAxisLabel)
+        .attr('transform', function(d) {
+          return 'translate(' + [labelOffset, xAxisBottom] + ')';
+        });
   };
 
   var formatUnits = function(text, units) {
@@ -220,8 +227,6 @@
       output.select('.eiti-bar-chart-x-value')
         .text(value.x);
       var y = output.select('.eiti-bar-chart-y-value');
-      console.log(output, y.attr('data-format'))
-      console.log('-------------')
       var format = d3.format(y.attr('data-format') || ',');
       var units = y.attr('data-units');
       y.text(formatUnits(format(value.y),units));

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -220,7 +220,8 @@
       output.select('.eiti-bar-chart-x-value')
         .text(value.x);
       var y = output.select('.eiti-bar-chart-y-value');
-
+      console.log(output, y.attr('data-format'))
+      console.log('-------------')
       var format = d3.format(y.attr('data-format') || ',');
       var units = y.attr('data-units');
       y.text(formatUnits(format(value.y),units));

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -24,10 +24,16 @@
   var top = margin.top;
   var bottom = height - margin.bottom;
 
+  var xAxisLabel = 'years';
+  var xAxisBottom = height + margin.bottom;
+  var labelOffset = width / 2;
+
+  var fullHeight = height + textMargin;
+
   var attached = function() {
     var svg = d3.select(this)
       .append('svg')
-        .attr('viewBox', [0, 0, width, height].join(' '));
+        .attr('viewBox', [0, 0, width, fullHeight].join(' '));
 
     svg.append('g')
       .attr('class', 'axis x-axis');
@@ -144,7 +150,7 @@
 
     svg.selectAll('.bar-mask')
       // extend all the way to the bottom of the screen
-      .attr('height', barHeight + textMargin * 2)
+      .attr('height', barHeight + textMargin)
       .attr('width', barWidth);
 
     selection.call(updateSelected, this.x);
@@ -172,6 +178,14 @@
       .call(axis)
       .selectAll('path, line')
         .attr('fill', 'none');
+
+    svg.append('g')
+      .attr('class', 'x-axis-label')
+      .append('text')
+      .text(xAxisLabel)
+      .attr('transform', function(d) {
+        return 'translate(' + [labelOffset, xAxisBottom] + ')';
+      });
   };
 
   var formatUnits = function(text, units) {
@@ -206,6 +220,7 @@
       output.select('.eiti-bar-chart-x-value')
         .text(value.x);
       var y = output.select('.eiti-bar-chart-y-value');
+
       var format = d3.format(y.attr('data-format') || ',');
       var units = y.attr('data-units');
       y.text(formatUnits(format(value.y),units));

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -112,8 +112,7 @@
 
           // start consolidate (translate) visible cells
           var cells = svgLegend.selectAll('.cell');
-          var cellHeight = legendSettings.shapeHeight() +
-            legendSettings.shapePadding();
+          var cellHeight = legend.shapeHeight() + legend.shapePadding();
           var count = 0;
           cells.each(function(cell, i) {
             var present = true; // uniqueSteps.indexOf(i) > -1;

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -5,7 +5,7 @@
   var eiti = require('./../eiti');
   var format = eiti.format;
 
-  exports.EITIDataMap = document.registerElement('data-map', {
+  exports.EITIDataMap = document.registerElement('eiti-data-map', {
     prototype: Object.create(
       HTMLElement.prototype,
       {
@@ -80,7 +80,7 @@
               .range(steps);
 
             var values = [];
-            data.forEach(function(d){
+            data.forEach(function(d) {
               values.push(getSteps(d));
             });
 
@@ -93,7 +93,7 @@
           svgLegend.append('g')
             .attr('class', 'legendScale');
 
-          var legendSettings = d3.legend.color()
+          var legend = d3.legend.color()
             .labelFormat(format.si)
             .useClass(false)
             .ascending(true)
@@ -102,10 +102,10 @@
             .scale(scale);
 
           svgLegend.select('.legendScale')
-            .call(legendSettings);
+            .call(legend);
 
           // reverse because the scale is in ascending order
-          var _steps = d3.range(0,9).reverse();
+          var _steps = d3.range(0, 9).reverse();
 
           // find which steps are represented in the map
           var uniqueSteps = getUnique(marks.data(), _steps, domain);
@@ -115,8 +115,8 @@
           var cellHeight = legendSettings.shapeHeight() +
             legendSettings.shapePadding();
           var count = 0;
-          cells.each(function(cell, i){
-            var present = uniqueSteps.indexOf(i) > -1;
+          cells.each(function(cell, i) {
+            var present = true; // uniqueSteps.indexOf(i) > -1;
 
             if (!present) {
               // hide cells swatches that aren't in the map

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -10,7 +10,7 @@
       HTMLElement.prototype,
       {
         attachedCallback: {value: function() {
-          this.marks
+          this.marks = d3.select(this).selectAll('[data-value]')
             .datum(function() {
               return +this.getAttribute('data-value') || 0;
             });
@@ -18,18 +18,14 @@
           this.update();
         }},
 
-        marks: {
-          get: function() {
-            return d3.select(this)
-              .selectAll('svg [data-value]');
-          }
-        },
-
         setYear: {value: function(year) {
           this.marks.datum(function() {
-            var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
-            return data[year] || 0;
-          });
+              var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+              return data[year] || 0;
+            })
+            .attr('data-value', function(d) {
+              return d;
+            });
           this.update();
         }},
 
@@ -115,7 +111,7 @@
           var cellHeight = legend.shapeHeight() + legend.shapePadding();
           var count = 0;
           cells.each(function(cell, i) {
-            var present = true; // uniqueSteps.indexOf(i) > -1;
+            var present = uniqueSteps.indexOf(i) > -1;
 
             if (!present) {
               // hide cells swatches that aren't in the map

--- a/js/components/year-switcher-section.js
+++ b/js/components/year-switcher-section.js
@@ -1,25 +1,26 @@
 (function(exports) {
 
   var attached = function() {
-    var select = this.querySelector('select');
-    var charts = d3.select(this).selectAll('eiti-bar-chart');
-    var maps = d3.select(this).selectAll('data-map');
+    var root = d3.select(this);
 
+    var select = root.selectAll('select.chart-selector');
+    var charts = root.selectAll('eiti-bar-chart');
+    var maps = root.selectAll('eiti-data-map');
 
     var update = function(year) {
       charts.property('x', year);
       maps.each(function() {
         this.setYear(year);
       });
-      select.value = year;
+      select.property('value',  year);
     };
 
-    select.addEventListener('change', function() {
+    select.on('change.year', function() {
       update(this.value);
     });
 
     charts.selectAll('g.bar')
-      .on('click', function(d) {
+      .on('click.year', function(d) {
         update(d.x);
       });
   };

--- a/js/components/year-switcher-section.js
+++ b/js/components/year-switcher-section.js
@@ -3,9 +3,14 @@
   var attached = function() {
     var select = this.querySelector('select');
     var charts = d3.select(this).selectAll('eiti-bar-chart');
+    var maps = d3.select(this).selectAll('data-map');
+
 
     var update = function(year) {
       charts.property('x', year);
+      maps.each(function() {
+        this.setYear(year);
+      });
       select.value = year;
     };
 

--- a/js/components/year-switcher-section.js
+++ b/js/components/year-switcher-section.js
@@ -1,0 +1,36 @@
+(function(exports) {
+
+  var attached = function() {
+    var select = this.querySelector('select');
+    var charts = d3.select(this).selectAll('eiti-bar-chart');
+
+    var update = function(year) {
+      charts.property('x', year);
+      select.value = year;
+    };
+
+    select.addEventListener('change', function() {
+      update(this.value);
+    });
+
+    charts.selectAll('g.bar')
+      .on('click', function(d) {
+        update(d.x);
+      });
+  };
+
+  var detached = function() {
+  };
+
+  exports.EITIYearSwitcherSection = document.registerElement('year-switcher-section', {
+    'extends': 'section',
+    prototype: Object.create(
+      HTMLElement.prototype,
+      {
+        attachedCallback: {value: attached},
+        detachdCallback: {value: detached}
+      }
+    )
+  })
+
+})(this);

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -103,7 +103,7 @@
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
 	  var d3 = {
-	    version: "3.5.16"
+	    version: "3.5.17"
 	  };
 	  var d3_arraySlice = [].slice, d3_array = function(list) {
 	    return d3_arraySlice.call(list);
@@ -3628,7 +3628,7 @@
 	        λ0 = λ, sinφ0 = sinφ, cosφ0 = cosφ, point0 = point;
 	      }
 	    }
-	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ winding & 1;
+	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ winding & 1;
 	  }
 	  function d3_geo_clipCircle(radius) {
 	    var cr = Math.cos(radius), smallRadius = cr > 0, notHemisphere = abs(cr) > ε, interpolate = d3_geo_circleInterpolate(radius, 6 * d3_radians);
@@ -10835,7 +10835,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
-	 * jQuery JavaScript Library v1.12.3
+	 * jQuery JavaScript Library v1.12.4
 	 * http://jquery.com/
 	 *
 	 * Includes Sizzle.js
@@ -10845,7 +10845,7 @@
 	 * Released under the MIT license
 	 * http://jquery.org/license
 	 *
-	 * Date: 2016-04-05T19:16Z
+	 * Date: 2016-05-20T17:17Z
 	 */
 
 	(function( global, factory ) {
@@ -10901,7 +10901,7 @@
 
 
 	var
-		version = "1.12.3",
+		version = "1.12.4",
 
 		// Define a local copy of jQuery
 		jQuery = function( selector, context ) {
@@ -17508,6 +17508,7 @@
 			if ( reliableHiddenOffsetsVal ) {
 				div.style.display = "";
 				div.innerHTML = "<table><tr><td></td><td>t</td></tr></table>";
+				div.childNodes[ 0 ].style.borderCollapse = "separate";
 				contents = div.getElementsByTagName( "td" );
 				contents[ 0 ].style.cssText = "margin:0;border:0;padding:0;display:none";
 				reliableHiddenOffsetsVal = contents[ 0 ].offsetHeight === 0;
@@ -17831,19 +17832,6 @@
 			styles = getStyles( elem ),
 			isBorderBox = support.boxSizing &&
 				jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
-
-		// Support: IE11 only
-		// In IE 11 fullscreen elements inside of an iframe have
-		// 100x too small dimensions (gh-1764).
-		if ( document.msFullscreenElement && window.top !== window ) {
-
-			// Support: IE11 only
-			// Running getBoundingClientRect on a disconnected node
-			// in IE throws an error.
-			if ( elem.getClientRects().length ) {
-				val = Math.round( elem.getBoundingClientRect()[ name ] * 100 );
-			}
-		}
 
 		// some non-html elements return undefined for offsetWidth, so check for null/undefined
 		// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
@@ -20835,6 +20823,11 @@
 	}
 
 	function filterHidden( elem ) {
+
+		// Disconnected elements are considered hidden
+		if ( !jQuery.contains( elem.ownerDocument || document, elem ) ) {
+			return true;
+		}
 		while ( elem && elem.nodeType === 1 ) {
 			if ( getDisplay( elem ) === "none" || elem.type === "hidden" ) {
 				return true;

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -103,7 +103,7 @@
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
 	  var d3 = {
-	    version: "3.5.17"
+	    version: "3.5.16"
 	  };
 	  var d3_arraySlice = [].slice, d3_array = function(list) {
 	    return d3_arraySlice.call(list);
@@ -3628,7 +3628,7 @@
 	        λ0 = λ, sinφ0 = sinφ, cosφ0 = cosφ, point0 = point;
 	      }
 	    }
-	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ winding & 1;
+	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ winding & 1;
 	  }
 	  function d3_geo_clipCircle(radius) {
 	    var cr = Math.cos(radius), smallRadius = cr > 0, notHemisphere = abs(cr) > ε, interpolate = d3_geo_circleInterpolate(radius, 6 * d3_radians);
@@ -10835,7 +10835,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
-	 * jQuery JavaScript Library v1.12.4
+	 * jQuery JavaScript Library v1.12.3
 	 * http://jquery.com/
 	 *
 	 * Includes Sizzle.js
@@ -10845,7 +10845,7 @@
 	 * Released under the MIT license
 	 * http://jquery.org/license
 	 *
-	 * Date: 2016-05-20T17:17Z
+	 * Date: 2016-04-05T19:16Z
 	 */
 
 	(function( global, factory ) {
@@ -10901,7 +10901,7 @@
 
 
 	var
-		version = "1.12.4",
+		version = "1.12.3",
 
 		// Define a local copy of jQuery
 		jQuery = function( selector, context ) {
@@ -17508,7 +17508,6 @@
 			if ( reliableHiddenOffsetsVal ) {
 				div.style.display = "";
 				div.innerHTML = "<table><tr><td></td><td>t</td></tr></table>";
-				div.childNodes[ 0 ].style.borderCollapse = "separate";
 				contents = div.getElementsByTagName( "td" );
 				contents[ 0 ].style.cssText = "margin:0;border:0;padding:0;display:none";
 				reliableHiddenOffsetsVal = contents[ 0 ].offsetHeight === 0;
@@ -17832,6 +17831,19 @@
 			styles = getStyles( elem ),
 			isBorderBox = support.boxSizing &&
 				jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
+
+		// Support: IE11 only
+		// In IE 11 fullscreen elements inside of an iframe have
+		// 100x too small dimensions (gh-1764).
+		if ( document.msFullscreenElement && window.top !== window ) {
+
+			// Support: IE11 only
+			// Running getBoundingClientRect on a disconnected node
+			// in IE throws an error.
+			if ( elem.getClientRects().length ) {
+				val = Math.round( elem.getBoundingClientRect()[ name ] * 100 );
+			}
+		}
 
 		// some non-html elements return undefined for offsetWidth, so check for null/undefined
 		// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
@@ -20823,11 +20835,6 @@
 	}
 
 	function filterHidden( elem ) {
-
-		// Disconnected elements are considered hidden
-		if ( !jQuery.contains( elem.ownerDocument || document, elem ) ) {
-			return true;
-		}
 		while ( elem && elem.nodeType === 1 ) {
 			if ( getDisplay( elem ) === "none" || elem.type === "hidden" ) {
 				return true;

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11391,8 +11391,7 @@
 
 	          // start consolidate (translate) visible cells
 	          var cells = svgLegend.selectAll('.cell');
-	          var cellHeight = legendSettings.shapeHeight() +
-	            legendSettings.shapePadding();
+	          var cellHeight = legend.shapeHeight() + legend.shapePadding();
 	          var count = 0;
 	          cells.each(function(cell, i) {
 	            var present = true; // uniqueSteps.indexOf(i) > -1;

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11289,6 +11289,26 @@
 	      HTMLElement.prototype,
 	      {
 	        attachedCallback: {value: function() {
+	          this.marks
+	            .datum(function() {
+	              return +this.getAttribute('data-value') || 0;
+	            });
+
+	          this.update();
+	        }},
+
+	        marks: {
+	          get: function() {
+	            return d3.select(this)
+	              .selectAll('svg [data-value]');
+	          }
+	        },
+
+	        setYear: {value: function(year) {
+	          this.marks.datum(function() {
+	            var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+	            return data[year] || 0;
+	          });
 	          this.update();
 	        }},
 
@@ -11306,11 +11326,7 @@
 	            );
 	          }
 
-	          var marks = d3.select(this)
-	            .selectAll('svg [data-value]')
-	            .datum(function() {
-	              return +this.getAttribute('data-value') || 0;
-	            });
+	          var marks = this.marks;
 
 	          var domain = this.hasAttribute('domain')
 	            ? JSON.parse(this.getAttribute('domain'))
@@ -12492,9 +12508,14 @@
 	  var attached = function() {
 	    var select = this.querySelector('select');
 	    var charts = d3.select(this).selectAll('eiti-bar-chart');
+	    var maps = d3.select(this).selectAll('data-map');
+
 
 	    var update = function(year) {
 	      charts.property('x', year);
+	      maps.each(function() {
+	        this.setYear(year);
+	      });
 	      select.value = year;
 	    };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -442,7 +442,7 @@
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
 	  var d3 = {
-	    version: "3.5.17"
+	    version: "3.5.16"
 	  };
 	  var d3_arraySlice = [].slice, d3_array = function(list) {
 	    return d3_arraySlice.call(list);
@@ -3967,7 +3967,7 @@
 	        λ0 = λ, sinφ0 = sinφ, cosφ0 = cosφ, point0 = point;
 	      }
 	    }
-	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ winding & 1;
+	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ winding & 1;
 	  }
 	  function d3_geo_clipCircle(radius) {
 	    var cr = Math.cos(radius), smallRadius = cr > 0, notHemisphere = abs(cr) > ε, interpolate = d3_geo_circleInterpolate(radius, 6 * d3_radians);
@@ -11298,7 +11298,6 @@
 	        }},
 
 	        setYear: {value: function(year) {
-	          console.log('setYear(%d)', year);
 	          this.marks.datum(function() {
 	              var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
 	              return data[year] || 0;
@@ -11490,7 +11489,7 @@
 
 
 	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6),
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
 	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
 	        shapes = cell.select("g." + classPrefix + "cell " + shape);
 
@@ -11869,7 +11868,7 @@
 
 
 	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6),
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
 	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
 	        shapes = cell.select("g." + classPrefix + "cell " + shape);
 
@@ -12074,7 +12073,7 @@
 	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
 
 	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6),
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
 	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
 	        shapes = cell.select("g." + classPrefix + "cell " + shape);
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11289,7 +11289,7 @@
 	      HTMLElement.prototype,
 	      {
 	        attachedCallback: {value: function() {
-	          this.marks
+	          this.marks = d3.select(this).selectAll('[data-value]')
 	            .datum(function() {
 	              return +this.getAttribute('data-value') || 0;
 	            });
@@ -11297,18 +11297,15 @@
 	          this.update();
 	        }},
 
-	        marks: {
-	          get: function() {
-	            return d3.select(this)
-	              .selectAll('svg [data-value]');
-	          }
-	        },
-
 	        setYear: {value: function(year) {
+	          console.log('setYear(%d)', year);
 	          this.marks.datum(function() {
-	            var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
-	            return data[year] || 0;
-	          });
+	              var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+	              return data[year] || 0;
+	            })
+	            .attr('data-value', function(d) {
+	              return d;
+	            });
 	          this.update();
 	        }},
 
@@ -11394,7 +11391,7 @@
 	          var cellHeight = legend.shapeHeight() + legend.shapePadding();
 	          var count = 0;
 	          cells.each(function(cell, i) {
-	            var present = true; // uniqueSteps.indexOf(i) > -1;
+	            var present = uniqueSteps.indexOf(i) > -1;
 
 	            if (!present) {
 	              // hide cells swatches that aren't in the map
@@ -12505,25 +12502,26 @@
 	(function(exports) {
 
 	  var attached = function() {
-	    var select = this.querySelector('select');
-	    var charts = d3.select(this).selectAll('eiti-bar-chart');
-	    var maps = d3.select(this).selectAll('data-map');
+	    var root = d3.select(this);
 
+	    var select = root.selectAll('select.chart-selector');
+	    var charts = root.selectAll('eiti-bar-chart');
+	    var maps = root.selectAll('eiti-data-map');
 
 	    var update = function(year) {
 	      charts.property('x', year);
 	      maps.each(function() {
 	        this.setYear(year);
 	      });
-	      select.value = year;
+	      select.property('value',  year);
 	    };
 
-	    select.addEventListener('change', function() {
+	    select.on('change.year', function() {
 	      update(this.value);
 	    });
 
 	    charts.selectAll('g.bar')
-	      .on('click', function(d) {
+	      .on('click.year', function(d) {
 	        update(d.x);
 	      });
 	  };

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12369,6 +12369,13 @@
 	        return String(x).substr(2);
 	      });
 
+	    svg.append('g')
+	      .attr('class', 'x-axis-baseline')
+	      .append('line')
+	        .attr('x1', 0)
+	        .attr('x2', width)
+	        .attr('transform', 'translate(' + [0, bottom] + ')');
+
 	    svg.select('.x-axis')
 	      .attr('transform', 'translate(' + [0, bottom] + ')')
 	      .call(axis)
@@ -12378,10 +12385,10 @@
 	    svg.append('g')
 	      .attr('class', 'x-axis-label')
 	      .append('text')
-	      .text(xAxisLabel)
-	      .attr('transform', function(d) {
-	        return 'translate(' + [labelOffset, xAxisBottom] + ')';
-	      });
+	        .text(xAxisLabel)
+	        .attr('transform', function(d) {
+	          return 'translate(' + [labelOffset, xAxisBottom] + ')';
+	        });
 	  };
 
 	  var formatUnits = function(text, units) {
@@ -12416,8 +12423,6 @@
 	      output.select('.eiti-bar-chart-x-value')
 	        .text(value.x);
 	      var y = output.select('.eiti-bar-chart-y-value');
-	      console.log(output, y.attr('data-format'))
-	      console.log('-------------')
 	      var format = d3.format(y.attr('data-format') || ',');
 	      var units = y.attr('data-units');
 	      y.text(formatUnits(format(value.y),units));

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12220,10 +12220,16 @@
 	  var top = margin.top;
 	  var bottom = height - margin.bottom;
 
+	  var xAxisLabel = 'years';
+	  var xAxisBottom = height + margin.bottom;
+	  var labelOffset = width / 2;
+
+	  var fullHeight = height + textMargin;
+
 	  var attached = function() {
 	    var svg = d3.select(this)
 	      .append('svg')
-	        .attr('viewBox', [0, 0, width, height].join(' '));
+	        .attr('viewBox', [0, 0, width, fullHeight].join(' '));
 
 	    svg.append('g')
 	      .attr('class', 'axis x-axis');
@@ -12340,7 +12346,7 @@
 
 	    svg.selectAll('.bar-mask')
 	      // extend all the way to the bottom of the screen
-	      .attr('height', barHeight + textMargin * 2)
+	      .attr('height', barHeight + textMargin)
 	      .attr('width', barWidth);
 
 	    selection.call(updateSelected, this.x);
@@ -12368,6 +12374,14 @@
 	      .call(axis)
 	      .selectAll('path, line')
 	        .attr('fill', 'none');
+
+	    svg.append('g')
+	      .attr('class', 'x-axis-label')
+	      .append('text')
+	      .text(xAxisLabel)
+	      .attr('transform', function(d) {
+	        return 'translate(' + [labelOffset, xAxisBottom] + ')';
+	      });
 	  };
 
 	  var formatUnits = function(text, units) {
@@ -12402,6 +12416,7 @@
 	      output.select('.eiti-bar-chart-x-value')
 	        .text(value.x);
 	      var y = output.select('.eiti-bar-chart-y-value');
+
 	      var format = d3.format(y.attr('data-format') || ',');
 	      var units = y.attr('data-units');
 	      y.text(formatUnits(format(value.y),units));

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12416,7 +12416,8 @@
 	      output.select('.eiti-bar-chart-x-value')
 	        .text(value.x);
 	      var y = output.select('.eiti-bar-chart-y-value');
-
+	      console.log(output, y.attr('data-format'))
+	      console.log('-------------')
 	      var format = d3.format(y.attr('data-format') || ',');
 	      var units = y.attr('data-units');
 	      y.text(formatUnits(format(value.y),units));

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -51,6 +51,7 @@
 	  __webpack_require__(25);
 	  __webpack_require__(26);
 	  __webpack_require__(33);
+	  __webpack_require__(34);
 
 	  __webpack_require__(4);
 	  __webpack_require__(1);
@@ -12478,6 +12479,48 @@
 	  // EITIBarChart.observedAttributes = observedAttributes;
 
 	  exports.EITIBarChart = EITIBarChart;
+
+	})(this);
+
+
+/***/ },
+/* 34 */
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  var attached = function() {
+	    var select = this.querySelector('select');
+	    var charts = d3.select(this).selectAll('eiti-bar-chart');
+
+	    var update = function(year) {
+	      charts.property('x', year);
+	      select.value = year;
+	    };
+
+	    select.addEventListener('change', function() {
+	      update(this.value);
+	    });
+
+	    charts.selectAll('g.bar')
+	      .on('click', function(d) {
+	        update(d.x);
+	      });
+	  };
+
+	  var detached = function() {
+	  };
+
+	  exports.EITIYearSwitcherSection = document.registerElement('year-switcher-section', {
+	    'extends': 'section',
+	    prototype: Object.create(
+	      HTMLElement.prototype,
+	      {
+	        attachedCallback: {value: attached},
+	        detachdCallback: {value: detached}
+	      }
+	    )
+	  })
 
 	})(this);
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -442,7 +442,7 @@
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
 	  var d3 = {
-	    version: "3.5.16"
+	    version: "3.5.17"
 	  };
 	  var d3_arraySlice = [].slice, d3_array = function(list) {
 	    return d3_arraySlice.call(list);
@@ -3967,7 +3967,7 @@
 	        λ0 = λ, sinφ0 = sinφ, cosφ0 = cosφ, point0 = point;
 	      }
 	    }
-	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ winding & 1;
+	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ winding & 1;
 	  }
 	  function d3_geo_clipCircle(radius) {
 	    var cr = Math.cos(radius), smallRadius = cr > 0, notHemisphere = abs(cr) > ε, interpolate = d3_geo_circleInterpolate(radius, 6 * d3_radians);
@@ -11284,7 +11284,7 @@
 	  var eiti = __webpack_require__(12);
 	  var format = eiti.format;
 
-	  exports.EITIDataMap = document.registerElement('data-map', {
+	  exports.EITIDataMap = document.registerElement('eiti-data-map', {
 	    prototype: Object.create(
 	      HTMLElement.prototype,
 	      {
@@ -11359,7 +11359,7 @@
 	              .range(steps);
 
 	            var values = [];
-	            data.forEach(function(d){
+	            data.forEach(function(d) {
 	              values.push(getSteps(d));
 	            });
 
@@ -11372,7 +11372,7 @@
 	          svgLegend.append('g')
 	            .attr('class', 'legendScale');
 
-	          var legendSettings = d3.legend.color()
+	          var legend = d3.legend.color()
 	            .labelFormat(format.si)
 	            .useClass(false)
 	            .ascending(true)
@@ -11381,10 +11381,10 @@
 	            .scale(scale);
 
 	          svgLegend.select('.legendScale')
-	            .call(legendSettings);
+	            .call(legend);
 
 	          // reverse because the scale is in ascending order
-	          var _steps = d3.range(0,9).reverse();
+	          var _steps = d3.range(0, 9).reverse();
 
 	          // find which steps are represented in the map
 	          var uniqueSteps = getUnique(marks.data(), _steps, domain);
@@ -11394,8 +11394,8 @@
 	          var cellHeight = legendSettings.shapeHeight() +
 	            legendSettings.shapePadding();
 	          var count = 0;
-	          cells.each(function(cell, i){
-	            var present = uniqueSteps.indexOf(i) > -1;
+	          cells.each(function(cell, i) {
+	            var present = true; // uniqueSteps.indexOf(i) > -1;
 
 	            if (!present) {
 	              // hide cells swatches that aren't in the map
@@ -11494,7 +11494,7 @@
 
 
 	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6),
 	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
 	        shapes = cell.select("g." + classPrefix + "cell " + shape);
 
@@ -11873,7 +11873,7 @@
 
 
 	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6),
 	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
 	        shapes = cell.select("g." + classPrefix + "cell " + shape);
 
@@ -12078,7 +12078,7 @@
 	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
 
 	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6),
 	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
 	        shapes = cell.select("g." + classPrefix + "cell " + shape);
 

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -3,7 +3,7 @@
 
   require('./../components/aria-toggle.js');
   require('./../components/bar-chart-table.js');
-  require('./../components/data-map.js');
+  require('./../components/eiti-data-map.js');
   require('./../components/eiti-bar-chart.js');
   require('./../components/year-switcher-section.js');
 

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -5,6 +5,7 @@
   require('./../components/bar-chart-table.js');
   require('./../components/data-map.js');
   require('./../components/eiti-bar-chart.js');
+  require('./../components/year-switcher-section.js');
 
   require('./../components/aria-tabs.js');
   require('./../components/sticky-nav.js');

--- a/maps/index.html
+++ b/maps/index.html
@@ -6,14 +6,14 @@ layout: default
   <div class="container-outer">
     <h2>US Map</h2>
     <figure>
-      <data-map color-scheme="Greens" steps="9">
+      <eiti-data-map color-scheme="Greens" steps="9">
         {%
           include state-map.html
           states=site.data.state_jobs
           href='#%'
           value='2013.count'
         %}
-      </data-map>
+      </eiti-data-map>
       <figcaption>State employment (number of extractives jobs)</figcaption>
     </figure>
   </div>
@@ -44,7 +44,7 @@ layout: default
           <td rowspan="{{ counties | size | plus: 1 }}">{{ state.name }}</td>
           <td rowspan="{{ counties | size | plus: 1 }}">
             <figure>
-              <data-map color-scheme="Greens" steps="7">
+              <eiti-data-map color-scheme="Greens" steps="7">
                 {%
                   include county-map.html
                   state=state_id
@@ -52,12 +52,12 @@ layout: default
                   value='employment.2013.count'
                   href='#county-%'
                 %}
-              </data-map>
+              </eiti-data-map>
               <figcaption>County extractives employment (number of jobs)</figcaption>
             </figure>
 
             <figure>
-              <data-map color-scheme="Reds" steps="7" domain="[0, 100]">
+              <eiti-data-map color-scheme="Reds" steps="7" domain="[0, 100]">
                 {%
                   include county-map.html
                   state=state_id
@@ -65,7 +65,7 @@ layout: default
                   value='employment.2013.percent'
                   href='#county-%'
                 %}
-              </data-map>
+              </eiti-data-map>
               <figcaption>County employment (percentage of extractives jobs)</figcaption>
             </figure>
           </td>
@@ -100,5 +100,5 @@ layout: default
 </section><!-- /.container-padded -->
 
 <script src="{{ site.baseurl }}/js/components/bar-chart-table.js"></script>
-<script src="{{ site.baseurl }}/js/components/data-map.js"></script>
+<script src="{{ site.baseurl }}/js/components/eiti-data-map.js"></script>
 <script src="{{ site.baseurl }}/js/components/map-thumbnail.js"></script>

--- a/maps/test.html
+++ b/maps/test.html
@@ -7,19 +7,19 @@ permalink: /maps/test/
   <div class="container-outer">
     <h2>US Map</h2>
     <figure>
-      <data-map color-scheme="Greens" steps="9">
+      <eiti-data-map color-scheme="Greens" steps="9">
         {%
           include state-map.html
           states=site.data.state_jobs
           href='#%'
           value='2013.count'
         %}
-      </data-map>
+      </eiti-data-map>
       <figcaption>State employment (number of extractives jobs)</figcaption>
     </figure>
 
     <figure>
-      <data-map color-scheme="Greens" steps="9">
+      <eiti-data-map color-scheme="Greens" steps="9">
         {%
           include county-map.html
           state='CA'
@@ -27,10 +27,10 @@ permalink: /maps/test/
           href='#%'
           value='employment.2013.count'
         %}
-      </data-map>
+      </eiti-data-map>
       <figcaption>California county-level employment (number of extractives jobs)</figcaption>
     </figure>
   </div>
 </section>
 
-<script src="{{ site.baseurl }}/js/components/data-map.js"></script>
+<script src="{{ site.baseurl }}/js/components/eiti-data-map.js"></script>

--- a/states/index.html
+++ b/states/index.html
@@ -48,6 +48,15 @@ nav_items:
 
   <div class="container-left-9">
 
+    <figure is="data-map" color-scheme="Reds" steps="9">
+      {%
+        include state-map.html
+        states=site.data.state_revenues
+        value='products.All.2013.revenue'
+        href='%/'
+      %}
+      <figcaption>State revenue (2013)</figcaption>
+    </figure>
 
     <section id="production">
       {% include location/national-all-production.html %}
@@ -69,16 +78,6 @@ nav_items:
     {% include location/national-exports.html %}
 
     </section>
-
-    <figure is="data-map" color-scheme="Reds" steps="9">
-        {%
-          include state-map.html
-          states=site.data.state_revenues
-          value='products.All.2013.revenue'
-          href='%/'
-        %}
-        <figcaption>State revenue (2013)</figcaption>
-    </figure>
 
     <!-- XXX setting display: none on this prevents the mask from working -->
     <svg width="0" height="0">


### PR DESCRIPTION
[:sunglasses: PREVIEW Utah](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-pages-new-layout/states/UT)
[:sunglasses: PREVIEW National page](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-pages-new-layout/states)

Changes proposed in this pull request:
- General layout changes for #1518 
- Year selector: #1582 (design) #1588 (implementation)
  * Introduces the `<section is="year-switcher-section">` component, which manages syncing year selections between inputs, bar charts, and maps.

- Renames `<data-map>` to `<eiti-data-map>` (more component renaming forthcoming!)

- Removes the `line-chart-data.json` include in favor of just using the new `map_hash` template filter:

  ```html
  data='{{ some_data | map_hash: 'some_key' | jsonify }}'
  ```

/cc @ericronne @gemfarmer 
