### PR TITLE
Multiply all production figures by 1000

### DIFF
--- a/_data/national_all_production.yml
+++ b/_data/national_all_production.yml
@@ -125,125 +125,125 @@ US:
       units: mcf
       volume:
         '1967':
-          volume: 339601000
+          volume: 339601
         '1968':
-          volume: 329318000
+          volume: 329318
         '1969':
-          volume: 311458000
+          volume: 311458
         '1970':
-          volume: 296347000
+          volume: 296347
         '1971':
-          volume: 254494000
+          volume: 254494
         '1972':
-          volume: 254850000
+          volume: 254850
         '1973':
-          volume: 290023000
+          volume: 290023
         '1974':
-          volume: 328059000
+          volume: 328059
         '1975':
-          volume: 361345000
+          volume: 361345
         '1976':
-          volume: 390005000
+          volume: 390005
         '1977':
-          volume: 430634000
+          volume: 430634
         '1978':
-          volume: 540769000
+          volume: 540769
         '1979':
-          volume: 589730000
+          volume: 589730
         '1980':
-          volume: 625570000
+          volume: 625570
         '1981':
-          volume: 652159000
+          volume: 652159
         '1982':
-          volume: 627062000
+          volume: 627062
         '1983':
-          volume: 578059000
+          volume: 578059
         '1984':
-          volume: 622619000
+          volume: 622619
         '1985':
-          volume: 623741000
+          volume: 623741
         '1986':
-          volume: 642125000
+          volume: 642125
         '1987':
-          volume: 673939000
+          volume: 673939
         '1988':
-          volume: 705483000
+          volume: 705483
         '1989':
-          volume: 680944000
+          volume: 680944
         '1990':
-          volume: 701729000
+          volume: 701729
         '1991':
-          volume: 741807000
+          volume: 741807
         '1992':
-          volume: 929054000
+          volume: 929054
         '1993':
-          volume: 971707000
+          volume: 971707
         '1994':
-          volume: 1098871000
+          volume: 1098871
         '1995':
-          volume: 1109696000
+          volume: 1109696
         '1996':
-          volume: 1133459000
+          volume: 1133459
         '1997':
-          volume: 1049920000
+          volume: 1049920
         '1998':
-          volume: 1024792000
+          volume: 1024792
         '1999':
-          volume: 1017176000
+          volume: 1017176
         '2000':
-          volume: 1012019000
+          volume: 1012019
         '2001':
-          volume: 1014148000
+          volume: 1014148
         '2002':
-          volume: 1036154000
+          volume: 1036154
         '2003':
-          volume: 1063840000
+          volume: 1063840
         '2004':
-          volume: 23969678000
+          volume: 23969678
         '2005':
-          volume: 23456821000
+          volume: 23456821
         '2006':
-          volume: 23535019000
+          volume: 23535019
         '2007':
-          volume: 24663658000
+          volume: 24663658
         '2008':
-          volume: 25636255000
+          volume: 25636255
         '2009':
-          volume: 26056892000
+          volume: 26056892
         '2010':
-          volume: 26816086000
+          volume: 26816086
         '2011':
-          volume: 28479024000
+          volume: 28479024
         '2012':
-          volume: 29542312000
+          volume: 29542312
         '2013':
-          volume: 29522554000
+          volume: 29522554
         '2014':
-          volume: 633855000
+          volume: 633855
     Oil (bbl):
       name: Oil
       units: bbl
       volume:
         '2004':
-          volume: 2315610
+          volume: 2315610000
         '2005':
-          volume: 2200374
+          volume: 2200374000
         '2006':
-          volume: 2120848
+          volume: 2120848000
         '2007':
-          volume: 2111350
+          volume: 2111350000
         '2008':
-          volume: 2075520
+          volume: 2075520000
         '2009':
-          volume: 2186983
+          volume: 2186983000
         '2010':
-          volume: 2213721
+          volume: 2213721000
         '2011':
-          volume: 2258749
+          volume: 2258749000
         '2012':
-          volume: 2558448
+          volume: 2558448000
         '2013':
-          volume: 2903313
+          volume: 2903313000
     Other biomass:
       name: Other biomass
       units: kilowatt hours

--- a/_data/state_all_production.yml
+++ b/_data/state_all_production.yml
@@ -181,43 +181,43 @@ AK:
       units: mcf
       volume:
         '2004':
-          volume: 3644084000
+          volume: 3644084
           percent: 15.2
           rank: 2
         '2005':
-          volume: 3642948000
+          volume: 3642948
           percent: 15.53
           rank: 2
         '2006':
-          volume: 3205751000
+          volume: 3205751
           percent: 13.62
           rank: 2
         '2007':
-          volume: 3479290000
+          volume: 3479290
           percent: 14.11
           rank: 2
         '2008':
-          volume: 3415884000
+          volume: 3415884
           percent: 13.32
           rank: 2
         '2009':
-          volume: 3312386000
+          volume: 3312386
           percent: 12.71
           rank: 2
         '2010':
-          volume: 3197100000
+          volume: 3197100
           percent: 11.92
           rank: 2
         '2011':
-          volume: 3162922000
+          volume: 3162922
           percent: 11.11
           rank: 2
         '2012':
-          volume: 3164791000
+          volume: 3164791
           percent: 10.71
           rank: 2
         '2013':
-          volume: 3215358000
+          volume: 3215358
           percent: 10.89
           rank: 3
     Oil (bbl):
@@ -225,43 +225,43 @@ AK:
       units: bbl
       volume:
         '2004':
-          volume: 332441
+          volume: 332441000
           percent: 14.36
           rank: 2
         '2005':
-          volume: 315387
+          volume: 315387000
           percent: 14.33
           rank: 2
         '2006':
-          volume: 270481
+          volume: 270481000
           percent: 12.75
           rank: 2
         '2007':
-          volume: 263595
+          volume: 263595000
           percent: 12.48
           rank: 2
         '2008':
-          volume: 249874
+          volume: 249874000
           percent: 12.04
           rank: 2
         '2009':
-          volume: 235491
+          volume: 235491000
           percent: 10.77
           rank: 2
         '2010':
-          volume: 218904
+          volume: 218904000
           percent: 9.89
           rank: 2
         '2011':
-          volume: 204829
+          volume: 204829000
           percent: 9.07
           rank: 2
         '2012':
-          volume: 192368
+          volume: 192368000
           percent: 7.52
           rank: 4
         '2013':
-          volume: 187954
+          volume: 187954000
           percent: 6.47
           rank: 4
     Other biomass:
@@ -535,195 +535,195 @@ AL:
       units: mcf
       volume:
         '1967':
-          volume: 2200000
+          volume: 2200
           percent: 0.65
           rank: 8
         '1968':
-          volume: 1802000
+          volume: 1802
           percent: 0.55
           rank: 8
         '1969':
-          volume: 2585000
+          volume: 2585
           percent: 0.83
           rank: 8
         '1970':
-          volume: 2987000
+          volume: 2987
           percent: 1.01
           rank: 7
         '1971':
-          volume: 663000
+          volume: 663
           percent: 0.26
           rank: 10
         '1972':
-          volume: 4610000
+          volume: 4610
           percent: 1.81
           rank: 6
         '1973':
-          volume: 13161000
+          volume: 13161
           percent: 4.54
           rank: 5
         '1974':
-          volume: 29357000
+          volume: 29357
           percent: 8.95
           rank: 5
         '1975':
-          volume: 38921000
+          volume: 38921
           percent: 10.77
           rank: 5
         '1976':
-          volume: 43600000
+          volume: 43600
           percent: 11.18
           rank: 5
         '1977':
-          volume: 61267000
+          volume: 61267
           percent: 14.23
           rank: 3
         '1978':
-          volume: 90012000
+          volume: 90012
           percent: 16.65
           rank: 3
         '1979':
-          volume: 90695000
+          volume: 90695
           percent: 15.38
           rank: 3
         '1980':
-          volume: 111836000
+          volume: 111836
           percent: 17.88
           rank: 3
         '1981':
-          volume: 125624000
+          volume: 125624
           percent: 19.26
           rank: 3
         '1982':
-          volume: 133298000
+          volume: 133298
           percent: 21.26
           rank: 3
         '1983':
-          volume: 125889000
+          volume: 125889
           percent: 21.78
           rank: 3
         '1984':
-          volume: 136427000
+          volume: 136427
           percent: 21.91
           rank: 3
         '1985':
-          volume: 143420000
+          volume: 143420
           percent: 22.99
           rank: 2
         '1986':
-          volume: 145625000
+          volume: 145625
           percent: 22.68
           rank: 2
         '1987':
-          volume: 155143000
+          volume: 155143
           percent: 23.02
           rank: 2
         '1988':
-          volume: 175054000
+          volume: 175054
           percent: 24.81
           rank: 2
         '1989':
-          volume: 180300000
+          volume: 180300
           percent: 26.48
           rank: 2
         '1990':
-          volume: 186542000
+          volume: 186542
           percent: 26.58
           rank: 2
         '1991':
-          volume: 223876000
+          volume: 223876
           percent: 30.18
           rank: 1
         '1992':
-          volume: 413614000
+          volume: 413614
           percent: 44.52
           rank: 1
         '1993':
-          volume: 446321000
+          volume: 446321
           percent: 45.93
           rank: 1
         '1994':
-          volume: 578863000
+          volume: 578863
           percent: 52.68
           rank: 1
         '1995':
-          volume: 580125000
+          volume: 580125
           percent: 52.28
           rank: 1
         '1996':
-          volume: 582301000
+          volume: 582301
           percent: 51.37
           rank: 1
         '1997':
-          volume: 435088000
+          volume: 435088
           percent: 41.44
           rank: 1
         '1998':
-          volume: 434470000
+          volume: 434470
           percent: 42.4
           rank: 1
         '1999':
-          volume: 420535000
+          volume: 420535
           percent: 41.34
           rank: 1
         '2000':
-          volume: 401336000
+          volume: 401336
           percent: 39.66
           rank: 1
         '2001':
-          volume: 391981000
+          volume: 391981
           percent: 38.65
           rank: 1
         '2002':
-          volume: 386502000
+          volume: 386502
           percent: 37.3
           rank: 1
         '2003':
-          volume: 370910000
+          volume: 370910
           percent: 34.87
           rank: 1
         '2004':
-          volume: 338735000
+          volume: 338735
           percent: 1.41
           rank: 9
         '2005':
-          volume: 317206000
+          volume: 317206
           percent: 1.35
           rank: 9
         '2006':
-          volume: 306144000
+          volume: 306144
           percent: 1.3
           rank: 11
         '2007':
-          volume: 289618000
+          volume: 289618
           percent: 1.17
           rank: 11
         '2008':
-          volume: 277553000
+          volume: 277553
           percent: 1.08
           rank: 13
         '2009':
-          volume: 255965000
+          volume: 255965
           percent: 0.98
           rank: 15
         '2010':
-          volume: 240703000
+          volume: 240703
           percent: 0.9
           rank: 15
         '2011':
-          volume: 218574000
+          volume: 218574
           percent: 0.77
           rank: 15
         '2012':
-          volume: 215710000
+          volume: 215710
           percent: 0.73
           rank: 16
         '2013':
-          volume: 196326000
+          volume: 196326
           percent: 0.67
           rank: 15
         '2014':
-          volume: 181054000
+          volume: 181054
           percent: 28.56
           rank: 1
     Oil (bbl):
@@ -731,43 +731,43 @@ AL:
       units: bbl
       volume:
         '2004':
-          volume: 7443
+          volume: 7443000
           percent: 0.32
           rank: 15
         '2005':
-          volume: 7861
+          volume: 7861000
           percent: 0.36
           rank: 15
         '2006':
-          volume: 7539
+          volume: 7539000
           percent: 0.36
           rank: 15
         '2007':
-          volume: 7171
+          volume: 7171000
           percent: 0.34
           rank: 15
         '2008':
-          volume: 7696
+          volume: 7696000
           percent: 0.37
           rank: 15
         '2009':
-          volume: 7189
+          volume: 7189000
           percent: 0.33
           rank: 15
         '2010':
-          volume: 7155
+          volume: 7155000
           percent: 0.32
           rank: 15
         '2011':
-          volume: 8373
+          volume: 8373000
           percent: 0.37
           rank: 15
         '2012':
-          volume: 9525
+          volume: 9525000
           percent: 0.37
           rank: 14
         '2013':
-          volume: 10391
+          volume: 10391000
           percent: 0.36
           rank: 14
     Other biomass:
@@ -1041,43 +1041,43 @@ AR:
       units: mcf
       volume:
         '2004':
-          volume: 187310000
+          volume: 187310
           percent: 0.78
           rank: 14
         '2005':
-          volume: 190774000
+          volume: 190774
           percent: 0.81
           rank: 14
         '2006':
-          volume: 270744000
+          volume: 270744
           percent: 1.15
           rank: 12
         '2007':
-          volume: 270414000
+          volume: 270414
           percent: 1.1
           rank: 14
         '2008':
-          volume: 447082000
+          volume: 447082
           percent: 1.74
           rank: 8
         '2009':
-          volume: 680613000
+          volume: 680613
           percent: 2.61
           rank: 8
         '2010':
-          volume: 927479000
+          volume: 927479
           percent: 3.46
           rank: 8
         '2011':
-          volume: 1076757000
+          volume: 1076757
           percent: 3.78
           rank: 9
         '2012':
-          volume: 1146168000
+          volume: 1146168
           percent: 3.88
           rank: 9
         '2013':
-          volume: 1139654000
+          volume: 1139654
           percent: 3.86
           rank: 9
     Oil (bbl):
@@ -1085,43 +1085,43 @@ AR:
       units: bbl
       volume:
         '2004':
-          volume: 6747
+          volume: 6747000
           percent: 0.29
           rank: 16
         '2005':
-          volume: 6175
+          volume: 6175000
           percent: 0.28
           rank: 16
         '2006':
-          volume: 5948
+          volume: 5948000
           percent: 0.28
           rank: 16
         '2007':
-          volume: 6031
+          volume: 6031000
           percent: 0.29
           rank: 16
         '2008':
-          volume: 6079
+          volume: 6079000
           percent: 0.29
           rank: 17
         '2009':
-          volume: 5755
+          volume: 5755000
           percent: 0.26
           rank: 17
         '2010':
-          volume: 5733
+          volume: 5733000
           percent: 0.26
           rank: 17
         '2011':
-          volume: 5877
+          volume: 5877000
           percent: 0.26
           rank: 17
         '2012':
-          volume: 6536
+          volume: 6536000
           percent: 0.26
           rank: 17
         '2013':
-          volume: 6640
+          volume: 6640000
           percent: 0.23
           rank: 19
     Other biomass:
@@ -1395,179 +1395,179 @@ AZ:
       units: mcf
       volume:
         '1971':
-          volume: 1215000
+          volume: 1215
           percent: 0.48
           rank: 9
         '1972':
-          volume: 809000
+          volume: 809
           percent: 0.32
           rank: 10
         '1973':
-          volume: 402000
+          volume: 402
           percent: 0.14
           rank: 10
         '1974':
-          volume: 250000
+          volume: 250
           percent: 0.08
           rank: 11
         '1975':
-          volume: 255000
+          volume: 255
           percent: 0.07
           rank: 12
         '1976':
-          volume: 294000
+          volume: 294
           percent: 0.08
           rank: 11
         '1977':
-          volume: 343000
+          volume: 343
           percent: 0.08
           rank: 11
         '1978':
-          volume: 286000
+          volume: 286
           percent: 0.05
           rank: 11
         '1979':
-          volume: 348000
+          volume: 348
           percent: 0.06
           rank: 13
         '1980':
-          volume: 357000
+          volume: 357
           percent: 0.06
           rank: 13
         '1981':
-          volume: 293000
+          volume: 293
           percent: 0.04
           rank: 13
         '1982':
-          volume: 261000
+          volume: 261
           percent: 0.04
           rank: 12
         '1983':
-          volume: 240000
+          volume: 240
           percent: 0.04
           rank: 12
         '1984':
-          volume: 227000
+          volume: 227
           percent: 0.04
           rank: 14
         '1985':
-          volume: 209000
+          volume: 209
           percent: 0.03
           rank: 14
         '1986':
-          volume: 185000
+          volume: 185
           percent: 0.03
           rank: 14
         '1987':
-          volume: 185000
+          volume: 185
           percent: 0.03
           rank: 14
         '1988':
-          volume: 179000
+          volume: 179
           percent: 0.03
           rank: 14
         '1989':
-          volume: 1455000
+          volume: 1455
           percent: 0.21
           rank: 12
         '1990':
-          volume: 2147000
+          volume: 2147
           percent: 0.31
           rank: 10
         '1991':
-          volume: 1280000
+          volume: 1280
           percent: 0.17
           rank: 11
         '1992':
-          volume: 794000
+          volume: 794
           percent: 0.09
           rank: 12
         '1993':
-          volume: 618000
+          volume: 618
           percent: 0.06
           rank: 12
         '1994':
-          volume: 759000
+          volume: 759
           percent: 0.07
           rank: 12
         '1995':
-          volume: 558000
+          volume: 558
           percent: 0.05
           rank: 12
         '1996':
-          volume: 464000
+          volume: 464
           percent: 0.04
           rank: 12
         '1997':
-          volume: 453000
+          volume: 453
           percent: 0.04
           rank: 13
         '1998':
-          volume: 457000
+          volume: 457
           percent: 0.04
           rank: 13
         '1999':
-          volume: 474000
+          volume: 474
           percent: 0.05
           rank: 13
         '2000':
-          volume: 368000
+          volume: 368
           percent: 0.04
           rank: 13
         '2001':
-          volume: 307000
+          volume: 307
           percent: 0.03
           rank: 13
         '2002':
-          volume: 301000
+          volume: 301
           percent: 0.03
           rank: 13
         '2003':
-          volume: 443000
+          volume: 443
           percent: 0.04
           rank: 13
         '2004':
-          volume: 331000
+          volume: 331
           percent: 0
           rank: 28
         '2005':
-          volume: 233000
+          volume: 233
           percent: 0
           rank: 29
         '2006':
-          volume: 611000
+          volume: 611
           percent: 0
           rank: 29
         '2007':
-          volume: 655000
+          volume: 655
           percent: 0
           rank: 29
         '2008':
-          volume: 523000
+          volume: 523
           percent: 0
           rank: 30
         '2009':
-          volume: 712000
+          volume: 712
           percent: 0
           rank: 29
         '2010':
-          volume: 183000
+          volume: 183
           percent: 0
           rank: 30
         '2011':
-          volume: 168000
+          volume: 168
           percent: 0
           rank: 30
         '2012':
-          volume: 117000
+          volume: 117
           percent: 0
           rank: 30
         '2013':
-          volume: 72000
+          volume: 72
           percent: 0
           rank: 30
         '2014':
-          volume: 106000
+          volume: 106
           percent: 0.02
           rank: 14
     Oil (bbl):
@@ -1575,43 +1575,43 @@ AZ:
       units: bbl
       volume:
         '2004':
-          volume: 54
+          volume: 54000
           percent: 0
           rank: 30
         '2005':
-          volume: 50
+          volume: 50000
           percent: 0
           rank: 30
         '2006':
-          volume: 55
+          volume: 55000
           percent: 0
           rank: 30
         '2007':
-          volume: 43
+          volume: 43000
           percent: 0
           rank: 30
         '2008':
-          volume: 52
+          volume: 52000
           percent: 0
           rank: 30
         '2009':
-          volume: 46
+          volume: 46000
           percent: 0
           rank: 30
         '2010':
-          volume: 40
+          volume: 40000
           percent: 0
           rank: 30
         '2011':
-          volume: 37
+          volume: 37000
           percent: 0
           rank: 30
         '2012':
-          volume: 52
+          volume: 52000
           percent: 0
           rank: 30
         '2013':
-          volume: 60
+          volume: 60000
           percent: 0
           rank: 29
     Other biomass:
@@ -1945,43 +1945,43 @@ CA:
       units: mcf
       volume:
         '2004':
-          volume: 294172000
+          volume: 294172
           percent: 1.23
           rank: 10
         '2005':
-          volume: 297956000
+          volume: 297956
           percent: 1.27
           rank: 11
         '2006':
-          volume: 308730000
+          volume: 308730
           percent: 1.31
           rank: 10
         '2007':
-          volume: 293873000
+          volume: 293873
           percent: 1.19
           rank: 10
         '2008':
-          volume: 288117000
+          volume: 288117
           percent: 1.12
           rank: 12
         '2009':
-          volume: 265034000
+          volume: 265034
           percent: 1.02
           rank: 13
         '2010':
-          volume: 278691000
+          volume: 278691
           percent: 1.04
           rank: 13
         '2011':
-          volume: 242551000
+          volume: 242551
           percent: 0.85
           rank: 14
         '2012':
-          volume: 219560000
+          volume: 219560
           percent: 0.74
           rank: 15
         '2013':
-          volume: 224856000
+          volume: 224856
           percent: 0.76
           rank: 14
     Oil (bbl):
@@ -1989,43 +1989,43 @@ CA:
       units: bbl
       volume:
         '2004':
-          volume: 240138
+          volume: 240138000
           percent: 10.37
           rank: 3
         '2005':
-          volume: 230230
+          volume: 230230000
           percent: 10.46
           rank: 3
         '2006':
-          volume: 223015
+          volume: 223015000
           percent: 10.52
           rank: 3
         '2007':
-          volume: 218518
+          volume: 218518000
           percent: 10.35
           rank: 3
         '2008':
-          volume: 214533
+          volume: 214533000
           percent: 10.34
           rank: 3
         '2009':
-          volume: 207262
+          volume: 207262000
           percent: 9.48
           rank: 3
         '2010':
-          volume: 200050
+          volume: 200050000
           percent: 9.04
           rank: 3
         '2011':
-          volume: 193996
+          volume: 193996000
           percent: 8.59
           rank: 3
         '2012':
-          volume: 197211
+          volume: 197211000
           percent: 7.71
           rank: 3
         '2013':
-          volume: 198928
+          volume: 198928000
           percent: 6.85
           rank: 3
     Other biomass:
@@ -2387,43 +2387,43 @@ CO:
       units: mcf
       volume:
         '2004':
-          volume: 1089622000
+          volume: 1089622
           percent: 4.55
           rank: 7
         '2005':
-          volume: 1143985000
+          volume: 1143985
           percent: 4.88
           rank: 7
         '2006':
-          volume: 1214396000
+          volume: 1214396
           percent: 5.16
           rank: 7
         '2007':
-          volume: 1254529000
+          volume: 1254529
           percent: 5.09
           rank: 7
         '2008':
-          volume: 1402845000
+          volume: 1402845
           percent: 5.47
           rank: 6
         '2009':
-          volume: 1511654000
+          volume: 1511654
           percent: 5.8
           rank: 6
         '2010':
-          volume: 1589664000
+          volume: 1589664
           percent: 5.93
           rank: 6
         '2011':
-          volume: 1649306000
+          volume: 1649306
           percent: 5.79
           rank: 6
         '2012':
-          volume: 1709376000
+          volume: 1709376
           percent: 5.79
           rank: 7
         '2013':
-          volume: 1604860000
+          volume: 1604860
           percent: 5.44
           rank: 7
     Oil (bbl):
@@ -2431,43 +2431,43 @@ CO:
       units: bbl
       volume:
         '2004':
-          volume: 22532
+          volume: 22532000
           percent: 0.97
           rank: 11
         '2005':
-          volume: 23227
+          volume: 23227000
           percent: 1.06
           rank: 11
         '2006':
-          volume: 24494
+          volume: 24494000
           percent: 1.15
           rank: 11
         '2007':
-          volume: 26172
+          volume: 26172000
           percent: 1.24
           rank: 11
         '2008':
-          volume: 29928
+          volume: 29928000
           percent: 1.44
           rank: 11
         '2009':
-          volume: 30350
+          volume: 30350000
           percent: 1.39
           rank: 10
         '2010':
-          volume: 32976
+          volume: 32976000
           percent: 1.49
           rank: 10
         '2011':
-          volume: 39430
+          volume: 39430000
           percent: 1.75
           rank: 10
         '2012':
-          volume: 49435
+          volume: 49435000
           percent: 1.93
           rank: 9
         '2013':
-          volume: 65257
+          volume: 65257000
           percent: 2.25
           rank: 8
     Other biomass:
@@ -3093,179 +3093,179 @@ FL:
       units: mcf
       volume:
         '1971':
-          volume: 1258000
+          volume: 1258
           percent: 0.49
           rank: 8
         '1972':
-          volume: 15805000
+          volume: 15805
           percent: 6.2
           rank: 4
         '1973':
-          volume: 33857000
+          volume: 33857
           percent: 11.67
           rank: 4
         '1974':
-          volume: 38137000
+          volume: 38137
           percent: 11.63
           rank: 4
         '1975':
-          volume: 44383000
+          volume: 44383
           percent: 12.28
           rank: 4
         '1976':
-          volume: 46513000
+          volume: 46513
           percent: 11.93
           rank: 4
         '1977':
-          volume: 48778000
+          volume: 48778
           percent: 11.33
           rank: 5
         '1978':
-          volume: 51595000
+          volume: 51595
           percent: 9.54
           rank: 5
         '1979':
-          volume: 50190000
+          volume: 50190
           percent: 8.51
           rank: 5
         '1980':
-          volume: 46421000
+          volume: 46421
           percent: 7.42
           rank: 5
         '1981':
-          volume: 38539000
+          volume: 38539
           percent: 5.91
           rank: 5
         '1982':
-          volume: 26397000
+          volume: 26397
           percent: 4.21
           rank: 5
         '1983':
-          volume: 23356000
+          volume: 23356
           percent: 4.04
           rank: 5
         '1984':
-          volume: 13867000
+          volume: 13867
           percent: 2.23
           rank: 6
         '1985':
-          volume: 11604000
+          volume: 11604
           percent: 1.86
           rank: 7
         '1986':
-          volume: 9766000
+          volume: 9766
           percent: 1.52
           rank: 7
         '1987':
-          volume: 9132000
+          volume: 9132
           percent: 1.36
           rank: 7
         '1988':
-          volume: 8407000
+          volume: 8407
           percent: 1.19
           rank: 7
         '1989':
-          volume: 8773000
+          volume: 8773
           percent: 1.29
           rank: 7
         '1990':
-          volume: 7566000
+          volume: 7566
           percent: 1.08
           rank: 7
         '1991':
-          volume: 5898000
+          volume: 5898
           percent: 0.8
           rank: 7
         '1992':
-          volume: 7584000
+          volume: 7584
           percent: 0.82
           rank: 7
         '1993':
-          volume: 8011000
+          volume: 8011
           percent: 0.82
           rank: 7
         '1994':
-          volume: 8468000
+          volume: 8468
           percent: 0.77
           rank: 7
         '1995':
-          volume: 7133000
+          volume: 7133
           percent: 0.64
           rank: 8
         '1996':
-          volume: 6706000
+          volume: 6706
           percent: 0.59
           rank: 8
         '1997':
-          volume: 6907000
+          volume: 6907
           percent: 0.66
           rank: 8
         '1998':
-          volume: 6547000
+          volume: 6547
           percent: 0.64
           rank: 8
         '1999':
-          volume: 6702000
+          volume: 6702
           percent: 0.66
           rank: 8
         '2000':
-          volume: 7279000
+          volume: 7279
           percent: 0.72
           rank: 8
         '2001':
-          volume: 6446000
+          volume: 6446
           percent: 0.64
           rank: 8
         '2002':
-          volume: 3785000
+          volume: 3785
           percent: 0.37
           rank: 8
         '2003':
-          volume: 3474000
+          volume: 3474
           percent: 0.33
           rank: 8
         '2004':
-          volume: 3525000
+          volume: 3525
           percent: 0.01
           rank: 23
         '2005':
-          volume: 2954000
+          volume: 2954
           percent: 0.01
           rank: 25
         '2006':
-          volume: 2845000
+          volume: 2845
           percent: 0.01
           rank: 25
         '2007':
-          volume: 2000000
+          volume: 2000
           percent: 0.01
           rank: 26
         '2008':
-          volume: 2742000
+          volume: 2742
           percent: 0.01
           rank: 27
         '2009':
-          volume: 290000
+          volume: 290
           percent: 0
           rank: 30
         '2010':
-          volume: 13938000
+          volume: 13938
           percent: 0.05
           rank: 23
         '2011':
-          volume: 17129000
+          volume: 17129
           percent: 0.06
           rank: 23
         '2012':
-          volume: 18681000
+          volume: 18681
           percent: 0.06
           rank: 23
         '2013':
-          volume: 18011000
+          volume: 18011
           percent: 0.06
           rank: 23
         '2014':
-          volume: 21259000
+          volume: 21259
           percent: 3.35
           rank: 6
     Oil (bbl):
@@ -3273,43 +3273,43 @@ FL:
       units: bbl
       volume:
         '2004':
-          volume: 2904
+          volume: 2904000
           percent: 0.13
           rank: 19
         '2005':
-          volume: 2585
+          volume: 2585000
           percent: 0.12
           rank: 19
         '2006':
-          volume: 2360
+          volume: 2360000
           percent: 0.11
           rank: 20
         '2007':
-          volume: 2078
+          volume: 2078000
           percent: 0.1
           rank: 22
         '2008':
-          volume: 1953
+          volume: 1953000
           percent: 0.09
           rank: 23
         '2009':
-          volume: 696
+          volume: 696000
           percent: 0.03
           rank: 25
         '2010':
-          volume: 1777
+          volume: 1777000
           percent: 0.08
           rank: 24
         '2011':
-          volume: 2023
+          volume: 2023000
           percent: 0.09
           rank: 23
         '2012':
-          volume: 2135
+          volume: 2135000
           percent: 0.08
           rank: 24
         '2013':
-          volume: 2174
+          volume: 2174000
           percent: 0.07
           rank: 24
     Other biomass:
@@ -4615,195 +4615,195 @@ IL:
       units: mcf
       volume:
         '1967':
-          volume: 5270000
+          volume: 5270
           percent: 1.55
           rank: 5
         '1968':
-          volume: 4482000
+          volume: 4482
           percent: 1.36
           rank: 6
         '1969':
-          volume: 3893000
+          volume: 3893
           percent: 1.25
           rank: 6
         '1970':
-          volume: 4972000
+          volume: 4972
           percent: 1.68
           rank: 5
         '1971':
-          volume: 4495000
+          volume: 4495
           percent: 1.77
           rank: 5
         '1972':
-          volume: 3000000
+          volume: 3000
           percent: 1.18
           rank: 8
         '1973':
-          volume: 1638000
+          volume: 1638
           percent: 0.56
           rank: 9
         '1974':
-          volume: 1436000
+          volume: 1436
           percent: 0.44
           rank: 9
         '1975':
-          volume: 1440000
+          volume: 1440
           percent: 0.4
           rank: 9
         '1976':
-          volume: 1556000
+          volume: 1556
           percent: 0.4
           rank: 9
         '1977':
-          volume: 1003000
+          volume: 1003
           percent: 0.23
           rank: 9
         '1978':
-          volume: 1159000
+          volume: 1159
           percent: 0.21
           rank: 10
         '1979':
-          volume: 1585000
+          volume: 1585
           percent: 0.27
           rank: 10
         '1980':
-          volume: 1574000
+          volume: 1574
           percent: 0.25
           rank: 9
         '1981':
-          volume: 1295000
+          volume: 1295
           percent: 0.2
           rank: 10
         '1982':
-          volume: 1162000
+          volume: 1162
           percent: 0.19
           rank: 11
         '1983':
-          volume: 1030000
+          volume: 1030
           percent: 0.18
           rank: 11
         '1984':
-          volume: 1530000
+          volume: 1530
           percent: 0.25
           rank: 12
         '1985':
-          volume: 1324000
+          volume: 1324
           percent: 0.21
           rank: 12
         '1986':
-          volume: 1887000
+          volume: 1887
           percent: 0.29
           rank: 11
         '1987':
-          volume: 1371000
+          volume: 1371
           percent: 0.2
           rank: 11
         '1988':
-          volume: 1338000
+          volume: 1338
           percent: 0.19
           rank: 11
         '1989':
-          volume: 1477000
+          volume: 1477
           percent: 0.22
           rank: 11
         '1990':
-          volume: 677000
+          volume: 677
           percent: 0.1
           rank: 13
         '1991':
-          volume: 466000
+          volume: 466
           percent: 0.06
           rank: 13
         '1992':
-          volume: 347000
+          volume: 347
           percent: 0.04
           rank: 13
         '1993':
-          volume: 340000
+          volume: 340
           percent: 0.03
           rank: 13
         '1994':
-          volume: 333000
+          volume: 333
           percent: 0.03
           rank: 13
         '1995':
-          volume: 335000
+          volume: 335
           percent: 0.03
           rank: 13
         '1996':
-          volume: 298000
+          volume: 298
           percent: 0.03
           rank: 14
         '1997':
-          volume: 231000
+          volume: 231
           percent: 0.02
           rank: 14
         '1998':
-          volume: 209000
+          volume: 209
           percent: 0.02
           rank: 14
         '1999':
-          volume: 195000
+          volume: 195
           percent: 0.02
           rank: 14
         '2000':
-          volume: 189000
+          volume: 189
           percent: 0.02
           rank: 14
         '2001':
-          volume: 185000
+          volume: 185
           percent: 0.02
           rank: 14
         '2002':
-          volume: 180000
+          volume: 180
           percent: 0.02
           rank: 14
         '2003':
-          volume: 174000
+          volume: 174
           percent: 0.02
           rank: 14
         '2004':
-          volume: 170000
+          volume: 170
           percent: 0
           rank: 29
         '2005':
-          volume: 166000
+          volume: 166
           percent: 0
           rank: 30
         '2006':
-          volume: 170000
+          volume: 170
           percent: 0
           rank: 30
         '2007':
-          volume: 1394000
+          volume: 1394
           percent: 0.01
           rank: 28
         '2008':
-          volume: 1193000
+          volume: 1193
           percent: 0
           rank: 28
         '2009':
-          volume: 1443000
+          volume: 1443
           percent: 0.01
           rank: 27
         '2010':
-          volume: 1702000
+          volume: 1702
           percent: 0.01
           rank: 28
         '2011':
-          volume: 2121000
+          volume: 2121
           percent: 0.01
           rank: 27
         '2012':
-          volume: 2125000
+          volume: 2125
           percent: 0.01
           rank: 27
         '2013':
-          volume: 2887000
+          volume: 2887
           percent: 0.01
           rank: 27
         '2014':
-          volume: 2626000
+          volume: 2626
           percent: 0.41
           rank: 11
     Oil (bbl):
@@ -4811,43 +4811,43 @@ IL:
       units: bbl
       volume:
         '2004':
-          volume: 10984
+          volume: 10984000
           percent: 0.47
           rank: 14
         '2005':
-          volume: 10207
+          volume: 10207000
           percent: 0.46
           rank: 14
         '2006':
-          volume: 10325
+          volume: 10325000
           percent: 0.49
           rank: 14
         '2007':
-          volume: 9608
+          volume: 9608000
           percent: 0.46
           rank: 14
         '2008':
-          volume: 9448
+          volume: 9448000
           percent: 0.46
           rank: 14
         '2009':
-          volume: 9097
+          volume: 9097000
           percent: 0.42
           rank: 14
         '2010':
-          volume: 9067
+          volume: 9067000
           percent: 0.41
           rank: 14
         '2011':
-          volume: 9158
+          volume: 9158000
           percent: 0.41
           rank: 14
         '2012':
-          volume: 8908
+          volume: 8908000
           percent: 0.35
           rank: 15
         '2013':
-          volume: 9539
+          volume: 9539000
           percent: 0.33
           rank: 15
     Other biomass:
@@ -5153,195 +5153,195 @@ IN:
       units: mcf
       volume:
         '1967':
-          volume: 198000
+          volume: 198
           percent: 0.06
           rank: 10
         '1968':
-          volume: 234000
+          volume: 234
           percent: 0.07
           rank: 10
         '1969':
-          volume: 171000
+          volume: 171
           percent: 0.05
           rank: 10
         '1970':
-          volume: 153000
+          volume: 153
           percent: 0.05
           rank: 10
         '1971':
-          volume: 537000
+          volume: 537
           percent: 0.21
           rank: 11
         '1972':
-          volume: 355000
+          volume: 355
           percent: 0.14
           rank: 11
         '1973':
-          volume: 276000
+          volume: 276
           percent: 0.1
           rank: 12
         '1974':
-          volume: 176000
+          volume: 176
           percent: 0.05
           rank: 12
         '1975':
-          volume: 346000
+          volume: 346
           percent: 0.1
           rank: 11
         '1976':
-          volume: 192000
+          volume: 192
           percent: 0.05
           rank: 12
         '1977':
-          volume: 183000
+          volume: 183
           percent: 0.04
           rank: 12
         '1978':
-          volume: 163000
+          volume: 163
           percent: 0.03
           rank: 12
         '1979':
-          volume: 350000
+          volume: 350
           percent: 0.06
           rank: 12
         '1980':
-          volume: 463000
+          volume: 463
           percent: 0.07
           rank: 12
         '1981':
-          volume: 330000
+          volume: 330
           percent: 0.05
           rank: 12
         '1982':
-          volume: 233000
+          volume: 233
           percent: 0.04
           rank: 13
         '1983':
-          volume: 135000
+          volume: 135
           percent: 0.02
           rank: 13
         '1984':
-          volume: 394000
+          volume: 394
           percent: 0.06
           rank: 13
         '1985':
-          volume: 367000
+          volume: 367
           percent: 0.06
           rank: 13
         '1986':
-          volume: 365000
+          volume: 365
           percent: 0.06
           rank: 13
         '1987':
-          volume: 217000
+          volume: 217
           percent: 0.03
           rank: 13
         '1988':
-          volume: 412000
+          volume: 412
           percent: 0.06
           rank: 13
         '1989':
-          volume: 416000
+          volume: 416
           percent: 0.06
           rank: 14
         '1990':
-          volume: 399000
+          volume: 399
           percent: 0.06
           rank: 14
         '1991':
-          volume: 232000
+          volume: 232
           percent: 0.03
           rank: 14
         '1992':
-          volume: 174000
+          volume: 174
           percent: 0.02
           rank: 14
         '1993':
-          volume: 192000
+          volume: 192
           percent: 0.02
           rank: 14
         '1994':
-          volume: 107000
+          volume: 107
           percent: 0.01
           rank: 14
         '1995':
-          volume: 249000
+          volume: 249
           percent: 0.02
           rank: 14
         '1996':
-          volume: 360000
+          volume: 360
           percent: 0.03
           rank: 13
         '1997':
-          volume: 526000
+          volume: 526
           percent: 0.05
           rank: 12
         '1998':
-          volume: 615000
+          volume: 615
           percent: 0.06
           rank: 12
         '1999':
-          volume: 855000
+          volume: 855
           percent: 0.08
           rank: 12
         '2000':
-          volume: 899000
+          volume: 899
           percent: 0.09
           rank: 12
         '2001':
-          volume: 1064000
+          volume: 1064
           percent: 0.1
           rank: 12
         '2002':
-          volume: 1309000
+          volume: 1309
           percent: 0.13
           rank: 10
         '2003':
-          volume: 1464000
+          volume: 1464
           percent: 0.14
           rank: 11
         '2004':
-          volume: 3401000
+          volume: 3401
           percent: 0.01
           rank: 24
         '2005':
-          volume: 3135000
+          volume: 3135
           percent: 0.01
           rank: 24
         '2006':
-          volume: 2921000
+          volume: 2921
           percent: 0.01
           rank: 24
         '2007':
-          volume: 3606000
+          volume: 3606
           percent: 0.01
           rank: 25
         '2008':
-          volume: 4701000
+          volume: 4701
           percent: 0.02
           rank: 24
         '2009':
-          volume: 4927000
+          volume: 4927
           percent: 0.02
           rank: 25
         '2010':
-          volume: 6802000
+          volume: 6802
           percent: 0.03
           rank: 25
         '2011':
-          volume: 9075000
+          volume: 9075
           percent: 0.03
           rank: 25
         '2012':
-          volume: 8814000
+          volume: 8814
           percent: 0.03
           rank: 25
         '2013':
-          volume: 7938000
+          volume: 7938
           percent: 0.03
           rank: 25
         '2014':
-          volume: 6616000
+          volume: 6616
           percent: 1.04
           rank: 9
     Oil (bbl):
@@ -5349,43 +5349,43 @@ IN:
       units: bbl
       volume:
         '2004':
-          volume: 1755
+          volume: 1755000
           percent: 0.08
           rank: 23
         '2005':
-          volume: 1727
+          volume: 1727000
           percent: 0.08
           rank: 23
         '2006':
-          volume: 1773
+          volume: 1773000
           percent: 0.08
           rank: 23
         '2007':
-          volume: 1727
+          volume: 1727000
           percent: 0.08
           rank: 24
         '2008':
-          volume: 1859
+          volume: 1859000
           percent: 0.09
           rank: 24
         '2009':
-          volume: 1803
+          volume: 1803000
           percent: 0.08
           rank: 22
         '2010':
-          volume: 1835
+          volume: 1835000
           percent: 0.08
           rank: 23
         '2011':
-          volume: 1987
+          volume: 1987000
           percent: 0.09
           rank: 24
         '2012':
-          volume: 2350
+          volume: 2350000
           percent: 0.09
           rank: 23
         '2013':
-          volume: 2399
+          volume: 2399000
           percent: 0.08
           rank: 23
     Other biomass:
@@ -5627,43 +5627,43 @@ KS:
       units: mcf
       volume:
         '2004':
-          volume: 398197000
+          volume: 398197
           percent: 1.66
           rank: 8
         '2005':
-          volume: 378250000
+          volume: 378250
           percent: 1.61
           rank: 8
         '2006':
-          volume: 372029000
+          volume: 372029
           percent: 1.58
           rank: 8
         '2007':
-          volume: 366859000
+          volume: 366859
           percent: 1.49
           rank: 9
         '2008':
-          volume: 375314000
+          volume: 375314
           percent: 1.46
           rank: 10
         '2009':
-          volume: 355394000
+          volume: 355394
           percent: 1.36
           rank: 10
         '2010':
-          volume: 325591000
+          volume: 325591
           percent: 1.21
           rank: 12
         '2011':
-          volume: 309952000
+          volume: 309952
           percent: 1.09
           rank: 13
         '2012':
-          volume: 296299000
+          volume: 296299
           percent: 1
           rank: 13
         '2013':
-          volume: 292467000
+          volume: 292467
           percent: 0.99
           rank: 13
     Oil (bbl):
@@ -5671,43 +5671,43 @@ KS:
       units: bbl
       volume:
         '2004':
-          volume: 33879
+          volume: 33879000
           percent: 1.46
           rank: 8
         '2005':
-          volume: 33620
+          volume: 33620000
           percent: 1.53
           rank: 9
         '2006':
-          volume: 35668
+          volume: 35668000
           percent: 1.68
           rank: 10
         '2007':
-          volume: 36590
+          volume: 36590000
           percent: 1.73
           rank: 9
         '2008':
-          volume: 39663
+          volume: 39663000
           percent: 1.91
           rank: 9
         '2009':
-          volume: 39466
+          volume: 39466000
           percent: 1.8
           rank: 9
         '2010':
-          volume: 40468
+          volume: 40468000
           percent: 1.83
           rank: 9
         '2011':
-          volume: 41507
+          volume: 41507000
           percent: 1.84
           rank: 9
         '2012':
-          volume: 43743
+          volume: 43743000
           percent: 1.71
           rank: 10
         '2013':
-          volume: 46845
+          volume: 46845000
           percent: 1.61
           rank: 10
     Other biomass:
@@ -5913,195 +5913,195 @@ KY:
       units: mcf
       volume:
         '1967':
-          volume: 89174000
+          volume: 89174
           percent: 26.26
           rank: 2
         '1968':
-          volume: 89039000
+          volume: 89039
           percent: 27.04
           rank: 2
         '1969':
-          volume: 81304000
+          volume: 81304
           percent: 26.1
           rank: 2
         '1970':
-          volume: 77892000
+          volume: 77892
           percent: 26.28
           rank: 2
         '1971':
-          volume: 72723000
+          volume: 72723
           percent: 28.58
           rank: 2
         '1972':
-          volume: 63648000
+          volume: 63648
           percent: 24.97
           rank: 2
         '1973':
-          volume: 62396000
+          volume: 62396
           percent: 21.51
           rank: 2
         '1974':
-          volume: 71876000
+          volume: 71876
           percent: 21.91
           rank: 2
         '1975':
-          volume: 60511000
+          volume: 60511
           percent: 16.75
           rank: 3
         '1976':
-          volume: 66137000
+          volume: 66137
           percent: 16.96
           rank: 3
         '1977':
-          volume: 60902000
+          volume: 60902
           percent: 14.14
           rank: 4
         '1978':
-          volume: 70044000
+          volume: 70044
           percent: 12.95
           rank: 4
         '1979':
-          volume: 59520000
+          volume: 59520
           percent: 10.09
           rank: 4
         '1980':
-          volume: 57180000
+          volume: 57180
           percent: 9.14
           rank: 4
         '1981':
-          volume: 61312000
+          volume: 61312
           percent: 9.4
           rank: 4
         '1982':
-          volume: 51924000
+          volume: 51924
           percent: 8.28
           rank: 4
         '1983':
-          volume: 46720000
+          volume: 46720
           percent: 8.08
           rank: 4
         '1984':
-          volume: 61518000
+          volume: 61518
           percent: 9.88
           rank: 4
         '1985':
-          volume: 73126000
+          volume: 73126
           percent: 11.72
           rank: 4
         '1986':
-          volume: 80195000
+          volume: 80195
           percent: 12.49
           rank: 4
         '1987':
-          volume: 70125000
+          volume: 70125
           percent: 10.41
           rank: 4
         '1988':
-          volume: 73629000
+          volume: 73629
           percent: 10.44
           rank: 4
         '1989':
-          volume: 72417000
+          volume: 72417
           percent: 10.63
           rank: 4
         '1990':
-          volume: 75333000
+          volume: 75333
           percent: 10.74
           rank: 4
         '1991':
-          volume: 78904000
+          volume: 78904
           percent: 10.64
           rank: 4
         '1992':
-          volume: 79690000
+          volume: 79690
           percent: 8.58
           rank: 4
         '1993':
-          volume: 86966000
+          volume: 86966
           percent: 8.95
           rank: 4
         '1994':
-          volume: 73081000
+          volume: 73081
           percent: 6.65
           rank: 4
         '1995':
-          volume: 74754000
+          volume: 74754
           percent: 6.74
           rank: 4
         '1996':
-          volume: 81435000
+          volume: 81435
           percent: 7.18
           rank: 4
         '1997':
-          volume: 79547000
+          volume: 79547
           percent: 7.58
           rank: 4
         '1998':
-          volume: 81869000
+          volume: 81869
           percent: 7.99
           rank: 4
         '1999':
-          volume: 76770000
+          volume: 76770
           percent: 7.55
           rank: 4
         '2000':
-          volume: 81545000
+          volume: 81545
           percent: 8.06
           rank: 4
         '2001':
-          volume: 81723000
+          volume: 81723
           percent: 8.06
           rank: 4
         '2002':
-          volume: 88259000
+          volume: 88259
           percent: 8.52
           rank: 4
         '2003':
-          volume: 87608000
+          volume: 87608
           percent: 8.24
           rank: 5
         '2004':
-          volume: 94259000
+          volume: 94259
           percent: 0.39
           rank: 17
         '2005':
-          volume: 92795000
+          volume: 92795
           percent: 0.4
           rank: 18
         '2006':
-          volume: 95320000
+          volume: 95320
           percent: 0.41
           rank: 19
         '2007':
-          volume: 95437000
+          volume: 95437
           percent: 0.39
           rank: 19
         '2008':
-          volume: 114116000
+          volume: 114116
           percent: 0.45
           rank: 19
         '2009':
-          volume: 113300000
+          volume: 113300
           percent: 0.43
           rank: 18
         '2010':
-          volume: 135330000
+          volume: 135330
           percent: 0.5
           rank: 18
         '2011':
-          volume: 124243000
+          volume: 124243
           percent: 0.44
           rank: 19
         '2012':
-          volume: 106122000
+          volume: 106122
           percent: 0.36
           rank: 19
         '2013':
-          volume: 94665000
+          volume: 94665
           percent: 0.32
           rank: 19
         '2014':
-          volume: 78737000
+          volume: 78737
           percent: 12.42
           rank: 4
     Oil (bbl):
@@ -6109,43 +6109,43 @@ KY:
       units: bbl
       volume:
         '2004':
-          volume: 2548
+          volume: 2548000
           percent: 0.11
           rank: 20
         '2005':
-          volume: 2535
+          volume: 2535000
           percent: 0.12
           rank: 20
         '2006':
-          volume: 2340
+          volume: 2340000
           percent: 0.11
           rank: 21
         '2007':
-          volume: 2666
+          volume: 2666000
           percent: 0.13
           rank: 20
         '2008':
-          volume: 2645
+          volume: 2645000
           percent: 0.13
           rank: 20
         '2009':
-          volume: 2609
+          volume: 2609000
           percent: 0.12
           rank: 20
         '2010':
-          volume: 2519
+          volume: 2519000
           percent: 0.11
           rank: 20
         '2011':
-          volume: 2326
+          volume: 2326000
           percent: 0.1
           rank: 21
         '2012':
-          volume: 3198
+          volume: 3198000
           percent: 0.12
           rank: 20
         '2013':
-          volume: 2893
+          volume: 2893000
           percent: 0.1
           rank: 21
     Other biomass:
@@ -6419,43 +6419,43 @@ LA:
       units: mcf
       volume:
         '2004':
-          volume: 1377295000
+          volume: 1377295
           percent: 5.75
           rank: 6
         '2005':
-          volume: 1309913000
+          volume: 1309913
           percent: 5.58
           rank: 6
         '2006':
-          volume: 1378238000
+          volume: 1378238
           percent: 5.86
           rank: 6
         '2007':
-          volume: 1382828000
+          volume: 1382828
           percent: 5.61
           rank: 6
         '2008':
-          volume: 1387722000
+          volume: 1387722
           percent: 5.41
           rank: 7
         '2009':
-          volume: 1558638000
+          volume: 1558638
           percent: 5.98
           rank: 5
         '2010':
-          volume: 2218283000
+          volume: 2218283
           percent: 8.27
           rank: 4
         '2011':
-          volume: 3040523000
+          volume: 3040523
           percent: 10.68
           rank: 3
         '2012':
-          volume: 2955437000
+          volume: 2955437
           percent: 10
           rank: 3
         '2013':
-          volume: 2366943000
+          volume: 2366943
           percent: 8.02
           rank: 4
     Oil (bbl):
@@ -6463,43 +6463,43 @@ LA:
       units: bbl
       volume:
         '2004':
-          volume: 83272
+          volume: 83272000
           percent: 3.6
           rank: 4
         '2005':
-          volume: 75199
+          volume: 75199000
           percent: 3.42
           rank: 4
         '2006':
-          volume: 73621
+          volume: 73621000
           percent: 3.47
           rank: 4
         '2007':
-          volume: 76979
+          volume: 76979000
           percent: 3.65
           rank: 4
         '2008':
-          volume: 72353
+          volume: 72353000
           percent: 3.49
           rank: 4
         '2009':
-          volume: 68824
+          volume: 68824000
           percent: 3.15
           rank: 5
         '2010':
-          volume: 67280
+          volume: 67280000
           percent: 3.04
           rank: 6
         '2011':
-          volume: 68965
+          volume: 68965000
           percent: 3.05
           rank: 7
         '2012':
-          volume: 70643
+          volume: 70643000
           percent: 2.76
           rank: 7
         '2013':
-          volume: 71815
+          volume: 71815000
           percent: 2.47
           rank: 7
     Other biomass:
@@ -7043,195 +7043,195 @@ MD:
       units: mcf
       volume:
         '1967':
-          volume: 621000
+          volume: 621
           percent: 0.18
           rank: 9
         '1968':
-          volume: 864000
+          volume: 864
           percent: 0.26
           rank: 9
         '1969':
-          volume: 978000
+          volume: 978
           percent: 0.31
           rank: 9
         '1970':
-          volume: 813000
+          volume: 813
           percent: 0.27
           rank: 9
         '1971':
-          volume: 214000
+          volume: 214
           percent: 0.08
           rank: 13
         '1972':
-          volume: 244000
+          volume: 244
           percent: 0.1
           rank: 12
         '1973':
-          volume: 298000
+          volume: 298
           percent: 0.1
           rank: 11
         '1974':
-          volume: 133000
+          volume: 133
           percent: 0.04
           rank: 13
         '1975':
-          volume: 93000
+          volume: 93
           percent: 0.03
           rank: 13
         '1976':
-          volume: 75000
+          volume: 75
           percent: 0.02
           rank: 13
         '1977':
-          volume: 82000
+          volume: 82
           percent: 0.02
           rank: 13
         '1978':
-          volume: 88000
+          volume: 88
           percent: 0.02
           rank: 13
         '1979':
-          volume: 28000
+          volume: 28
           percent: 0
           rank: 14
         '1980':
-          volume: 68000
+          volume: 68
           percent: 0.01
           rank: 14
         '1981':
-          volume: 56000
+          volume: 56
           percent: 0.01
           rank: 14
         '1982':
-          volume: 36000
+          volume: 36
           percent: 0.01
           rank: 14
         '1983':
-          volume: 31000
+          volume: 31
           percent: 0.01
           rank: 14
         '1984':
-          volume: 60000
+          volume: 60
           percent: 0.01
           rank: 15
         '1985':
-          volume: 39000
+          volume: 39
           percent: 0.01
           rank: 15
         '1986':
-          volume: 20000
+          volume: 20
           percent: 0
           rank: 15
         '1987':
-          volume: 44000
+          volume: 44
           percent: 0.01
           rank: 15
         '1988':
-          volume: 29000
+          volume: 29
           percent: 0
           rank: 15
         '1989':
-          volume: 34000
+          volume: 34
           percent: 0
           rank: 15
         '1990':
-          volume: 22000
+          volume: 22
           percent: 0
           rank: 15
         '1991':
-          volume: 29000
+          volume: 29
           percent: 0
           rank: 16
         '1992':
-          volume: 33000
+          volume: 33
           percent: 0
           rank: 15
         '1993':
-          volume: 28000
+          volume: 28
           percent: 0
           rank: 15
         '1994':
-          volume: 26000
+          volume: 26
           percent: 0
           rank: 15
         '1995':
-          volume: 22000
+          volume: 22
           percent: 0
           rank: 15
         '1996':
-          volume: 135000
+          volume: 135
           percent: 0.01
           rank: 15
         '1997':
-          volume: 118000
+          volume: 118
           percent: 0.01
           rank: 15
         '1998':
-          volume: 63000
+          volume: 63
           percent: 0.01
           rank: 15
         '1999':
-          volume: 18000
+          volume: 18
           percent: 0
           rank: 15
         '2000':
-          volume: 34000
+          volume: 34
           percent: 0
           rank: 15
         '2001':
-          volume: 32000
+          volume: 32
           percent: 0
           rank: 15
         '2002':
-          volume: 22000
+          volume: 22
           percent: 0
           rank: 15
         '2003':
-          volume: 48000
+          volume: 48
           percent: 0
           rank: 15
         '2004':
-          volume: 34000
+          volume: 34
           percent: 0
           rank: 30
         '2005':
-          volume: 46000
+          volume: 46
           percent: 0
           rank: 31
         '2006':
-          volume: 48000
+          volume: 48
           percent: 0
           rank: 31
         '2007':
-          volume: 35000
+          volume: 35
           percent: 0
           rank: 31
         '2008':
-          volume: 28000
+          volume: 28
           percent: 0
           rank: 31
         '2009':
-          volume: 43000
+          volume: 43
           percent: 0
           rank: 31
         '2010':
-          volume: 43000
+          volume: 43
           percent: 0
           rank: 31
         '2011':
-          volume: 34000
+          volume: 34
           percent: 0
           rank: 31
         '2012':
-          volume: 44000
+          volume: 44
           percent: 0
           rank: 31
         '2013':
-          volume: 32000
+          volume: 32
           percent: 0
           rank: 31
         '2014':
-          volume: 20000
+          volume: 20
           percent: 0
           rank: 15
     Other biomass:
@@ -7751,195 +7751,195 @@ MI:
       units: mcf
       volume:
         '1967':
-          volume: 43092000
+          volume: 43092
           percent: 12.69
           rank: 3
         '1968':
-          volume: 43930000
+          volume: 43930
           percent: 13.34
           rank: 3
         '1969':
-          volume: 38690000
+          volume: 38690
           percent: 12.42
           rank: 3
         '1970':
-          volume: 40038000
+          volume: 40038
           percent: 13.51
           rank: 3
         '1971':
-          volume: 26450000
+          volume: 26450
           percent: 10.39
           rank: 3
         '1972':
-          volume: 35253000
+          volume: 35253
           percent: 13.83
           rank: 3
         '1973':
-          volume: 45696000
+          volume: 45696
           percent: 15.76
           rank: 3
         '1974':
-          volume: 70464000
+          volume: 70464
           percent: 21.48
           rank: 3
         '1975':
-          volume: 103901000
+          volume: 103901
           percent: 28.75
           rank: 1
         '1976':
-          volume: 121631000
+          volume: 121631
           percent: 31.19
           rank: 1
         '1977':
-          volume: 133226000
+          volume: 133226
           percent: 30.94
           rank: 1
         '1978':
-          volume: 152184000
+          volume: 152184
           percent: 28.14
           rank: 1
         '1979':
-          volume: 164860000
+          volume: 164860
           percent: 27.96
           rank: 2
         '1980':
-          volume: 164110000
+          volume: 164110
           percent: 26.23
           rank: 2
         '1981':
-          volume: 158293000
+          volume: 158293
           percent: 24.27
           rank: 2
         '1982':
-          volume: 158771000
+          volume: 158771
           percent: 25.32
           rank: 2
         '1983':
-          volume: 144574000
+          volume: 144574
           percent: 25.01
           rank: 2
         '1984':
-          volume: 150201000
+          volume: 150201
           percent: 24.12
           rank: 2
         '1985':
-          volume: 137519000
+          volume: 137519
           percent: 22.05
           rank: 3
         '1986':
-          volume: 132951000
+          volume: 132951
           percent: 20.7
           rank: 3
         '1987':
-          volume: 153307000
+          volume: 153307
           percent: 22.75
           rank: 3
         '1988':
-          volume: 151809000
+          volume: 151809
           percent: 21.52
           rank: 3
         '1989':
-          volume: 162826000
+          volume: 162826
           percent: 23.91
           rank: 3
         '1990':
-          volume: 177815000
+          volume: 177815
           percent: 25.34
           rank: 3
         '1991':
-          volume: 201413000
+          volume: 201413
           percent: 27.15
           rank: 2
         '1992':
-          volume: 200479000
+          volume: 200479
           percent: 21.58
           rank: 2
         '1993':
-          volume: 210299000
+          volume: 210299
           percent: 21.64
           rank: 2
         '1994':
-          volume: 228321000
+          volume: 228321
           percent: 20.78
           rank: 2
         '1995':
-          volume: 243867000
+          volume: 243867
           percent: 21.98
           rank: 2
         '1996':
-          volume: 251404000
+          volume: 251404
           percent: 22.18
           rank: 2
         '1997':
-          volume: 311614000
+          volume: 311614
           percent: 29.68
           rank: 2
         '1998':
-          volume: 283740000
+          volume: 283740
           percent: 27.69
           rank: 2
         '1999':
-          volume: 283028000
+          volume: 283028
           percent: 27.82
           rank: 2
         '2000':
-          volume: 302220000
+          volume: 302220
           percent: 29.86
           rank: 2
         '2001':
-          volume: 280700000
+          volume: 280700
           percent: 27.68
           rank: 2
         '2002':
-          volume: 280140000
+          volume: 280140
           percent: 27.04
           rank: 2
         '2003':
-          volume: 242651000
+          volume: 242651
           percent: 22.81
           rank: 2
         '2004':
-          volume: 265345000
+          volume: 265345
           percent: 1.11
           rank: 12
         '2005':
-          volume: 266776000
+          volume: 266776
           percent: 1.14
           rank: 12
         '2006':
-          volume: 268673000
+          volume: 268673
           percent: 1.14
           rank: 13
         '2007':
-          volume: 270571000
+          volume: 270571
           percent: 1.1
           rank: 13
         '2008':
-          volume: 158794000
+          volume: 158794
           percent: 0.62
           rank: 16
         '2009':
-          volume: 159400000
+          volume: 159400
           percent: 0.61
           rank: 16
         '2010':
-          volume: 136782000
+          volume: 136782
           percent: 0.51
           rank: 17
         '2011':
-          volume: 143826000
+          volume: 143826
           percent: 0.51
           rank: 18
         '2012':
-          volume: 129333000
+          volume: 129333
           percent: 0.44
           rank: 18
         '2013':
-          volume: 123622000
+          volume: 123622
           percent: 0.42
           rank: 18
         '2014':
-          volume: 114946000
+          volume: 114946
           percent: 18.13
           rank: 3
     Oil (bbl):
@@ -7947,43 +7947,43 @@ MI:
       units: bbl
       volume:
         '2004':
-          volume: 5951
+          volume: 5951000
           percent: 0.26
           rank: 17
         '2005':
-          volume: 5734
+          volume: 5734000
           percent: 0.26
           rank: 17
         '2006':
-          volume: 5828
+          volume: 5828000
           percent: 0.27
           rank: 17
         '2007':
-          volume: 5646
+          volume: 5646000
           percent: 0.27
           rank: 17
         '2008':
-          volume: 6271
+          volume: 6271000
           percent: 0.3
           rank: 16
         '2009':
-          volume: 6223
+          volume: 6223000
           percent: 0.28
           rank: 16
         '2010':
-          volume: 6943
+          volume: 6943000
           percent: 0.31
           rank: 16
         '2011':
-          volume: 7012
+          volume: 7012000
           percent: 0.31
           rank: 16
         '2012':
-          volume: 7426
+          volume: 7426000
           percent: 0.29
           rank: 16
         '2013':
-          volume: 7706
+          volume: 7706000
           percent: 0.27
           rank: 17
     Other biomass:
@@ -8591,87 +8591,87 @@ MO:
           percent: 0
           rank: 11
         '1971':
-          volume: 22000
+          volume: 22
           percent: 0.01
           rank: 14
         '1972':
-          volume: 9000
+          volume: 9
           percent: 0
           rank: 14
         '1973':
-          volume: 33000
+          volume: 33
           percent: 0.01
           rank: 14
         '1974':
-          volume: 33000
+          volume: 33
           percent: 0.01
           rank: 15
         '1975':
-          volume: 30000
+          volume: 30
           percent: 0.01
           rank: 15
         '1976':
-          volume: 29000
+          volume: 29
           percent: 0.01
           rank: 15
         '1977':
-          volume: 20000
+          volume: 20
           percent: 0
           rank: 15
         '1984':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 16
         '1985':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 16
         '1986':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 16
         '1987':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 16
         '1988':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 16
         '1989':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 16
         '1990':
-          volume: 7000
+          volume: 7
           percent: 0
           rank: 16
         '1991':
-          volume: 15000
+          volume: 15
           percent: 0
           rank: 17
         '1992':
-          volume: 27000
+          volume: 27
           percent: 0
           rank: 17
         '1993':
-          volume: 14000
+          volume: 14
           percent: 0
           rank: 17
         '1994':
-          volume: 8000
+          volume: 8
           percent: 0
           rank: 17
         '1995':
-          volume: 16000
+          volume: 16
           percent: 0
           rank: 16
         '1996':
-          volume: 25000
+          volume: 25
           percent: 0
           rank: 16
         '1997':
-          volume: 5000
+          volume: 5
           percent: 0
           rank: 17
         '1998':
@@ -8715,11 +8715,11 @@ MO:
           percent: 0
           rank: 33
         '2013':
-          volume: 9000
+          volume: 9
           percent: 0
           rank: 32
         '2014':
-          volume: 9000
+          volume: 9
           percent: 0
           rank: 16
     Oil (bbl):
@@ -8727,43 +8727,43 @@ MO:
       units: bbl
       volume:
         '2004':
-          volume: 88
+          volume: 88000
           percent: 0
           rank: 29
         '2005':
-          volume: 86
+          volume: 86000
           percent: 0
           rank: 29
         '2006':
-          volume: 87
+          volume: 87000
           percent: 0
           rank: 29
         '2007':
-          volume: 80
+          volume: 80000
           percent: 0
           rank: 29
         '2008':
-          volume: 99
+          volume: 99000
           percent: 0
           rank: 29
         '2009':
-          volume: 106
+          volume: 106000
           percent: 0
           rank: 29
         '2010':
-          volume: 146
+          volume: 146000
           percent: 0.01
           rank: 29
         '2011':
-          volume: 118
+          volume: 118000
           percent: 0.01
           rank: 29
         '2012':
-          volume: 175
+          volume: 175000
           percent: 0.01
           rank: 29
         '2013':
-          volume: 199
+          volume: 199000
           percent: 0.01
           rank: 28
     Other biomass:
@@ -8993,195 +8993,195 @@ MS:
       units: mcf
       volume:
         '1967':
-          volume: 181309000
+          volume: 181309
           percent: 53.39
           rank: 1
         '1968':
-          volume: 171617000
+          volume: 171617
           percent: 52.11
           rank: 1
         '1969':
-          volume: 168714000
+          volume: 168714
           percent: 54.17
           rank: 1
         '1970':
-          volume: 157020000
+          volume: 157020
           percent: 52.99
           rank: 1
         '1971':
-          volume: 136536000
+          volume: 136536
           percent: 53.65
           rank: 1
         '1972':
-          volume: 119697000
+          volume: 119697
           percent: 46.97
           rank: 1
         '1973':
-          volume: 117761000
+          volume: 117761
           percent: 40.6
           rank: 1
         '1974':
-          volume: 98995000
+          volume: 98995
           percent: 30.18
           rank: 1
         '1975':
-          volume: 92500000
+          volume: 92500
           percent: 25.6
           rank: 2
         '1976':
-          volume: 89914000
+          volume: 89914
           percent: 23.05
           rank: 2
         '1977':
-          volume: 102155000
+          volume: 102155
           percent: 23.72
           rank: 2
         '1978':
-          volume: 148482000
+          volume: 148482
           percent: 27.46
           rank: 2
         '1979':
-          volume: 192376000
+          volume: 192376
           percent: 32.62
           rank: 1
         '1980':
-          volume: 215105000
+          volume: 215105
           percent: 34.39
           rank: 1
         '1981':
-          volume: 232870000
+          volume: 232870
           percent: 35.71
           rank: 1
         '1982':
-          volume: 221696000
+          volume: 221696
           percent: 35.35
           rank: 1
         '1983':
-          volume: 201984000
+          volume: 201984
           percent: 34.94
           rank: 1
         '1984':
-          volume: 209268000
+          volume: 209268
           percent: 33.61
           rank: 1
         '1985':
-          volume: 191898000
+          volume: 191898
           percent: 30.77
           rank: 1
         '1986':
-          volume: 210086000
+          volume: 210086
           percent: 32.72
           rank: 1
         '1987':
-          volume: 224983000
+          volume: 224983
           percent: 33.38
           rank: 1
         '1988':
-          volume: 237180000
+          volume: 237180
           percent: 33.62
           rank: 1
         '1989':
-          volume: 199856000
+          volume: 199856
           percent: 29.35
           rank: 1
         '1990':
-          volume: 200592000
+          volume: 200592
           percent: 28.59
           rank: 1
         '1991':
-          volume: 180772000
+          volume: 180772
           percent: 24.37
           rank: 3
         '1992':
-          volume: 165538000
+          volume: 165538
           percent: 17.82
           rank: 3
         '1993':
-          volume: 145026000
+          volume: 145026
           percent: 14.92
           rank: 3
         '1994':
-          volume: 121802000
+          volume: 121802
           percent: 11.08
           rank: 3
         '1995':
-          volume: 119452000
+          volume: 119452
           percent: 10.76
           rank: 3
         '1996':
-          volume: 123622000
+          volume: 123622
           percent: 10.91
           rank: 3
         '1997':
-          volume: 126623000
+          volume: 126623
           percent: 12.06
           rank: 3
         '1998':
-          volume: 129216000
+          volume: 129216
           percent: 12.61
           rank: 3
         '1999':
-          volume: 126755000
+          volume: 126755
           percent: 12.46
           rank: 3
         '2000':
-          volume: 114380000
+          volume: 114380
           percent: 11.3
           rank: 3
         '2001':
-          volume: 136740000
+          volume: 136740
           percent: 13.48
           rank: 3
         '2002':
-          volume: 147415000
+          volume: 147415
           percent: 14.23
           rank: 3
         '2003':
-          volume: 161676000
+          volume: 161676
           percent: 15.2
           rank: 3
         '2004':
-          volume: 176329000
+          volume: 176329
           percent: 0.74
           rank: 15
         '2005':
-          volume: 189371000
+          volume: 189371
           percent: 0.81
           rank: 15
         '2006':
-          volume: 212081000
+          volume: 212081
           percent: 0.9
           rank: 15
         '2007':
-          volume: 272878000
+          volume: 272878
           percent: 1.11
           rank: 12
         '2008':
-          volume: 346465000
+          volume: 346465
           percent: 1.35
           rank: 11
         '2009':
-          volume: 352888000
+          volume: 352888
           percent: 1.35
           rank: 11
         '2010':
-          volume: 401660000
+          volume: 401660
           percent: 1.5
           rank: 11
         '2011':
-          volume: 443351000
+          volume: 443351
           percent: 1.56
           rank: 11
         '2012':
-          volume: 452915000
+          volume: 452915
           percent: 1.53
           rank: 12
         '2013':
-          volume: 59272000
+          volume: 59272
           percent: 0.2
           rank: 21
         '2014':
-          volume: 54440000
+          volume: 54440
           percent: 8.59
           rank: 5
     Oil (bbl):
@@ -9189,43 +9189,43 @@ MS:
       units: bbl
       volume:
         '2004':
-          volume: 19242
+          volume: 19242000
           percent: 0.83
           rank: 12
         '2005':
-          volume: 17695
+          volume: 17695000
           percent: 0.8
           rank: 12
         '2006':
-          volume: 17356
+          volume: 17356000
           percent: 0.82
           rank: 13
         '2007':
-          volume: 20672
+          volume: 20672000
           percent: 0.98
           rank: 12
         '2008':
-          volume: 22104
+          volume: 22104000
           percent: 1.06
           rank: 12
         '2009':
-          volume: 23232
+          volume: 23232000
           percent: 1.06
           rank: 12
         '2010':
-          volume: 24080
+          volume: 24080000
           percent: 1.09
           rank: 13
         '2011':
-          volume: 24246
+          volume: 24246000
           percent: 1.07
           rank: 12
         '2012':
-          volume: 24593
+          volume: 24593000
           percent: 0.96
           rank: 13
         '2013':
-          volume: 24345
+          volume: 24345000
           percent: 0.84
           rank: 13
     Other biomass:
@@ -9491,43 +9491,43 @@ MT:
       units: mcf
       volume:
         '2004':
-          volume: 97838000
+          volume: 97838
           percent: 0.41
           rank: 16
         '2005':
-          volume: 108555000
+          volume: 108555
           percent: 0.46
           rank: 17
         '2006':
-          volume: 114037000
+          volume: 114037
           percent: 0.48
           rank: 17
         '2007':
-          volume: 120575000
+          volume: 120575
           percent: 0.49
           rank: 17
         '2008':
-          volume: 119399000
+          volume: 119399
           percent: 0.47
           rank: 18
         '2009':
-          volume: 105251000
+          volume: 105251
           percent: 0.4
           rank: 19
         '2010':
-          volume: 93266000
+          volume: 93266
           percent: 0.35
           rank: 20
         '2011':
-          volume: 79506000
+          volume: 79506
           percent: 0.28
           rank: 20
         '2012':
-          volume: 66954000
+          volume: 66954
           percent: 0.23
           rank: 21
         '2013':
-          volume: 63242000
+          volume: 63242
           percent: 0.21
           rank: 20
     Oil (bbl):
@@ -9535,43 +9535,43 @@ MT:
       units: bbl
       volume:
         '2004':
-          volume: 24718
+          volume: 24718000
           percent: 1.07
           rank: 10
         '2005':
-          volume: 32787
+          volume: 32787000
           percent: 1.49
           rank: 10
         '2006':
-          volume: 36294
+          volume: 36294000
           percent: 1.71
           rank: 9
         '2007':
-          volume: 34907
+          volume: 34907000
           percent: 1.65
           rank: 10
         '2008':
-          volume: 31596
+          volume: 31596000
           percent: 1.52
           rank: 10
         '2009':
-          volume: 27835
+          volume: 27835000
           percent: 1.27
           rank: 11
         '2010':
-          volume: 25332
+          volume: 25332000
           percent: 1.14
           rank: 11
         '2011':
-          volume: 24155
+          volume: 24155000
           percent: 1.07
           rank: 13
         '2012':
-          volume: 26495
+          volume: 26495000
           percent: 1.04
           rank: 12
         '2013':
-          volume: 29288
+          volume: 29288000
           percent: 1.01
           rank: 12
     Wind:
@@ -10079,43 +10079,43 @@ ND:
       units: mcf
       volume:
         '2004':
-          volume: 57333000
+          volume: 57333
           percent: 0.24
           rank: 20
         '2005':
-          volume: 55904000
+          volume: 55904
           percent: 0.24
           rank: 21
         '2006':
-          volume: 62786000
+          volume: 62786
           percent: 0.27
           rank: 21
         '2007':
-          volume: 70797000
+          volume: 70797
           percent: 0.29
           rank: 21
         '2008':
-          volume: 87188000
+          volume: 87188
           percent: 0.34
           rank: 20
         '2009':
-          volume: 92489000
+          volume: 92489
           percent: 0.35
           rank: 20
         '2010':
-          volume: 113867000
+          volume: 113867
           percent: 0.42
           rank: 19
         '2011':
-          volume: 157025000
+          volume: 157025
           percent: 0.55
           rank: 16
         '2012':
-          volume: 258568000
+          volume: 258568
           percent: 0.88
           rank: 14
         '2013':
-          volume: 345787000
+          volume: 345787
           percent: 1.17
           rank: 12
     Oil (bbl):
@@ -10123,43 +10123,43 @@ ND:
       units: bbl
       volume:
         '2004':
-          volume: 31152
+          volume: 31152000
           percent: 1.35
           rank: 9
         '2005':
-          volume: 35675
+          volume: 35675000
           percent: 1.62
           rank: 8
         '2006':
-          volume: 39943
+          volume: 39943000
           percent: 1.88
           rank: 8
         '2007':
-          volume: 45122
+          volume: 45122000
           percent: 2.14
           rank: 8
         '2008':
-          volume: 62780
+          volume: 62780000
           percent: 3.02
           rank: 6
         '2009':
-          volume: 79728
+          volume: 79728000
           percent: 3.65
           rank: 4
         '2010':
-          volume: 113064
+          volume: 113064000
           percent: 5.11
           rank: 4
         '2011':
-          volume: 153015
+          volume: 153015000
           percent: 6.77
           rank: 4
         '2012':
-          volume: 243236
+          volume: 243236000
           percent: 9.51
           rank: 2
         '2013':
-          volume: 313823
+          volume: 313823000
           percent: 10.81
           rank: 2
     Other biomass:
@@ -10389,195 +10389,195 @@ NE:
       units: mcf
       volume:
         '1967':
-          volume: 10082000
+          volume: 10082
           percent: 2.97
           rank: 4
         '1968':
-          volume: 9329000
+          volume: 9329
           percent: 2.83
           rank: 4
         '1969':
-          volume: 7416000
+          volume: 7416
           percent: 2.38
           rank: 4
         '1970':
-          volume: 6309000
+          volume: 6309
           percent: 2.13
           rank: 4
         '1971':
-          volume: 5054000
+          volume: 5054
           percent: 1.99
           rank: 4
         '1972':
-          volume: 4741000
+          volume: 4741
           percent: 1.86
           rank: 5
         '1973':
-          volume: 4670000
+          volume: 4670
           percent: 1.61
           rank: 7
         '1974':
-          volume: 4675000
+          volume: 4675
           percent: 1.43
           rank: 8
         '1975':
-          volume: 3963000
+          volume: 3963
           percent: 1.1
           rank: 8
         '1976':
-          volume: 3308000
+          volume: 3308
           percent: 0.85
           rank: 8
         '1977':
-          volume: 2849000
+          volume: 2849
           percent: 0.66
           rank: 8
         '1978':
-          volume: 2882000
+          volume: 2882
           percent: 0.53
           rank: 8
         '1979':
-          volume: 3208000
+          volume: 3208
           percent: 0.54
           rank: 8
         '1980':
-          volume: 2550000
+          volume: 2550
           percent: 0.41
           rank: 8
         '1981':
-          volume: 2713000
+          volume: 2713
           percent: 0.42
           rank: 8
         '1982':
-          volume: 2280000
+          volume: 2280
           percent: 0.36
           rank: 10
         '1983':
-          volume: 2091000
+          volume: 2091
           percent: 0.36
           rank: 10
         '1984':
-          volume: 2300000
+          volume: 2300
           percent: 0.37
           rank: 11
         '1985':
-          volume: 1944000
+          volume: 1944
           percent: 0.31
           rank: 11
         '1986':
-          volume: 1403000
+          volume: 1403
           percent: 0.22
           rank: 12
         '1987':
-          volume: 1261000
+          volume: 1261
           percent: 0.19
           rank: 12
         '1988':
-          volume: 910000
+          volume: 910
           percent: 0.13
           rank: 12
         '1989':
-          volume: 878000
+          volume: 878
           percent: 0.13
           rank: 13
         '1990':
-          volume: 793000
+          volume: 793
           percent: 0.11
           rank: 12
         '1991':
-          volume: 784000
+          volume: 784
           percent: 0.11
           rank: 12
         '1992':
-          volume: 1177000
+          volume: 1177
           percent: 0.13
           rank: 11
         '1993':
-          volume: 2114000
+          volume: 2114
           percent: 0.22
           rank: 10
         '1994':
-          volume: 2898000
+          volume: 2898
           percent: 0.26
           rank: 10
         '1995':
-          volume: 2240000
+          volume: 2240
           percent: 0.2
           rank: 10
         '1996':
-          volume: 1876000
+          volume: 1876
           percent: 0.17
           rank: 9
         '1997':
-          volume: 1670000
+          volume: 1670
           percent: 0.16
           rank: 9
         '1998':
-          volume: 1695000
+          volume: 1695
           percent: 0.17
           rank: 9
         '1999':
-          volume: 1395000
+          volume: 1395
           percent: 0.14
           rank: 10
         '2000':
-          volume: 1218000
+          volume: 1218
           percent: 0.12
           rank: 10
         '2001':
-          volume: 1208000
+          volume: 1208
           percent: 0.12
           rank: 10
         '2002':
-          volume: 1193000
+          volume: 1193
           percent: 0.12
           rank: 11
         '2003':
-          volume: 1466000
+          volume: 1466
           percent: 0.14
           rank: 10
         '2004':
-          volume: 1499000
+          volume: 1499
           percent: 0.01
           rank: 26
         '2005':
-          volume: 1201000
+          volume: 1201
           percent: 0.01
           rank: 27
         '2006':
-          volume: 1217000
+          volume: 1217
           percent: 0.01
           rank: 27
         '2007':
-          volume: 1560000
+          volume: 1560
           percent: 0.01
           rank: 27
         '2008':
-          volume: 3083000
+          volume: 3083
           percent: 0.01
           rank: 26
         '2009':
-          volume: 2916000
+          volume: 2916
           percent: 0.01
           rank: 26
         '2010':
-          volume: 2255000
+          volume: 2255
           percent: 0.01
           rank: 27
         '2011':
-          volume: 1980000
+          volume: 1980
           percent: 0.01
           rank: 28
         '2012':
-          volume: 1328000
+          volume: 1328
           percent: 0
           rank: 28
         '2013':
-          volume: 1032000
+          volume: 1032
           percent: 0
           rank: 28
         '2014':
-          volume: 402000
+          volume: 402
           percent: 0.06
           rank: 13
     Oil (bbl):
@@ -10585,43 +10585,43 @@ NE:
       units: bbl
       volume:
         '2004':
-          volume: 2506
+          volume: 2506000
           percent: 0.11
           rank: 21
         '2005':
-          volume: 2408
+          volume: 2408000
           percent: 0.11
           rank: 22
         '2006':
-          volume: 2313
+          volume: 2313000
           percent: 0.11
           rank: 22
         '2007':
-          volume: 2335
+          volume: 2335000
           percent: 0.11
           rank: 21
         '2008':
-          volume: 2394
+          volume: 2394000
           percent: 0.12
           rank: 21
         '2009':
-          volume: 2239
+          volume: 2239000
           percent: 0.1
           rank: 21
         '2010':
-          volume: 2331
+          volume: 2331000
           percent: 0.11
           rank: 21
         '2011':
-          volume: 2544
+          volume: 2544000
           percent: 0.11
           rank: 20
         '2012':
-          volume: 3025
+          volume: 3025000
           percent: 0.12
           rank: 21
         '2013':
-          volume: 2808
+          volume: 2808000
           percent: 0.1
           rank: 22
     Other biomass:
@@ -11383,43 +11383,43 @@ NM:
       units: mcf
       volume:
         '2004':
-          volume: 1644738000
+          volume: 1644738
           percent: 6.86
           rank: 5
         '2005':
-          volume: 1656850000
+          volume: 1656850
           percent: 7.06
           rank: 4
         '2006':
-          volume: 1619528000
+          volume: 1619528
           percent: 6.88
           rank: 5
         '2007':
-          volume: 1555450000
+          volume: 1555450
           percent: 6.31
           rank: 5
         '2008':
-          volume: 1487123000
+          volume: 1487123
           percent: 5.8
           rank: 5
         '2009':
-          volume: 1425222000
+          volume: 1425222
           percent: 5.47
           rank: 7
         '2010':
-          volume: 1341475000
+          volume: 1341475
           percent: 5
           rank: 7
         '2011':
-          volume: 1287682000
+          volume: 1287682
           percent: 4.52
           rank: 8
         '2012':
-          volume: 1276296000
+          volume: 1276296
           percent: 4.32
           rank: 8
         '2013':
-          volume: 1247394000
+          volume: 1247394
           percent: 4.23
           rank: 8
     Oil (bbl):
@@ -11427,43 +11427,43 @@ NM:
       units: bbl
       volume:
         '2004':
-          volume: 64517
+          volume: 64517000
           percent: 2.79
           rank: 5
         '2005':
-          volume: 60963
+          volume: 60963000
           percent: 2.77
           rank: 6
         '2006':
-          volume: 59452
+          volume: 59452000
           percent: 2.8
           rank: 6
         '2007':
-          volume: 59179
+          volume: 59179000
           percent: 2.8
           rank: 6
         '2008':
-          volume: 60156
+          volume: 60156000
           percent: 2.9
           rank: 7
         '2009':
-          volume: 61156
+          volume: 61156000
           percent: 2.8
           rank: 7
         '2010':
-          volume: 65373
+          volume: 65373000
           percent: 2.95
           rank: 7
         '2011':
-          volume: 71249
+          volume: 71249000
           percent: 3.15
           rank: 6
         '2012':
-          volume: 85334
+          volume: 85334000
           percent: 3.34
           rank: 6
         '2013':
-          volume: 101451
+          volume: 101451000
           percent: 3.49
           rank: 6
     Other biomass:
@@ -11725,99 +11725,99 @@ NV:
       units: mcf
       volume:
         '1991':
-          volume: 53000
+          volume: 53
           percent: 0.01
           rank: 15
         '1992':
-          volume: 30000
+          volume: 30
           percent: 0
           rank: 16
         '1993':
-          volume: 21000
+          volume: 21
           percent: 0
           rank: 16
         '1994':
-          volume: 16000
+          volume: 16
           percent: 0
           rank: 16
         '1995':
-          volume: 13000
+          volume: 13
           percent: 0
           rank: 17
         '1996':
-          volume: 11000
+          volume: 11
           percent: 0
           rank: 17
         '1997':
-          volume: 9000
+          volume: 9
           percent: 0
           rank: 16
         '1998':
-          volume: 9000
+          volume: 9
           percent: 0
           rank: 16
         '1999':
-          volume: 8000
+          volume: 8
           percent: 0
           rank: 16
         '2000':
-          volume: 7000
+          volume: 7
           percent: 0
           rank: 16
         '2001':
-          volume: 7000
+          volume: 7
           percent: 0
           rank: 16
         '2002':
-          volume: 6000
+          volume: 6
           percent: 0
           rank: 16
         '2003':
-          volume: 6000
+          volume: 6
           percent: 0
           rank: 16
         '2004':
-          volume: 5000
+          volume: 5
           percent: 0
           rank: 31
         '2005':
-          volume: 5000
+          volume: 5
           percent: 0
           rank: 32
         '2006':
-          volume: 5000
+          volume: 5
           percent: 0
           rank: 32
         '2007':
-          volume: 5000
+          volume: 5
           percent: 0
           rank: 32
         '2008':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 32
         '2009':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 32
         '2010':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 32
         '2011':
-          volume: 3000
+          volume: 3
           percent: 0
           rank: 32
         '2012':
-          volume: 4000
+          volume: 4
           percent: 0
           rank: 32
         '2013':
-          volume: 3000
+          volume: 3
           percent: 0
           rank: 33
         '2014':
-          volume: 3000
+          volume: 3
           percent: 0
           rank: 17
     Oil (bbl):
@@ -11825,43 +11825,43 @@ NV:
       units: bbl
       volume:
         '2004':
-          volume: 463
+          volume: 463000
           percent: 0.02
           rank: 26
         '2005':
-          volume: 447
+          volume: 447000
           percent: 0.02
           rank: 26
         '2006':
-          volume: 426
+          volume: 426000
           percent: 0.02
           rank: 26
         '2007':
-          volume: 408
+          volume: 408000
           percent: 0.02
           rank: 26
         '2008':
-          volume: 436
+          volume: 436000
           percent: 0.02
           rank: 26
         '2009':
-          volume: 438
+          volume: 438000
           percent: 0.02
           rank: 26
         '2010':
-          volume: 426
+          volume: 426000
           percent: 0.02
           rank: 26
         '2011':
-          volume: 408
+          volume: 408000
           percent: 0.02
           rank: 26
         '2012':
-          volume: 368
+          volume: 368000
           percent: 0.01
           rank: 27
         '2013':
-          volume: 334
+          volume: 334000
           percent: 0.01
           rank: 26
     Other biomass:
@@ -12067,195 +12067,195 @@ NY:
       units: mcf
       volume:
         '1967':
-          volume: 3837000
+          volume: 3837
           percent: 1.13
           rank: 6
         '1968':
-          volume: 4632000
+          volume: 4632
           percent: 1.41
           rank: 5
         '1969':
-          volume: 4861000
+          volume: 4861
           percent: 1.56
           rank: 5
         '1970':
-          volume: 3358000
+          volume: 3358
           percent: 1.13
           rank: 6
         '1971':
-          volume: 2202000
+          volume: 2202
           percent: 0.87
           rank: 7
         '1972':
-          volume: 3679000
+          volume: 3679
           percent: 1.44
           rank: 7
         '1973':
-          volume: 4539000
+          volume: 4539
           percent: 1.57
           rank: 8
         '1974':
-          volume: 4990000
+          volume: 4990
           percent: 1.52
           rank: 7
         '1975':
-          volume: 7628000
+          volume: 7628
           percent: 2.11
           rank: 6
         '1976':
-          volume: 9235000
+          volume: 9235
           percent: 2.37
           rank: 6
         '1977':
-          volume: 10682000
+          volume: 10682
           percent: 2.48
           rank: 6
         '1978':
-          volume: 13900000
+          volume: 13900
           percent: 2.57
           rank: 6
         '1979':
-          volume: 15500000
+          volume: 15500
           percent: 2.63
           rank: 6
         '1980':
-          volume: 15650000
+          volume: 15650
           percent: 2.5
           rank: 6
         '1981':
-          volume: 19000000
+          volume: 19000
           percent: 2.91
           rank: 6
         '1982':
-          volume: 18760000
+          volume: 18760
           percent: 2.99
           rank: 6
         '1983':
-          volume: 21580000
+          volume: 21580
           percent: 3.73
           rank: 6
         '1984':
-          volume: 27600000
+          volume: 27600
           percent: 4.43
           rank: 5
         '1985':
-          volume: 35334000
+          volume: 35334
           percent: 5.66
           rank: 5
         '1986':
-          volume: 33684000
+          volume: 33684
           percent: 5.25
           rank: 5
         '1987':
-          volume: 28478000
+          volume: 28478
           percent: 4.23
           rank: 5
         '1988':
-          volume: 27467000
+          volume: 27467
           percent: 3.89
           rank: 5
         '1989':
-          volume: 25469000
+          volume: 25469
           percent: 3.74
           rank: 5
         '1990':
-          volume: 25398000
+          volume: 25398
           percent: 3.62
           rank: 5
         '1991':
-          volume: 22778000
+          volume: 22778
           percent: 3.07
           rank: 5
         '1992':
-          volume: 23521000
+          volume: 23521
           percent: 2.53
           rank: 6
         '1993':
-          volume: 21197000
+          volume: 21197
           percent: 2.18
           rank: 6
         '1994':
-          volume: 20476000
+          volume: 20476
           percent: 1.86
           rank: 6
         '1995':
-          volume: 18400000
+          volume: 18400
           percent: 1.66
           rank: 6
         '1996':
-          volume: 18134000
+          volume: 18134
           percent: 1.6
           rank: 6
         '1997':
-          volume: 16193000
+          volume: 16193
           percent: 1.54
           rank: 6
         '1998':
-          volume: 16704000
+          volume: 16704
           percent: 1.63
           rank: 6
         '1999':
-          volume: 16127000
+          volume: 16127
           percent: 1.59
           rank: 6
         '2000':
-          volume: 17757000
+          volume: 17757
           percent: 1.75
           rank: 6
         '2001':
-          volume: 27787000
+          volume: 27787
           percent: 2.74
           rank: 6
         '2002':
-          volume: 36816000
+          volume: 36816
           percent: 3.55
           rank: 6
         '2003':
-          volume: 36137000
+          volume: 36137
           percent: 3.4
           rank: 6
         '2004':
-          volume: 46050000
+          volume: 46050
           percent: 0.19
           rank: 21
         '2005':
-          volume: 55180000
+          volume: 55180
           percent: 0.24
           rank: 22
         '2006':
-          volume: 55980000
+          volume: 55980
           percent: 0.24
           rank: 22
         '2007':
-          volume: 54942000
+          volume: 54942
           percent: 0.22
           rank: 22
         '2008':
-          volume: 50320000
+          volume: 50320
           percent: 0.2
           rank: 22
         '2009':
-          volume: 44849000
+          volume: 44849
           percent: 0.17
           rank: 22
         '2010':
-          volume: 35813000
+          volume: 35813
           percent: 0.13
           rank: 22
         '2011':
-          volume: 31124000
+          volume: 31124
           percent: 0.11
           rank: 22
         '2012':
-          volume: 26424000
+          volume: 26424
           percent: 0.09
           rank: 22
         '2013':
-          volume: 23458000
+          volume: 23458
           percent: 0.08
           rank: 22
         '2014':
-          volume: 20201000
+          volume: 20201
           percent: 3.19
           rank: 7
     Oil (bbl):
@@ -12263,43 +12263,43 @@ NY:
       units: bbl
       volume:
         '2004':
-          volume: 170
+          volume: 170000
           percent: 0.01
           rank: 28
         '2005':
-          volume: 202
+          volume: 202000
           percent: 0.01
           rank: 28
         '2006':
-          volume: 312
+          volume: 312000
           percent: 0.01
           rank: 27
         '2007':
-          volume: 379
+          volume: 379000
           percent: 0.02
           rank: 27
         '2008':
-          volume: 387
+          volume: 387000
           percent: 0.02
           rank: 27
         '2009':
-          volume: 333
+          volume: 333000
           percent: 0.02
           rank: 27
         '2010':
-          volume: 381
+          volume: 381000
           percent: 0.02
           rank: 27
         '2011':
-          volume: 375
+          volume: 375000
           percent: 0.02
           rank: 27
         '2012':
-          volume: 362
+          volume: 362000
           percent: 0.01
           rank: 28
         '2013':
-          volume: 313
+          volume: 313000
           percent: 0.01
           rank: 27
     Other biomass:
@@ -12633,43 +12633,43 @@ OH:
       units: mcf
       volume:
         '2004':
-          volume: 90476000
+          volume: 90476
           percent: 0.38
           rank: 18
         '2005':
-          volume: 83523000
+          volume: 83523
           percent: 0.36
           rank: 20
         '2006':
-          volume: 86315000
+          volume: 86315
           percent: 0.37
           rank: 20
         '2007':
-          volume: 88095000
+          volume: 88095
           percent: 0.36
           rank: 20
         '2008':
-          volume: 84858000
+          volume: 84858
           percent: 0.33
           rank: 21
         '2009':
-          volume: 88824000
+          volume: 88824
           percent: 0.34
           rank: 21
         '2010':
-          volume: 78122000
+          volume: 78122
           percent: 0.29
           rank: 21
         '2011':
-          volume: 78858000
+          volume: 78858
           percent: 0.28
           rank: 21
         '2012':
-          volume: 84482000
+          volume: 84482
           percent: 0.29
           rank: 20
         '2013':
-          volume: 166017000
+          volume: 166017
           percent: 0.56
           rank: 16
     Oil (bbl):
@@ -12677,43 +12677,43 @@ OH:
       units: bbl
       volume:
         '2004':
-          volume: 5783
+          volume: 5783000
           percent: 0.25
           rank: 18
         '2005':
-          volume: 5658
+          volume: 5658000
           percent: 0.26
           rank: 18
         '2006':
-          volume: 5439
+          volume: 5439000
           percent: 0.26
           rank: 18
         '2007':
-          volume: 5155
+          volume: 5155000
           percent: 0.24
           rank: 18
         '2008':
-          volume: 5113
+          volume: 5113000
           percent: 0.25
           rank: 18
         '2009':
-          volume: 4877
+          volume: 4877000
           percent: 0.22
           rank: 18
         '2010':
-          volume: 4769
+          volume: 4769000
           percent: 0.22
           rank: 18
         '2011':
-          volume: 4654
+          volume: 4654000
           percent: 0.21
           rank: 18
         '2012':
-          volume: 5109
+          volume: 5109000
           percent: 0.2
           rank: 18
         '2013':
-          volume: 7962
+          volume: 7962000
           percent: 0.27
           rank: 16
     Other biomass:
@@ -13047,43 +13047,43 @@ OK:
       units: mcf
       volume:
         '2004':
-          volume: 1655769000
+          volume: 1655769
           percent: 6.91
           rank: 4
         '2005':
-          volume: 1639310000
+          volume: 1639310
           percent: 6.99
           rank: 5
         '2006':
-          volume: 1688985000
+          volume: 1688985
           percent: 7.18
           rank: 4
         '2007':
-          volume: 1783682000
+          volume: 1783682
           percent: 7.23
           rank: 4
         '2008':
-          volume: 1886710000
+          volume: 1886710
           percent: 7.36
           rank: 4
         '2009':
-          volume: 1901556000
+          volume: 1901556
           percent: 7.3
           rank: 4
         '2010':
-          volume: 1827328000
+          volume: 1827328
           percent: 6.81
           rank: 5
         '2011':
-          volume: 1888870000
+          volume: 1888870
           percent: 6.63
           rank: 5
         '2012':
-          volume: 2023461000
+          volume: 2023461
           percent: 6.85
           rank: 6
         '2013':
-          volume: 1993754000
+          volume: 1993754
           percent: 6.75
           rank: 6
     Oil (bbl):
@@ -13091,43 +13091,43 @@ OK:
       units: bbl
       volume:
         '2004':
-          volume: 63977
+          volume: 63977000
           percent: 2.76
           rank: 6
         '2005':
-          volume: 61262
+          volume: 61262000
           percent: 2.78
           rank: 5
         '2006':
-          volume: 64236
+          volume: 64236000
           percent: 3.03
           rank: 5
         '2007':
-          volume: 63951
+          volume: 63951000
           percent: 3.03
           rank: 5
         '2008':
-          volume: 67357
+          volume: 67357000
           percent: 3.25
           rank: 5
         '2009':
-          volume: 66637
+          volume: 66637000
           percent: 3.05
           rank: 6
         '2010':
-          volume: 67418
+          volume: 67418000
           percent: 3.05
           rank: 5
         '2011':
-          volume: 73423
+          volume: 73423000
           percent: 3.25
           rank: 5
         '2012':
-          volume: 87538
+          volume: 87538000
           percent: 3.42
           rank: 5
         '2013':
-          volume: 114486
+          volume: 114486000
           percent: 3.94
           rank: 5
     Other biomass:
@@ -13401,147 +13401,147 @@ OR:
       units: mcf
       volume:
         '1979':
-          volume: 2000
+          volume: 2
           percent: 0
           rank: 15
         '1980':
-          volume: 5000
+          volume: 5
           percent: 0
           rank: 15
         '1981':
-          volume: 5000
+          volume: 5
           percent: 0
           rank: 15
         '1982':
-          volume: 3000
+          volume: 3
           percent: 0
           rank: 15
         '1983':
-          volume: 3000
+          volume: 3
           percent: 0
           rank: 15
         '1984':
-          volume: 2790000
+          volume: 2790
           percent: 0.45
           rank: 9
         '1985':
-          volume: 4080000
+          volume: 4080
           percent: 0.65
           rank: 9
         '1986':
-          volume: 4600000
+          volume: 4600
           percent: 0.72
           rank: 8
         '1987':
-          volume: 3800000
+          volume: 3800
           percent: 0.56
           rank: 8
         '1988':
-          volume: 4000000
+          volume: 4000
           percent: 0.57
           rank: 9
         '1989':
-          volume: 2500000
+          volume: 2500
           percent: 0.37
           rank: 9
         '1990':
-          volume: 2815000
+          volume: 2815
           percent: 0.4
           rank: 9
         '1991':
-          volume: 2741000
+          volume: 2741
           percent: 0.37
           rank: 9
         '1992':
-          volume: 2580000
+          volume: 2580
           percent: 0.28
           rank: 9
         '1993':
-          volume: 4003000
+          volume: 4003
           percent: 0.41
           rank: 9
         '1994':
-          volume: 4200000
+          volume: 4200
           percent: 0.38
           rank: 9
         '1995':
-          volume: 2520000
+          volume: 2520
           percent: 0.23
           rank: 9
         '1996':
-          volume: 1743000
+          volume: 1743
           percent: 0.15
           rank: 10
         '1997':
-          volume: 1382000
+          volume: 1382
           percent: 0.13
           rank: 11
         '1998':
-          volume: 1263000
+          volume: 1263
           percent: 0.12
           rank: 11
         '1999':
-          volume: 1555000
+          volume: 1555
           percent: 0.15
           rank: 9
         '2000':
-          volume: 1412000
+          volume: 1412
           percent: 0.14
           rank: 9
         '2001':
-          volume: 1112000
+          volume: 1112
           percent: 0.11
           rank: 11
         '2002':
-          volume: 837000
+          volume: 837
           percent: 0.08
           rank: 12
         '2003':
-          volume: 731000
+          volume: 731
           percent: 0.07
           rank: 12
         '2004':
-          volume: 467000
+          volume: 467
           percent: 0
           rank: 27
         '2005':
-          volume: 454000
+          volume: 454
           percent: 0
           rank: 28
         '2006':
-          volume: 621000
+          volume: 621
           percent: 0
           rank: 28
         '2007':
-          volume: 409000
+          volume: 409
           percent: 0
           rank: 30
         '2008':
-          volume: 778000
+          volume: 778
           percent: 0
           rank: 29
         '2009':
-          volume: 821000
+          volume: 821
           percent: 0
           rank: 28
         '2010':
-          volume: 1407000
+          volume: 1407
           percent: 0.01
           rank: 29
         '2011':
-          volume: 1344000
+          volume: 1344
           percent: 0
           rank: 29
         '2012':
-          volume: 770000
+          volume: 770
           percent: 0
           rank: 29
         '2013':
-          volume: 770000
+          volume: 770
           percent: 0
           rank: 29
         '2014':
-          volume: 950000
+          volume: 950
           percent: 0.15
           rank: 12
     Other biomass:
@@ -13827,43 +13827,43 @@ PA:
       units: mcf
       volume:
         '2004':
-          volume: 197217000
+          volume: 197217
           percent: 0.82
           rank: 13
         '2005':
-          volume: 168501000
+          volume: 168501
           percent: 0.72
           rank: 16
         '2006':
-          volume: 175950000
+          volume: 175950
           percent: 0.75
           rank: 16
         '2007':
-          volume: 182277000
+          volume: 182277
           percent: 0.74
           rank: 16
         '2008':
-          volume: 198295000
+          volume: 198295
           percent: 0.77
           rank: 15
         '2009':
-          volume: 273869000
+          volume: 273869
           percent: 1.05
           rank: 12
         '2010':
-          volume: 572902000
+          volume: 572902
           percent: 2.14
           rank: 9
         '2011':
-          volume: 1310592000
+          volume: 1310592
           percent: 4.6
           rank: 7
         '2012':
-          volume: 2256696000
+          volume: 2256696
           percent: 7.64
           rank: 4
         '2013':
-          volume: 3259042000
+          volume: 3259042
           percent: 11.04
           rank: 2
     Oil (bbl):
@@ -13871,43 +13871,43 @@ PA:
       units: bbl
       volume:
         '2004':
-          volume: 2396
+          volume: 2396000
           percent: 0.1
           rank: 22
         '2005':
-          volume: 2460
+          volume: 2460000
           percent: 0.11
           rank: 21
         '2006':
-          volume: 2589
+          volume: 2589000
           percent: 0.12
           rank: 19
         '2007':
-          volume: 2788
+          volume: 2788000
           percent: 0.13
           rank: 19
         '2008':
-          volume: 2999
+          volume: 2999000
           percent: 0.14
           rank: 19
         '2009':
-          volume: 2967
+          volume: 2967000
           percent: 0.14
           rank: 19
         '2010':
-          volume: 3236
+          volume: 3236000
           percent: 0.15
           rank: 19
         '2011':
-          volume: 3463
+          volume: 3463000
           percent: 0.15
           rank: 19
         '2012':
-          volume: 4304
+          volume: 4304000
           percent: 0.17
           rank: 19
         '2013':
-          volume: 5246
+          volume: 5246000
           percent: 0.18
           rank: 20
     Other biomass:
@@ -14605,175 +14605,175 @@ SD:
           percent: 0
           rank: 11
         '1971':
-          volume: 9000
+          volume: 9
           percent: 0
           rank: 15
         '1972':
-          volume: 8000
+          volume: 8
           percent: 0
           rank: 15
         '1973':
-          volume: 10000
+          volume: 10
           percent: 0
           rank: 15
         '1974':
-          volume: 48000
+          volume: 48
           percent: 0.01
           rank: 14
         '1975':
-          volume: 39000
+          volume: 39
           percent: 0.01
           rank: 14
         '1976':
-          volume: 52000
+          volume: 52
           percent: 0.01
           rank: 14
         '1977':
-          volume: 69000
+          volume: 69
           percent: 0.02
           rank: 14
         '1979':
-          volume: 919000
+          volume: 919
           percent: 0.16
           rank: 11
         '1980':
-          volume: 1198000
+          volume: 1198
           percent: 0.19
           rank: 11
         '1981':
-          volume: 1207000
+          volume: 1207
           percent: 0.19
           rank: 11
         '1982':
-          volume: 2385000
+          volume: 2385
           percent: 0.38
           rank: 9
         '1983':
-          volume: 2130000
+          volume: 2130
           percent: 0.37
           rank: 9
         '1984':
-          volume: 2483000
+          volume: 2483
           percent: 0.4
           rank: 10
         '1985':
-          volume: 3146000
+          volume: 3146
           percent: 0.5
           rank: 10
         '1986':
-          volume: 2463000
+          volume: 2463
           percent: 0.38
           rank: 10
         '1987':
-          volume: 3662000
+          volume: 3662
           percent: 0.54
           rank: 9
         '1988':
-          volume: 4283000
+          volume: 4283
           percent: 0.61
           rank: 8
         '1989':
-          volume: 4704000
+          volume: 4704
           percent: 0.69
           rank: 8
         '1990':
-          volume: 4782000
+          volume: 4782
           percent: 0.68
           rank: 8
         '1991':
-          volume: 5804000
+          volume: 5804
           percent: 0.78
           rank: 8
         '1992':
-          volume: 6963000
+          volume: 6963
           percent: 0.75
           rank: 8
         '1993':
-          volume: 7057000
+          volume: 7057
           percent: 0.73
           rank: 8
         '1994':
-          volume: 7264000
+          volume: 7264
           percent: 0.66
           rank: 8
         '1995':
-          volume: 8374000
+          volume: 8374
           percent: 0.75
           rank: 7
         '1996':
-          volume: 8965000
+          volume: 8965
           percent: 0.79
           rank: 7
         '1997':
-          volume: 9795000
+          volume: 9795
           percent: 0.93
           rank: 7
         '1998':
-          volume: 9252000
+          volume: 9252
           percent: 0.9
           rank: 7
         '1999':
-          volume: 9340000
+          volume: 9340
           percent: 0.92
           rank: 7
         '2000':
-          volume: 10680000
+          volume: 10680
           percent: 1.06
           rank: 7
         '2001':
-          volume: 11313000
+          volume: 11313
           percent: 1.12
           rank: 7
         '2002':
-          volume: 10424000
+          volume: 10424
           percent: 1.01
           rank: 7
         '2003':
-          volume: 11605000
+          volume: 11605
           percent: 1.09
           rank: 7
         '2004':
-          volume: 11768000
+          volume: 11768
           percent: 0.05
           rank: 22
         '2005':
-          volume: 11349000
+          volume: 11349
           percent: 0.05
           rank: 23
         '2006':
-          volume: 10616000
+          volume: 10616
           percent: 0.05
           rank: 23
         '2007':
-          volume: 11880000
+          volume: 11880
           percent: 0.05
           rank: 23
         '2008':
-          volume: 12007000
+          volume: 12007
           percent: 0.05
           rank: 23
         '2009':
-          volume: 12927000
+          volume: 12927
           percent: 0.05
           rank: 23
         '2010':
-          volume: 12540000
+          volume: 12540
           percent: 0.05
           rank: 24
         '2011':
-          volume: 12449000
+          volume: 12449
           percent: 0.04
           rank: 24
         '2012':
-          volume: 15085000
+          volume: 15085
           percent: 0.05
           rank: 24
         '2013':
-          volume: 16205000
+          volume: 16205
           percent: 0.05
           rank: 24
         '2014':
-          volume: 15307000
+          volume: 15307
           percent: 2.41
           rank: 8
     Oil (bbl):
@@ -14781,43 +14781,43 @@ SD:
       units: bbl
       volume:
         '2004':
-          volume: 1357
+          volume: 1357000
           percent: 0.06
           rank: 25
         '2005':
-          volume: 1394
+          volume: 1394000
           percent: 0.06
           rank: 25
         '2006':
-          volume: 1389
+          volume: 1389000
           percent: 0.07
           rank: 25
         '2007':
-          volume: 1632
+          volume: 1632000
           percent: 0.08
           rank: 25
         '2008':
-          volume: 1713
+          volume: 1713000
           percent: 0.08
           rank: 25
         '2009':
-          volume: 1676
+          volume: 1676000
           percent: 0.08
           rank: 23
         '2010':
-          volume: 1604
+          volume: 1604000
           percent: 0.07
           rank: 25
         '2011':
-          volume: 1625
+          volume: 1625000
           percent: 0.07
           rank: 25
         '2012':
-          volume: 1756
+          volume: 1756000
           percent: 0.07
           rank: 25
         '2013':
-          volume: 1829
+          volume: 1829000
           percent: 0.06
           rank: 25
     Other biomass:
@@ -15075,179 +15075,179 @@ TN:
           percent: 0
           rank: 11
         '1971':
-          volume: 497000
+          volume: 497
           percent: 0.2
           rank: 12
         '1972':
-          volume: 205000
+          volume: 205
           percent: 0.08
           rank: 13
         '1973':
-          volume: 185000
+          volume: 185
           percent: 0.06
           rank: 13
         '1974':
-          volume: 393000
+          volume: 393
           percent: 0.12
           rank: 10
         '1975':
-          volume: 612000
+          volume: 612
           percent: 0.17
           rank: 10
         '1976':
-          volume: 532000
+          volume: 532
           percent: 0.14
           rank: 10
         '1977':
-          volume: 855000
+          volume: 855
           percent: 0.2
           rank: 10
         '1978':
-          volume: 1482000
+          volume: 1482
           percent: 0.27
           rank: 9
         '1979':
-          volume: 1605000
+          volume: 1605
           percent: 0.27
           rank: 9
         '1980':
-          volume: 1241000
+          volume: 1241
           percent: 0.2
           rank: 10
         '1981':
-          volume: 1719000
+          volume: 1719
           percent: 0.26
           rank: 9
         '1982':
-          volume: 2976000
+          volume: 2976
           percent: 0.47
           rank: 8
         '1983':
-          volume: 3950000
+          volume: 3950
           percent: 0.68
           rank: 8
         '1984':
-          volume: 5022000
+          volume: 5022
           percent: 0.81
           rank: 8
         '1985':
-          volume: 4686000
+          volume: 4686
           percent: 0.75
           rank: 8
         '1986':
-          volume: 3464000
+          volume: 3464
           percent: 0.54
           rank: 9
         '1987':
-          volume: 2707000
+          volume: 2707
           percent: 0.4
           rank: 10
         '1988':
-          volume: 2100000
+          volume: 2100
           percent: 0.3
           rank: 10
         '1989':
-          volume: 1900000
+          volume: 1900
           percent: 0.28
           rank: 10
         '1990':
-          volume: 2067000
+          volume: 2067
           percent: 0.29
           rank: 11
         '1991':
-          volume: 1856000
+          volume: 1856
           percent: 0.25
           rank: 10
         '1992':
-          volume: 1770000
+          volume: 1770
           percent: 0.19
           rank: 10
         '1993':
-          volume: 1660000
+          volume: 1660
           percent: 0.17
           rank: 11
         '1994':
-          volume: 1990000
+          volume: 1990
           percent: 0.18
           rank: 11
         '1995':
-          volume: 1820000
+          volume: 1820
           percent: 0.16
           rank: 11
         '1996':
-          volume: 1690000
+          volume: 1690
           percent: 0.15
           rank: 11
         '1997':
-          volume: 1510000
+          volume: 1510
           percent: 0.14
           rank: 10
         '1998':
-          volume: 1420000
+          volume: 1420
           percent: 0.14
           rank: 10
         '1999':
-          volume: 1230000
+          volume: 1230
           percent: 0.12
           rank: 11
         '2000':
-          volume: 1150000
+          volume: 1150
           percent: 0.11
           rank: 11
         '2001':
-          volume: 2000000
+          volume: 2000
           percent: 0.2
           rank: 9
         '2002':
-          volume: 2050000
+          volume: 2050
           percent: 0.2
           rank: 9
         '2003':
-          volume: 1803000
+          volume: 1803
           percent: 0.17
           rank: 9
         '2004':
-          volume: 2100000
+          volume: 2100
           percent: 0.01
           rank: 25
         '2005':
-          volume: 2200000
+          volume: 2200
           percent: 0.01
           rank: 26
         '2006':
-          volume: 2663000
+          volume: 2663
           percent: 0.01
           rank: 26
         '2007':
-          volume: 3942000
+          volume: 3942
           percent: 0.02
           rank: 24
         '2008':
-          volume: 4700000
+          volume: 4700
           percent: 0.02
           rank: 25
         '2009':
-          volume: 5478000
+          volume: 5478
           percent: 0.02
           rank: 24
         '2010':
-          volume: 5144000
+          volume: 5144
           percent: 0.02
           rank: 26
         '2011':
-          volume: 4851000
+          volume: 4851
           percent: 0.02
           rank: 26
         '2012':
-          volume: 5825000
+          volume: 5825
           percent: 0.02
           rank: 26
         '2013':
-          volume: 5400000
+          volume: 5400
           percent: 0.02
           rank: 26
         '2014':
-          volume: 5294000
+          volume: 5294
           percent: 0.84
           rank: 10
     Oil (bbl):
@@ -15255,43 +15255,43 @@ TN:
       units: bbl
       volume:
         '2004':
-          volume: 361
+          volume: 361000
           percent: 0.02
           rank: 27
         '2005':
-          volume: 324
+          volume: 324000
           percent: 0.01
           rank: 27
         '2006':
-          volume: 192
+          volume: 192000
           percent: 0.01
           rank: 28
         '2007':
-          volume: 284
+          volume: 284000
           percent: 0.01
           rank: 28
         '2008':
-          volume: 338
+          volume: 338000
           percent: 0.02
           rank: 28
         '2009':
-          volume: 268
+          volume: 268000
           percent: 0.01
           rank: 28
         '2010':
-          volume: 257
+          volume: 257000
           percent: 0.01
           rank: 28
         '2011':
-          volume: 296
+          volume: 296000
           percent: 0.01
           rank: 28
         '2012':
-          volume: 371
+          volume: 371000
           percent: 0.01
           rank: 26
         '2013':
-          volume: 334
+          volume: 334000
           percent: 0.01
           rank: 26
     Other biomass:
@@ -15621,43 +15621,43 @@ TX:
       units: mcf
       volume:
         '2004':
-          volume: 5733918000
+          volume: 5733918
           percent: 23.92
           rank: 1
         '2005':
-          volume: 6006837000
+          volume: 6006837
           percent: 25.61
           rank: 1
         '2006':
-          volume: 6326433000
+          volume: 6326433
           percent: 26.88
           rank: 1
         '2007':
-          volume: 6960858000
+          volume: 6960858
           percent: 28.22
           rank: 1
         '2008':
-          volume: 7800655000
+          volume: 7800655
           percent: 30.43
           rank: 1
         '2009':
-          volume: 7653647000
+          volume: 7653647
           percent: 29.37
           rank: 1
         '2010':
-          volume: 7593697000
+          volume: 7593697
           percent: 28.32
           rank: 1
         '2011':
-          volume: 7934689000
+          volume: 7934689
           percent: 27.86
           rank: 1
         '2012':
-          volume: 8143510000
+          volume: 8143510
           percent: 27.57
           rank: 1
         '2013':
-          volume: 8299472000
+          volume: 8299472
           percent: 28.11
           rank: 1
     Oil (bbl):
@@ -15665,43 +15665,43 @@ TX:
       units: bbl
       volume:
         '2004':
-          volume: 392714
+          volume: 392714000
           percent: 16.96
           rank: 1
         '2005':
-          volume: 392601
+          volume: 392601000
           percent: 17.84
           rank: 1
         '2006':
-          volume: 392481
+          volume: 392481000
           percent: 18.51
           rank: 1
         '2007':
-          volume: 391270
+          volume: 391270000
           percent: 18.53
           rank: 1
         '2008':
-          volume: 406007
+          volume: 406007000
           percent: 19.56
           rank: 1
         '2009':
-          volume: 399344
+          volume: 399344000
           percent: 18.26
           rank: 1
         '2010':
-          volume: 426666
+          volume: 426666000
           percent: 19.27
           rank: 1
         '2011':
-          volume: 528844
+          volume: 528844000
           percent: 23.41
           rank: 1
         '2012':
-          volume: 722130
+          volume: 722130000
           percent: 28.23
           rank: 1
         '2013':
-          volume: 923561
+          volume: 923561000
           percent: 31.81
           rank: 1
     Other biomass:
@@ -16083,43 +16083,43 @@ UT:
       units: mcf
       volume:
         '2004':
-          volume: 290586000
+          volume: 290586
           percent: 1.21
           rank: 11
         '2005':
-          volume: 311994000
+          volume: 311994
           percent: 1.33
           rank: 10
         '2006':
-          volume: 356321000
+          volume: 356321
           percent: 1.51
           rank: 9
         '2007':
-          volume: 385361000
+          volume: 385361
           percent: 1.56
           rank: 8
         '2008':
-          volume: 441598000
+          volume: 441598
           percent: 1.72
           rank: 9
         '2009':
-          volume: 449511000
+          volume: 449511
           percent: 1.73
           rank: 9
         '2010':
-          volume: 436885000
+          volume: 436885
           percent: 1.63
           rank: 10
         '2011':
-          volume: 461507000
+          volume: 461507
           percent: 1.62
           rank: 10
         '2012':
-          volume: 490393000
+          volume: 490393
           percent: 1.66
           rank: 11
         '2013':
-          volume: 470863000
+          volume: 470863
           percent: 1.59
           rank: 11
     Oil (bbl):
@@ -16127,43 +16127,43 @@ UT:
       units: bbl
       volume:
         '2004':
-          volume: 14744
+          volume: 14744000
           percent: 0.64
           rank: 13
         '2005':
-          volume: 16673
+          volume: 16673000
           percent: 0.76
           rank: 13
         '2006':
-          volume: 17927
+          volume: 17927000
           percent: 0.85
           rank: 12
         '2007':
-          volume: 19535
+          volume: 19535000
           percent: 0.93
           rank: 13
         '2008':
-          volume: 22041
+          volume: 22041000
           percent: 1.06
           rank: 13
         '2009':
-          volume: 22943
+          volume: 22943000
           percent: 1.05
           rank: 13
         '2010':
-          volume: 24674
+          volume: 24674000
           percent: 1.11
           rank: 12
         '2011':
-          volume: 26331
+          volume: 26331000
           percent: 1.17
           rank: 11
         '2012':
-          volume: 30268
+          volume: 30268000
           percent: 1.18
           rank: 11
         '2013':
-          volume: 34912
+          volume: 34912000
           percent: 1.2
           rank: 11
     Other biomass:
@@ -16433,195 +16433,195 @@ VA:
       units: mcf
       volume:
         '1967':
-          volume: 3818000
+          volume: 3818
           percent: 1.12
           rank: 7
         '1968':
-          volume: 3389000
+          volume: 3389
           percent: 1.03
           rank: 7
         '1969':
-          volume: 2846000
+          volume: 2846
           percent: 0.91
           rank: 7
         '1970':
-          volume: 2805000
+          volume: 2805
           percent: 0.95
           rank: 8
         '1971':
-          volume: 2619000
+          volume: 2619
           percent: 1.03
           rank: 6
         '1972':
-          volume: 2787000
+          volume: 2787
           percent: 1.09
           rank: 9
         '1973':
-          volume: 5101000
+          volume: 5101
           percent: 1.76
           rank: 6
         '1974':
-          volume: 7096000
+          volume: 7096
           percent: 2.16
           rank: 6
         '1975':
-          volume: 6723000
+          volume: 6723
           percent: 1.86
           rank: 7
         '1976':
-          volume: 6937000
+          volume: 6937
           percent: 1.78
           rank: 7
         '1977':
-          volume: 8220000
+          volume: 8220
           percent: 1.91
           rank: 7
         '1978':
-          volume: 8492000
+          volume: 8492
           percent: 1.57
           rank: 7
         '1979':
-          volume: 8544000
+          volume: 8544
           percent: 1.45
           rank: 7
         '1980':
-          volume: 7812000
+          volume: 7812
           percent: 1.25
           rank: 7
         '1981':
-          volume: 8903000
+          volume: 8903
           percent: 1.37
           rank: 7
         '1982':
-          volume: 6880000
+          volume: 6880
           percent: 1.1
           rank: 7
         '1983':
-          volume: 4346000
+          volume: 4346
           percent: 0.75
           rank: 7
         '1984':
-          volume: 8928000
+          volume: 8928
           percent: 1.43
           rank: 7
         '1985':
-          volume: 15041000
+          volume: 15041
           percent: 2.41
           rank: 6
         '1986':
-          volume: 15427000
+          volume: 15427
           percent: 2.4
           rank: 6
         '1987':
-          volume: 19520000
+          volume: 19520
           percent: 2.9
           rank: 6
         '1988':
-          volume: 18682000
+          volume: 18682
           percent: 2.65
           rank: 6
         '1989':
-          volume: 17935000
+          volume: 17935
           percent: 2.63
           rank: 6
         '1990':
-          volume: 14774000
+          volume: 14774
           percent: 2.11
           rank: 6
         '1991':
-          volume: 14906000
+          volume: 14906
           percent: 2.01
           rank: 6
         '1992':
-          volume: 24733000
+          volume: 24733
           percent: 2.66
           rank: 5
         '1993':
-          volume: 37840000
+          volume: 37840
           percent: 3.89
           rank: 5
         '1994':
-          volume: 50259000
+          volume: 50259
           percent: 4.57
           rank: 5
         '1995':
-          volume: 49818000
+          volume: 49818
           percent: 4.49
           rank: 5
         '1996':
-          volume: 54290000
+          volume: 54290
           percent: 4.79
           rank: 5
         '1997':
-          volume: 58249000
+          volume: 58249
           percent: 5.55
           rank: 5
         '1998':
-          volume: 57263000
+          volume: 57263
           percent: 5.59
           rank: 5
         '1999':
-          volume: 72189000
+          volume: 72189
           percent: 7.1
           rank: 5
         '2000':
-          volume: 71545000
+          volume: 71545
           percent: 7.07
           rank: 5
         '2001':
-          volume: 71543000
+          volume: 71543
           percent: 7.05
           rank: 5
         '2002':
-          volume: 76915000
+          volume: 76915
           percent: 7.42
           rank: 5
         '2003':
-          volume: 143644000
+          volume: 143644
           percent: 13.5
           rank: 4
         '2004':
-          volume: 85508000
+          volume: 85508
           percent: 0.36
           rank: 19
         '2005':
-          volume: 88610000
+          volume: 88610
           percent: 0.38
           rank: 19
         '2006':
-          volume: 103027000
+          volume: 103027
           percent: 0.44
           rank: 18
         '2007':
-          volume: 112057000
+          volume: 112057
           percent: 0.45
           rank: 18
         '2008':
-          volume: 128454000
+          volume: 128454
           percent: 0.5
           rank: 17
         '2009':
-          volume: 140738000
+          volume: 140738
           percent: 0.54
           rank: 17
         '2010':
-          volume: 147255000
+          volume: 147255
           percent: 0.55
           rank: 16
         '2011':
-          volume: 151094000
+          volume: 151094
           percent: 0.53
           rank: 17
         '2012':
-          volume: 146405000
+          volume: 146405
           percent: 0.5
           rank: 17
         '2013':
-          volume: 139382000
+          volume: 139382
           percent: 0.47
           rank: 17
         '2014':
-          volume: 131885000
+          volume: 131885
           percent: 20.81
           rank: 2
     Oil (bbl):
@@ -16629,43 +16629,43 @@ VA:
       units: bbl
       volume:
         '2004':
-          volume: 19
+          volume: 19000
           percent: 0
           rank: 31
         '2005':
-          volume: 26
+          volume: 26000
           percent: 0
           rank: 31
         '2006':
-          volume: 17
+          volume: 17000
           percent: 0
           rank: 31
         '2007':
-          volume: 19
+          volume: 19000
           percent: 0
           rank: 31
         '2008':
-          volume: 16
+          volume: 16000
           percent: 0
           rank: 31
         '2009':
-          volume: 11
+          volume: 11000
           percent: 0
           rank: 31
         '2010':
-          volume: 12
+          volume: 12000
           percent: 0
           rank: 31
         '2011':
-          volume: 11
+          volume: 11000
           percent: 0
           rank: 31
         '2012':
-          volume: 9
+          volume: 9000
           percent: 0
           rank: 31
         '2013':
-          volume: 9
+          volume: 9000
           percent: 0
           rank: 30
     Other biomass:
@@ -17705,43 +17705,43 @@ WV:
       units: mcf
       volume:
         '2004':
-          volume: 197217000
+          volume: 197217
           percent: 0.82
           rank: 13
         '2005':
-          volume: 221108000
+          volume: 221108
           percent: 0.94
           rank: 13
         '2006':
-          volume: 225530000
+          volume: 225530
           percent: 0.96
           rank: 14
         '2007':
-          volume: 231184000
+          volume: 231184
           percent: 0.94
           rank: 15
         '2008':
-          volume: 244880000
+          volume: 244880
           percent: 0.96
           rank: 14
         '2009':
-          volume: 264436000
+          volume: 264436
           percent: 1.01
           rank: 14
         '2010':
-          volume: 265174000
+          volume: 265174
           percent: 0.99
           rank: 14
         '2011':
-          volume: 394125000
+          volume: 394125
           percent: 1.38
           rank: 12
         '2012':
-          volume: 539860000
+          volume: 539860
           percent: 1.83
           rank: 10
         '2013':
-          volume: 741853000
+          volume: 741853
           percent: 2.51
           rank: 10
     Oil (bbl):
@@ -17749,43 +17749,43 @@ WV:
       units: bbl
       volume:
         '2004':
-          volume: 1735
+          volume: 1735000
           percent: 0.07
           rank: 24
         '2005':
-          volume: 1696
+          volume: 1696000
           percent: 0.08
           rank: 24
         '2006':
-          volume: 1726
+          volume: 1726000
           percent: 0.08
           rank: 24
         '2007':
-          volume: 1992
+          volume: 1992000
           percent: 0.09
           rank: 23
         '2008':
-          volume: 2126
+          volume: 2126000
           percent: 0.1
           rank: 22
         '2009':
-          volume: 1501
+          volume: 1501000
           percent: 0.07
           rank: 24
         '2010':
-          volume: 1842
+          volume: 1842000
           percent: 0.08
           rank: 22
         '2011':
-          volume: 2146
+          volume: 2146000
           percent: 0.1
           rank: 22
         '2012':
-          volume: 2573
+          volume: 2573000
           percent: 0.1
           rank: 22
         '2013':
-          volume: 7564
+          volume: 7564000
           percent: 0.26
           rank: 18
     Other biomass:
@@ -18003,43 +18003,43 @@ WY:
       units: mcf
       volume:
         '2004':
-          volume: 1929040000
+          volume: 1929040
           percent: 8.05
           rank: 3
         '2005':
-          volume: 2003826000
+          volume: 2003826
           percent: 8.54
           rank: 3
         '2006':
-          volume: 2111766000
+          volume: 2111766
           percent: 8.97
           rank: 3
         '2007':
-          volume: 2257884000
+          volume: 2257884
           percent: 9.15
           rank: 3
         '2008':
-          volume: 2488267000
+          volume: 2488267
           percent: 9.71
           rank: 3
         '2009':
-          volume: 2536336000
+          volume: 2536336
           percent: 9.73
           rank: 3
         '2010':
-          volume: 2514657000
+          volume: 2514657
           percent: 9.38
           rank: 3
         '2011':
-          volume: 2375301000
+          volume: 2375301
           percent: 8.34
           rank: 4
         '2012':
-          volume: 2225622000
+          volume: 2225622
           percent: 7.53
           rank: 5
         '2013':
-          volume: 2047757000
+          volume: 2047757
           percent: 6.94
           rank: 5
     Oil (bbl):
@@ -18047,43 +18047,43 @@ WY:
       units: bbl
       volume:
         '2004':
-          volume: 51940
+          volume: 51940000
           percent: 2.24
           rank: 7
         '2005':
-          volume: 51770
+          volume: 51770000
           percent: 2.35
           rank: 7
         '2006':
-          volume: 52974
+          volume: 52974000
           percent: 2.5
           rank: 7
         '2007':
-          volume: 54116
+          volume: 54116000
           percent: 2.56
           rank: 7
         '2008':
-          volume: 53045
+          volume: 53045000
           percent: 2.56
           rank: 8
         '2009':
-          volume: 51533
+          volume: 51533000
           percent: 2.36
           rank: 8
         '2010':
-          volume: 53891
+          volume: 53891000
           percent: 2.43
           rank: 8
         '2011':
-          volume: 54670
+          volume: 54670000
           percent: 2.42
           rank: 8
         '2012':
-          volume: 57830
+          volume: 57830000
           percent: 2.26
           rank: 8
         '2013':
-          volume: 63285
+          volume: 63285000
           percent: 2.18
           rank: 9
     Wind:

--- a/_data/top_state_products/AK.yml
+++ b/_data/top_state_products/AK.yml
@@ -3,117 +3,117 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3642948000
+      value: 3642948
       rank: 2
       percent: 15.53
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 315387
+      value: 315387000
       rank: 2
       percent: 14.33
   '2006':
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3205751000
+      value: 3205751
       rank: 2
       percent: 13.62
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 270481
+      value: 270481000
       rank: 2
       percent: 12.75
   '2007':
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3479290000
+      value: 3479290
       rank: 2
       percent: 14.11
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 263595
+      value: 263595000
       rank: 2
       percent: 12.48
   '2008':
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3415884000
+      value: 3415884
       rank: 2
       percent: 13.32
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 249874
+      value: 249874000
       rank: 2
       percent: 12.04
   '2009':
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3312386000
+      value: 3312386
       rank: 2
       percent: 12.71
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 235491
+      value: 235491000
       rank: 2
       percent: 10.77
   '2010':
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3197100000
+      value: 3197100
       rank: 2
       percent: 11.92
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 218904
+      value: 218904000
       rank: 2
       percent: 9.89
   '2011':
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3162922000
+      value: 3162922
       rank: 2
       percent: 11.11
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 204829
+      value: 204829000
       rank: 2
       percent: 9.07
   '2012':
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3164791000
+      value: 3164791
       rank: 2
       percent: 10.71
   '2013':
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3215358000
+      value: 3215358
       rank: 3
       percent: 10.89
 revenue:
   '2009':
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 32081423.62
       rank: 3
       percent: 12.41
   '2015':
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 5227217.18

--- a/_data/top_state_products/AL.yml
+++ b/_data/top_state_products/AL.yml
@@ -2,35 +2,35 @@ all_production:
   '2005':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3630000
       rank: 2
       percent: 9.34
   '2006':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3865000
       rank: 1
       percent: 9.97
   '2007':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3784000
       rank: 2
       percent: 9.7
   '2008':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3324000
       rank: 3
       percent: 8.91
   '2009':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3035000
       rank: 3
       percent: 8.42
@@ -45,7 +45,7 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 181054000
+      value: 181054
       rank: 1
       percent: 28.56
 revenue:

--- a/_data/top_state_products/AZ.yml
+++ b/_data/top_state_products/AZ.yml
@@ -2,35 +2,35 @@ all_production:
   '2005':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 14000
       rank: 2
       percent: 2.54
   '2006':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 13000
       rank: 2
       percent: 2.56
   '2007':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 9000
       rank: 3
       percent: 1.47
   '2012':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 955000
       rank: 2
       percent: 22.08
   '2013':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 2111000
       rank: 2
       percent: 23.37

--- a/_data/top_state_products/CA.yml
+++ b/_data/top_state_products/CA.yml
@@ -271,484 +271,484 @@ all_production:
   '2005':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 537000
       rank: 1
       percent: 97.46
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 13023000
       rank: 1
       percent: 88.63
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 23654000
       rank: 1
       percent: 27.09
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 4262000
       rank: 1
       percent: 23.93
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 5833000
       rank: 1
       percent: 10.75
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 39632000
       rank: 2
       percent: 14.66
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2224000
       rank: 2
       percent: 14.42
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 230230
+      value: 230230000
       rank: 3
       percent: 10.46
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3609000
       rank: 3
       percent: 9.29
   '2006':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 495000
       rank: 1
       percent: 97.44
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 12821000
       rank: 1
       percent: 88.01
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 23915000
       rank: 1
       percent: 24.78
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 5717000
       rank: 1
       percent: 10.42
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 4883000
       rank: 2
       percent: 18.36
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 48047000
       rank: 2
       percent: 16.61
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2294000
       rank: 2
       percent: 14.25
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 223015
+      value: 223015000
       rank: 3
       percent: 10.52
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3422000
       rank: 3
       percent: 8.83
   '2007':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 557000
       rank: 1
       percent: 91.01
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 12991000
       rank: 1
       percent: 88.75
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 24845000
       rank: 1
       percent: 23.61
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 5713000
       rank: 1
       percent: 10.29
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 5585000
       rank: 2
       percent: 16.21
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2305000
       rank: 2
       percent: 13.95
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 27328000
       rank: 3
       percent: 11.04
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 218518
+      value: 218518000
       rank: 3
       percent: 10.35
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3407000
       rank: 3
       percent: 8.73
   '2008':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 12883000
       rank: 1
       percent: 86.81
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 670000
       rank: 1
       percent: 77.55
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 24784000
       rank: 1
       percent: 19.65
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2362000
       rank: 1
       percent: 13.32
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 5846000
       rank: 1
       percent: 10.62
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 5385000
       rank: 2
       percent: 9.73
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3484000
       rank: 2
       percent: 9.34
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 214533
+      value: 214533000
       rank: 3
       percent: 10.34
   '2009':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 12853000
       rank: 1
       percent: 85.64
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 647000
       rank: 1
       percent: 72.62
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 25540000
       rank: 1
       percent: 17.7
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2468000
       rank: 1
       percent: 13.38
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 6200000
       rank: 1
       percent: 11.38
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3732000
       rank: 1
       percent: 10.35
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 27888000
       rank: 3
       percent: 10.2
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 207262
+      value: 207262000
       rank: 3
       percent: 9.48
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 5840000
       rank: 3
       percent: 7.9
   '2010':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 12600000
       rank: 1
       percent: 82.79
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 769000
       rank: 1
       percent: 63.5
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2451000
       rank: 1
       percent: 12.96
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 6002000
       rank: 1
       percent: 10.7
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3551000
       rank: 1
       percent: 9.55
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 25450000
       rank: 2
       percent: 15.22
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 33431000
       rank: 2
       percent: 12.85
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 200050
+      value: 200050000
       rank: 3
       percent: 9.04
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 6079000
       rank: 3
       percent: 6.42
   '2011':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 12552000
       rank: 1
       percent: 81.96
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 889000
       rank: 1
       percent: 48.9
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2585000
       rank: 1
       percent: 13.45
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 6029000
       rank: 1
       percent: 10.64
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 27222000
       rank: 2
       percent: 14.03
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 42557000
       rank: 2
       percent: 13.33
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3445000
       rank: 2
       percent: 9.2
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 193996
+      value: 193996000
       rank: 3
       percent: 8.59
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 7752000
       rank: 3
       percent: 6.45
   '2012':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 12519000
       rank: 1
       percent: 80.44
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 1382000
       rank: 1
       percent: 31.95
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2514000
       rank: 1
       percent: 12.68
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 6311000
       rank: 1
       percent: 10.95
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3798000
       rank: 1
       percent: 10.05
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 29967000
       rank: 2
       percent: 13.73
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 26837000
       rank: 3
       percent: 9.72
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 197211
+      value: 197211000
       rank: 3
       percent: 7.71
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 9754000
       rank: 3
       percent: 6.93
   '2013':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 12307000
       rank: 1
       percent: 78.01
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 3814000
       rank: 1
       percent: 42.23
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2843000
       rank: 1
       percent: 13.65
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 6635000
       rank: 1
       percent: 10.9
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3792000
       rank: 1
       percent: 9.47
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 35578000
       rank: 2
       percent: 14.03
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 12822000
       rank: 3
       percent: 7.64
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 198928
+      value: 198928000
       rank: 3
       percent: 6.85
 revenue:

--- a/_data/top_state_products/CO.yml
+++ b/_data/top_state_products/CO.yml
@@ -150,7 +150,7 @@ revenue:
       value: 219803614.07
       rank: 3
       percent: 4.07
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 152655930.02
@@ -395,14 +395,14 @@ all_production:
   '2008':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 18000
       rank: 3
       percent: 2.08
   '2009':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 26000
       rank: 3
       percent: 2.92

--- a/_data/top_state_products/FL.yml
+++ b/_data/top_state_products/FL.yml
@@ -2,141 +2,141 @@ all_production:
   '2005':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2305000
       rank: 1
       percent: 14.95
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4327000
       rank: 2
       percent: 7.97
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 4327000
       rank: 3
       percent: 4.95
   '2006':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2352000
       rank: 1
       percent: 14.61
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4331000
       rank: 2
       percent: 7.89
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 4331000
       rank: 3
       percent: 4.49
   '2007':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2373000
       rank: 1
       percent: 14.36
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4303000
       rank: 2
       percent: 7.75
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 4303000
       rank: 3
       percent: 4.09
   '2008':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2334000
       rank: 2
       percent: 13.16
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4303000
       rank: 2
       percent: 7.82
   '2009':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2377000
       rank: 2
       percent: 12.89
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4331000
       rank: 2
       percent: 7.95
   '2010':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2387000
       rank: 2
       percent: 12.62
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4406000
       rank: 2
       percent: 7.86
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 80000
       rank: 3
       percent: 6.61
   '2011':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2335000
       rank: 2
       percent: 12.15
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4544000
       rank: 2
       percent: 8.02
   '2012':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2273000
       rank: 2
       percent: 11.46
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4330000
       rank: 2
       percent: 7.51
   '2013':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 2309000
       rank: 2
       percent: 11.09
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4449000
       rank: 2
       percent: 7.31

--- a/_data/top_state_products/GA.yml
+++ b/_data/top_state_products/GA.yml
@@ -2,34 +2,34 @@ all_production:
   '2010':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3054000
       rank: 3
       percent: 8.22
   '2011':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3070000
       rank: 3
       percent: 8.2
   '2012':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3107000
       rank: 2
       percent: 8.22
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 3276000
       rank: 3
       percent: 5.69
   '2013':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3409000
       rank: 3
       percent: 8.52

--- a/_data/top_state_products/HI.yml
+++ b/_data/top_state_products/HI.yml
@@ -2,21 +2,21 @@ all_production:
   '2005':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 222000
       rank: 3
       percent: 1.51
   '2006':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 212000
       rank: 3
       percent: 1.46
   '2007':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 230000
       rank: 3
       percent: 1.57

--- a/_data/top_state_products/IA.yml
+++ b/_data/top_state_products/IA.yml
@@ -2,86 +2,86 @@ all_production:
   '2005':
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 1647000
       rank: 3
       percent: 9.25
   '2006':
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 2318000
       rank: 3
       percent: 8.72
   '2007':
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 2757000
       rank: 3
       percent: 8
   '2009':
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 7421000
       rank: 2
       percent: 10.04
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 7589000
       rank: 3
       percent: 5.26
   '2010':
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 9170000
       rank: 2
       percent: 9.69
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 9360000
       rank: 3
       percent: 5.6
   '2011':
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 10709000
       rank: 2
       percent: 8.91
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 10870000
       rank: 3
       percent: 5.6
   '2012':
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 14032000
       rank: 2
       percent: 9.96
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 14183000
       rank: 3
       percent: 6.5
   '2013':
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 15568000
       rank: 2
       percent: 9.28
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 15727000
       rank: 3
       percent: 6.2

--- a/_data/top_state_products/ID.yml
+++ b/_data/top_state_products/ID.yml
@@ -146,7 +146,7 @@ revenue:
       value: 10550366.22
       rank: 1
       percent: 98.97
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 3877908

--- a/_data/top_state_products/LA.yml
+++ b/_data/top_state_products/LA.yml
@@ -1,6 +1,6 @@
 revenue:
   '2010':
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 38249065.09
@@ -11,13 +11,13 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3040523000
+      value: 3040523
       rank: 3
       percent: 10.68
   '2012':
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 2955437000
+      value: 2955437
       rank: 3
       percent: 10

--- a/_data/top_state_products/ME.yml
+++ b/_data/top_state_products/ME.yml
@@ -2,111 +2,111 @@ all_production:
   '2005':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3778000
       rank: 1
       percent: 9.72
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4068000
       rank: 3
       percent: 7.49
   '2006':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3685000
       rank: 2
       percent: 9.51
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 3968000
       rank: 3
       percent: 7.23
   '2007':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3848000
       rank: 1
       percent: 9.86
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 4108000
       rank: 3
       percent: 7.4
   '2008':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3669000
       rank: 1
       percent: 9.84
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 3926000
       rank: 3
       percent: 7.13
   '2009':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3367000
       rank: 2
       percent: 9.34
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 3640000
       rank: 3
       percent: 6.68
   '2010':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3390000
       rank: 2
       percent: 9.12
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 3653000
       rank: 3
       percent: 6.51
   '2011':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3511000
       rank: 1
       percent: 9.38
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 3788000
       rank: 3
       percent: 6.68
   '2012':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 2945000
       rank: 3
       percent: 7.79
   '2013':
     - product: Wood and wood-derived fuels
       name: Wood and wood-derived fuels
-      units: null
+      units: kilowatt hours
       value: 3625000
       rank: 2
       percent: 9.06
     - product: Biomass (total)
       name: Biomass (total)
-      units: null
+      units: kilowatt hours
       value: 3846000
       rank: 3
       percent: 6.32

--- a/_data/top_state_products/MI.yml
+++ b/_data/top_state_products/MI.yml
@@ -3,6 +3,6 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 114946000
+      value: 114946
       rank: 3
       percent: 18.13

--- a/_data/top_state_products/MN.yml
+++ b/_data/top_state_products/MN.yml
@@ -73,13 +73,13 @@ all_production:
   '2008':
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 4355000
       rank: 3
       percent: 7.87
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 5851000
       rank: 3
       percent: 4.64

--- a/_data/top_state_products/ND.yml
+++ b/_data/top_state_products/ND.yml
@@ -1,6 +1,6 @@
 revenue:
   '2009':
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 94899390.71
@@ -13,14 +13,14 @@ revenue:
       rank: 3
       percent: 0
   '2011':
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 103702962.35
       rank: 2
       percent: 26.8
   '2013':
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 63976335.46
@@ -33,7 +33,7 @@ revenue:
       value: 205994943.62
       rank: 3
       percent: 12.3
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 27746136.27
@@ -51,13 +51,13 @@ all_production:
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 243236
+      value: 243236000
       rank: 2
       percent: 9.51
   '2013':
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 313823
+      value: 313823000
       rank: 2
       percent: 10.81

--- a/_data/top_state_products/NM.yml
+++ b/_data/top_state_products/NM.yml
@@ -395,7 +395,7 @@ revenue:
       value: 174693712.76
       rank: 2
       percent: 4.09
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 119888752.87
@@ -438,7 +438,7 @@ revenue:
       value: 199231130.08
       rank: 2
       percent: 4.51
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 133919564.78
@@ -487,7 +487,7 @@ revenue:
       value: 164599129.22
       rank: 1
       percent: 30.04
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 69379138.84
@@ -604,7 +604,7 @@ revenue:
       value: 160960169.82
       rank: 1
       percent: 28.25
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 56992111.04
@@ -653,7 +653,7 @@ revenue:
       value: 121934129.34
       rank: 2
       percent: 22.14
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 85769258.6
@@ -696,7 +696,7 @@ revenue:
       value: 90428259.67
       rank: 1
       percent: 22.71
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 76474927.03
@@ -733,7 +733,7 @@ revenue:
       value: 350157717.03
       rank: 2
       percent: 29.01
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 154012670.35
@@ -776,7 +776,7 @@ revenue:
       value: 230104991.93
       rank: 2
       percent: 29.87
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 73019949.76
@@ -804,7 +804,7 @@ all_production:
   '2011':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 128000
       rank: 3
       percent: 7.04

--- a/_data/top_state_products/NV.yml
+++ b/_data/top_state_products/NV.yml
@@ -133,105 +133,105 @@ all_production:
   '2005':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 1263000
       rank: 2
       percent: 8.6
   '2006':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 1344000
       rank: 2
       percent: 9.23
   '2007':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 1253000
       rank: 2
       percent: 8.56
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 44000
       rank: 2
       percent: 7.19
   '2008':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 156000
       rank: 2
       percent: 18.06
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 1383000
       rank: 2
       percent: 9.32
   '2009':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 174000
       rank: 2
       percent: 19.53
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 1633000
       rank: 2
       percent: 10.88
   '2010':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 217000
       rank: 2
       percent: 17.92
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 2070000
       rank: 2
       percent: 13.6
   '2011':
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 291000
       rank: 2
       percent: 16.01
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 2146000
       rank: 2
       percent: 14.01
   '2012':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 2347000
       rank: 2
       percent: 15.08
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 473000
       rank: 3
       percent: 10.93
   '2013':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 2670000
       rank: 2
       percent: 16.92
     - product: Solar
       name: Solar
-      units: null
+      units: kilowatt hours
       value: 745000
       rank: 3
       percent: 8.25
@@ -249,7 +249,7 @@ revenue:
       value: 11619.42
       rank: 3
       percent: 0.18
-    - product: 'Sand & Gravel'
+    - product: Sand & Gravel
       name: null
       units: null
       value: 2.4
@@ -275,7 +275,7 @@ revenue:
       value: 12626
       rank: 3
       percent: 0.1
-    - product: 'Sand & Gravel'
+    - product: Sand & Gravel
       name: null
       units: null
       value: 320.59

--- a/_data/top_state_products/NY.yml
+++ b/_data/top_state_products/NY.yml
@@ -2,34 +2,34 @@ all_production:
   '2005':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1358000
       rank: 3
       percent: 8.81
   '2008':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 26723000
       rank: 3
       percent: 10.49
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1513000
       rank: 3
       percent: 8.53
   '2009':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1665000
       rank: 3
       percent: 9.03
   '2013':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 24973000
       rank: 3
       percent: 9.3

--- a/_data/top_state_products/OR.yml
+++ b/_data/top_state_products/OR.yml
@@ -2,63 +2,63 @@ all_production:
   '2005':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 30948000
       rank: 3
       percent: 11.45
   '2006':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 37850000
       rank: 3
       percent: 13.09
   '2007':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 33587000
       rank: 2
       percent: 13.57
   '2008':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 33805000
       rank: 2
       percent: 13.27
   '2009':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 33034000
       rank: 2
       percent: 12.08
   '2010':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 30542000
       rank: 3
       percent: 11.74
   '2011':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 42315000
       rank: 3
       percent: 13.25
   '2012':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 39410000
       rank: 2
       percent: 14.27
   '2013':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 33098000
       rank: 2
       percent: 12.32

--- a/_data/top_state_products/PA.yml
+++ b/_data/top_state_products/PA.yml
@@ -2,42 +2,42 @@ all_production:
   '2005':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1358000
       rank: 3
       percent: 8.81
   '2006':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1429000
       rank: 3
       percent: 8.88
   '2007':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1457000
       rank: 3
       percent: 8.82
   '2010':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1708000
       rank: 3
       percent: 9.03
   '2011':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1653000
       rank: 3
       percent: 8.6
   '2012':
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1765000
       rank: 3
       percent: 8.9
@@ -45,12 +45,12 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 3259042000
+      value: 3259042
       rank: 2
       percent: 11.04
     - product: Other biomass
       name: Other biomass
-      units: null
+      units: kilowatt hours
       value: 1847000
       rank: 3
       percent: 8.87

--- a/_data/top_state_products/TX.yml
+++ b/_data/top_state_products/TX.yml
@@ -3,24 +3,24 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 6006837000
+      value: 6006837
       rank: 1
       percent: 25.61
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 392601
+      value: 392601000
       rank: 1
       percent: 17.84
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 4237000
       rank: 2
       percent: 23.79
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 5336000
       rank: 2
       percent: 6.11
@@ -34,24 +34,24 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 6326433000
+      value: 6326433
       rank: 1
       percent: 26.88
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 6671000
       rank: 1
       percent: 25.09
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 392481
+      value: 392481000
       rank: 1
       percent: 18.51
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 7818000
       rank: 2
       percent: 8.1
@@ -65,24 +65,24 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 6960858000
+      value: 6960858
       rank: 1
       percent: 28.22
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 9006000
       rank: 1
       percent: 26.14
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 391270
+      value: 391270000
       rank: 1
       percent: 18.53
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 10288000
       rank: 2
       percent: 9.78
@@ -96,24 +96,24 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 7800655000
+      value: 7800655
       rank: 1
       percent: 30.43
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 16225000
       rank: 1
       percent: 29.31
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 406007
+      value: 406007000
       rank: 1
       percent: 19.56
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 17639000
       rank: 2
       percent: 13.99
@@ -127,24 +127,24 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 7653647000
+      value: 7653647
       rank: 1
       percent: 29.37
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 20026000
       rank: 1
       percent: 27.1
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 399344
+      value: 399344000
       rank: 1
       percent: 18.26
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 21104000
       rank: 2
       percent: 14.63
@@ -152,24 +152,24 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 7593697000
+      value: 7593697
       rank: 1
       percent: 28.32
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 26251000
       rank: 1
       percent: 27.73
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 426666
+      value: 426666000
       rank: 1
       percent: 19.27
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 27705000
       rank: 1
       percent: 16.57
@@ -183,24 +183,24 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 7934689000
+      value: 7934689
       rank: 1
       percent: 27.86
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 30548000
       rank: 1
       percent: 25.42
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 528844
+      value: 528844000
       rank: 1
       percent: 23.41
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 32183000
       rank: 1
       percent: 16.59
@@ -214,24 +214,24 @@ all_production:
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 722130
+      value: 722130000
       rank: 1
       percent: 28.23
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 8143510000
+      value: 8143510
       rank: 1
       percent: 27.57
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 32214000
       rank: 1
       percent: 22.88
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 34017000
       rank: 1
       percent: 15.58
@@ -239,24 +239,24 @@ all_production:
     - product: Oil (bbl)
       name: Oil
       units: bbl
-      value: 923561
+      value: 923561000
       rank: 1
       percent: 31.81
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 8299472000
+      value: 8299472
       rank: 1
       percent: 28.11
     - product: Wind
       name: Wind
-      units: null
+      units: kilowatt hours
       value: 35874000
       rank: 1
       percent: 21.37
     - product: All Other Renewables
       name: All Other Renewables
-      units: null
+      units: kilowatt hours
       value: 37760000
       rank: 1
       percent: 14.89
@@ -268,7 +268,7 @@ all_production:
       percent: 5.82
 revenue:
   '2010':
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 43706522.92

--- a/_data/top_state_products/UT.yml
+++ b/_data/top_state_products/UT.yml
@@ -143,7 +143,7 @@ revenue:
       value: 343414435.78
       rank: 3
       percent: 2.75
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 103022389.78
@@ -186,7 +186,7 @@ revenue:
       rank: 2
       percent: 15.53
   '2007':
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 46994077.87
@@ -419,7 +419,7 @@ revenue:
       value: 341548770.97
       rank: 3
       percent: 2.7
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 52438848.72
@@ -600,42 +600,42 @@ all_production:
   '2008':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 254000
       rank: 3
       percent: 1.71
   '2009':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 279000
       rank: 3
       percent: 1.86
   '2010':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 277000
       rank: 3
       percent: 1.82
   '2011':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 330000
       rank: 3
       percent: 2.15
   '2012':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 335000
       rank: 3
       percent: 2.15
   '2013':
     - product: Geothermal
       name: Geothermal
-      units: null
+      units: kilowatt hours
       value: 319000
       rank: 3
       percent: 2.02

--- a/_data/top_state_products/VA.yml
+++ b/_data/top_state_products/VA.yml
@@ -81,6 +81,6 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 131885000
+      value: 131885
       rank: 2
       percent: 20.81

--- a/_data/top_state_products/WA.yml
+++ b/_data/top_state_products/WA.yml
@@ -2,63 +2,63 @@ all_production:
   '2005':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 72075000
       rank: 1
       percent: 26.66
   '2006':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 82008000
       rank: 1
       percent: 28.35
   '2007':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 78829000
       rank: 1
       percent: 31.85
   '2008':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 77637000
       rank: 1
       percent: 30.47
   '2009':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 72933000
       rank: 1
       percent: 26.67
   '2010':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 68288000
       rank: 1
       percent: 26.24
   '2011':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 91818000
       rank: 1
       percent: 28.75
   '2012':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 89464000
       rank: 1
       percent: 32.39
   '2013':
     - product: Conventional Hydroelectric
       name: Conventional Hydroelectric
-      units: null
+      units: kilowatt hours
       value: 78155000
       rank: 1
       percent: 29.1

--- a/_data/top_state_products/WY.yml
+++ b/_data/top_state_products/WY.yml
@@ -362,7 +362,7 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 2003826000
+      value: 2003826
       rank: 3
       percent: 8.54
   '2006':
@@ -375,7 +375,7 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 2111766000
+      value: 2111766
       rank: 3
       percent: 8.97
   '2007':
@@ -388,7 +388,7 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 2257884000
+      value: 2257884
       rank: 3
       percent: 9.15
   '2008':
@@ -401,7 +401,7 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 2488267000
+      value: 2488267
       rank: 3
       percent: 9.71
   '2009':
@@ -414,7 +414,7 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 2536336000
+      value: 2536336
       rank: 3
       percent: 9.73
   '2010':
@@ -427,7 +427,7 @@ all_production:
     - product: Natural Gas (mcf)
       name: Natural Gas
       units: mcf
-      value: 2514657000
+      value: 2514657
       rank: 3
       percent: 9.38
   '2011':
@@ -477,7 +477,7 @@ revenue:
       value: 197127988.32
       rank: 1
       percent: 4.62
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 49661556.5
@@ -544,7 +544,7 @@ revenue:
       value: 58637672.7
       rank: 2
       percent: 14.48
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 41243505.95
@@ -593,7 +593,7 @@ revenue:
       value: 354318589.75
       rank: 1
       percent: 6.08
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 95350185.3
@@ -648,7 +648,7 @@ revenue:
       value: 183699381.28
       rank: 1
       percent: 6.2
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 55443027.47
@@ -703,7 +703,7 @@ revenue:
       value: 256931525.83
       rank: 2
       percent: 5.03
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 65210661.5
@@ -752,7 +752,7 @@ revenue:
       value: 320106663.19
       rank: 2
       percent: 4.98
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 136313735.74
@@ -813,7 +813,7 @@ revenue:
       value: 132172213.43
       rank: 1
       percent: 24
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 61028635.86
@@ -862,7 +862,7 @@ revenue:
       value: 341686585.41
       rank: 2
       percent: 4.86
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 63327416.67
@@ -923,7 +923,7 @@ revenue:
       value: 121439972.42
       rank: 1
       percent: 41.53
-    - product: 'Oil & Gas (Non-Royalty)'
+    - product: Oil & Gas (Non-Royalty)
       name: null
       units: null
       value: 68752649.15

--- a/data/all-production/rollup.sql
+++ b/data/all-production/rollup.sql
@@ -21,7 +21,7 @@ UNION
         'Natural Gas (mcf)' AS product,
         'Natural Gas' AS product_name,
         'mcf' AS units,
-        volume * 1000 AS volume
+        volume
     FROM all_production_naturalgas
 UNION
     SELECT
@@ -41,7 +41,7 @@ UNION
         'Oil (bbl)' AS product,
         'Oil' AS product_name,
         'bbl' AS units,
-        volume
+        volume * 1000 AS volume
     FROM all_production_oil;
 
 DROP TABLE IF EXISTS all_national_production;


### PR DESCRIPTION
Fixes issue(s) #1375

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/[BRANCH_NAME]/states/)

Changes proposed in this pull request:

For all production data
- natural gas: existing numbers are too big, divide by 1000
- oil: existing numbers are too small, multiply by 1000
- apply changes to `top_state_products`
- update units in top_state_products renewables section (incidental change)

/cc @shawnbot 

