### PR TITLE
Update county level tables

### DIFF
--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -12,10 +12,8 @@
        data-percent-max='100'>
   <thead>
     <tr>
-      <th>County</th>
-
-      <th class='numeric' data-series='volume'>{{ units | capitalize }}</th>
-      <th></th>
+      <th>Locality</th>
+      <th colspans="2" class='numeric' data-series='volume'>{{ units | capitalize }}</th>
     </tr>
   </thead>
   <tbody>

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -8,13 +8,13 @@
 
 
 <label>{{ caption }}</label>
-<table is="bar-chart-table"
-       data-percent-max="100">
+<table is='bar-chart-table'
+       data-percent-max='100'>
   <thead>
     <tr>
       <th>County</th>
 
-      <th class="numeric" data-series="volume">{{ units | capitalize }}</th>
+      <th class='numeric' data-series='volume'>{{ units | capitalize }}</th>
       <th></th>
     </tr>
   </thead>
@@ -25,14 +25,14 @@
     {% assign years_values =  county[1].products[product_ref].volume %}
     {% if years_values != 'null' years_values != null %}
       <tr data-year-values='{{ years_values | jsonify }}'>
-        <td><div class="swatch"
-                 data-value-swatch="{{ product_volume }}"
-                 data-year-values="{{ years_values | jsonify }}"></div>{{ county[1].name }}</td>
-        <td data-value-text="{{ product_volume }}"
+        <td><div class='swatch'
+                 data-value-swatch='{{ product_volume }}'
+                 data-year-values='{{ years_values | jsonify }}'></div>{{ county[1].name }}</td>
+        <td data-value-text='{{ product_volume }}'
             data-year-values='{{ years_values | jsonify }}'>{{ product_volume | intcomma }}</td>
-        <td class="numberless"
-            data-series="volume"
-            data-value="{{ product_volume }}"
+        <td class='numberless'
+            data-series='volume'
+            data-value='{{ product_volume }}'
             data-year-values='{{ years_values | jsonify }}'>{{ product_volume | intcomma }}</td>
       </tr>
     {% endif %}

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -6,8 +6,10 @@
   {% assign units = include.long_units %}
 {% endif %}
 
+
 <label>{{ caption }}</label>
-<table is="bar-chart-table" data-percent-max="100">
+<table is="bar-chart-table"
+       data-percent-max="100">
   <thead>
     <tr>
       <th>County</th>
@@ -20,12 +22,19 @@
   {% for county in include.values %}
     {% assign product_volume = county[1].products[product_ref].volume[include.year] %}
 
-    {% if product_volume > 0 %}
-    <tr>
-      <td><div class="swatch" data-value-swatch="{{ product_volume }}"></div>{{ county[1].name }}</td>
-      <td>{{ product_volume | intcomma }}</td>
-      <td class="numberless" data-series="volume" data-value="{{ product_volume }}">{{ product_volume | intcomma }}</td>
-    </tr>
+    {% assign years_values =  county[1].products[product_ref].volume %}
+    {% if years_values != 'null' years_values != null %}
+      <tr data-year-values='{{ years_values | jsonify }}'>
+        <td><div class="swatch"
+                 data-value-swatch="{{ product_volume }}"
+                 data-year-values="{{ years_values | jsonify }}"></div>{{ county[1].name }}</td>
+        <td data-value-text="{{ product_volume }}"
+            data-year-values='{{ years_values | jsonify }}'>{{ product_volume | intcomma }}</td>
+        <td class="numberless"
+            data-series="volume"
+            data-value="{{ product_volume }}"
+            data-year-values='{{ years_values | jsonify }}'>{{ product_volume | intcomma }}</td>
+      </tr>
     {% endif %}
   {% endfor %}
   </tbody>

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -9,7 +9,8 @@
 
 <label>{{ caption }}</label>
 <table is='bar-chart-table'
-       data-percent-max='100'>
+       data-percent-max='100'
+       class="county-table">
   <thead>
     <tr>
       <th>Locality</th>

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -1,18 +1,19 @@
 {% assign product_ref = include.product_ref %}
-
-{% assign product_name = county[1].products[1].name %}
+{% assign caption = include.caption %}
 
 {% assign units = county[1].products[1].units %}
 {% if include.long_units %}
   {% assign units = include.long_units %}
 {% endif %}
 
+<label>{{ caption }}</label>
 <table is="bar-chart-table" data-percent-max="100">
   <thead>
     <tr>
       <th>County</th>
 
-      <th class="numeric" data-series="volume">Volume {{ county[1].products[1].name }} ({{ units }})</th>
+      <th class="numeric" data-series="volume">{{ units | capitalize }}</th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -21,8 +22,9 @@
 
     {% if product_volume > 0 %}
     <tr>
-      <td>{{ county[1].name }}</td>
-      <td class="numeric" data-series="volume" data-value="{{ product_volume }}">{{ product_volume | intcomma }}</td>
+      <td><div class="swatch" data-value-swatch="{{ product_volume }}"></div>{{ county[1].name }}</td>
+      <td>{{ product_volume | intcomma }}</td>
+      <td class="numberless" data-series="volume" data-value="{{ product_volume }}">{{ product_volume | intcomma }}</td>
     </tr>
     {% endif %}
   {% endfor %}

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -1,0 +1,30 @@
+{% assign product_ref = include.product_ref %}
+
+{% assign product_name = county[1].products[1].name %}
+
+{% assign units = county[1].products[1].units %}
+{% if include.long_units %}
+  {% assign units = include.long_units %}
+{% endif %}
+
+<table is="bar-chart-table" data-percent-max="100">
+  <thead>
+    <tr>
+      <th>County</th>
+
+      <th class="numeric" data-series="volume">Volume {{ county[1].products[1].name }} ({{ units }})</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for county in include.values %}
+    {% assign product_volume = county[1].products[product_ref].volume[include.year] %}
+
+    {% if product_volume > 0 %}
+    <tr>
+      <td>{{ county[1].name }}</td>
+      <td class="numeric" data-series="volume" data-value="{{ product_volume }}">{{ product_volume | intcomma }}</td>
+    </tr>
+    {% endif %}
+  {% endfor %}
+  </tbody>
+</table>

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -4,9 +4,8 @@
 <table is="bar-chart-table" data-percent-max="100">
   <thead>
     <tr>
-      <th>County</th>
-      <th class="numeric" data-series="volume">Revenue</th>
-      <th></th>
+      <th>Locality</th>
+      <th colspans="2" class="numeric" data-series="volume">Revenue</th>
     </tr>
   </thead>
   <tbody>

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -1,0 +1,20 @@
+<table is="bar-chart-table" data-percent-max="100">
+  <thead>
+    <tr>
+      <th>County</th>
+      <th class="numeric" data-series="volume">Revenue</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for county in include.values %}
+    {% assign revenue_amount = county[1].revenue[include.year] %}
+
+    {% if revenue_amount > 0 %}
+    <tr>
+      <td>{{ county[1].name }}</td>
+      <td class="numeric" data-series="volume" data-value="{{ revenue_amount }}">${{ revenue_amount | intcomma }}</td>
+    </tr>
+    {% endif %}
+  {% endfor %}
+  </tbody>
+</table>

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -1,7 +1,7 @@
 {% assign caption = include.caption %}
 
 <label>{{ caption }}</label>
-<table is="bar-chart-table" data-percent-max="100">
+<table is="bar-chart-table" data-percent-max="100" class="county-table">
   <thead>
     <tr>
       <th>Locality</th>

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -1,18 +1,29 @@
+{% assign caption = include.caption %}
+
+<label>{{ caption }}</label>
 <table is="bar-chart-table" data-percent-max="100">
   <thead>
     <tr>
       <th>County</th>
       <th class="numeric" data-series="volume">Revenue</th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
   {% for county in include.values %}
     {% assign revenue_amount = county[1].revenue[include.year] %}
-
+    {% assign years_values =  county[1].revenue %}
     {% if revenue_amount > 0 %}
-    <tr>
-      <td>{{ county[1].name }}</td>
-      <td class="numeric" data-series="volume" data-value="{{ revenue_amount }}">${{ revenue_amount | intcomma }}</td>
+    <tr data-year-values='{{ years_values | jsonify }}'>
+      <td><div class='swatch'
+                 data-value-swatch='{{ revenue_amount }}'
+                 data-year-values='{{ years_values | jsonify }}'></div>{{ county[1].name }}</td>
+      <td data-value-text='{{ revenue_amount }}'
+          data-year-values='{{ years_values | jsonify }}'>${{ revenue_amount | intcomma }}</td>
+      <td class='numberless'
+            data-series='volume'
+            data-value='{{ revenue_amount }}'
+            data-year-values='{{ years_values | jsonify }}'>{{ revenue_amount | intcomma }}</td>
     </tr>
     {% endif %}
   {% endfor %}

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -19,7 +19,8 @@
                  data-value-swatch='{{ revenue_amount }}'
                  data-year-values='{{ years_values | jsonify }}'></div>{{ county[1].name }}</td>
       <td data-value-text='{{ revenue_amount }}'
-          data-year-values='{{ years_values | jsonify }}'>${{ revenue_amount | intcomma }}</td>
+          data-year-values='{{ years_values | jsonify }}'
+          data-format="$,">${{ revenue_amount | intcomma }}</td>
       <td class='numberless'
             data-series='volume'
             data-value='{{ revenue_amount }}'

--- a/_includes/location/display-jobs-county.html
+++ b/_includes/location/display-jobs-county.html
@@ -1,7 +1,7 @@
 {% assign caption = include.caption %}
 
 <label>{{ caption }}</label>
-<table is='bar-chart-table' data-percent-max='100'>
+<table is='bar-chart-table' data-percent-max='100' class="county-table">
   <thead>
     <tr>
       <th>Locality</th>

--- a/_includes/location/display-jobs-county.html
+++ b/_includes/location/display-jobs-county.html
@@ -1,22 +1,42 @@
-<table is="bar-chart-table" data-percent-max="100">
+{% assign caption = include.caption %}
+
+<label>{{ caption }}</label>
+<table is='bar-chart-table' data-percent-max='100'>
   <thead>
     <tr>
       <th>County</th>
-      <th class="numeric" data-series="jobs">Jobs</th>
-      {% if include.percent %}
-      <th class="numeric" data-series="percent">County %</th>
-      {% endif %}
+      <th class='numeric' data-series='jobs'>Jobs</th>
+      <th></th>
+      <th class='numeric' data-series='percent'>Locality %</th>
     </tr>
   </thead>
   <tbody>
   {% for county in include.values %}
     {% if county[1].employment[include.year].count > 0 %}
-    <tr>
-      <td>{{ county[1].name }}</td>
-      <td class="numeric" data-series="jobs" data-value="{{ county[1].employment[year].count }}">{{ county[1].employment[year].count | intcomma }}</td>
-      {% if include.percent %}
-      <td class="numeric" data-series="percent" data-value="{{ county[1].employment[year].percent }}">{{ county[1].employment[year].percent | percent }}%</td>
-      {% endif %}
+
+    {% assign years_values = county[1].employment %}
+
+    {% assign jobs_percent = county[1].employment[year].percent %}
+    <!-- {{ jobs_percent }} -->
+    {% assign jobs_count = county[1].employment[year].count %}
+
+    <tr data-year-values='{{ years_values | jsonify }}' data-years-property='count'>
+      <td><div class='swatch'
+               data-value-swatch='{{ jobs_count }}'
+               data-year-values='{{ years_values | jsonify }}'
+               data-years-property='count'></div>{{ county[1].name }}</td>
+      <td data-value-text='{{ jobs_count }}'
+          data-year-values='{{ years_values | jsonify }}'
+          data-years-property='count'>{{ jobs_count | intcomma }}</td>
+      <td class='numberless'
+          data-series='jobs'
+          data-value='{{ jobs_count }}'
+          data-year-values='{{ years_values | jsonify }}'
+          data-years-property='count'>{{ jobs_count | intcomma }}</td>
+      <td data-value-text='{{ jobs_percent }}'
+          data-year-values='{{ years_values | jsonify }}'
+          data-years-property='percent'
+          data-format='%'>{{ jobs_percent }}%</td>
     </tr>
     {% endif %}
   {% endfor %}

--- a/_includes/location/display-jobs-county.html
+++ b/_includes/location/display-jobs-county.html
@@ -4,9 +4,8 @@
 <table is='bar-chart-table' data-percent-max='100'>
   <thead>
     <tr>
-      <th>County</th>
-      <th class='numeric' data-series='jobs'>Jobs</th>
-      <th></th>
+      <th>Locality</th>
+      <th colspans="2" class='numeric' data-series='jobs'>Jobs</th>
       <th class='numeric' data-series='percent'>Locality %</th>
     </tr>
   </thead>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -120,20 +120,23 @@
                   caption=caption
                   toggle=toggle
                 %}
+
+                <div class="eiti-data-map-table" id="{{ toggle }}" aria-hidden="true">
+                  {% assign product_ref = product[0] %}
+                  {%
+                    include location/display-federal-production-county.html
+                    year=year
+                    values=county_federal_products
+                    product_ref=product_ref
+                    long_units=long_units
+                    caption=caption
+                  %}
+                </div><!-- /.table-container -->
               </eiti-data-map>
 
             </figure>
 
-            <div class="table-container" id="{{ toggle }}" aria-hidden="true">
-              {% assign product_ref = product[0] %}
-              {%
-                include location/display-federal-production-county.html
-                year=year
-                values=county_federal_products
-                product_ref=product_ref
-                long_units=long_units
-              %}
-            </div><!-- /.table-container -->
+
 
           </div><!-- /.map-container -->
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -4,6 +4,9 @@
 {% assign federal_products_num = federal_products | size %}
 {% assign units_map = site.data.production_units %}
 
+{% assign county_federal_products = site.data.federal_county_production[state_id] %}
+
+
 <section id="federal-production" is="year-switcher-section" class="federal production">
 
   <h3>Production on federal land in {{ state_name }}</h2>
@@ -121,17 +124,16 @@
 
             </figure>
 
-
-            <div id="{{ toggle }}" aria-hidden="true">
+            <div class="table-container" id="{{ toggle }}" aria-hidden="true">
+              {% assign product_ref = product[0] %}
               {%
-                include location/display-production.html
-                units=units
+                include location/display-federal-production-county.html
                 year=year
-                values=production_values
-                percent=false
-                rank=false
+                values=county_federal_products
+                product_ref=product_ref
+                long_units=long_units
               %}
-            </div>
+            </div><!-- /.table-container -->
 
           </div><!-- /.map-container -->
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -7,7 +7,7 @@
 {% assign county_federal_products = site.data.federal_county_production[state_id] %}
 
 
-<section id="federal-production" is="year-switcher-section" class="federal production">
+<section id="federal-production" class="federal production">
 
   <h3>Production on federal land in {{ state_name }}</h2>
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -104,7 +104,7 @@
               {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
               {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
               {% assign _width ='inherit' %}
-              {% capture caption %}Local production of {{ product_name | downcase | suffix:units_suffix }} in {{ year }}{% endcapture %}
+              {% capture caption %}Local production of {{ product_name | downcase | suffix:units_suffix }} in <span data-year="{{ year }}">{{ year }}</span>{% endcapture %}
 
               <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
                 {% assign federal_county_production = site.data.federal_county_production[state_id] %}

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -126,6 +126,7 @@
                   {%
                     include location/display-federal-production-county.html
                     year=year
+                    years=years_key
                     values=county_federal_products
                     product_ref=product_ref
                     long_units=long_units

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -121,23 +121,24 @@
                   toggle=toggle
                 %}
 
-                <div class="eiti-data-map-table" id="{{ toggle }}" aria-hidden="true">
-                  {% assign product_ref = product[0] %}
-                  {%
-                    include location/display-federal-production-county.html
-                    year=year
-                    years=years_key
-                    values=county_federal_products
-                    product_ref=product_ref
-                    long_units=long_units
-                    caption=caption
-                  %}
-                </div><!-- /.table-container -->
+
+
               </eiti-data-map>
 
+              <div class="eiti-data-map-table" id="{{ toggle }}" aria-hidden="true">
+                {% assign product_ref = product[0] %}
+                {%
+                  include location/display-federal-production-county.html
+                  year=year
+                  years=years_key
+                  values=county_federal_products
+                  product_ref=product_ref
+                  long_units=long_units
+                  caption=caption
+                %}
+              </div><!-- /.table-container -->
+
             </figure>
-
-
 
           </div><!-- /.map-container -->
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -130,7 +130,6 @@
                 {%
                   include location/display-federal-production-county.html
                   year=year
-                  years=years_key
                   values=county_federal_products
                   product_ref=product_ref
                   long_units=long_units

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -78,7 +78,7 @@
         <figure class="container">
           <eiti-data-map color-scheme="Reds" steps="{{ steps }}">
             {% capture value_key %}employment.{{ year }}.count{% endcapture %}
-            {% capture caption %}Local employment in extractive industries (jobs, {{ year }}){% endcapture %}
+            {% capture caption %}Local employment in extractive industries (jobs, <span data-year="{{ year }}">{{ year }}</span>){% endcapture %}
 
             {%
               include county-map.html
@@ -93,15 +93,17 @@
               toggle=toggle
             %}
           </eiti-data-map>
+          <div class="eiti-data-map-table" id="{{ toggle }}" aria-hidden="true">
+            {%
+              include location/display-jobs-county.html
+              year=year
+              values=county_jobs
+              percent=true
+              caption=caption
+            %}
+          </div><!-- /.table-container -->
         </figure>
-        <div class="table-container" id="{{ toggle }}" aria-hidden="true">
-          {%
-            include location/display-jobs-county.html
-            year=year
-            values=county_jobs
-            percent=true
-          %}
-        </div><!-- /.table-container -->
+
       </div><!-- /.map-container -->
     </div><!-- /.row-container -->
 

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -86,53 +86,6 @@
         %}
       </section>
 
-      {% for commodity in revenue_commodities %}
-        {% assign revenue = commodity[1][year].revenue %}
-        {% assign commodity_name = commodity[0] | lookup: commodity_names %}
-        {% assign commodity_slug = commodity[0] | slugify %}
-
-        {% if commodity[0] != 'All' %}
-          <section id="revenue-{{ commodity_slug }}" class="chart-item">
-
-            <h3 class="chart-title">{{ commodity_name }}</h3>
-
-            <figure class="chart">
-              {% assign annual_revenue = commodity[1] %}
-              <figcaption id="revenue-figures-{{ commodity_slug }}">
-                In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
-                  companies paid the federal government <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span> to extract
-                {{ commodity_name | downcase }} on federal land in {{ state_name }}.
-
-              </figcaption>
-              <eiti-bar-chart
-                data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
-                aria-controls="revenue-figures-{{ commodity_slug }}"
-                x-range="{{ year_range }}"
-                x-value="{{ year }}">
-              </eiti-bar-chart>
-
-            </figure>
-
-            <!-- <h4>
-              <button is="aria-toggle"
-                aria-controls="revenue-detail-{{ commodity_slug }}">&plus; Details</button>
-            </h4>
-            <div id="revenue-detail-{{ commodity_slug }}" aria-hidden="true">
-              {% assign revenue_values = commodity[1] %}
-              {%
-                include location/display-revenue.html
-                year=year
-                values=revenue_values
-                percent=false
-                rank=false
-              %}
-            </div> -->
-
-          </section>
-        {% endif %}
-
-      {% endfor %}
-
     </section>
     <!-- .chart-list -->
 

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -62,7 +62,7 @@
       </article>
     </div>
 
-    <section class="chart-list">
+    <section class="chart-list has-intro">
 
       <h4>Revenue from resources extracted on federal land in {{ state_name }}</h4>
 
@@ -75,49 +75,61 @@
         </p>
       </div>
 
+      <section class="county-map-table">
+        {% assign county_revenue = site.data.county_revenue[state_id] %}
+        {%
+          include location/state-federal-revenue-county.html
+          county_revenue=county_revenue
+          state_revenue=revenue_commodities
+          year=year
+          year_range=year_range
+        %}
+      </section>
 
       {% for commodity in revenue_commodities %}
         {% assign revenue = commodity[1][year].revenue %}
         {% assign commodity_name = commodity[0] | lookup: commodity_names %}
         {% assign commodity_slug = commodity[0] | slugify %}
 
-        <section id="revenue-{{ commodity_slug }}" class="chart-item">
+        {% if commodity[0] != 'All' %}
+          <section id="revenue-{{ commodity_slug }}" class="chart-item">
 
-          <h3 class="chart-title">{{ commodity_name }}</h3>
+            <h3 class="chart-title">{{ commodity_name }}</h3>
 
-          <figure class="chart">
-            {% assign annual_revenue = commodity[1] %}
-            <figcaption id="revenue-figures-{{ commodity_slug }}">
-              In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
-                companies paid the federal government <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span> to extract
-              {{ commodity_name | downcase }} on federal land in {{ state_name }}.
+            <figure class="chart">
+              {% assign annual_revenue = commodity[1] %}
+              <figcaption id="revenue-figures-{{ commodity_slug }}">
+                In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+                  companies paid the federal government <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span> to extract
+                {{ commodity_name | downcase }} on federal land in {{ state_name }}.
 
-            </figcaption>
-            <eiti-bar-chart
-              data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
-              aria-controls="revenue-figures-{{ commodity_slug }}"
-              x-range="{{ year_range }}"
-              x-value="{{ year }}">
-            </eiti-bar-chart>
+              </figcaption>
+              <eiti-bar-chart
+                data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
+                aria-controls="revenue-figures-{{ commodity_slug }}"
+                x-range="{{ year_range }}"
+                x-value="{{ year }}">
+              </eiti-bar-chart>
 
-          </figure>
+            </figure>
 
-          <!-- <h4>
-            <button is="aria-toggle"
-              aria-controls="revenue-detail-{{ commodity_slug }}">&plus; Details</button>
-          </h4>
-          <div id="revenue-detail-{{ commodity_slug }}" aria-hidden="true">
-            {% assign revenue_values = commodity[1] %}
-            {%
-              include location/display-revenue.html
-              year=year
-              values=revenue_values
-              percent=false
-              rank=false
-            %}
-          </div> -->
+            <!-- <h4>
+              <button is="aria-toggle"
+                aria-controls="revenue-detail-{{ commodity_slug }}">&plus; Details</button>
+            </h4>
+            <div id="revenue-detail-{{ commodity_slug }}" aria-hidden="true">
+              {% assign revenue_values = commodity[1] %}
+              {%
+                include location/display-revenue.html
+                year=year
+                values=revenue_values
+                percent=false
+                rank=false
+              %}
+            </div> -->
 
-        </section>
+          </section>
+        {% endif %}
 
       {% endfor %}
 

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -1,0 +1,102 @@
+{% assign county_revenue = include.county_revenue %}
+{% assign state_revenue = include.state_revenue %}
+
+{% if include.year %}
+  {% assign year = include.year %}
+{% endif %}
+
+{% if include.year_range %}
+  {% assign year_range = include.year_range %}
+{% endif %}
+
+{% assign state_revenue_all = state_revenue.All %}
+{% assign current_revenue = state_revenue_all[year].revenue %}
+
+
+<section id="federal-revenue-county" class="product chart-item full-width">
+
+  <div class="row-container">
+
+    <div class="chart-container">
+
+      <h4 class="chart-title">
+        All commodities
+      </h4>
+
+      <figure class="chart">
+        <figcaption id="federal-revenue-county-figures-All">
+        <span class="eiti-bar-chart-y-value"
+                data-format="$,">${{ current_revenue | intcomma }}</span>
+        was collected from federal land in {{ state_name }} in
+        <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+
+        </figcaption>
+        <eiti-bar-chart
+          aria-controls="federal-revenue-county-figures-All"
+          data='{{ state_revenue_all | map_hash: "revenue" | jsonify }}'
+          x-range="{{ year_range }}"
+          x-value="{{ year }}">
+        </eiti-bar-chart>
+
+      </figure>
+
+      <!-- <h4>
+        <button is="aria-toggle"
+          aria-controls="federal-production-{{ product_slug }}-years">&plus; Details</button>
+      </h4>
+      <div id="federal-production-{{ product_slug }}-years" aria-hidden="true">
+        {%
+          include location/display-production.html
+          units=units
+          year=year
+          values=production_values
+          percent=true
+          rank=true
+        %}
+      </div> -->
+    </div><!-- /.chart-container -->
+
+    <div class="map-container">
+
+      <h4 class="chart-title">
+        Local revenue collected
+      </h4>
+
+
+      {% capture toggle %}federal-reveneu-All-counties{% endcapture %}
+      <figure>
+        {% capture value_key %}revenue.{{ year }}{% endcapture %}
+        {% capture years_key %}revenue{% endcapture %}
+        {% assign _width ='inherit' %}
+        {% capture caption %}Local revenue in {{ year }}{% endcapture %}
+
+        <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
+
+          {%
+            include county-map.html
+            state=state_id
+            counties=county_revenue
+            value=value_key
+            years=years_key
+            steps=steps
+            inherit_width=true
+            caption=caption
+            toggle=toggle
+          %}
+        </eiti-data-map>
+
+      </figure>
+
+      <div class="table-container" id="{{ toggle }}" aria-hidden="true">
+        {%
+          include location/display-federal-revenue-county.html
+          year=year
+          values=county_revenue
+        %}
+      </div><!-- /.table-container -->
+
+    </div><!-- /.map-container -->
+
+  </div><!-- /.row-container -->
+
+</section>

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -70,7 +70,7 @@
         {% assign _width ='inherit' %}
         {% capture caption %}Local revenue in <span data-year="{{ year }}">{{ year }}</span>{% endcapture %}
 
-        <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
+        <eiti-data-map color-scheme="Reds" steps="{{ steps }}" units="{{ units }}">
 
           {%
             include county-map.html

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -63,12 +63,12 @@
       </h4>
 
 
-      {% capture toggle %}federal-reveneu-All-counties{% endcapture %}
+      {% capture toggle %}federal-revenue-All-counties{% endcapture %}
       <figure>
         {% capture value_key %}revenue.{{ year }}{% endcapture %}
         {% capture years_key %}revenue{% endcapture %}
         {% assign _width ='inherit' %}
-        {% capture caption %}Local revenue in {{ year }}{% endcapture %}
+        {% capture caption %}Local revenue in <span data-year="{{ year }}">{{ year }}</span>{% endcapture %}
 
         <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
 
@@ -85,15 +85,17 @@
           %}
         </eiti-data-map>
 
+        <div class="eiti-data-map-table" id="{{ toggle }}" aria-hidden="true">
+          {%
+            include location/display-federal-revenue-county.html
+            year=year
+            values=county_revenue
+            caption=caption
+          %}
+        </div><!-- /.table-container -->
       </figure>
 
-      <div class="table-container" id="{{ toggle }}" aria-hidden="true">
-        {%
-          include location/display-federal-revenue-county.html
-          year=year
-          values=county_revenue
-        %}
-      </div><!-- /.table-container -->
+
 
     </div><!-- /.map-container -->
 

--- a/_sass/blocks/_all.scss
+++ b/_sass/blocks/_all.scss
@@ -4,6 +4,7 @@
 @import 'chart-list';
 @import 'nav-drawer';
 @import 'home-explore';
+@import 'county-bar-table';
 
 // Case Studies
 //

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -97,6 +97,11 @@
     margin: 0;
     min-height: inherit;
   }
+
+  .county-map-table {
+    margin-bottom: $standard-padding-extra;
+    width: 100%;
+  }
 }
 
 .chart-selector-wrapper {

--- a/_sass/blocks/_county-bar-table.scss
+++ b/_sass/blocks/_county-bar-table.scss
@@ -1,26 +1,26 @@
 .eiti-data-map-table {
-	label {
-		float: left;
-	}
+  label {
+    float: left;
+  }
 
-	table[is="bar-chart-table"] {
-		border: 0;
-		width: 100%;
+  table[is="bar-chart-table"] {
+    border: 0;
+    width: 100%;
 
-		td,
-		th {
-			border: 0;
-		}
+    td,
+    th {
+      border: 0;
+    }
 
-		tr {
-			border-bottom: 1px solid $mid-gray;
-		}
+    tr {
+      border-bottom: 1px solid $mid-gray;
+    }
 
-		thead {
-			background-color: transparent;
-			tr {
-				border-bottom: 2px solid $mid-gray;
-			}
-		}
-	}
+    thead {
+      background-color: transparent;
+      tr {
+        border-bottom: 2px solid $mid-gray;
+      }
+    }
+  }
 }

--- a/_sass/blocks/_county-bar-table.scss
+++ b/_sass/blocks/_county-bar-table.scss
@@ -3,7 +3,7 @@
     float: left;
   }
 
-  table[is="bar-chart-table"] {
+  [is="bar-chart-table"] {
     border: 0;
     width: 100%;
 
@@ -18,6 +18,7 @@
 
     thead {
       background-color: transparent;
+
       tr {
         border-bottom: 2px solid $mid-gray;
       }

--- a/_sass/blocks/_county-bar-table.scss
+++ b/_sass/blocks/_county-bar-table.scss
@@ -1,0 +1,26 @@
+.eiti-data-map-table {
+	label {
+		float: left;
+	}
+
+	table[is="bar-chart-table"] {
+		border: 0;
+		width: 100%;
+
+		td,
+		th {
+			border: 0;
+		}
+
+		tr {
+			border-bottom: 1px solid $mid-gray;
+		}
+
+		thead {
+			background-color: transparent;
+			tr {
+				border-bottom: 2px solid $mid-gray;
+			}
+		}
+	}
+}

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -24,6 +24,10 @@
     }
   }
 
+  [data-year-values="null"] {
+    display: none;
+  }
+
   .swatch {
     background: $neutral-gray;
     border: 1px solid $neutral-gray;

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -26,6 +26,10 @@
     .bar {
       background-color: transparent
     }
+
+    &[data-value^="-"] .bar {
+      border: 0px;
+    }
   }
 
   [data-year-values="null"] {

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -16,11 +16,15 @@
     background: $light-gray;
   }
 
-  .numberless {
+  .numberless[data-value] {
     vertical-align: middle;
 
     .text {
       display: none;
+    }
+
+    .bar {
+      background-color: transparent
     }
   }
 

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -16,6 +16,24 @@
     background: $light-gray;
   }
 
+  .numberless {
+    vertical-align: middle;
+
+    .text {
+      display: none;
+    }
+  }
+
+  .swatch {
+    background: $neutral-gray;
+    border: 1px solid $neutral-gray;
+    display: inline-block;
+    height: 1rem;
+    margin-right: $standard-padding-lite;
+    vertical-align: text-bottom;
+    width: 1rem;
+  }
+
   .numeric,
   [data-value] {
     text-align: left;

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -19,6 +19,16 @@
       return JSON.parse(yearVals);
     }
 
+    function cellData(data, year, property) {
+      if (data && data[year] && property) {
+        return data[year][property] || 0;
+      } else if (data && !property) {
+        return data[year] || 0;
+      } else {
+        return 0;
+      }
+    }
+
     var root = d3.select(this);
 
     var year = year || '2013';
@@ -31,31 +41,36 @@
 
     bars.datum(function() {
         var data = parseYearVals(this)
-        if (data) {
-          return data[year] || 0;
-        } else {
-          return 0;
-        }
+        var property = this.getAttribute('data-years-property');
+        return cellData(data, year, property);
       })
       .attr('data-value', function(d) {
-        console.log('data-value', d)
         return d;
       });
 
     texts.datum(function() {
         var data = parseYearVals(this)
-        if (data) {
-          return data[year] || 0;
-        } else {
-          return 0;
-        }
+        var property = this.getAttribute('data-years-property');
+        return cellData(data, year, property);
       })
       .attr('data-value-text', function(d) {
         return d;
       })
       .text(function(d) {
         var format = d3.format(this.getAttribute('data-format') || ',')
-        console.log('data-value', d)
+
+        if (this.getAttribute('data-format') === '%') {
+          format = function(d) {
+            if (d === 0) {
+              return 0;
+            } else if (d < 1) {
+              return '<1%';
+            }
+
+            return d3.format('%')(d / 100);
+          }
+        }
+
         if (format) {
           return format(d);
         } else {
@@ -66,14 +81,10 @@
     var that = this;
     swatches.datum(function() {
         var data = parseYearVals(this)
-        if (data) {
-          return data[year] || 0;
-        } else {
-          return 0;
-        }
+        var property = this.getAttribute('data-years-property');
+        return cellData(data, year, property);
       })
       .attr('data-value-swatch', function(d) {
-        console.log('data-value-swatch', d)
         return d;
       })
       .style('background-color', function (d) {
@@ -91,7 +102,6 @@
       return data[year] || 0;
     })
     .attr('aria-hidden', function (d) {
-      console.log(d)
       return !d;
     })
   }

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -12,10 +12,13 @@
 
   var setYear = function(year) {
 
+    var root = d3.select(this);
+
     var year = year || '2013';
-    var bars = d3.select(this).selectAll('[data-value]')
-    var texts = d3.select(this).selectAll('[data-value-text]')
-    var swatches = d3.select(this).selectAll('[data-value-swatch]')
+    var bars = root.selectAll('[data-value]');
+    var texts = root.selectAll('[data-value-text]');
+    var swatches = root.selectAll('[data-value-swatch]');
+    var label = d3.select(this.parentElement).select('label');
 
     bars.datum(function() {
         var yearVals = this.getAttribute('data-year-values') &&
@@ -81,6 +84,10 @@
           return that.eitiDataMap.scale(d);
         }
       });
+
+    label.select('[data-year]')
+      .attr('data-year', year)
+      .text(year)
   }
 
   var update = function() {

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -11,99 +11,102 @@
   };
 
   var setYear = function(year) {
-    function parseYearVals(context) {
-      var yearVals = context.getAttribute('data-year-values') &&
-          context.getAttribute('data-year-values') !== 'null'
-            ? context.getAttribute('data-year-values')
-            : '{}';
-      return JSON.parse(yearVals);
-    }
-
-    function cellData(data, year, property) {
-      if (data && data[year] && property) {
-        return data[year][property] || 0;
-      } else if (data && !property) {
-        return data[year] || 0;
-      } else {
-        return 0;
-      }
-    }
-
     var root = d3.select(this);
 
-    var year = year || '2013';
-    var bars = root.selectAll('[data-value]');
-    var texts = root.selectAll('[data-value-text]');
-    var swatches = root.selectAll('[data-value-swatch]');
-    var label = d3.select(this.parentElement).select('label');
+    if (root.classed('county-table')) {
 
-    var rows = root.selectAll('tr[data-year-values]');
+      function parseYearVals(context) {
+        var yearVals = context.getAttribute('data-year-values') &&
+            context.getAttribute('data-year-values') !== 'null'
+              ? context.getAttribute('data-year-values')
+              : '{}';
+        return JSON.parse(yearVals);
+      }
 
-    bars.datum(function() {
-        var data = parseYearVals(this)
-        var property = this.getAttribute('data-years-property');
-        return cellData(data, year, property);
-      })
-      .attr('data-value', function(d) {
-        return d;
-      });
-
-    texts.datum(function() {
-        var data = parseYearVals(this)
-        var property = this.getAttribute('data-years-property');
-        return cellData(data, year, property);
-      })
-      .attr('data-value-text', function(d) {
-        return d;
-      })
-      .text(function(d) {
-        var format = d3.format(this.getAttribute('data-format') || ',')
-
-        if (this.getAttribute('data-format') === '%') {
-          format = function(d) {
-            if (d === 0) {
-              return 0;
-            } else if (d < 1) {
-              return '<1%';
-            }
-
-            return d3.format('%')(d / 100);
-          }
-        }
-
-        if (format) {
-          return format(d);
+      function cellData(data, year, property) {
+        if (data && data[year] && property) {
+          return data[year][property] || 0;
+        } else if (data && !property) {
+          return data[year] || 0;
         } else {
+          return 0;
+        }
+      }
+
+      var year = year || '2013';
+      var bars = root.selectAll('[data-value]');
+      var texts = root.selectAll('[data-value-text]');
+      var swatches = root.selectAll('[data-value-swatch]');
+      var label = d3.select(this.parentElement).select('label');
+
+      var rows = root.selectAll('tr[data-year-values]');
+
+      bars.datum(function() {
+          var data = parseYearVals(this)
+          var property = this.getAttribute('data-years-property');
+          return cellData(data, year, property);
+        })
+        .attr('data-value', function(d) {
           return d;
-        }
-      });
+        });
 
-    var that = this;
-    swatches.datum(function() {
-        var data = parseYearVals(this)
-        var property = this.getAttribute('data-years-property');
-        return cellData(data, year, property);
+      texts.datum(function() {
+          var data = parseYearVals(this)
+          var property = this.getAttribute('data-years-property');
+          return cellData(data, year, property);
+        })
+        .attr('data-value-text', function(d) {
+          return d;
+        })
+        .text(function(d) {
+          var format = d3.format(this.getAttribute('data-format') || ',')
+
+          if (this.getAttribute('data-format') === '%') {
+            format = function(d) {
+              if (d === 0) {
+                return 0;
+              } else if (d < 1) {
+                return '<1%';
+              }
+
+              return d3.format('%')(d / 100);
+            }
+          }
+
+          if (format) {
+            return format(d);
+          } else {
+            return d;
+          }
+        });
+
+      var that = this;
+      swatches.datum(function() {
+          var data = parseYearVals(this)
+          var property = this.getAttribute('data-years-property');
+          return cellData(data, year, property);
+        })
+        .attr('data-value-swatch', function(d) {
+          return d;
+        })
+        .style('background-color', function (d) {
+          if (d && that.eitiDataMap.scale) {
+            return that.eitiDataMap.scale(d);
+          }
+        });
+
+      label.select('[data-year]')
+        .attr('data-year', year)
+        .text(year)
+
+      rows.datum(function(){
+        var data = parseYearVals(this);
+        return data[year] || 0;
       })
-      .attr('data-value-swatch', function(d) {
-        return d;
-      })
-      .style('background-color', function (d) {
-        if (d && that.eitiDataMap.scale) {
-          return that.eitiDataMap.scale(d);
-        }
+      .attr('aria-hidden', function (d) {
+        return !d;
       });
-
-    label.select('[data-year]')
-      .attr('data-year', year)
-      .text(year)
-
-    rows.datum(function(){
-      var data = parseYearVals(this);
-      return data[year] || 0;
-    })
-    .attr('aria-hidden', function (d) {
-      return !d;
-    })
+    }
   }
 
   var update = function() {

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -5,11 +5,12 @@
     this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
     this._cells = this._cells.concat(this.nested_cells)
 
-    // this.update();
-    this.setYear();
+    this.update();
+    // this.setYear();
   };
 
   var setYear = function(year) {
+    console.log('setYear-==============')
     var updateValues = function(year, context, attr, text) {
       var values = JSON.parse(context.getAttribute('data-year-values'));
       // var format = d3.format(context.attr('data-format') || ',');
@@ -28,31 +29,39 @@
 
     if (bars.attr('data-year-values')) {
       bars.datum(function() {
-          if (this.getAttribute('data-year-values')) {
-            var data = JSON.parse(this.getAttribute('data-year-values') || null);
-            if (data) {
-              return data[year] || 0;
-            }
-
+          var yearVals = this.getAttribute('data-year-values') &&
+            this.getAttribute('data-year-values') !== 'null'
+              ? this.getAttribute('data-year-values')
+              : '{}';
+          var data = JSON.parse(yearVals);
+          if (data) {
+            return data[year] || 0;
+          } else {
+            return 0;
           }
         })
         .attr('data-value', function(d) {
+          console.log('data-value', d)
           return d;
         });
     }
 
     if (texts.attr('data-year-values')) {
       texts.datum(function() {
-          if (this.getAttribute('data-year-values')) {
-            var data = JSON.parse(this.getAttribute('data-year-values') || null);
-            if (data) {
-              return data[year] || 0;
-            }
-
+          var yearVals = this.getAttribute('data-year-values') &&
+            this.getAttribute('data-year-values') !== 'null'
+              ? this.getAttribute('data-year-values')
+              : '{}';
+          var data = JSON.parse(yearVals);
+          if (data) {
+            return data[year] || 0;
+          } else {
+            return 0;
           }
         })
         .text(function(d) {
           var format = d3.format(this.getAttribute('data-format') || ',')
+          console.log('data-value', d)
           if (format) {
             return format(d);
           } else {
@@ -62,23 +71,27 @@
         });
     }
 
-    if (swatches.attr('data-year-values')) {
-      swatches.datum(function() {
-          if (this.getAttribute('data-year-values')) {
-            var data = JSON.parse(this.getAttribute('data-year-values') || null);
-            if (data) {
-              return data[year] || 0;
-            }
+    // if (swatches.attr('data-year-values')) {
+    //   swatches.datum(function() {
+    //       var yearVals = this.getAttribute('data-year-values') &&
+    //           this.getAttribute('data-year-values') !== 'null'
+    //             ? this.getAttribute('data-year-values')
+    //             : '{}';
+    //       var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+    //       if (data) {
+    //         return data[year] || 0;
+    //       } else {
+    //         return 0;
+    //       }
+    //     })
+    //     .attr('data-value-swatch', function(d) {
+    //       console.log('data-value-swatch', d)
+    //       return d;
+    //     });
+    // }
 
-          }
-        })
-        .attr('data-value-swatch', function(d) {
-          return d;
-        });
-    }
 
-
-    this.update();
+    // this.update();
       // .each(function(){
       //   // updateValues(year, this, 'data-value')
 
@@ -97,6 +110,7 @@
   }
 
   var update = function() {
+    console.log('update-------------------------------')
     if (!this._cells.length) {
       return;
     }

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -11,6 +11,13 @@
   };
 
   var setYear = function(year) {
+    function parseYearVals(context) {
+      var yearVals = context.getAttribute('data-year-values') &&
+          context.getAttribute('data-year-values') !== 'null'
+            ? context.getAttribute('data-year-values')
+            : '{}';
+      return JSON.parse(yearVals);
+    }
 
     var root = d3.select(this);
 
@@ -20,12 +27,10 @@
     var swatches = root.selectAll('[data-value-swatch]');
     var label = d3.select(this.parentElement).select('label');
 
+    var rows = root.selectAll('tr[data-year-values]');
+
     bars.datum(function() {
-        var yearVals = this.getAttribute('data-year-values') &&
-          this.getAttribute('data-year-values') !== 'null'
-            ? this.getAttribute('data-year-values')
-            : '{}';
-        var data = JSON.parse(yearVals);
+        var data = parseYearVals(this)
         if (data) {
           return data[year] || 0;
         } else {
@@ -38,11 +43,7 @@
       });
 
     texts.datum(function() {
-        var yearVals = this.getAttribute('data-year-values') &&
-          this.getAttribute('data-year-values') !== 'null'
-            ? this.getAttribute('data-year-values')
-            : '{}';
-        var data = JSON.parse(yearVals);
+        var data = parseYearVals(this)
         if (data) {
           return data[year] || 0;
         } else {
@@ -64,11 +65,7 @@
 
     var that = this;
     swatches.datum(function() {
-        var yearVals = this.getAttribute('data-year-values') &&
-            this.getAttribute('data-year-values') !== 'null'
-              ? this.getAttribute('data-year-values')
-              : '{}';
-        var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+        var data = parseYearVals(this)
         if (data) {
           return data[year] || 0;
         } else {
@@ -88,6 +85,15 @@
     label.select('[data-year]')
       .attr('data-year', year)
       .text(year)
+
+    rows.datum(function(){
+      var data = parseYearVals(this);
+      return data[year] || 0;
+    })
+    .attr('aria-hidden', function (d) {
+      console.log(d)
+      return !d;
+    })
   }
 
   var update = function() {

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -5,8 +5,96 @@
     this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
     this._cells = this._cells.concat(this.nested_cells)
 
-    this.update();
+    // this.update();
+    this.setYear();
   };
+
+  var setYear = function(year) {
+    var updateValues = function(year, context, attr, text) {
+      var values = JSON.parse(context.getAttribute('data-year-values'));
+      // var format = d3.format(context.attr('data-format') || ',');
+      if (values) {
+        console.log(values)
+        context.setAttribute(attr, values[year])
+        if (text) {
+          context.innerHTML = values[year];
+        }
+      }
+    }
+    var year = year || '2013';
+    var bars = d3.select(this).selectAll('[data-value]')
+    var texts = d3.select(this).selectAll('[data-value-text]')
+    var swatches = d3.select(this).selectAll('[data-value-swatch]')
+
+    if (bars.attr('data-year-values')) {
+      bars.datum(function() {
+          if (this.getAttribute('data-year-values')) {
+            var data = JSON.parse(this.getAttribute('data-year-values') || null);
+            if (data) {
+              return data[year] || 0;
+            }
+
+          }
+        })
+        .attr('data-value', function(d) {
+          return d;
+        });
+    }
+
+    if (texts.attr('data-year-values')) {
+      texts.datum(function() {
+          if (this.getAttribute('data-year-values')) {
+            var data = JSON.parse(this.getAttribute('data-year-values') || null);
+            if (data) {
+              return data[year] || 0;
+            }
+
+          }
+        })
+        .text(function(d) {
+          var format = d3.format(this.getAttribute('data-format') || ',')
+          if (format) {
+            return format(d);
+          } else {
+            return d;
+          }
+
+        });
+    }
+
+    if (swatches.attr('data-year-values')) {
+      swatches.datum(function() {
+          if (this.getAttribute('data-year-values')) {
+            var data = JSON.parse(this.getAttribute('data-year-values') || null);
+            if (data) {
+              return data[year] || 0;
+            }
+
+          }
+        })
+        .attr('data-value-swatch', function(d) {
+          return d;
+        });
+    }
+
+
+    this.update();
+      // .each(function(){
+      //   // updateValues(year, this, 'data-value')
+
+      //   var values = JSON.parse(this.attr('data-year-values')
+      // });
+
+    // var texts = d3.select(this).selectAll('[data-value-text]')
+    //   .each(function(){
+    //     updateValues(year, this, 'data-value-text', true)
+    //   });
+
+    // var swatches = d3.select(this).selectAll('[data-value-swatch]')
+    //   .each(function(){
+    //     updateValues(year, this, 'data-value-swatch')
+    //   });
+  }
 
   var update = function() {
     if (!this._cells.length) {
@@ -166,6 +254,8 @@
         }},
 
         update: {value: update},
+
+        setYear: {value: setYear},
 
         orient: {
           get: function() {

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -4,113 +4,86 @@
     this._cells = [].slice.call(this.querySelectorAll('tr > [data-value]'));
     this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
     this._cells = this._cells.concat(this.nested_cells)
+    this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
 
+    this.setYear();
     this.update();
-    // this.setYear();
   };
 
   var setYear = function(year) {
-    console.log('setYear-==============')
-    var updateValues = function(year, context, attr, text) {
-      var values = JSON.parse(context.getAttribute('data-year-values'));
-      // var format = d3.format(context.attr('data-format') || ',');
-      if (values) {
-        console.log(values)
-        context.setAttribute(attr, values[year])
-        if (text) {
-          context.innerHTML = values[year];
-        }
-      }
-    }
+
     var year = year || '2013';
     var bars = d3.select(this).selectAll('[data-value]')
     var texts = d3.select(this).selectAll('[data-value-text]')
     var swatches = d3.select(this).selectAll('[data-value-swatch]')
 
-    if (bars.attr('data-year-values')) {
-      bars.datum(function() {
-          var yearVals = this.getAttribute('data-year-values') &&
-            this.getAttribute('data-year-values') !== 'null'
-              ? this.getAttribute('data-year-values')
-              : '{}';
-          var data = JSON.parse(yearVals);
-          if (data) {
-            return data[year] || 0;
-          } else {
-            return 0;
-          }
-        })
-        .attr('data-value', function(d) {
-          console.log('data-value', d)
+    bars.datum(function() {
+        var yearVals = this.getAttribute('data-year-values') &&
+          this.getAttribute('data-year-values') !== 'null'
+            ? this.getAttribute('data-year-values')
+            : '{}';
+        var data = JSON.parse(yearVals);
+        if (data) {
+          return data[year] || 0;
+        } else {
+          return 0;
+        }
+      })
+      .attr('data-value', function(d) {
+        console.log('data-value', d)
+        return d;
+      });
+
+    texts.datum(function() {
+        var yearVals = this.getAttribute('data-year-values') &&
+          this.getAttribute('data-year-values') !== 'null'
+            ? this.getAttribute('data-year-values')
+            : '{}';
+        var data = JSON.parse(yearVals);
+        if (data) {
+          return data[year] || 0;
+        } else {
+          return 0;
+        }
+      })
+      .attr('data-value-text', function(d) {
+        return d;
+      })
+      .text(function(d) {
+        var format = d3.format(this.getAttribute('data-format') || ',')
+        console.log('data-value', d)
+        if (format) {
+          return format(d);
+        } else {
           return d;
-        });
-    }
+        }
+      });
 
-    if (texts.attr('data-year-values')) {
-      texts.datum(function() {
-          var yearVals = this.getAttribute('data-year-values') &&
+    var that = this;
+    swatches.datum(function() {
+        var yearVals = this.getAttribute('data-year-values') &&
             this.getAttribute('data-year-values') !== 'null'
               ? this.getAttribute('data-year-values')
               : '{}';
-          var data = JSON.parse(yearVals);
-          if (data) {
-            return data[year] || 0;
-          } else {
-            return 0;
-          }
-        })
-        .text(function(d) {
-          var format = d3.format(this.getAttribute('data-format') || ',')
-          console.log('data-value', d)
-          if (format) {
-            return format(d);
-          } else {
-            return d;
-          }
-
-        });
-    }
-
-    // if (swatches.attr('data-year-values')) {
-    //   swatches.datum(function() {
-    //       var yearVals = this.getAttribute('data-year-values') &&
-    //           this.getAttribute('data-year-values') !== 'null'
-    //             ? this.getAttribute('data-year-values')
-    //             : '{}';
-    //       var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
-    //       if (data) {
-    //         return data[year] || 0;
-    //       } else {
-    //         return 0;
-    //       }
-    //     })
-    //     .attr('data-value-swatch', function(d) {
-    //       console.log('data-value-swatch', d)
-    //       return d;
-    //     });
-    // }
-
-
-    // this.update();
-      // .each(function(){
-      //   // updateValues(year, this, 'data-value')
-
-      //   var values = JSON.parse(this.attr('data-year-values')
-      // });
-
-    // var texts = d3.select(this).selectAll('[data-value-text]')
-    //   .each(function(){
-    //     updateValues(year, this, 'data-value-text', true)
-    //   });
-
-    // var swatches = d3.select(this).selectAll('[data-value-swatch]')
-    //   .each(function(){
-    //     updateValues(year, this, 'data-value-swatch')
-    //   });
+        var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+        if (data) {
+          return data[year] || 0;
+        } else {
+          return 0;
+        }
+      })
+      .attr('data-value-swatch', function(d) {
+        console.log('data-value-swatch', d)
+        return d;
+      })
+      .style('background-color', function (d) {
+        if (d && that.eitiDataMap.scale) {
+          return that.eitiDataMap.scale(d);
+        }
+      });
   }
 
   var update = function() {
-    console.log('update-------------------------------')
     if (!this._cells.length) {
       return;
     }

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -64,6 +64,8 @@
           marks.attr('fill', scale);
 
 
+          this.scale = scale;
+
           // start map legend
           function uniq(value, index, self) {
             return self.indexOf(value) === index;

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -61,8 +61,6 @@
             .domain(domain)
             .range(colors);
 
-          this.setAttribute('scale', scale);
-
           marks.attr('fill', scale);
 
 
@@ -146,13 +144,13 @@
           // end trim
 
 
-          var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
-            .datum(function() {
-              return +this.getAttribute('data-value-swatch') || 0;
-            });
+          // var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
+          //   .datum(function() {
+          //     return +this.getAttribute('data-value-swatch') || 0;
+          //   });
 
-          swatches.style('background-color', scale);
-          console.log(swatches)
+          // swatches.style('background-color', scale);
+          // console.log(swatches)
         }}
       }
     )

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -61,6 +61,7 @@
             .domain(domain)
             .range(colors);
 
+          this.setAttribute('scale', scale);
 
           marks.attr('fill', scale);
 
@@ -127,22 +128,31 @@
           // end consolidation
           // end map legend
 
-           // start trim height on map container
-           var svgContainer = d3.select(this)
-             .selectAll('.svg-container[data-dimensions]')
-             .datum(function() {
-               return (this.getBoundingClientRect().width
-                 * +this.getAttribute('data-dimensions')
-                 / 100)
-                 + 50;
-             });
+          // start trim height on map container
+          var svgContainer = d3.select(this)
+            .selectAll('.svg-container[data-dimensions]')
+            .datum(function() {
+              return (this.getBoundingClientRect().width
+                * +this.getAttribute('data-dimensions')
+                / 100)
+                + 50;
+            });
 
-           function pixelize(d) {
-             return d + 'px';
-           }
+          function pixelize(d) {
+            return d + 'px';
+          }
 
-           svgContainer.style('padding-bottom', pixelize);
-           // end trim
+          svgContainer.style('padding-bottom', pixelize);
+          // end trim
+
+
+          var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
+            .datum(function() {
+              return +this.getAttribute('data-value-swatch') || 0;
+            });
+
+          swatches.style('background-color', scale);
+          console.log(swatches)
         }}
       }
     )

--- a/js/components/year-switcher-section.js
+++ b/js/components/year-switcher-section.js
@@ -6,6 +6,7 @@
     var select = root.selectAll('select.chart-selector');
     var charts = root.selectAll('eiti-bar-chart');
     var maps = root.selectAll('eiti-data-map');
+    var chartTables = maps.selectAll('table[is="bar-chart-table"]')
 
     var update = function(year) {
       charts.property('x', year);
@@ -13,6 +14,9 @@
         this.setYear(year);
       });
       select.property('value',  year);
+      chartTables.each(function(){
+        this.setYear(year);
+      })
     };
 
     select.on('change.year', function() {

--- a/js/components/year-switcher-section.js
+++ b/js/components/year-switcher-section.js
@@ -10,9 +10,6 @@
     var mapTables = root.selectAll('.eiti-data-map-table');
 
     var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
-    console.log(maps)
-    console.log('=============')
-    console.log(chartTables)
 
     var update = function(year) {
       charts.property('x', year);

--- a/js/components/year-switcher-section.js
+++ b/js/components/year-switcher-section.js
@@ -6,16 +6,24 @@
     var select = root.selectAll('select.chart-selector');
     var charts = root.selectAll('eiti-bar-chart');
     var maps = root.selectAll('eiti-data-map');
-    var chartTables = maps.selectAll('table[is="bar-chart-table"]')
+
+    var mapTables = root.selectAll('.eiti-data-map-table');
+
+    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
+    console.log(maps)
+    console.log('=============')
+    console.log(chartTables)
 
     var update = function(year) {
       charts.property('x', year);
       maps.each(function() {
         this.setYear(year);
       });
-      select.property('value',  year);
+      select.property('value', year);
       chartTables.each(function(){
+        console.log(this)
         this.setYear(year);
+        this.update();
       })
     };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12040,99 +12040,102 @@
 	  };
 
 	  var setYear = function(year) {
-	    function parseYearVals(context) {
-	      var yearVals = context.getAttribute('data-year-values') &&
-	          context.getAttribute('data-year-values') !== 'null'
-	            ? context.getAttribute('data-year-values')
-	            : '{}';
-	      return JSON.parse(yearVals);
-	    }
-
-	    function cellData(data, year, property) {
-	      if (data && data[year] && property) {
-	        return data[year][property] || 0;
-	      } else if (data && !property) {
-	        return data[year] || 0;
-	      } else {
-	        return 0;
-	      }
-	    }
-
 	    var root = d3.select(this);
 
-	    var year = year || '2013';
-	    var bars = root.selectAll('[data-value]');
-	    var texts = root.selectAll('[data-value-text]');
-	    var swatches = root.selectAll('[data-value-swatch]');
-	    var label = d3.select(this.parentElement).select('label');
+	    if (root.classed('county-table')) {
 
-	    var rows = root.selectAll('tr[data-year-values]');
+	      function parseYearVals(context) {
+	        var yearVals = context.getAttribute('data-year-values') &&
+	            context.getAttribute('data-year-values') !== 'null'
+	              ? context.getAttribute('data-year-values')
+	              : '{}';
+	        return JSON.parse(yearVals);
+	      }
 
-	    bars.datum(function() {
-	        var data = parseYearVals(this)
-	        var property = this.getAttribute('data-years-property');
-	        return cellData(data, year, property);
-	      })
-	      .attr('data-value', function(d) {
-	        return d;
-	      });
-
-	    texts.datum(function() {
-	        var data = parseYearVals(this)
-	        var property = this.getAttribute('data-years-property');
-	        return cellData(data, year, property);
-	      })
-	      .attr('data-value-text', function(d) {
-	        return d;
-	      })
-	      .text(function(d) {
-	        var format = d3.format(this.getAttribute('data-format') || ',')
-
-	        if (this.getAttribute('data-format') === '%') {
-	          format = function(d) {
-	            if (d === 0) {
-	              return 0;
-	            } else if (d < 1) {
-	              return '<1%';
-	            }
-
-	            return d3.format('%')(d / 100);
-	          }
-	        }
-
-	        if (format) {
-	          return format(d);
+	      function cellData(data, year, property) {
+	        if (data && data[year] && property) {
+	          return data[year][property] || 0;
+	        } else if (data && !property) {
+	          return data[year] || 0;
 	        } else {
+	          return 0;
+	        }
+	      }
+
+	      var year = year || '2013';
+	      var bars = root.selectAll('[data-value]');
+	      var texts = root.selectAll('[data-value-text]');
+	      var swatches = root.selectAll('[data-value-swatch]');
+	      var label = d3.select(this.parentElement).select('label');
+
+	      var rows = root.selectAll('tr[data-year-values]');
+
+	      bars.datum(function() {
+	          var data = parseYearVals(this)
+	          var property = this.getAttribute('data-years-property');
+	          return cellData(data, year, property);
+	        })
+	        .attr('data-value', function(d) {
 	          return d;
-	        }
-	      });
+	        });
 
-	    var that = this;
-	    swatches.datum(function() {
-	        var data = parseYearVals(this)
-	        var property = this.getAttribute('data-years-property');
-	        return cellData(data, year, property);
+	      texts.datum(function() {
+	          var data = parseYearVals(this)
+	          var property = this.getAttribute('data-years-property');
+	          return cellData(data, year, property);
+	        })
+	        .attr('data-value-text', function(d) {
+	          return d;
+	        })
+	        .text(function(d) {
+	          var format = d3.format(this.getAttribute('data-format') || ',')
+
+	          if (this.getAttribute('data-format') === '%') {
+	            format = function(d) {
+	              if (d === 0) {
+	                return 0;
+	              } else if (d < 1) {
+	                return '<1%';
+	              }
+
+	              return d3.format('%')(d / 100);
+	            }
+	          }
+
+	          if (format) {
+	            return format(d);
+	          } else {
+	            return d;
+	          }
+	        });
+
+	      var that = this;
+	      swatches.datum(function() {
+	          var data = parseYearVals(this)
+	          var property = this.getAttribute('data-years-property');
+	          return cellData(data, year, property);
+	        })
+	        .attr('data-value-swatch', function(d) {
+	          return d;
+	        })
+	        .style('background-color', function (d) {
+	          if (d && that.eitiDataMap.scale) {
+	            return that.eitiDataMap.scale(d);
+	          }
+	        });
+
+	      label.select('[data-year]')
+	        .attr('data-year', year)
+	        .text(year)
+
+	      rows.datum(function(){
+	        var data = parseYearVals(this);
+	        return data[year] || 0;
 	      })
-	      .attr('data-value-swatch', function(d) {
-	        return d;
-	      })
-	      .style('background-color', function (d) {
-	        if (d && that.eitiDataMap.scale) {
-	          return that.eitiDataMap.scale(d);
-	        }
+	      .attr('aria-hidden', function (d) {
+	        return !d;
 	      });
-
-	    label.select('[data-year]')
-	      .attr('data-year', year)
-	      .text(year)
-
-	    rows.datum(function(){
-	      var data = parseYearVals(this);
-	      return data[year] || 0;
-	    })
-	    .attr('aria-hidden', function (d) {
-	      return !d;
-	    })
+	    }
 	  }
 
 	  var update = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -48,8 +48,8 @@
 	  'use strict';
 
 	  __webpack_require__(24);
+	  __webpack_require__(26);
 	  __webpack_require__(25);
-	  __webpack_require__(32);
 	  __webpack_require__(33);
 	  __webpack_require__(34);
 
@@ -11086,945 +11086,6 @@
 
 /***/ },
 /* 25 */
-/***/ function(module, exports, __webpack_require__) {
-
-	(function(exports) {
-
-	  __webpack_require__(26);
-
-	  var eiti = __webpack_require__(12);
-	  var format = eiti.format;
-
-	  exports.EITIDataMap = document.registerElement('eiti-data-map', {
-	    prototype: Object.create(
-	      HTMLElement.prototype,
-	      {
-	        attachedCallback: {value: function() {
-	          this.marks = d3.select(this).selectAll('[data-value]')
-	            .datum(function() {
-	              return +this.getAttribute('data-value') || 0;
-	            });
-
-	          this.update();
-	        }},
-
-	        setYear: {value: function(year) {
-	          this.marks.datum(function() {
-	              var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
-	              return data[year] || 0;
-	            })
-	            .attr('data-value', function(d) {
-	              return d;
-	            });
-	          this.update();
-	        }},
-
-	        update: {value: function() {
-	          var type = this.getAttribute('scale-type') || 'quantize';
-	          var scheme = this.getAttribute('color-scheme') || 'Blues';
-	          var steps = this.getAttribute('steps') || 5;
-	          var units = this.getAttribute('units') || '';
-
-
-	          var colors = colorbrewer[scheme][steps];
-	          if (!colors) {
-	            return console.error(
-	              'bad # of steps (%d) for color scheme:', steps, scheme
-	            );
-	          }
-
-	          var marks = this.marks;
-
-	          var domain = this.hasAttribute('domain')
-	            ? JSON.parse(this.getAttribute('domain'))
-	            : d3.extent(marks.data());
-
-	          if (domain[0] > 0) {
-	            domain[0] = 0;
-	          } else if (domain[0] < 0) {
-	            domain[1] = Math.max(0, domain[1]);
-	          }
-
-	          // FIXME: do something with divergent scales??
-
-	          var scale = d3.scale[type]()
-	            .domain(domain)
-	            .range(colors);
-
-	          marks.attr('fill', scale);
-
-
-	          this.scale = scale;
-
-	          // start map legend
-	          function uniq(value, index, self) {
-	            return self.indexOf(value) === index;
-	          }
-
-	          function getUnique(data, steps, domain) {
-	            var getSteps = d3.scale[type]()
-	              .domain(domain)
-	              .range(steps);
-
-	            var values = [];
-	            data.forEach(function(d) {
-	              values.push(getSteps(d));
-	            });
-
-	            return values.filter(uniq);
-	          }
-
-	          var svgLegend = d3.select(this)
-	            .select('.legend-svg');
-
-	          svgLegend.append('g')
-	            .attr('class', 'legendScale');
-
-	          var legend = d3.legend.color()
-	            .labelFormat(format.si)
-	            .useClass(false)
-	            .ascending(true)
-	            .labelDelimiter('-')
-	            .shapePadding(6)
-	            .scale(scale);
-
-	          svgLegend.select('.legendScale')
-	            .call(legend);
-
-	          // reverse because the scale is in ascending order
-	          var _steps = d3.range(0, 9).reverse();
-
-	          // find which steps are represented in the map
-	          var uniqueSteps = getUnique(marks.data(), _steps, domain);
-
-	          // start consolidate (translate) visible cells
-	          var cells = svgLegend.selectAll('.cell');
-	          var cellHeight = legend.shapeHeight() + legend.shapePadding();
-	          var count = 0;
-	          cells.each(function(cell, i) {
-	            var present = uniqueSteps.indexOf(i) > -1;
-
-	            if (!present) {
-	              // hide cells swatches that aren't in the map
-	              cells[0][i].setAttribute('aria-hidden', true);
-	              count++;
-	            } else  {
-	              // trim spacing between swatches that are visible
-	              var translateHeight = (i * cellHeight) - (count * cellHeight);
-	              cells[0][i].setAttribute('transform',
-	                'translate(0,' + translateHeight + ')');
-	            }
-	          });
-	          // end consolidation
-	          // end map legend
-
-	          // start trim height on map container
-	          var svgContainer = d3.select(this)
-	            .selectAll('.svg-container[data-dimensions]')
-	            .datum(function() {
-	              return (this.getBoundingClientRect().width
-	                * +this.getAttribute('data-dimensions')
-	                / 100)
-	                + 50;
-	            });
-
-	          function pixelize(d) {
-	            return d + 'px';
-	          }
-
-	          svgContainer.style('padding-bottom', pixelize);
-	          // end trim
-
-
-	          // var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
-	          //   .datum(function() {
-	          //     return +this.getAttribute('data-value-swatch') || 0;
-	          //   });
-
-	          // swatches.style('background-color', scale);
-	          // console.log(swatches)
-	        }}
-	      }
-	    )
-	  });
-
-	})(this);
-
-
-/***/ },
-/* 26 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var d3 = __webpack_require__(5);
-
-	d3.legend = __webpack_require__(27);
-
-	module.exports = d3;
-
-
-/***/ },
-/* 27 */
-/***/ function(module, exports, __webpack_require__) {
-
-	module.exports = {
-	  color: __webpack_require__(28),
-	  size: __webpack_require__(30),
-	  symbol: __webpack_require__(31)
-	};
-
-
-/***/ },
-/* 28 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var helper = __webpack_require__(29);
-
-	module.exports = function(){
-
-	  var scale = d3.scale.linear(),
-	    shape = "rect",
-	    shapeWidth = 15,
-	    shapeHeight = 15,
-	    shapeRadius = 10,
-	    shapePadding = 2,
-	    cells = [5],
-	    labels = [],
-	    classPrefix = "",
-	    useClass = false,
-	    title = "",
-	    labelFormat = d3.format(".01f"),
-	    labelOffset = 10,
-	    labelAlign = "middle",
-	    labelDelimiter = "to",
-	    orient = "vertical",
-	    ascending = false,
-	    path,
-	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
-
-	    function legend(svg){
-
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
-	        legendG = svg.selectAll('g').data([scale]);
-
-	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
-
-
-	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
-	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
-	        shapes = cell.select("g." + classPrefix + "cell " + shape);
-
-	      //add event handlers
-	      helper.d3_addEvents(cellEnter, legendDispatcher);
-
-	      cell.exit().transition().style("opacity", 0).remove();
-
-	      helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, path);
-
-	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
-
-	      // sets placement
-	      var text = cell.select("text"),
-	        shapeSize = shapes[0].map( function(d){ return d.getBBox(); });
-
-	      //sets scale
-	      //everything is fill except for line which is stroke,
-	      if (!useClass){
-	        if (shape == "line"){
-	          shapes.style("stroke", type.feature);
-	        } else {
-	          shapes.style("fill", type.feature);
-	        }
-	      } else {
-	        shapes.attr("class", function(d){ return classPrefix + "swatch " + type.feature(d); });
-	      }
-
-	      var cellTrans,
-	      textTrans,
-	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
-
-	      //positions cells and text
-	      if (orient === "vertical"){
-	        cellTrans = function(d,i) { return "translate(0, " + (i * (shapeSize[i].height + shapePadding)) + ")"; };
-	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width + shapeSize[i].x +
-	          labelOffset) + "," + (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
-
-	      } else if (orient === "horizontal"){
-	        cellTrans = function(d,i) { return "translate(" + (i * (shapeSize[i].width + shapePadding)) + ",0)"; }
-	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) +
-	          "," + (shapeSize[i].height + shapeSize[i].y + labelOffset + 8) + ")"; };
-	      }
-
-	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
-	      helper.d3_title(svg, legendG, title, classPrefix);
-
-	      cell.transition().style("opacity", 1);
-
-	    }
-
-
-
-	  legend.scale = function(_) {
-	    if (!arguments.length) return scale;
-	    scale = _;
-	    return legend;
-	  };
-
-	  legend.cells = function(_) {
-	    if (!arguments.length) return cells;
-	    if (_.length > 1 || _ >= 2 ){
-	      cells = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.shape = function(_, d) {
-	    if (!arguments.length) return shape;
-	    if (_ == "rect" || _ == "circle" || _ == "line" || (_ == "path" && (typeof d === 'string')) ){
-	      shape = _;
-	      path = d;
-	    }
-	    return legend;
-	  };
-
-	  legend.shapeWidth = function(_) {
-	    if (!arguments.length) return shapeWidth;
-	    shapeWidth = +_;
-	    return legend;
-	  };
-
-	  legend.shapeHeight = function(_) {
-	    if (!arguments.length) return shapeHeight;
-	    shapeHeight = +_;
-	    return legend;
-	  };
-
-	  legend.shapeRadius = function(_) {
-	    if (!arguments.length) return shapeRadius;
-	    shapeRadius = +_;
-	    return legend;
-	  };
-
-	  legend.shapePadding = function(_) {
-	    if (!arguments.length) return shapePadding;
-	    shapePadding = +_;
-	    return legend;
-	  };
-
-	  legend.labels = function(_) {
-	    if (!arguments.length) return labels;
-	    labels = _;
-	    return legend;
-	  };
-
-	  legend.labelAlign = function(_) {
-	    if (!arguments.length) return labelAlign;
-	    if (_ == "start" || _ == "end" || _ == "middle") {
-	      labelAlign = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.labelFormat = function(_) {
-	    if (!arguments.length) return labelFormat;
-	    labelFormat = _;
-	    return legend;
-	  };
-
-	  legend.labelOffset = function(_) {
-	    if (!arguments.length) return labelOffset;
-	    labelOffset = +_;
-	    return legend;
-	  };
-
-	  legend.labelDelimiter = function(_) {
-	    if (!arguments.length) return labelDelimiter;
-	    labelDelimiter = _;
-	    return legend;
-	  };
-
-	  legend.useClass = function(_) {
-	    if (!arguments.length) return useClass;
-	    if (_ === true || _ === false){
-	      useClass = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.orient = function(_){
-	    if (!arguments.length) return orient;
-	    _ = _.toLowerCase();
-	    if (_ == "horizontal" || _ == "vertical") {
-	      orient = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.ascending = function(_) {
-	    if (!arguments.length) return ascending;
-	    ascending = !!_;
-	    return legend;
-	  };
-
-	  legend.classPrefix = function(_) {
-	    if (!arguments.length) return classPrefix;
-	    classPrefix = _;
-	    return legend;
-	  };
-
-	  legend.title = function(_) {
-	    if (!arguments.length) return title;
-	    title = _;
-	    return legend;
-	  };
-
-	  d3.rebind(legend, legendDispatcher, "on");
-
-	  return legend;
-
-	};
-
-
-/***/ },
-/* 29 */
-/***/ function(module, exports) {
-
-	module.exports = {
-
-	  d3_identity: function (d) {
-	    return d;
-	  },
-
-	  d3_mergeLabels: function (gen, labels) {
-
-	      if(labels.length === 0) return gen;
-
-	      gen = (gen) ? gen : [];
-
-	      var i = labels.length;
-	      for (; i < gen.length; i++) {
-	        labels.push(gen[i]);
-	      }
-	      return labels;
-	    },
-
-	  d3_linearLegend: function (scale, cells, labelFormat) {
-	    var data = [];
-
-	    if (cells.length > 1){
-	      data = cells;
-
-	    } else {
-	      var domain = scale.domain(),
-	      increment = (domain[domain.length - 1] - domain[0])/(cells - 1),
-	      i = 0;
-
-	      for (; i < cells; i++){
-	        data.push(domain[0] + i*increment);
-	      }
-	    }
-
-	    var labels = data.map(labelFormat);
-
-	    return {data: data,
-	            labels: labels,
-	            feature: function(d){ return scale(d); }};
-	  },
-
-	  d3_quantLegend: function (scale, labelFormat, labelDelimiter) {
-	    var labels = scale.range().map(function(d){
-	      var invert = scale.invertExtent(d),
-	      a = labelFormat(invert[0]),
-	      b = labelFormat(invert[1]);
-
-	      // if (( (a) && (a.isNan()) && b){
-	      //   console.log("in initial statement")
-	        return labelFormat(invert[0]) + " " + labelDelimiter + " " + labelFormat(invert[1]);
-	      // } else if (a || b) {
-	      //   console.log('in else statement')
-	      //   return (a) ? a : b;
-	      // }
-
-	    });
-
-	    return {data: scale.range(),
-	            labels: labels,
-	            feature: this.d3_identity
-	          };
-	  },
-
-	  d3_ordinalLegend: function (scale) {
-	    return {data: scale.domain(),
-	            labels: scale.domain(),
-	            feature: function(d){ return scale(d); }};
-	  },
-
-	  d3_drawShapes: function (shape, shapes, shapeHeight, shapeWidth, shapeRadius, path) {
-	    if (shape === "rect"){
-	        shapes.attr("height", shapeHeight).attr("width", shapeWidth);
-
-	    } else if (shape === "circle") {
-	        shapes.attr("r", shapeRadius)//.attr("cx", shapeRadius).attr("cy", shapeRadius);
-
-	    } else if (shape === "line") {
-	        shapes.attr("x1", 0).attr("x2", shapeWidth).attr("y1", 0).attr("y2", 0);
-
-	    } else if (shape === "path") {
-	      shapes.attr("d", path);
-	    }
-	  },
-
-	  d3_addText: function (svg, enter, labels, classPrefix){
-	    enter.append("text").attr("class", classPrefix + "label");
-	    svg.selectAll("g." + classPrefix + "cell text").data(labels).text(this.d3_identity);
-	  },
-
-	  d3_calcType: function (scale, ascending, cells, labels, labelFormat, labelDelimiter){
-	    var type = scale.ticks ?
-	            this.d3_linearLegend(scale, cells, labelFormat) : scale.invertExtent ?
-	            this.d3_quantLegend(scale, labelFormat, labelDelimiter) : this.d3_ordinalLegend(scale);
-
-	    type.labels = this.d3_mergeLabels(type.labels, labels);
-
-	    if (ascending) {
-	      type.labels = this.d3_reverse(type.labels);
-	      type.data = this.d3_reverse(type.data);
-	    }
-
-	    return type;
-	  },
-
-	  d3_reverse: function(arr) {
-	    var mirror = [];
-	    for (var i = 0, l = arr.length; i < l; i++) {
-	      mirror[i] = arr[l-i-1];
-	    }
-	    return mirror;
-	  },
-
-	  d3_placement: function (orient, cell, cellTrans, text, textTrans, labelAlign) {
-	    cell.attr("transform", cellTrans);
-	    text.attr("transform", textTrans);
-	    if (orient === "horizontal"){
-	      text.style("text-anchor", labelAlign);
-	    }
-	  },
-
-	  d3_addEvents: function(cells, dispatcher){
-	    var _ = this;
-
-	      cells.on("mouseover.legend", function (d) { _.d3_cellOver(dispatcher, d, this); })
-	          .on("mouseout.legend", function (d) { _.d3_cellOut(dispatcher, d, this); })
-	          .on("click.legend", function (d) { _.d3_cellClick(dispatcher, d, this); });
-	  },
-
-	  d3_cellOver: function(cellDispatcher, d, obj){
-	    cellDispatcher.cellover.call(obj, d);
-	  },
-
-	  d3_cellOut: function(cellDispatcher, d, obj){
-	    cellDispatcher.cellout.call(obj, d);
-	  },
-
-	  d3_cellClick: function(cellDispatcher, d, obj){
-	    cellDispatcher.cellclick.call(obj, d);
-	  },
-
-	  d3_title: function(svg, cellsSvg, title, classPrefix){
-	    if (title !== ""){
-
-	      var titleText = svg.selectAll('text.' + classPrefix + 'legendTitle');
-
-	      titleText.data([title])
-	        .enter()
-	        .append('text')
-	        .attr('class', classPrefix + 'legendTitle');
-
-	        svg.selectAll('text.' + classPrefix + 'legendTitle')
-	            .text(title)
-
-	      var yOffset = svg.select('.' + classPrefix + 'legendTitle')
-	          .map(function(d) { return d[0].getBBox().height})[0],
-	      xOffset = -cellsSvg.map(function(d) { return d[0].getBBox().x})[0];
-
-	      cellsSvg.attr('transform', 'translate(' + xOffset + ',' + (yOffset + 10) + ')');
-
-	    }
-	  }
-	}
-
-
-/***/ },
-/* 30 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var helper = __webpack_require__(29);
-
-	module.exports =  function(){
-
-	  var scale = d3.scale.linear(),
-	    shape = "rect",
-	    shapeWidth = 15,
-	    shapePadding = 2,
-	    cells = [5],
-	    labels = [],
-	    useStroke = false,
-	    classPrefix = "",
-	    title = "",
-	    labelFormat = d3.format(".01f"),
-	    labelOffset = 10,
-	    labelAlign = "middle",
-	    labelDelimiter = "to",
-	    orient = "vertical",
-	    ascending = false,
-	    path,
-	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
-
-	    function legend(svg){
-
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
-	        legendG = svg.selectAll('g').data([scale]);
-
-	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
-
-
-	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
-	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
-	        shapes = cell.select("g." + classPrefix + "cell " + shape);
-
-	      //add event handlers
-	      helper.d3_addEvents(cellEnter, legendDispatcher);
-
-	      cell.exit().transition().style("opacity", 0).remove();
-
-	      //creates shape
-	      if (shape === "line"){
-	        helper.d3_drawShapes(shape, shapes, 0, shapeWidth);
-	        shapes.attr("stroke-width", type.feature);
-	      } else {
-	        helper.d3_drawShapes(shape, shapes, type.feature, type.feature, type.feature, path);
-	      }
-
-	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
-
-	      //sets placement
-	      var text = cell.select("text"),
-	        shapeSize = shapes[0].map(
-	          function(d, i){
-	            var bbox = d.getBBox()
-	            var stroke = scale(type.data[i]);
-
-	            if (shape === "line" && orient === "horizontal") {
-	              bbox.height = bbox.height + stroke;
-	            } else if (shape === "line" && orient === "vertical"){
-	              bbox.width = bbox.width;
-	            }
-
-	            return bbox;
-	        });
-
-	      var maxH = d3.max(shapeSize, function(d){ return d.height + d.y; }),
-	      maxW = d3.max(shapeSize, function(d){ return d.width + d.x; });
-
-	      var cellTrans,
-	      textTrans,
-	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
-
-	      //positions cells and text
-	      if (orient === "vertical"){
-
-	        cellTrans = function(d,i) {
-	            var height = d3.sum(shapeSize.slice(0, i + 1 ), function(d){ return d.height; });
-	            return "translate(0, " + (height + i*shapePadding) + ")"; };
-
-	        textTrans = function(d,i) { return "translate(" + (maxW + labelOffset) + "," +
-	          (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
-
-	      } else if (orient === "horizontal"){
-	        cellTrans = function(d,i) {
-	            var width = d3.sum(shapeSize.slice(0, i + 1 ), function(d){ return d.width; });
-	            return "translate(" + (width + i*shapePadding) + ",0)"; };
-
-	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) + "," +
-	              (maxH + labelOffset ) + ")"; };
-	      }
-
-	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
-	      helper.d3_title(svg, legendG, title, classPrefix);
-
-	      cell.transition().style("opacity", 1);
-
-	    }
-
-	  legend.scale = function(_) {
-	    if (!arguments.length) return scale;
-	    scale = _;
-	    return legend;
-	  };
-
-	  legend.cells = function(_) {
-	    if (!arguments.length) return cells;
-	    if (_.length > 1 || _ >= 2 ){
-	      cells = _;
-	    }
-	    return legend;
-	  };
-
-
-	  legend.shape = function(_, d) {
-	    if (!arguments.length) return shape;
-	    if (_ == "rect" || _ == "circle" || _ == "line" ){
-	      shape = _;
-	      path = d;
-	    }
-	    return legend;
-	  };
-
-	  legend.shapeWidth = function(_) {
-	    if (!arguments.length) return shapeWidth;
-	    shapeWidth = +_;
-	    return legend;
-	  };
-
-	  legend.shapePadding = function(_) {
-	    if (!arguments.length) return shapePadding;
-	    shapePadding = +_;
-	    return legend;
-	  };
-
-	  legend.labels = function(_) {
-	    if (!arguments.length) return labels;
-	    labels = _;
-	    return legend;
-	  };
-
-	  legend.labelAlign = function(_) {
-	    if (!arguments.length) return labelAlign;
-	    if (_ == "start" || _ == "end" || _ == "middle") {
-	      labelAlign = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.labelFormat = function(_) {
-	    if (!arguments.length) return labelFormat;
-	    labelFormat = _;
-	    return legend;
-	  };
-
-	  legend.labelOffset = function(_) {
-	    if (!arguments.length) return labelOffset;
-	    labelOffset = +_;
-	    return legend;
-	  };
-
-	  legend.labelDelimiter = function(_) {
-	    if (!arguments.length) return labelDelimiter;
-	    labelDelimiter = _;
-	    return legend;
-	  };
-
-	  legend.orient = function(_){
-	    if (!arguments.length) return orient;
-	    _ = _.toLowerCase();
-	    if (_ == "horizontal" || _ == "vertical") {
-	      orient = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.ascending = function(_) {
-	    if (!arguments.length) return ascending;
-	    ascending = !!_;
-	    return legend;
-	  };
-
-	  legend.classPrefix = function(_) {
-	    if (!arguments.length) return classPrefix;
-	    classPrefix = _;
-	    return legend;
-	  };
-
-	  legend.title = function(_) {
-	    if (!arguments.length) return title;
-	    title = _;
-	    return legend;
-	  };
-
-	  d3.rebind(legend, legendDispatcher, "on");
-
-	  return legend;
-
-	};
-
-
-/***/ },
-/* 31 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var helper = __webpack_require__(29);
-
-	module.exports = function(){
-
-	  var scale = d3.scale.linear(),
-	    shape = "path",
-	    shapeWidth = 15,
-	    shapeHeight = 15,
-	    shapeRadius = 10,
-	    shapePadding = 5,
-	    cells = [5],
-	    labels = [],
-	    classPrefix = "",
-	    useClass = false,
-	    title = "",
-	    labelFormat = d3.format(".01f"),
-	    labelAlign = "middle",
-	    labelOffset = 10,
-	    labelDelimiter = "to",
-	    orient = "vertical",
-	    ascending = false,
-	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
-
-	    function legend(svg){
-
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
-	        legendG = svg.selectAll('g').data([scale]);
-
-	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
-
-	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
-	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
-	        shapes = cell.select("g." + classPrefix + "cell " + shape);
-
-	      //add event handlers
-	      helper.d3_addEvents(cellEnter, legendDispatcher);
-
-	      //remove old shapes
-	      cell.exit().transition().style("opacity", 0).remove();
-
-	      helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, type.feature);
-	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
-
-	      // sets placement
-	      var text = cell.select("text"),
-	        shapeSize = shapes[0].map( function(d){ return d.getBBox(); });
-
-	      var maxH = d3.max(shapeSize, function(d){ return d.height; }),
-	      maxW = d3.max(shapeSize, function(d){ return d.width; });
-
-	      var cellTrans,
-	      textTrans,
-	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
-
-	      //positions cells and text
-	      if (orient === "vertical"){
-	        cellTrans = function(d,i) { return "translate(0, " + (i * (maxH + shapePadding)) + ")"; };
-	        textTrans = function(d,i) { return "translate(" + (maxW + labelOffset) + "," +
-	              (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
-
-	      } else if (orient === "horizontal"){
-	        cellTrans = function(d,i) { return "translate(" + (i * (maxW + shapePadding)) + ",0)"; };
-	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) + "," +
-	              (maxH + labelOffset ) + ")"; };
-	      }
-
-	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
-	      helper.d3_title(svg, legendG, title, classPrefix);
-	      cell.transition().style("opacity", 1);
-
-	    }
-
-
-	  legend.scale = function(_) {
-	    if (!arguments.length) return scale;
-	    scale = _;
-	    return legend;
-	  };
-
-	  legend.cells = function(_) {
-	    if (!arguments.length) return cells;
-	    if (_.length > 1 || _ >= 2 ){
-	      cells = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.shapePadding = function(_) {
-	    if (!arguments.length) return shapePadding;
-	    shapePadding = +_;
-	    return legend;
-	  };
-
-	  legend.labels = function(_) {
-	    if (!arguments.length) return labels;
-	    labels = _;
-	    return legend;
-	  };
-
-	  legend.labelAlign = function(_) {
-	    if (!arguments.length) return labelAlign;
-	    if (_ == "start" || _ == "end" || _ == "middle") {
-	      labelAlign = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.labelFormat = function(_) {
-	    if (!arguments.length) return labelFormat;
-	    labelFormat = _;
-	    return legend;
-	  };
-
-	  legend.labelOffset = function(_) {
-	    if (!arguments.length) return labelOffset;
-	    labelOffset = +_;
-	    return legend;
-	  };
-
-	  legend.labelDelimiter = function(_) {
-	    if (!arguments.length) return labelDelimiter;
-	    labelDelimiter = _;
-	    return legend;
-	  };
-
-	  legend.orient = function(_){
-	    if (!arguments.length) return orient;
-	    _ = _.toLowerCase();
-	    if (_ == "horizontal" || _ == "vertical") {
-	      orient = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.ascending = function(_) {
-	    if (!arguments.length) return ascending;
-	    ascending = !!_;
-	    return legend;
-	  };
-
-	  legend.classPrefix = function(_) {
-	    if (!arguments.length) return classPrefix;
-	    classPrefix = _;
-	    return legend;
-	  };
-
-	  legend.title = function(_) {
-	    if (!arguments.length) return title;
-	    title = _;
-	    return legend;
-	  };
-
-	  d3.rebind(legend, legendDispatcher, "on");
-
-	  return legend;
-
-	};
-
-
-/***/ },
-/* 32 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -12311,6 +11372,945 @@
 	  });
 
 	})(this);
+
+
+/***/ },
+/* 26 */
+/***/ function(module, exports, __webpack_require__) {
+
+	(function(exports) {
+
+	  __webpack_require__(27);
+
+	  var eiti = __webpack_require__(12);
+	  var format = eiti.format;
+
+	  exports.EITIDataMap = document.registerElement('eiti-data-map', {
+	    prototype: Object.create(
+	      HTMLElement.prototype,
+	      {
+	        attachedCallback: {value: function() {
+	          this.marks = d3.select(this).selectAll('[data-value]')
+	            .datum(function() {
+	              return +this.getAttribute('data-value') || 0;
+	            });
+
+	          this.update();
+	        }},
+
+	        setYear: {value: function(year) {
+	          this.marks.datum(function() {
+	              var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+	              return data[year] || 0;
+	            })
+	            .attr('data-value', function(d) {
+	              return d;
+	            });
+	          this.update();
+	        }},
+
+	        update: {value: function() {
+	          var type = this.getAttribute('scale-type') || 'quantize';
+	          var scheme = this.getAttribute('color-scheme') || 'Blues';
+	          var steps = this.getAttribute('steps') || 5;
+	          var units = this.getAttribute('units') || '';
+
+
+	          var colors = colorbrewer[scheme][steps];
+	          if (!colors) {
+	            return console.error(
+	              'bad # of steps (%d) for color scheme:', steps, scheme
+	            );
+	          }
+
+	          var marks = this.marks;
+
+	          var domain = this.hasAttribute('domain')
+	            ? JSON.parse(this.getAttribute('domain'))
+	            : d3.extent(marks.data());
+
+	          if (domain[0] > 0) {
+	            domain[0] = 0;
+	          } else if (domain[0] < 0) {
+	            domain[1] = Math.max(0, domain[1]);
+	          }
+
+	          // FIXME: do something with divergent scales??
+
+	          var scale = d3.scale[type]()
+	            .domain(domain)
+	            .range(colors);
+
+	          marks.attr('fill', scale);
+
+
+	          this.scale = scale;
+
+	          // start map legend
+	          function uniq(value, index, self) {
+	            return self.indexOf(value) === index;
+	          }
+
+	          function getUnique(data, steps, domain) {
+	            var getSteps = d3.scale[type]()
+	              .domain(domain)
+	              .range(steps);
+
+	            var values = [];
+	            data.forEach(function(d) {
+	              values.push(getSteps(d));
+	            });
+
+	            return values.filter(uniq);
+	          }
+
+	          var svgLegend = d3.select(this)
+	            .select('.legend-svg');
+
+	          svgLegend.append('g')
+	            .attr('class', 'legendScale');
+
+	          var legend = d3.legend.color()
+	            .labelFormat(format.si)
+	            .useClass(false)
+	            .ascending(true)
+	            .labelDelimiter('-')
+	            .shapePadding(6)
+	            .scale(scale);
+
+	          svgLegend.select('.legendScale')
+	            .call(legend);
+
+	          // reverse because the scale is in ascending order
+	          var _steps = d3.range(0, 9).reverse();
+
+	          // find which steps are represented in the map
+	          var uniqueSteps = getUnique(marks.data(), _steps, domain);
+
+	          // start consolidate (translate) visible cells
+	          var cells = svgLegend.selectAll('.cell');
+	          var cellHeight = legend.shapeHeight() + legend.shapePadding();
+	          var count = 0;
+	          cells.each(function(cell, i) {
+	            var present = uniqueSteps.indexOf(i) > -1;
+
+	            if (!present) {
+	              // hide cells swatches that aren't in the map
+	              cells[0][i].setAttribute('aria-hidden', true);
+	              count++;
+	            } else  {
+	              // trim spacing between swatches that are visible
+	              var translateHeight = (i * cellHeight) - (count * cellHeight);
+	              cells[0][i].setAttribute('transform',
+	                'translate(0,' + translateHeight + ')');
+	            }
+	          });
+	          // end consolidation
+	          // end map legend
+
+	          // start trim height on map container
+	          var svgContainer = d3.select(this)
+	            .selectAll('.svg-container[data-dimensions]')
+	            .datum(function() {
+	              return (this.getBoundingClientRect().width
+	                * +this.getAttribute('data-dimensions')
+	                / 100)
+	                + 50;
+	            });
+
+	          function pixelize(d) {
+	            return d + 'px';
+	          }
+
+	          svgContainer.style('padding-bottom', pixelize);
+	          // end trim
+
+
+	          // var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
+	          //   .datum(function() {
+	          //     return +this.getAttribute('data-value-swatch') || 0;
+	          //   });
+
+	          // swatches.style('background-color', scale);
+	          // console.log(swatches)
+	        }}
+	      }
+	    )
+	  });
+
+	})(this);
+
+
+/***/ },
+/* 27 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var d3 = __webpack_require__(5);
+
+	d3.legend = __webpack_require__(28);
+
+	module.exports = d3;
+
+
+/***/ },
+/* 28 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = {
+	  color: __webpack_require__(29),
+	  size: __webpack_require__(31),
+	  symbol: __webpack_require__(32)
+	};
+
+
+/***/ },
+/* 29 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var helper = __webpack_require__(30);
+
+	module.exports = function(){
+
+	  var scale = d3.scale.linear(),
+	    shape = "rect",
+	    shapeWidth = 15,
+	    shapeHeight = 15,
+	    shapeRadius = 10,
+	    shapePadding = 2,
+	    cells = [5],
+	    labels = [],
+	    classPrefix = "",
+	    useClass = false,
+	    title = "",
+	    labelFormat = d3.format(".01f"),
+	    labelOffset = 10,
+	    labelAlign = "middle",
+	    labelDelimiter = "to",
+	    orient = "vertical",
+	    ascending = false,
+	    path,
+	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
+
+	    function legend(svg){
+
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
+	        legendG = svg.selectAll('g').data([scale]);
+
+	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
+
+
+	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
+	        shapes = cell.select("g." + classPrefix + "cell " + shape);
+
+	      //add event handlers
+	      helper.d3_addEvents(cellEnter, legendDispatcher);
+
+	      cell.exit().transition().style("opacity", 0).remove();
+
+	      helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, path);
+
+	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
+
+	      // sets placement
+	      var text = cell.select("text"),
+	        shapeSize = shapes[0].map( function(d){ return d.getBBox(); });
+
+	      //sets scale
+	      //everything is fill except for line which is stroke,
+	      if (!useClass){
+	        if (shape == "line"){
+	          shapes.style("stroke", type.feature);
+	        } else {
+	          shapes.style("fill", type.feature);
+	        }
+	      } else {
+	        shapes.attr("class", function(d){ return classPrefix + "swatch " + type.feature(d); });
+	      }
+
+	      var cellTrans,
+	      textTrans,
+	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
+
+	      //positions cells and text
+	      if (orient === "vertical"){
+	        cellTrans = function(d,i) { return "translate(0, " + (i * (shapeSize[i].height + shapePadding)) + ")"; };
+	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width + shapeSize[i].x +
+	          labelOffset) + "," + (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
+
+	      } else if (orient === "horizontal"){
+	        cellTrans = function(d,i) { return "translate(" + (i * (shapeSize[i].width + shapePadding)) + ",0)"; }
+	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) +
+	          "," + (shapeSize[i].height + shapeSize[i].y + labelOffset + 8) + ")"; };
+	      }
+
+	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
+	      helper.d3_title(svg, legendG, title, classPrefix);
+
+	      cell.transition().style("opacity", 1);
+
+	    }
+
+
+
+	  legend.scale = function(_) {
+	    if (!arguments.length) return scale;
+	    scale = _;
+	    return legend;
+	  };
+
+	  legend.cells = function(_) {
+	    if (!arguments.length) return cells;
+	    if (_.length > 1 || _ >= 2 ){
+	      cells = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.shape = function(_, d) {
+	    if (!arguments.length) return shape;
+	    if (_ == "rect" || _ == "circle" || _ == "line" || (_ == "path" && (typeof d === 'string')) ){
+	      shape = _;
+	      path = d;
+	    }
+	    return legend;
+	  };
+
+	  legend.shapeWidth = function(_) {
+	    if (!arguments.length) return shapeWidth;
+	    shapeWidth = +_;
+	    return legend;
+	  };
+
+	  legend.shapeHeight = function(_) {
+	    if (!arguments.length) return shapeHeight;
+	    shapeHeight = +_;
+	    return legend;
+	  };
+
+	  legend.shapeRadius = function(_) {
+	    if (!arguments.length) return shapeRadius;
+	    shapeRadius = +_;
+	    return legend;
+	  };
+
+	  legend.shapePadding = function(_) {
+	    if (!arguments.length) return shapePadding;
+	    shapePadding = +_;
+	    return legend;
+	  };
+
+	  legend.labels = function(_) {
+	    if (!arguments.length) return labels;
+	    labels = _;
+	    return legend;
+	  };
+
+	  legend.labelAlign = function(_) {
+	    if (!arguments.length) return labelAlign;
+	    if (_ == "start" || _ == "end" || _ == "middle") {
+	      labelAlign = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.labelFormat = function(_) {
+	    if (!arguments.length) return labelFormat;
+	    labelFormat = _;
+	    return legend;
+	  };
+
+	  legend.labelOffset = function(_) {
+	    if (!arguments.length) return labelOffset;
+	    labelOffset = +_;
+	    return legend;
+	  };
+
+	  legend.labelDelimiter = function(_) {
+	    if (!arguments.length) return labelDelimiter;
+	    labelDelimiter = _;
+	    return legend;
+	  };
+
+	  legend.useClass = function(_) {
+	    if (!arguments.length) return useClass;
+	    if (_ === true || _ === false){
+	      useClass = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.orient = function(_){
+	    if (!arguments.length) return orient;
+	    _ = _.toLowerCase();
+	    if (_ == "horizontal" || _ == "vertical") {
+	      orient = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.ascending = function(_) {
+	    if (!arguments.length) return ascending;
+	    ascending = !!_;
+	    return legend;
+	  };
+
+	  legend.classPrefix = function(_) {
+	    if (!arguments.length) return classPrefix;
+	    classPrefix = _;
+	    return legend;
+	  };
+
+	  legend.title = function(_) {
+	    if (!arguments.length) return title;
+	    title = _;
+	    return legend;
+	  };
+
+	  d3.rebind(legend, legendDispatcher, "on");
+
+	  return legend;
+
+	};
+
+
+/***/ },
+/* 30 */
+/***/ function(module, exports) {
+
+	module.exports = {
+
+	  d3_identity: function (d) {
+	    return d;
+	  },
+
+	  d3_mergeLabels: function (gen, labels) {
+
+	      if(labels.length === 0) return gen;
+
+	      gen = (gen) ? gen : [];
+
+	      var i = labels.length;
+	      for (; i < gen.length; i++) {
+	        labels.push(gen[i]);
+	      }
+	      return labels;
+	    },
+
+	  d3_linearLegend: function (scale, cells, labelFormat) {
+	    var data = [];
+
+	    if (cells.length > 1){
+	      data = cells;
+
+	    } else {
+	      var domain = scale.domain(),
+	      increment = (domain[domain.length - 1] - domain[0])/(cells - 1),
+	      i = 0;
+
+	      for (; i < cells; i++){
+	        data.push(domain[0] + i*increment);
+	      }
+	    }
+
+	    var labels = data.map(labelFormat);
+
+	    return {data: data,
+	            labels: labels,
+	            feature: function(d){ return scale(d); }};
+	  },
+
+	  d3_quantLegend: function (scale, labelFormat, labelDelimiter) {
+	    var labels = scale.range().map(function(d){
+	      var invert = scale.invertExtent(d),
+	      a = labelFormat(invert[0]),
+	      b = labelFormat(invert[1]);
+
+	      // if (( (a) && (a.isNan()) && b){
+	      //   console.log("in initial statement")
+	        return labelFormat(invert[0]) + " " + labelDelimiter + " " + labelFormat(invert[1]);
+	      // } else if (a || b) {
+	      //   console.log('in else statement')
+	      //   return (a) ? a : b;
+	      // }
+
+	    });
+
+	    return {data: scale.range(),
+	            labels: labels,
+	            feature: this.d3_identity
+	          };
+	  },
+
+	  d3_ordinalLegend: function (scale) {
+	    return {data: scale.domain(),
+	            labels: scale.domain(),
+	            feature: function(d){ return scale(d); }};
+	  },
+
+	  d3_drawShapes: function (shape, shapes, shapeHeight, shapeWidth, shapeRadius, path) {
+	    if (shape === "rect"){
+	        shapes.attr("height", shapeHeight).attr("width", shapeWidth);
+
+	    } else if (shape === "circle") {
+	        shapes.attr("r", shapeRadius)//.attr("cx", shapeRadius).attr("cy", shapeRadius);
+
+	    } else if (shape === "line") {
+	        shapes.attr("x1", 0).attr("x2", shapeWidth).attr("y1", 0).attr("y2", 0);
+
+	    } else if (shape === "path") {
+	      shapes.attr("d", path);
+	    }
+	  },
+
+	  d3_addText: function (svg, enter, labels, classPrefix){
+	    enter.append("text").attr("class", classPrefix + "label");
+	    svg.selectAll("g." + classPrefix + "cell text").data(labels).text(this.d3_identity);
+	  },
+
+	  d3_calcType: function (scale, ascending, cells, labels, labelFormat, labelDelimiter){
+	    var type = scale.ticks ?
+	            this.d3_linearLegend(scale, cells, labelFormat) : scale.invertExtent ?
+	            this.d3_quantLegend(scale, labelFormat, labelDelimiter) : this.d3_ordinalLegend(scale);
+
+	    type.labels = this.d3_mergeLabels(type.labels, labels);
+
+	    if (ascending) {
+	      type.labels = this.d3_reverse(type.labels);
+	      type.data = this.d3_reverse(type.data);
+	    }
+
+	    return type;
+	  },
+
+	  d3_reverse: function(arr) {
+	    var mirror = [];
+	    for (var i = 0, l = arr.length; i < l; i++) {
+	      mirror[i] = arr[l-i-1];
+	    }
+	    return mirror;
+	  },
+
+	  d3_placement: function (orient, cell, cellTrans, text, textTrans, labelAlign) {
+	    cell.attr("transform", cellTrans);
+	    text.attr("transform", textTrans);
+	    if (orient === "horizontal"){
+	      text.style("text-anchor", labelAlign);
+	    }
+	  },
+
+	  d3_addEvents: function(cells, dispatcher){
+	    var _ = this;
+
+	      cells.on("mouseover.legend", function (d) { _.d3_cellOver(dispatcher, d, this); })
+	          .on("mouseout.legend", function (d) { _.d3_cellOut(dispatcher, d, this); })
+	          .on("click.legend", function (d) { _.d3_cellClick(dispatcher, d, this); });
+	  },
+
+	  d3_cellOver: function(cellDispatcher, d, obj){
+	    cellDispatcher.cellover.call(obj, d);
+	  },
+
+	  d3_cellOut: function(cellDispatcher, d, obj){
+	    cellDispatcher.cellout.call(obj, d);
+	  },
+
+	  d3_cellClick: function(cellDispatcher, d, obj){
+	    cellDispatcher.cellclick.call(obj, d);
+	  },
+
+	  d3_title: function(svg, cellsSvg, title, classPrefix){
+	    if (title !== ""){
+
+	      var titleText = svg.selectAll('text.' + classPrefix + 'legendTitle');
+
+	      titleText.data([title])
+	        .enter()
+	        .append('text')
+	        .attr('class', classPrefix + 'legendTitle');
+
+	        svg.selectAll('text.' + classPrefix + 'legendTitle')
+	            .text(title)
+
+	      var yOffset = svg.select('.' + classPrefix + 'legendTitle')
+	          .map(function(d) { return d[0].getBBox().height})[0],
+	      xOffset = -cellsSvg.map(function(d) { return d[0].getBBox().x})[0];
+
+	      cellsSvg.attr('transform', 'translate(' + xOffset + ',' + (yOffset + 10) + ')');
+
+	    }
+	  }
+	}
+
+
+/***/ },
+/* 31 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var helper = __webpack_require__(30);
+
+	module.exports =  function(){
+
+	  var scale = d3.scale.linear(),
+	    shape = "rect",
+	    shapeWidth = 15,
+	    shapePadding = 2,
+	    cells = [5],
+	    labels = [],
+	    useStroke = false,
+	    classPrefix = "",
+	    title = "",
+	    labelFormat = d3.format(".01f"),
+	    labelOffset = 10,
+	    labelAlign = "middle",
+	    labelDelimiter = "to",
+	    orient = "vertical",
+	    ascending = false,
+	    path,
+	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
+
+	    function legend(svg){
+
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
+	        legendG = svg.selectAll('g').data([scale]);
+
+	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
+
+
+	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
+	        shapes = cell.select("g." + classPrefix + "cell " + shape);
+
+	      //add event handlers
+	      helper.d3_addEvents(cellEnter, legendDispatcher);
+
+	      cell.exit().transition().style("opacity", 0).remove();
+
+	      //creates shape
+	      if (shape === "line"){
+	        helper.d3_drawShapes(shape, shapes, 0, shapeWidth);
+	        shapes.attr("stroke-width", type.feature);
+	      } else {
+	        helper.d3_drawShapes(shape, shapes, type.feature, type.feature, type.feature, path);
+	      }
+
+	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
+
+	      //sets placement
+	      var text = cell.select("text"),
+	        shapeSize = shapes[0].map(
+	          function(d, i){
+	            var bbox = d.getBBox()
+	            var stroke = scale(type.data[i]);
+
+	            if (shape === "line" && orient === "horizontal") {
+	              bbox.height = bbox.height + stroke;
+	            } else if (shape === "line" && orient === "vertical"){
+	              bbox.width = bbox.width;
+	            }
+
+	            return bbox;
+	        });
+
+	      var maxH = d3.max(shapeSize, function(d){ return d.height + d.y; }),
+	      maxW = d3.max(shapeSize, function(d){ return d.width + d.x; });
+
+	      var cellTrans,
+	      textTrans,
+	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
+
+	      //positions cells and text
+	      if (orient === "vertical"){
+
+	        cellTrans = function(d,i) {
+	            var height = d3.sum(shapeSize.slice(0, i + 1 ), function(d){ return d.height; });
+	            return "translate(0, " + (height + i*shapePadding) + ")"; };
+
+	        textTrans = function(d,i) { return "translate(" + (maxW + labelOffset) + "," +
+	          (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
+
+	      } else if (orient === "horizontal"){
+	        cellTrans = function(d,i) {
+	            var width = d3.sum(shapeSize.slice(0, i + 1 ), function(d){ return d.width; });
+	            return "translate(" + (width + i*shapePadding) + ",0)"; };
+
+	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) + "," +
+	              (maxH + labelOffset ) + ")"; };
+	      }
+
+	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
+	      helper.d3_title(svg, legendG, title, classPrefix);
+
+	      cell.transition().style("opacity", 1);
+
+	    }
+
+	  legend.scale = function(_) {
+	    if (!arguments.length) return scale;
+	    scale = _;
+	    return legend;
+	  };
+
+	  legend.cells = function(_) {
+	    if (!arguments.length) return cells;
+	    if (_.length > 1 || _ >= 2 ){
+	      cells = _;
+	    }
+	    return legend;
+	  };
+
+
+	  legend.shape = function(_, d) {
+	    if (!arguments.length) return shape;
+	    if (_ == "rect" || _ == "circle" || _ == "line" ){
+	      shape = _;
+	      path = d;
+	    }
+	    return legend;
+	  };
+
+	  legend.shapeWidth = function(_) {
+	    if (!arguments.length) return shapeWidth;
+	    shapeWidth = +_;
+	    return legend;
+	  };
+
+	  legend.shapePadding = function(_) {
+	    if (!arguments.length) return shapePadding;
+	    shapePadding = +_;
+	    return legend;
+	  };
+
+	  legend.labels = function(_) {
+	    if (!arguments.length) return labels;
+	    labels = _;
+	    return legend;
+	  };
+
+	  legend.labelAlign = function(_) {
+	    if (!arguments.length) return labelAlign;
+	    if (_ == "start" || _ == "end" || _ == "middle") {
+	      labelAlign = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.labelFormat = function(_) {
+	    if (!arguments.length) return labelFormat;
+	    labelFormat = _;
+	    return legend;
+	  };
+
+	  legend.labelOffset = function(_) {
+	    if (!arguments.length) return labelOffset;
+	    labelOffset = +_;
+	    return legend;
+	  };
+
+	  legend.labelDelimiter = function(_) {
+	    if (!arguments.length) return labelDelimiter;
+	    labelDelimiter = _;
+	    return legend;
+	  };
+
+	  legend.orient = function(_){
+	    if (!arguments.length) return orient;
+	    _ = _.toLowerCase();
+	    if (_ == "horizontal" || _ == "vertical") {
+	      orient = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.ascending = function(_) {
+	    if (!arguments.length) return ascending;
+	    ascending = !!_;
+	    return legend;
+	  };
+
+	  legend.classPrefix = function(_) {
+	    if (!arguments.length) return classPrefix;
+	    classPrefix = _;
+	    return legend;
+	  };
+
+	  legend.title = function(_) {
+	    if (!arguments.length) return title;
+	    title = _;
+	    return legend;
+	  };
+
+	  d3.rebind(legend, legendDispatcher, "on");
+
+	  return legend;
+
+	};
+
+
+/***/ },
+/* 32 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var helper = __webpack_require__(30);
+
+	module.exports = function(){
+
+	  var scale = d3.scale.linear(),
+	    shape = "path",
+	    shapeWidth = 15,
+	    shapeHeight = 15,
+	    shapeRadius = 10,
+	    shapePadding = 5,
+	    cells = [5],
+	    labels = [],
+	    classPrefix = "",
+	    useClass = false,
+	    title = "",
+	    labelFormat = d3.format(".01f"),
+	    labelAlign = "middle",
+	    labelOffset = 10,
+	    labelDelimiter = "to",
+	    orient = "vertical",
+	    ascending = false,
+	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
+
+	    function legend(svg){
+
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
+	        legendG = svg.selectAll('g').data([scale]);
+
+	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
+
+	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
+	        shapes = cell.select("g." + classPrefix + "cell " + shape);
+
+	      //add event handlers
+	      helper.d3_addEvents(cellEnter, legendDispatcher);
+
+	      //remove old shapes
+	      cell.exit().transition().style("opacity", 0).remove();
+
+	      helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, type.feature);
+	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
+
+	      // sets placement
+	      var text = cell.select("text"),
+	        shapeSize = shapes[0].map( function(d){ return d.getBBox(); });
+
+	      var maxH = d3.max(shapeSize, function(d){ return d.height; }),
+	      maxW = d3.max(shapeSize, function(d){ return d.width; });
+
+	      var cellTrans,
+	      textTrans,
+	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
+
+	      //positions cells and text
+	      if (orient === "vertical"){
+	        cellTrans = function(d,i) { return "translate(0, " + (i * (maxH + shapePadding)) + ")"; };
+	        textTrans = function(d,i) { return "translate(" + (maxW + labelOffset) + "," +
+	              (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
+
+	      } else if (orient === "horizontal"){
+	        cellTrans = function(d,i) { return "translate(" + (i * (maxW + shapePadding)) + ",0)"; };
+	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) + "," +
+	              (maxH + labelOffset ) + ")"; };
+	      }
+
+	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
+	      helper.d3_title(svg, legendG, title, classPrefix);
+	      cell.transition().style("opacity", 1);
+
+	    }
+
+
+	  legend.scale = function(_) {
+	    if (!arguments.length) return scale;
+	    scale = _;
+	    return legend;
+	  };
+
+	  legend.cells = function(_) {
+	    if (!arguments.length) return cells;
+	    if (_.length > 1 || _ >= 2 ){
+	      cells = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.shapePadding = function(_) {
+	    if (!arguments.length) return shapePadding;
+	    shapePadding = +_;
+	    return legend;
+	  };
+
+	  legend.labels = function(_) {
+	    if (!arguments.length) return labels;
+	    labels = _;
+	    return legend;
+	  };
+
+	  legend.labelAlign = function(_) {
+	    if (!arguments.length) return labelAlign;
+	    if (_ == "start" || _ == "end" || _ == "middle") {
+	      labelAlign = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.labelFormat = function(_) {
+	    if (!arguments.length) return labelFormat;
+	    labelFormat = _;
+	    return legend;
+	  };
+
+	  legend.labelOffset = function(_) {
+	    if (!arguments.length) return labelOffset;
+	    labelOffset = +_;
+	    return legend;
+	  };
+
+	  legend.labelDelimiter = function(_) {
+	    if (!arguments.length) return labelDelimiter;
+	    labelDelimiter = _;
+	    return legend;
+	  };
+
+	  legend.orient = function(_){
+	    if (!arguments.length) return orient;
+	    _ = _.toLowerCase();
+	    if (_ == "horizontal" || _ == "vertical") {
+	      orient = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.ascending = function(_) {
+	    if (!arguments.length) return ascending;
+	    ascending = !!_;
+	    return legend;
+	  };
+
+	  legend.classPrefix = function(_) {
+	    if (!arguments.length) return classPrefix;
+	    classPrefix = _;
+	    return legend;
+	  };
+
+	  legend.title = function(_) {
+	    if (!arguments.length) return title;
+	    title = _;
+	    return legend;
+	  };
+
+	  d3.rebind(legend, legendDispatcher, "on");
+
+	  return legend;
+
+	};
 
 
 /***/ },

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11101,6 +11101,13 @@
 	  };
 
 	  var setYear = function(year) {
+	    function parseYearVals(context) {
+	      var yearVals = context.getAttribute('data-year-values') &&
+	          context.getAttribute('data-year-values') !== 'null'
+	            ? context.getAttribute('data-year-values')
+	            : '{}';
+	      return JSON.parse(yearVals);
+	    }
 
 	    var root = d3.select(this);
 
@@ -11110,12 +11117,10 @@
 	    var swatches = root.selectAll('[data-value-swatch]');
 	    var label = d3.select(this.parentElement).select('label');
 
+	    var rows = root.selectAll('tr[data-year-values]');
+
 	    bars.datum(function() {
-	        var yearVals = this.getAttribute('data-year-values') &&
-	          this.getAttribute('data-year-values') !== 'null'
-	            ? this.getAttribute('data-year-values')
-	            : '{}';
-	        var data = JSON.parse(yearVals);
+	        var data = parseYearVals(this)
 	        if (data) {
 	          return data[year] || 0;
 	        } else {
@@ -11128,11 +11133,7 @@
 	      });
 
 	    texts.datum(function() {
-	        var yearVals = this.getAttribute('data-year-values') &&
-	          this.getAttribute('data-year-values') !== 'null'
-	            ? this.getAttribute('data-year-values')
-	            : '{}';
-	        var data = JSON.parse(yearVals);
+	        var data = parseYearVals(this)
 	        if (data) {
 	          return data[year] || 0;
 	        } else {
@@ -11154,11 +11155,7 @@
 
 	    var that = this;
 	    swatches.datum(function() {
-	        var yearVals = this.getAttribute('data-year-values') &&
-	            this.getAttribute('data-year-values') !== 'null'
-	              ? this.getAttribute('data-year-values')
-	              : '{}';
-	        var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+	        var data = parseYearVals(this)
 	        if (data) {
 	          return data[year] || 0;
 	        } else {
@@ -11178,6 +11175,15 @@
 	    label.select('[data-year]')
 	      .attr('data-year', year)
 	      .text(year)
+
+	    rows.datum(function(){
+	      var data = parseYearVals(this);
+	      return data[year] || 0;
+	    })
+	    .attr('aria-hidden', function (d) {
+	      console.log(d)
+	      return !d;
+	    })
 	  }
 
 	  var update = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -48,10 +48,11 @@
 	  'use strict';
 
 	  __webpack_require__(24);
-	  __webpack_require__(25);
 	  __webpack_require__(26);
+	  __webpack_require__(25);
 	  __webpack_require__(33);
 	  __webpack_require__(34);
+
 
 	  __webpack_require__(4);
 	  __webpack_require__(1);
@@ -11093,113 +11094,86 @@
 	    this._cells = [].slice.call(this.querySelectorAll('tr > [data-value]'));
 	    this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
 	    this._cells = this._cells.concat(this.nested_cells)
+	    this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
 
+	    this.setYear();
 	    this.update();
-	    // this.setYear();
 	  };
 
 	  var setYear = function(year) {
-	    console.log('setYear-==============')
-	    var updateValues = function(year, context, attr, text) {
-	      var values = JSON.parse(context.getAttribute('data-year-values'));
-	      // var format = d3.format(context.attr('data-format') || ',');
-	      if (values) {
-	        console.log(values)
-	        context.setAttribute(attr, values[year])
-	        if (text) {
-	          context.innerHTML = values[year];
-	        }
-	      }
-	    }
+
 	    var year = year || '2013';
 	    var bars = d3.select(this).selectAll('[data-value]')
 	    var texts = d3.select(this).selectAll('[data-value-text]')
 	    var swatches = d3.select(this).selectAll('[data-value-swatch]')
 
-	    if (bars.attr('data-year-values')) {
-	      bars.datum(function() {
-	          var yearVals = this.getAttribute('data-year-values') &&
-	            this.getAttribute('data-year-values') !== 'null'
-	              ? this.getAttribute('data-year-values')
-	              : '{}';
-	          var data = JSON.parse(yearVals);
-	          if (data) {
-	            return data[year] || 0;
-	          } else {
-	            return 0;
-	          }
-	        })
-	        .attr('data-value', function(d) {
-	          console.log('data-value', d)
+	    bars.datum(function() {
+	        var yearVals = this.getAttribute('data-year-values') &&
+	          this.getAttribute('data-year-values') !== 'null'
+	            ? this.getAttribute('data-year-values')
+	            : '{}';
+	        var data = JSON.parse(yearVals);
+	        if (data) {
+	          return data[year] || 0;
+	        } else {
+	          return 0;
+	        }
+	      })
+	      .attr('data-value', function(d) {
+	        console.log('data-value', d)
+	        return d;
+	      });
+
+	    texts.datum(function() {
+	        var yearVals = this.getAttribute('data-year-values') &&
+	          this.getAttribute('data-year-values') !== 'null'
+	            ? this.getAttribute('data-year-values')
+	            : '{}';
+	        var data = JSON.parse(yearVals);
+	        if (data) {
+	          return data[year] || 0;
+	        } else {
+	          return 0;
+	        }
+	      })
+	      .attr('data-value-text', function(d) {
+	        return d;
+	      })
+	      .text(function(d) {
+	        var format = d3.format(this.getAttribute('data-format') || ',')
+	        console.log('data-value', d)
+	        if (format) {
+	          return format(d);
+	        } else {
 	          return d;
-	        });
-	    }
+	        }
+	      });
 
-	    if (texts.attr('data-year-values')) {
-	      texts.datum(function() {
-	          var yearVals = this.getAttribute('data-year-values') &&
+	    var that = this;
+	    swatches.datum(function() {
+	        var yearVals = this.getAttribute('data-year-values') &&
 	            this.getAttribute('data-year-values') !== 'null'
 	              ? this.getAttribute('data-year-values')
 	              : '{}';
-	          var data = JSON.parse(yearVals);
-	          if (data) {
-	            return data[year] || 0;
-	          } else {
-	            return 0;
-	          }
-	        })
-	        .text(function(d) {
-	          var format = d3.format(this.getAttribute('data-format') || ',')
-	          console.log('data-value', d)
-	          if (format) {
-	            return format(d);
-	          } else {
-	            return d;
-	          }
-
-	        });
-	    }
-
-	    // if (swatches.attr('data-year-values')) {
-	    //   swatches.datum(function() {
-	    //       var yearVals = this.getAttribute('data-year-values') &&
-	    //           this.getAttribute('data-year-values') !== 'null'
-	    //             ? this.getAttribute('data-year-values')
-	    //             : '{}';
-	    //       var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
-	    //       if (data) {
-	    //         return data[year] || 0;
-	    //       } else {
-	    //         return 0;
-	    //       }
-	    //     })
-	    //     .attr('data-value-swatch', function(d) {
-	    //       console.log('data-value-swatch', d)
-	    //       return d;
-	    //     });
-	    // }
-
-
-	    // this.update();
-	      // .each(function(){
-	      //   // updateValues(year, this, 'data-value')
-
-	      //   var values = JSON.parse(this.attr('data-year-values')
-	      // });
-
-	    // var texts = d3.select(this).selectAll('[data-value-text]')
-	    //   .each(function(){
-	    //     updateValues(year, this, 'data-value-text', true)
-	    //   });
-
-	    // var swatches = d3.select(this).selectAll('[data-value-swatch]')
-	    //   .each(function(){
-	    //     updateValues(year, this, 'data-value-swatch')
-	    //   });
+	        var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+	        if (data) {
+	          return data[year] || 0;
+	        } else {
+	          return 0;
+	        }
+	      })
+	      .attr('data-value-swatch', function(d) {
+	        console.log('data-value-swatch', d)
+	        return d;
+	      })
+	      .style('background-color', function (d) {
+	        if (d && that.eitiDataMap.scale) {
+	          return that.eitiDataMap.scale(d);
+	        }
+	      });
 	  }
 
 	  var update = function() {
-	    console.log('update-------------------------------')
 	    if (!this._cells.length) {
 	      return;
 	    }
@@ -11446,6 +11420,8 @@
 
 	          marks.attr('fill', scale);
 
+
+	          this.scale = scale;
 
 	          // start map legend
 	          function uniq(value, index, self) {
@@ -12622,9 +12598,6 @@
 	    var mapTables = root.selectAll('.eiti-data-map-table');
 
 	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
-	    console.log(maps)
-	    console.log('=============')
-	    console.log(chartTables)
 
 	    var update = function(year) {
 	      charts.property('x', year);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11094,11 +11094,12 @@
 	    this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
 	    this._cells = this._cells.concat(this.nested_cells)
 
-	    // this.update();
-	    this.setYear();
+	    this.update();
+	    // this.setYear();
 	  };
 
 	  var setYear = function(year) {
+	    console.log('setYear-==============')
 	    var updateValues = function(year, context, attr, text) {
 	      var values = JSON.parse(context.getAttribute('data-year-values'));
 	      // var format = d3.format(context.attr('data-format') || ',');
@@ -11117,31 +11118,39 @@
 
 	    if (bars.attr('data-year-values')) {
 	      bars.datum(function() {
-	          if (this.getAttribute('data-year-values')) {
-	            var data = JSON.parse(this.getAttribute('data-year-values') || null);
-	            if (data) {
-	              return data[year] || 0;
-	            }
-
+	          var yearVals = this.getAttribute('data-year-values') &&
+	            this.getAttribute('data-year-values') !== 'null'
+	              ? this.getAttribute('data-year-values')
+	              : '{}';
+	          var data = JSON.parse(yearVals);
+	          if (data) {
+	            return data[year] || 0;
+	          } else {
+	            return 0;
 	          }
 	        })
 	        .attr('data-value', function(d) {
+	          console.log('data-value', d)
 	          return d;
 	        });
 	    }
 
 	    if (texts.attr('data-year-values')) {
 	      texts.datum(function() {
-	          if (this.getAttribute('data-year-values')) {
-	            var data = JSON.parse(this.getAttribute('data-year-values') || null);
-	            if (data) {
-	              return data[year] || 0;
-	            }
-
+	          var yearVals = this.getAttribute('data-year-values') &&
+	            this.getAttribute('data-year-values') !== 'null'
+	              ? this.getAttribute('data-year-values')
+	              : '{}';
+	          var data = JSON.parse(yearVals);
+	          if (data) {
+	            return data[year] || 0;
+	          } else {
+	            return 0;
 	          }
 	        })
 	        .text(function(d) {
 	          var format = d3.format(this.getAttribute('data-format') || ',')
+	          console.log('data-value', d)
 	          if (format) {
 	            return format(d);
 	          } else {
@@ -11151,23 +11160,27 @@
 	        });
 	    }
 
-	    if (swatches.attr('data-year-values')) {
-	      swatches.datum(function() {
-	          if (this.getAttribute('data-year-values')) {
-	            var data = JSON.parse(this.getAttribute('data-year-values') || null);
-	            if (data) {
-	              return data[year] || 0;
-	            }
+	    // if (swatches.attr('data-year-values')) {
+	    //   swatches.datum(function() {
+	    //       var yearVals = this.getAttribute('data-year-values') &&
+	    //           this.getAttribute('data-year-values') !== 'null'
+	    //             ? this.getAttribute('data-year-values')
+	    //             : '{}';
+	    //       var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+	    //       if (data) {
+	    //         return data[year] || 0;
+	    //       } else {
+	    //         return 0;
+	    //       }
+	    //     })
+	    //     .attr('data-value-swatch', function(d) {
+	    //       console.log('data-value-swatch', d)
+	    //       return d;
+	    //     });
+	    // }
 
-	          }
-	        })
-	        .attr('data-value-swatch', function(d) {
-	          return d;
-	        });
-	    }
 
-
-	    this.update();
+	    // this.update();
 	      // .each(function(){
 	      //   // updateValues(year, this, 'data-value')
 
@@ -11186,6 +11199,7 @@
 	  }
 
 	  var update = function() {
+	    console.log('update-------------------------------')
 	    if (!this._cells.length) {
 	      return;
 	    }
@@ -11430,8 +11444,6 @@
 	            .domain(domain)
 	            .range(colors);
 
-	          this.setAttribute('scale', scale);
-
 	          marks.attr('fill', scale);
 
 
@@ -11515,13 +11527,13 @@
 	          // end trim
 
 
-	          var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
-	            .datum(function() {
-	              return +this.getAttribute('data-value-swatch') || 0;
-	            });
+	          // var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
+	          //   .datum(function() {
+	          //     return +this.getAttribute('data-value-swatch') || 0;
+	          //   });
 
-	          swatches.style('background-color', scale);
-	          console.log(swatches)
+	          // swatches.style('background-color', scale);
+	          // console.log(swatches)
 	        }}
 	      }
 	    )
@@ -12606,16 +12618,24 @@
 	    var select = root.selectAll('select.chart-selector');
 	    var charts = root.selectAll('eiti-bar-chart');
 	    var maps = root.selectAll('eiti-data-map');
-	    var chartTables = maps.selectAll('table[is="bar-chart-table"]')
+
+	    var mapTables = root.selectAll('.eiti-data-map-table');
+
+	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
+	    console.log(maps)
+	    console.log('=============')
+	    console.log(chartTables)
 
 	    var update = function(year) {
 	      charts.property('x', year);
 	      maps.each(function() {
 	        this.setYear(year);
 	      });
-	      select.property('value',  year);
+	      select.property('value', year);
 	      chartTables.each(function(){
+	        console.log(this)
 	        this.setYear(year);
+	        this.update();
 	      })
 	    };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -48,8 +48,8 @@
 	  'use strict';
 
 	  __webpack_require__(24);
-	  __webpack_require__(26);
 	  __webpack_require__(25);
+	  __webpack_require__(32);
 	  __webpack_require__(33);
 	  __webpack_require__(34);
 
@@ -11086,291 +11086,11 @@
 
 /***/ },
 /* 25 */
-/***/ function(module, exports) {
-
-	(function(exports) {
-
-	  var initialize = function() {
-	    this._cells = [].slice.call(this.querySelectorAll('tr > [data-value]'));
-	    this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
-	    this._cells = this._cells.concat(this.nested_cells)
-	    this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
-
-	    this.setYear();
-	    this.update();
-	  };
-
-	  var setYear = function(year) {
-	    function parseYearVals(context) {
-	      var yearVals = context.getAttribute('data-year-values') &&
-	          context.getAttribute('data-year-values') !== 'null'
-	            ? context.getAttribute('data-year-values')
-	            : '{}';
-	      return JSON.parse(yearVals);
-	    }
-
-	    var root = d3.select(this);
-
-	    var year = year || '2013';
-	    var bars = root.selectAll('[data-value]');
-	    var texts = root.selectAll('[data-value-text]');
-	    var swatches = root.selectAll('[data-value-swatch]');
-	    var label = d3.select(this.parentElement).select('label');
-
-	    var rows = root.selectAll('tr[data-year-values]');
-
-	    bars.datum(function() {
-	        var data = parseYearVals(this)
-	        if (data) {
-	          return data[year] || 0;
-	        } else {
-	          return 0;
-	        }
-	      })
-	      .attr('data-value', function(d) {
-	        console.log('data-value', d)
-	        return d;
-	      });
-
-	    texts.datum(function() {
-	        var data = parseYearVals(this)
-	        if (data) {
-	          return data[year] || 0;
-	        } else {
-	          return 0;
-	        }
-	      })
-	      .attr('data-value-text', function(d) {
-	        return d;
-	      })
-	      .text(function(d) {
-	        var format = d3.format(this.getAttribute('data-format') || ',')
-	        console.log('data-value', d)
-	        if (format) {
-	          return format(d);
-	        } else {
-	          return d;
-	        }
-	      });
-
-	    var that = this;
-	    swatches.datum(function() {
-	        var data = parseYearVals(this)
-	        if (data) {
-	          return data[year] || 0;
-	        } else {
-	          return 0;
-	        }
-	      })
-	      .attr('data-value-swatch', function(d) {
-	        console.log('data-value-swatch', d)
-	        return d;
-	      })
-	      .style('background-color', function (d) {
-	        if (d && that.eitiDataMap.scale) {
-	          return that.eitiDataMap.scale(d);
-	        }
-	      });
-
-	    label.select('[data-year]')
-	      .attr('data-year', year)
-	      .text(year)
-
-	    rows.datum(function(){
-	      var data = parseYearVals(this);
-	      return data[year] || 0;
-	    })
-	    .attr('aria-hidden', function (d) {
-	      console.log(d)
-	      return !d;
-	    })
-	  }
-
-	  var update = function() {
-	    if (!this._cells.length) {
-	      return;
-	    }
-
-	    var series = {};
-	    var autolabel = this.getAttribute('autolabel') === 'true';
-
-	    this._cells.forEach(function(cell) {
-	      var key = cell.dataset.series || 'default';
-	      if (key in series) {
-	        series[key].push(cell);
-	      } else {
-	        series[key] = [cell];
-	      }
-	    });
-
-	    Object.keys(series).forEach(function(key) {
-	      var cells = series[key];
-	      var values = cells.map(function(cell) {
-	        return +cell.dataset.value;
-	      });
-
-	      var extent = d3.extent(values);
-	      if (this.hasAttribute('data-' + key + '-min')) {
-	        extent[0] = +this.dataset[key + 'Min'];
-	      } else if (this.hasAttribute('data-min')) {
-	        extent[0] = +this.dataset.min;
-	      } else {
-	        extent[0] = Math.min(extent[0], 0);
-	      }
-
-	      if (this.hasAttribute('data-' + key + '-max')) {
-	        extent[1] = +this.dataset[key + 'Max'];
-	      } else if (this.hasAttribute('data-max')) {
-	        extent[1] = +this.dataset.max;
-	      }
-
-	      var range = [0, 100];
-	      var min = extent[0];
-	      var max = extent[1];
-	      var negative = min < 0;
-	      var zero = 0;
-	      var width = d3.scale.linear()
-	        .domain(extent)
-	        .range(range)
-	        .clamp(true);
-
-	      var offset;
-	      var sizeProperty = 'width';
-	      var offsetProperty = 'margin-left';
-
-	      if (negative) {
-	        var length = max - min;
-	        zero = 100 * (0 - min) / length;
-	        offset = d3.scale.linear()
-	          .domain([min, 0, max])
-	          .range([0, zero, zero])
-	          .clamp(true);
-	        width = d3.scale.linear()
-	          .domain([min, 0, max])
-	          .range([100 * -min / length, 0, 100 * max / length])
-	          .clamp(true);
-	      }
-
-	      if (this.orient === 'vertical') {
-	        sizeProperty = 'height';
-	        offsetProperty = 'bottom';
-	      }
-
-	      cells.forEach(function(cell, i) {
-	        if (!cell) {
-	          console.warn('no cell @', i);
-	          return;
-	        } else if (cell.parentNode.hasAttribute('data-value')) {
-	          console.warn('cell is child', i);
-	        }
-
-	        var childCell = cell.querySelector('[data-value]');
-
-	        // TODO only do this if autolabel="true"?
-	        if (cell.childNodes.length === 1 && cell.firstChild.nodeType === Node.TEXT_NODE) {
-	          if (autolabel) {
-	            cell.setAttribute('aria-label', cell.firstChild.textContent);
-	            cell.removeChild(cell.firstChild);
-	          } else {
-	            var text = cell.removeChild(cell.firstChild);
-	            var span = cell.appendChild(document.createElement('span'));
-	            span.className = 'text';
-	            span.appendChild(text);
-	          }
-	        }
-
-
-	        var barExtent = cell.querySelector('.bar');
-	        if (barExtent) {
-	          var bar = barExtent.querySelector('.bar');
-	        }
-
-	        if (!barExtent && !bar) {
-	          barExtent = document.createElement('div');
-	          barExtent.className = 'bar';
-	          bar = document.createElement('div');
-	          bar.className = 'bar';
-	          var span = cell.querySelector('span');
-	          if (span && barExtent && bar) {
-	            cell.insertBefore(barExtent,span);
-	            barExtent.appendChild(bar);
-	          }
-	        }
-
-	        if (childCell) {
-	          var childBar = document.createElement('div');
-	          childBar.className = 'bar';
-	          bar.appendChild(childBar);
-	        }
-
-	        var value = +cell.dataset.value;
-	        var size = width(value);
-
-	        if (childCell) {
-	          var childValue = +childCell.dataset.value;
-	          size = width(value) + width(childValue);
-	          var diff = childValue - value;
-	          var largerSize = diff > 0
-	            ? width(childValue) / (size / 100)
-	            : width(value) / (size / 100);
-	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
-	          childBar.style.setProperty(sizeProperty, Math.abs(largerSize) + '%');
-	        } else {
-	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
-	        }
-
-	        if (offset) {
-	          bar.style.setProperty(offsetProperty, offset(value) + '%');
-	        } else {
-	          bar.style.removeProperty(offsetProperty);
-	        }
-	      });
-
-	    }, this);
-	  };
-
-	  exports.EITIBarChartTable = document.registerElement('bar-chart-table', {
-	    'extends': 'table',
-	    prototype: Object.create(
-	      HTMLTableElement.prototype,
-	      {
-	        attachedCallback: {value: initialize},
-
-	        attributeChangedCallback: {value: function(attr, old, value) {
-	          switch (attr) {
-	            case 'orient':
-	              this.update();
-	          }
-	        }},
-
-	        update: {value: update},
-
-	        setYear: {value: setYear},
-
-	        orient: {
-	          get: function() {
-	            return this.getAttribute('orient');
-	          },
-	          set: function(value) {
-	            if (value !== this.orient) {
-	              this.setAttribute('orient', value);
-	            }
-	          }
-	        }
-	      }
-	    )
-	  });
-
-	})(this);
-
-
-/***/ },
-/* 26 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
 
-	  __webpack_require__(27);
+	  __webpack_require__(26);
 
 	  var eiti = __webpack_require__(12);
 	  var format = eiti.format;
@@ -11532,32 +11252,32 @@
 
 
 /***/ },
-/* 27 */
+/* 26 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var d3 = __webpack_require__(5);
 
-	d3.legend = __webpack_require__(28);
+	d3.legend = __webpack_require__(27);
 
 	module.exports = d3;
+
+
+/***/ },
+/* 27 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = {
+	  color: __webpack_require__(28),
+	  size: __webpack_require__(30),
+	  symbol: __webpack_require__(31)
+	};
 
 
 /***/ },
 /* 28 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = {
-	  color: __webpack_require__(29),
-	  size: __webpack_require__(31),
-	  symbol: __webpack_require__(32)
-	};
-
-
-/***/ },
-/* 29 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var helper = __webpack_require__(30);
+	var helper = __webpack_require__(29);
 
 	module.exports = function(){
 
@@ -11766,7 +11486,7 @@
 
 
 /***/ },
-/* 30 */
+/* 29 */
 /***/ function(module, exports) {
 
 	module.exports = {
@@ -11935,10 +11655,10 @@
 
 
 /***/ },
-/* 31 */
+/* 30 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var helper = __webpack_require__(30);
+	var helper = __webpack_require__(29);
 
 	module.exports =  function(){
 
@@ -12140,10 +11860,10 @@
 
 
 /***/ },
-/* 32 */
+/* 31 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var helper = __webpack_require__(30);
+	var helper = __webpack_require__(29);
 
 	module.exports = function(){
 
@@ -12301,6 +12021,296 @@
 	  return legend;
 
 	};
+
+
+/***/ },
+/* 32 */
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  var initialize = function() {
+	    this._cells = [].slice.call(this.querySelectorAll('tr > [data-value]'));
+	    this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
+	    this._cells = this._cells.concat(this.nested_cells)
+	    this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
+
+	    this.setYear();
+	    this.update();
+	  };
+
+	  var setYear = function(year) {
+	    function parseYearVals(context) {
+	      var yearVals = context.getAttribute('data-year-values') &&
+	          context.getAttribute('data-year-values') !== 'null'
+	            ? context.getAttribute('data-year-values')
+	            : '{}';
+	      return JSON.parse(yearVals);
+	    }
+
+	    function cellData(data, year, property) {
+	      if (data && data[year] && property) {
+	        return data[year][property] || 0;
+	      } else if (data && !property) {
+	        return data[year] || 0;
+	      } else {
+	        return 0;
+	      }
+	    }
+
+	    var root = d3.select(this);
+
+	    var year = year || '2013';
+	    var bars = root.selectAll('[data-value]');
+	    var texts = root.selectAll('[data-value-text]');
+	    var swatches = root.selectAll('[data-value-swatch]');
+	    var label = d3.select(this.parentElement).select('label');
+
+	    var rows = root.selectAll('tr[data-year-values]');
+
+	    bars.datum(function() {
+	        var data = parseYearVals(this)
+	        var property = this.getAttribute('data-years-property');
+	        return cellData(data, year, property);
+	      })
+	      .attr('data-value', function(d) {
+	        return d;
+	      });
+
+	    texts.datum(function() {
+	        var data = parseYearVals(this)
+	        var property = this.getAttribute('data-years-property');
+	        return cellData(data, year, property);
+	      })
+	      .attr('data-value-text', function(d) {
+	        return d;
+	      })
+	      .text(function(d) {
+	        var format = d3.format(this.getAttribute('data-format') || ',')
+
+	        if (this.getAttribute('data-format') === '%') {
+	          format = function(d) {
+	            if (d === 0) {
+	              return 0;
+	            } else if (d < 1) {
+	              return '<1%';
+	            }
+
+	            return d3.format('%')(d / 100);
+	          }
+	        }
+
+	        if (format) {
+	          return format(d);
+	        } else {
+	          return d;
+	        }
+	      });
+
+	    var that = this;
+	    swatches.datum(function() {
+	        var data = parseYearVals(this)
+	        var property = this.getAttribute('data-years-property');
+	        return cellData(data, year, property);
+	      })
+	      .attr('data-value-swatch', function(d) {
+	        return d;
+	      })
+	      .style('background-color', function (d) {
+	        if (d && that.eitiDataMap.scale) {
+	          return that.eitiDataMap.scale(d);
+	        }
+	      });
+
+	    label.select('[data-year]')
+	      .attr('data-year', year)
+	      .text(year)
+
+	    rows.datum(function(){
+	      var data = parseYearVals(this);
+	      return data[year] || 0;
+	    })
+	    .attr('aria-hidden', function (d) {
+	      return !d;
+	    })
+	  }
+
+	  var update = function() {
+	    if (!this._cells.length) {
+	      return;
+	    }
+
+	    var series = {};
+	    var autolabel = this.getAttribute('autolabel') === 'true';
+
+	    this._cells.forEach(function(cell) {
+	      var key = cell.dataset.series || 'default';
+	      if (key in series) {
+	        series[key].push(cell);
+	      } else {
+	        series[key] = [cell];
+	      }
+	    });
+
+	    Object.keys(series).forEach(function(key) {
+	      var cells = series[key];
+	      var values = cells.map(function(cell) {
+	        return +cell.dataset.value;
+	      });
+
+	      var extent = d3.extent(values);
+	      if (this.hasAttribute('data-' + key + '-min')) {
+	        extent[0] = +this.dataset[key + 'Min'];
+	      } else if (this.hasAttribute('data-min')) {
+	        extent[0] = +this.dataset.min;
+	      } else {
+	        extent[0] = Math.min(extent[0], 0);
+	      }
+
+	      if (this.hasAttribute('data-' + key + '-max')) {
+	        extent[1] = +this.dataset[key + 'Max'];
+	      } else if (this.hasAttribute('data-max')) {
+	        extent[1] = +this.dataset.max;
+	      }
+
+	      var range = [0, 100];
+	      var min = extent[0];
+	      var max = extent[1];
+	      var negative = min < 0;
+	      var zero = 0;
+	      var width = d3.scale.linear()
+	        .domain(extent)
+	        .range(range)
+	        .clamp(true);
+
+	      var offset;
+	      var sizeProperty = 'width';
+	      var offsetProperty = 'margin-left';
+
+	      if (negative) {
+	        var length = max - min;
+	        zero = 100 * (0 - min) / length;
+	        offset = d3.scale.linear()
+	          .domain([min, 0, max])
+	          .range([0, zero, zero])
+	          .clamp(true);
+	        width = d3.scale.linear()
+	          .domain([min, 0, max])
+	          .range([100 * -min / length, 0, 100 * max / length])
+	          .clamp(true);
+	      }
+
+	      if (this.orient === 'vertical') {
+	        sizeProperty = 'height';
+	        offsetProperty = 'bottom';
+	      }
+
+	      cells.forEach(function(cell, i) {
+	        if (!cell) {
+	          console.warn('no cell @', i);
+	          return;
+	        } else if (cell.parentNode.hasAttribute('data-value')) {
+	          console.warn('cell is child', i);
+	        }
+
+	        var childCell = cell.querySelector('[data-value]');
+
+	        // TODO only do this if autolabel="true"?
+	        if (cell.childNodes.length === 1 && cell.firstChild.nodeType === Node.TEXT_NODE) {
+	          if (autolabel) {
+	            cell.setAttribute('aria-label', cell.firstChild.textContent);
+	            cell.removeChild(cell.firstChild);
+	          } else {
+	            var text = cell.removeChild(cell.firstChild);
+	            var span = cell.appendChild(document.createElement('span'));
+	            span.className = 'text';
+	            span.appendChild(text);
+	          }
+	        }
+
+
+	        var barExtent = cell.querySelector('.bar');
+	        if (barExtent) {
+	          var bar = barExtent.querySelector('.bar');
+	        }
+
+	        if (!barExtent && !bar) {
+	          barExtent = document.createElement('div');
+	          barExtent.className = 'bar';
+	          bar = document.createElement('div');
+	          bar.className = 'bar';
+	          var span = cell.querySelector('span');
+	          if (span && barExtent && bar) {
+	            cell.insertBefore(barExtent,span);
+	            barExtent.appendChild(bar);
+	          }
+	        }
+
+	        if (childCell) {
+	          var childBar = document.createElement('div');
+	          childBar.className = 'bar';
+	          bar.appendChild(childBar);
+	        }
+
+	        var value = +cell.dataset.value;
+	        var size = width(value);
+
+	        if (childCell) {
+	          var childValue = +childCell.dataset.value;
+	          size = width(value) + width(childValue);
+	          var diff = childValue - value;
+	          var largerSize = diff > 0
+	            ? width(childValue) / (size / 100)
+	            : width(value) / (size / 100);
+	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
+	          childBar.style.setProperty(sizeProperty, Math.abs(largerSize) + '%');
+	        } else {
+	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
+	        }
+
+	        if (offset) {
+	          bar.style.setProperty(offsetProperty, offset(value) + '%');
+	        } else {
+	          bar.style.removeProperty(offsetProperty);
+	        }
+	      });
+
+	    }, this);
+	  };
+
+	  exports.EITIBarChartTable = document.registerElement('bar-chart-table', {
+	    'extends': 'table',
+	    prototype: Object.create(
+	      HTMLTableElement.prototype,
+	      {
+	        attachedCallback: {value: initialize},
+
+	        attributeChangedCallback: {value: function(attr, old, value) {
+	          switch (attr) {
+	            case 'orient':
+	              this.update();
+	          }
+	        }},
+
+	        update: {value: update},
+
+	        setYear: {value: setYear},
+
+	        orient: {
+	          get: function() {
+	            return this.getAttribute('orient');
+	          },
+	          set: function(value) {
+	            if (value !== this.orient) {
+	              this.setAttribute('orient', value);
+	            }
+	          }
+	        }
+	      }
+	    )
+	  });
+
+	})(this);
 
 
 /***/ },

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -48,8 +48,8 @@
 	  'use strict';
 
 	  __webpack_require__(24);
-	  __webpack_require__(26);
 	  __webpack_require__(25);
+	  __webpack_require__(32);
 	  __webpack_require__(33);
 	  __webpack_require__(34);
 
@@ -11086,6 +11086,945 @@
 
 /***/ },
 /* 25 */
+/***/ function(module, exports, __webpack_require__) {
+
+	(function(exports) {
+
+	  __webpack_require__(26);
+
+	  var eiti = __webpack_require__(12);
+	  var format = eiti.format;
+
+	  exports.EITIDataMap = document.registerElement('eiti-data-map', {
+	    prototype: Object.create(
+	      HTMLElement.prototype,
+	      {
+	        attachedCallback: {value: function() {
+	          this.marks = d3.select(this).selectAll('[data-value]')
+	            .datum(function() {
+	              return +this.getAttribute('data-value') || 0;
+	            });
+
+	          this.update();
+	        }},
+
+	        setYear: {value: function(year) {
+	          this.marks.datum(function() {
+	              var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
+	              return data[year] || 0;
+	            })
+	            .attr('data-value', function(d) {
+	              return d;
+	            });
+	          this.update();
+	        }},
+
+	        update: {value: function() {
+	          var type = this.getAttribute('scale-type') || 'quantize';
+	          var scheme = this.getAttribute('color-scheme') || 'Blues';
+	          var steps = this.getAttribute('steps') || 5;
+	          var units = this.getAttribute('units') || '';
+
+
+	          var colors = colorbrewer[scheme][steps];
+	          if (!colors) {
+	            return console.error(
+	              'bad # of steps (%d) for color scheme:', steps, scheme
+	            );
+	          }
+
+	          var marks = this.marks;
+
+	          var domain = this.hasAttribute('domain')
+	            ? JSON.parse(this.getAttribute('domain'))
+	            : d3.extent(marks.data());
+
+	          if (domain[0] > 0) {
+	            domain[0] = 0;
+	          } else if (domain[0] < 0) {
+	            domain[1] = Math.max(0, domain[1]);
+	          }
+
+	          // FIXME: do something with divergent scales??
+
+	          var scale = d3.scale[type]()
+	            .domain(domain)
+	            .range(colors);
+
+	          marks.attr('fill', scale);
+
+
+	          this.scale = scale;
+
+	          // start map legend
+	          function uniq(value, index, self) {
+	            return self.indexOf(value) === index;
+	          }
+
+	          function getUnique(data, steps, domain) {
+	            var getSteps = d3.scale[type]()
+	              .domain(domain)
+	              .range(steps);
+
+	            var values = [];
+	            data.forEach(function(d) {
+	              values.push(getSteps(d));
+	            });
+
+	            return values.filter(uniq);
+	          }
+
+	          var svgLegend = d3.select(this)
+	            .select('.legend-svg');
+
+	          svgLegend.append('g')
+	            .attr('class', 'legendScale');
+
+	          var legend = d3.legend.color()
+	            .labelFormat(format.si)
+	            .useClass(false)
+	            .ascending(true)
+	            .labelDelimiter('-')
+	            .shapePadding(6)
+	            .scale(scale);
+
+	          svgLegend.select('.legendScale')
+	            .call(legend);
+
+	          // reverse because the scale is in ascending order
+	          var _steps = d3.range(0, 9).reverse();
+
+	          // find which steps are represented in the map
+	          var uniqueSteps = getUnique(marks.data(), _steps, domain);
+
+	          // start consolidate (translate) visible cells
+	          var cells = svgLegend.selectAll('.cell');
+	          var cellHeight = legend.shapeHeight() + legend.shapePadding();
+	          var count = 0;
+	          cells.each(function(cell, i) {
+	            var present = uniqueSteps.indexOf(i) > -1;
+
+	            if (!present) {
+	              // hide cells swatches that aren't in the map
+	              cells[0][i].setAttribute('aria-hidden', true);
+	              count++;
+	            } else  {
+	              // trim spacing between swatches that are visible
+	              var translateHeight = (i * cellHeight) - (count * cellHeight);
+	              cells[0][i].setAttribute('transform',
+	                'translate(0,' + translateHeight + ')');
+	            }
+	          });
+	          // end consolidation
+	          // end map legend
+
+	          // start trim height on map container
+	          var svgContainer = d3.select(this)
+	            .selectAll('.svg-container[data-dimensions]')
+	            .datum(function() {
+	              return (this.getBoundingClientRect().width
+	                * +this.getAttribute('data-dimensions')
+	                / 100)
+	                + 50;
+	            });
+
+	          function pixelize(d) {
+	            return d + 'px';
+	          }
+
+	          svgContainer.style('padding-bottom', pixelize);
+	          // end trim
+
+
+	          // var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
+	          //   .datum(function() {
+	          //     return +this.getAttribute('data-value-swatch') || 0;
+	          //   });
+
+	          // swatches.style('background-color', scale);
+	          // console.log(swatches)
+	        }}
+	      }
+	    )
+	  });
+
+	})(this);
+
+
+/***/ },
+/* 26 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var d3 = __webpack_require__(5);
+
+	d3.legend = __webpack_require__(27);
+
+	module.exports = d3;
+
+
+/***/ },
+/* 27 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = {
+	  color: __webpack_require__(28),
+	  size: __webpack_require__(30),
+	  symbol: __webpack_require__(31)
+	};
+
+
+/***/ },
+/* 28 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var helper = __webpack_require__(29);
+
+	module.exports = function(){
+
+	  var scale = d3.scale.linear(),
+	    shape = "rect",
+	    shapeWidth = 15,
+	    shapeHeight = 15,
+	    shapeRadius = 10,
+	    shapePadding = 2,
+	    cells = [5],
+	    labels = [],
+	    classPrefix = "",
+	    useClass = false,
+	    title = "",
+	    labelFormat = d3.format(".01f"),
+	    labelOffset = 10,
+	    labelAlign = "middle",
+	    labelDelimiter = "to",
+	    orient = "vertical",
+	    ascending = false,
+	    path,
+	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
+
+	    function legend(svg){
+
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
+	        legendG = svg.selectAll('g').data([scale]);
+
+	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
+
+
+	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
+	        shapes = cell.select("g." + classPrefix + "cell " + shape);
+
+	      //add event handlers
+	      helper.d3_addEvents(cellEnter, legendDispatcher);
+
+	      cell.exit().transition().style("opacity", 0).remove();
+
+	      helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, path);
+
+	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
+
+	      // sets placement
+	      var text = cell.select("text"),
+	        shapeSize = shapes[0].map( function(d){ return d.getBBox(); });
+
+	      //sets scale
+	      //everything is fill except for line which is stroke,
+	      if (!useClass){
+	        if (shape == "line"){
+	          shapes.style("stroke", type.feature);
+	        } else {
+	          shapes.style("fill", type.feature);
+	        }
+	      } else {
+	        shapes.attr("class", function(d){ return classPrefix + "swatch " + type.feature(d); });
+	      }
+
+	      var cellTrans,
+	      textTrans,
+	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
+
+	      //positions cells and text
+	      if (orient === "vertical"){
+	        cellTrans = function(d,i) { return "translate(0, " + (i * (shapeSize[i].height + shapePadding)) + ")"; };
+	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width + shapeSize[i].x +
+	          labelOffset) + "," + (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
+
+	      } else if (orient === "horizontal"){
+	        cellTrans = function(d,i) { return "translate(" + (i * (shapeSize[i].width + shapePadding)) + ",0)"; }
+	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) +
+	          "," + (shapeSize[i].height + shapeSize[i].y + labelOffset + 8) + ")"; };
+	      }
+
+	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
+	      helper.d3_title(svg, legendG, title, classPrefix);
+
+	      cell.transition().style("opacity", 1);
+
+	    }
+
+
+
+	  legend.scale = function(_) {
+	    if (!arguments.length) return scale;
+	    scale = _;
+	    return legend;
+	  };
+
+	  legend.cells = function(_) {
+	    if (!arguments.length) return cells;
+	    if (_.length > 1 || _ >= 2 ){
+	      cells = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.shape = function(_, d) {
+	    if (!arguments.length) return shape;
+	    if (_ == "rect" || _ == "circle" || _ == "line" || (_ == "path" && (typeof d === 'string')) ){
+	      shape = _;
+	      path = d;
+	    }
+	    return legend;
+	  };
+
+	  legend.shapeWidth = function(_) {
+	    if (!arguments.length) return shapeWidth;
+	    shapeWidth = +_;
+	    return legend;
+	  };
+
+	  legend.shapeHeight = function(_) {
+	    if (!arguments.length) return shapeHeight;
+	    shapeHeight = +_;
+	    return legend;
+	  };
+
+	  legend.shapeRadius = function(_) {
+	    if (!arguments.length) return shapeRadius;
+	    shapeRadius = +_;
+	    return legend;
+	  };
+
+	  legend.shapePadding = function(_) {
+	    if (!arguments.length) return shapePadding;
+	    shapePadding = +_;
+	    return legend;
+	  };
+
+	  legend.labels = function(_) {
+	    if (!arguments.length) return labels;
+	    labels = _;
+	    return legend;
+	  };
+
+	  legend.labelAlign = function(_) {
+	    if (!arguments.length) return labelAlign;
+	    if (_ == "start" || _ == "end" || _ == "middle") {
+	      labelAlign = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.labelFormat = function(_) {
+	    if (!arguments.length) return labelFormat;
+	    labelFormat = _;
+	    return legend;
+	  };
+
+	  legend.labelOffset = function(_) {
+	    if (!arguments.length) return labelOffset;
+	    labelOffset = +_;
+	    return legend;
+	  };
+
+	  legend.labelDelimiter = function(_) {
+	    if (!arguments.length) return labelDelimiter;
+	    labelDelimiter = _;
+	    return legend;
+	  };
+
+	  legend.useClass = function(_) {
+	    if (!arguments.length) return useClass;
+	    if (_ === true || _ === false){
+	      useClass = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.orient = function(_){
+	    if (!arguments.length) return orient;
+	    _ = _.toLowerCase();
+	    if (_ == "horizontal" || _ == "vertical") {
+	      orient = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.ascending = function(_) {
+	    if (!arguments.length) return ascending;
+	    ascending = !!_;
+	    return legend;
+	  };
+
+	  legend.classPrefix = function(_) {
+	    if (!arguments.length) return classPrefix;
+	    classPrefix = _;
+	    return legend;
+	  };
+
+	  legend.title = function(_) {
+	    if (!arguments.length) return title;
+	    title = _;
+	    return legend;
+	  };
+
+	  d3.rebind(legend, legendDispatcher, "on");
+
+	  return legend;
+
+	};
+
+
+/***/ },
+/* 29 */
+/***/ function(module, exports) {
+
+	module.exports = {
+
+	  d3_identity: function (d) {
+	    return d;
+	  },
+
+	  d3_mergeLabels: function (gen, labels) {
+
+	      if(labels.length === 0) return gen;
+
+	      gen = (gen) ? gen : [];
+
+	      var i = labels.length;
+	      for (; i < gen.length; i++) {
+	        labels.push(gen[i]);
+	      }
+	      return labels;
+	    },
+
+	  d3_linearLegend: function (scale, cells, labelFormat) {
+	    var data = [];
+
+	    if (cells.length > 1){
+	      data = cells;
+
+	    } else {
+	      var domain = scale.domain(),
+	      increment = (domain[domain.length - 1] - domain[0])/(cells - 1),
+	      i = 0;
+
+	      for (; i < cells; i++){
+	        data.push(domain[0] + i*increment);
+	      }
+	    }
+
+	    var labels = data.map(labelFormat);
+
+	    return {data: data,
+	            labels: labels,
+	            feature: function(d){ return scale(d); }};
+	  },
+
+	  d3_quantLegend: function (scale, labelFormat, labelDelimiter) {
+	    var labels = scale.range().map(function(d){
+	      var invert = scale.invertExtent(d),
+	      a = labelFormat(invert[0]),
+	      b = labelFormat(invert[1]);
+
+	      // if (( (a) && (a.isNan()) && b){
+	      //   console.log("in initial statement")
+	        return labelFormat(invert[0]) + " " + labelDelimiter + " " + labelFormat(invert[1]);
+	      // } else if (a || b) {
+	      //   console.log('in else statement')
+	      //   return (a) ? a : b;
+	      // }
+
+	    });
+
+	    return {data: scale.range(),
+	            labels: labels,
+	            feature: this.d3_identity
+	          };
+	  },
+
+	  d3_ordinalLegend: function (scale) {
+	    return {data: scale.domain(),
+	            labels: scale.domain(),
+	            feature: function(d){ return scale(d); }};
+	  },
+
+	  d3_drawShapes: function (shape, shapes, shapeHeight, shapeWidth, shapeRadius, path) {
+	    if (shape === "rect"){
+	        shapes.attr("height", shapeHeight).attr("width", shapeWidth);
+
+	    } else if (shape === "circle") {
+	        shapes.attr("r", shapeRadius)//.attr("cx", shapeRadius).attr("cy", shapeRadius);
+
+	    } else if (shape === "line") {
+	        shapes.attr("x1", 0).attr("x2", shapeWidth).attr("y1", 0).attr("y2", 0);
+
+	    } else if (shape === "path") {
+	      shapes.attr("d", path);
+	    }
+	  },
+
+	  d3_addText: function (svg, enter, labels, classPrefix){
+	    enter.append("text").attr("class", classPrefix + "label");
+	    svg.selectAll("g." + classPrefix + "cell text").data(labels).text(this.d3_identity);
+	  },
+
+	  d3_calcType: function (scale, ascending, cells, labels, labelFormat, labelDelimiter){
+	    var type = scale.ticks ?
+	            this.d3_linearLegend(scale, cells, labelFormat) : scale.invertExtent ?
+	            this.d3_quantLegend(scale, labelFormat, labelDelimiter) : this.d3_ordinalLegend(scale);
+
+	    type.labels = this.d3_mergeLabels(type.labels, labels);
+
+	    if (ascending) {
+	      type.labels = this.d3_reverse(type.labels);
+	      type.data = this.d3_reverse(type.data);
+	    }
+
+	    return type;
+	  },
+
+	  d3_reverse: function(arr) {
+	    var mirror = [];
+	    for (var i = 0, l = arr.length; i < l; i++) {
+	      mirror[i] = arr[l-i-1];
+	    }
+	    return mirror;
+	  },
+
+	  d3_placement: function (orient, cell, cellTrans, text, textTrans, labelAlign) {
+	    cell.attr("transform", cellTrans);
+	    text.attr("transform", textTrans);
+	    if (orient === "horizontal"){
+	      text.style("text-anchor", labelAlign);
+	    }
+	  },
+
+	  d3_addEvents: function(cells, dispatcher){
+	    var _ = this;
+
+	      cells.on("mouseover.legend", function (d) { _.d3_cellOver(dispatcher, d, this); })
+	          .on("mouseout.legend", function (d) { _.d3_cellOut(dispatcher, d, this); })
+	          .on("click.legend", function (d) { _.d3_cellClick(dispatcher, d, this); });
+	  },
+
+	  d3_cellOver: function(cellDispatcher, d, obj){
+	    cellDispatcher.cellover.call(obj, d);
+	  },
+
+	  d3_cellOut: function(cellDispatcher, d, obj){
+	    cellDispatcher.cellout.call(obj, d);
+	  },
+
+	  d3_cellClick: function(cellDispatcher, d, obj){
+	    cellDispatcher.cellclick.call(obj, d);
+	  },
+
+	  d3_title: function(svg, cellsSvg, title, classPrefix){
+	    if (title !== ""){
+
+	      var titleText = svg.selectAll('text.' + classPrefix + 'legendTitle');
+
+	      titleText.data([title])
+	        .enter()
+	        .append('text')
+	        .attr('class', classPrefix + 'legendTitle');
+
+	        svg.selectAll('text.' + classPrefix + 'legendTitle')
+	            .text(title)
+
+	      var yOffset = svg.select('.' + classPrefix + 'legendTitle')
+	          .map(function(d) { return d[0].getBBox().height})[0],
+	      xOffset = -cellsSvg.map(function(d) { return d[0].getBBox().x})[0];
+
+	      cellsSvg.attr('transform', 'translate(' + xOffset + ',' + (yOffset + 10) + ')');
+
+	    }
+	  }
+	}
+
+
+/***/ },
+/* 30 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var helper = __webpack_require__(29);
+
+	module.exports =  function(){
+
+	  var scale = d3.scale.linear(),
+	    shape = "rect",
+	    shapeWidth = 15,
+	    shapePadding = 2,
+	    cells = [5],
+	    labels = [],
+	    useStroke = false,
+	    classPrefix = "",
+	    title = "",
+	    labelFormat = d3.format(".01f"),
+	    labelOffset = 10,
+	    labelAlign = "middle",
+	    labelDelimiter = "to",
+	    orient = "vertical",
+	    ascending = false,
+	    path,
+	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
+
+	    function legend(svg){
+
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
+	        legendG = svg.selectAll('g').data([scale]);
+
+	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
+
+
+	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
+	        shapes = cell.select("g." + classPrefix + "cell " + shape);
+
+	      //add event handlers
+	      helper.d3_addEvents(cellEnter, legendDispatcher);
+
+	      cell.exit().transition().style("opacity", 0).remove();
+
+	      //creates shape
+	      if (shape === "line"){
+	        helper.d3_drawShapes(shape, shapes, 0, shapeWidth);
+	        shapes.attr("stroke-width", type.feature);
+	      } else {
+	        helper.d3_drawShapes(shape, shapes, type.feature, type.feature, type.feature, path);
+	      }
+
+	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
+
+	      //sets placement
+	      var text = cell.select("text"),
+	        shapeSize = shapes[0].map(
+	          function(d, i){
+	            var bbox = d.getBBox()
+	            var stroke = scale(type.data[i]);
+
+	            if (shape === "line" && orient === "horizontal") {
+	              bbox.height = bbox.height + stroke;
+	            } else if (shape === "line" && orient === "vertical"){
+	              bbox.width = bbox.width;
+	            }
+
+	            return bbox;
+	        });
+
+	      var maxH = d3.max(shapeSize, function(d){ return d.height + d.y; }),
+	      maxW = d3.max(shapeSize, function(d){ return d.width + d.x; });
+
+	      var cellTrans,
+	      textTrans,
+	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
+
+	      //positions cells and text
+	      if (orient === "vertical"){
+
+	        cellTrans = function(d,i) {
+	            var height = d3.sum(shapeSize.slice(0, i + 1 ), function(d){ return d.height; });
+	            return "translate(0, " + (height + i*shapePadding) + ")"; };
+
+	        textTrans = function(d,i) { return "translate(" + (maxW + labelOffset) + "," +
+	          (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
+
+	      } else if (orient === "horizontal"){
+	        cellTrans = function(d,i) {
+	            var width = d3.sum(shapeSize.slice(0, i + 1 ), function(d){ return d.width; });
+	            return "translate(" + (width + i*shapePadding) + ",0)"; };
+
+	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) + "," +
+	              (maxH + labelOffset ) + ")"; };
+	      }
+
+	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
+	      helper.d3_title(svg, legendG, title, classPrefix);
+
+	      cell.transition().style("opacity", 1);
+
+	    }
+
+	  legend.scale = function(_) {
+	    if (!arguments.length) return scale;
+	    scale = _;
+	    return legend;
+	  };
+
+	  legend.cells = function(_) {
+	    if (!arguments.length) return cells;
+	    if (_.length > 1 || _ >= 2 ){
+	      cells = _;
+	    }
+	    return legend;
+	  };
+
+
+	  legend.shape = function(_, d) {
+	    if (!arguments.length) return shape;
+	    if (_ == "rect" || _ == "circle" || _ == "line" ){
+	      shape = _;
+	      path = d;
+	    }
+	    return legend;
+	  };
+
+	  legend.shapeWidth = function(_) {
+	    if (!arguments.length) return shapeWidth;
+	    shapeWidth = +_;
+	    return legend;
+	  };
+
+	  legend.shapePadding = function(_) {
+	    if (!arguments.length) return shapePadding;
+	    shapePadding = +_;
+	    return legend;
+	  };
+
+	  legend.labels = function(_) {
+	    if (!arguments.length) return labels;
+	    labels = _;
+	    return legend;
+	  };
+
+	  legend.labelAlign = function(_) {
+	    if (!arguments.length) return labelAlign;
+	    if (_ == "start" || _ == "end" || _ == "middle") {
+	      labelAlign = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.labelFormat = function(_) {
+	    if (!arguments.length) return labelFormat;
+	    labelFormat = _;
+	    return legend;
+	  };
+
+	  legend.labelOffset = function(_) {
+	    if (!arguments.length) return labelOffset;
+	    labelOffset = +_;
+	    return legend;
+	  };
+
+	  legend.labelDelimiter = function(_) {
+	    if (!arguments.length) return labelDelimiter;
+	    labelDelimiter = _;
+	    return legend;
+	  };
+
+	  legend.orient = function(_){
+	    if (!arguments.length) return orient;
+	    _ = _.toLowerCase();
+	    if (_ == "horizontal" || _ == "vertical") {
+	      orient = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.ascending = function(_) {
+	    if (!arguments.length) return ascending;
+	    ascending = !!_;
+	    return legend;
+	  };
+
+	  legend.classPrefix = function(_) {
+	    if (!arguments.length) return classPrefix;
+	    classPrefix = _;
+	    return legend;
+	  };
+
+	  legend.title = function(_) {
+	    if (!arguments.length) return title;
+	    title = _;
+	    return legend;
+	  };
+
+	  d3.rebind(legend, legendDispatcher, "on");
+
+	  return legend;
+
+	};
+
+
+/***/ },
+/* 31 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var helper = __webpack_require__(29);
+
+	module.exports = function(){
+
+	  var scale = d3.scale.linear(),
+	    shape = "path",
+	    shapeWidth = 15,
+	    shapeHeight = 15,
+	    shapeRadius = 10,
+	    shapePadding = 5,
+	    cells = [5],
+	    labels = [],
+	    classPrefix = "",
+	    useClass = false,
+	    title = "",
+	    labelFormat = d3.format(".01f"),
+	    labelAlign = "middle",
+	    labelOffset = 10,
+	    labelDelimiter = "to",
+	    orient = "vertical",
+	    ascending = false,
+	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
+
+	    function legend(svg){
+
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
+	        legendG = svg.selectAll('g').data([scale]);
+
+	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
+
+	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
+	        shapes = cell.select("g." + classPrefix + "cell " + shape);
+
+	      //add event handlers
+	      helper.d3_addEvents(cellEnter, legendDispatcher);
+
+	      //remove old shapes
+	      cell.exit().transition().style("opacity", 0).remove();
+
+	      helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, type.feature);
+	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
+
+	      // sets placement
+	      var text = cell.select("text"),
+	        shapeSize = shapes[0].map( function(d){ return d.getBBox(); });
+
+	      var maxH = d3.max(shapeSize, function(d){ return d.height; }),
+	      maxW = d3.max(shapeSize, function(d){ return d.width; });
+
+	      var cellTrans,
+	      textTrans,
+	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
+
+	      //positions cells and text
+	      if (orient === "vertical"){
+	        cellTrans = function(d,i) { return "translate(0, " + (i * (maxH + shapePadding)) + ")"; };
+	        textTrans = function(d,i) { return "translate(" + (maxW + labelOffset) + "," +
+	              (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
+
+	      } else if (orient === "horizontal"){
+	        cellTrans = function(d,i) { return "translate(" + (i * (maxW + shapePadding)) + ",0)"; };
+	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) + "," +
+	              (maxH + labelOffset ) + ")"; };
+	      }
+
+	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
+	      helper.d3_title(svg, legendG, title, classPrefix);
+	      cell.transition().style("opacity", 1);
+
+	    }
+
+
+	  legend.scale = function(_) {
+	    if (!arguments.length) return scale;
+	    scale = _;
+	    return legend;
+	  };
+
+	  legend.cells = function(_) {
+	    if (!arguments.length) return cells;
+	    if (_.length > 1 || _ >= 2 ){
+	      cells = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.shapePadding = function(_) {
+	    if (!arguments.length) return shapePadding;
+	    shapePadding = +_;
+	    return legend;
+	  };
+
+	  legend.labels = function(_) {
+	    if (!arguments.length) return labels;
+	    labels = _;
+	    return legend;
+	  };
+
+	  legend.labelAlign = function(_) {
+	    if (!arguments.length) return labelAlign;
+	    if (_ == "start" || _ == "end" || _ == "middle") {
+	      labelAlign = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.labelFormat = function(_) {
+	    if (!arguments.length) return labelFormat;
+	    labelFormat = _;
+	    return legend;
+	  };
+
+	  legend.labelOffset = function(_) {
+	    if (!arguments.length) return labelOffset;
+	    labelOffset = +_;
+	    return legend;
+	  };
+
+	  legend.labelDelimiter = function(_) {
+	    if (!arguments.length) return labelDelimiter;
+	    labelDelimiter = _;
+	    return legend;
+	  };
+
+	  legend.orient = function(_){
+	    if (!arguments.length) return orient;
+	    _ = _.toLowerCase();
+	    if (_ == "horizontal" || _ == "vertical") {
+	      orient = _;
+	    }
+	    return legend;
+	  };
+
+	  legend.ascending = function(_) {
+	    if (!arguments.length) return ascending;
+	    ascending = !!_;
+	    return legend;
+	  };
+
+	  legend.classPrefix = function(_) {
+	    if (!arguments.length) return classPrefix;
+	    classPrefix = _;
+	    return legend;
+	  };
+
+	  legend.title = function(_) {
+	    if (!arguments.length) return title;
+	    title = _;
+	    return legend;
+	  };
+
+	  d3.rebind(legend, legendDispatcher, "on");
+
+	  return legend;
+
+	};
+
+
+/***/ },
+/* 32 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -11372,945 +12311,6 @@
 	  });
 
 	})(this);
-
-
-/***/ },
-/* 26 */
-/***/ function(module, exports, __webpack_require__) {
-
-	(function(exports) {
-
-	  __webpack_require__(27);
-
-	  var eiti = __webpack_require__(12);
-	  var format = eiti.format;
-
-	  exports.EITIDataMap = document.registerElement('eiti-data-map', {
-	    prototype: Object.create(
-	      HTMLElement.prototype,
-	      {
-	        attachedCallback: {value: function() {
-	          this.marks = d3.select(this).selectAll('[data-value]')
-	            .datum(function() {
-	              return +this.getAttribute('data-value') || 0;
-	            });
-
-	          this.update();
-	        }},
-
-	        setYear: {value: function(year) {
-	          this.marks.datum(function() {
-	              var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
-	              return data[year] || 0;
-	            })
-	            .attr('data-value', function(d) {
-	              return d;
-	            });
-	          this.update();
-	        }},
-
-	        update: {value: function() {
-	          var type = this.getAttribute('scale-type') || 'quantize';
-	          var scheme = this.getAttribute('color-scheme') || 'Blues';
-	          var steps = this.getAttribute('steps') || 5;
-	          var units = this.getAttribute('units') || '';
-
-
-	          var colors = colorbrewer[scheme][steps];
-	          if (!colors) {
-	            return console.error(
-	              'bad # of steps (%d) for color scheme:', steps, scheme
-	            );
-	          }
-
-	          var marks = this.marks;
-
-	          var domain = this.hasAttribute('domain')
-	            ? JSON.parse(this.getAttribute('domain'))
-	            : d3.extent(marks.data());
-
-	          if (domain[0] > 0) {
-	            domain[0] = 0;
-	          } else if (domain[0] < 0) {
-	            domain[1] = Math.max(0, domain[1]);
-	          }
-
-	          // FIXME: do something with divergent scales??
-
-	          var scale = d3.scale[type]()
-	            .domain(domain)
-	            .range(colors);
-
-	          marks.attr('fill', scale);
-
-
-	          this.scale = scale;
-
-	          // start map legend
-	          function uniq(value, index, self) {
-	            return self.indexOf(value) === index;
-	          }
-
-	          function getUnique(data, steps, domain) {
-	            var getSteps = d3.scale[type]()
-	              .domain(domain)
-	              .range(steps);
-
-	            var values = [];
-	            data.forEach(function(d) {
-	              values.push(getSteps(d));
-	            });
-
-	            return values.filter(uniq);
-	          }
-
-	          var svgLegend = d3.select(this)
-	            .select('.legend-svg');
-
-	          svgLegend.append('g')
-	            .attr('class', 'legendScale');
-
-	          var legend = d3.legend.color()
-	            .labelFormat(format.si)
-	            .useClass(false)
-	            .ascending(true)
-	            .labelDelimiter('-')
-	            .shapePadding(6)
-	            .scale(scale);
-
-	          svgLegend.select('.legendScale')
-	            .call(legend);
-
-	          // reverse because the scale is in ascending order
-	          var _steps = d3.range(0, 9).reverse();
-
-	          // find which steps are represented in the map
-	          var uniqueSteps = getUnique(marks.data(), _steps, domain);
-
-	          // start consolidate (translate) visible cells
-	          var cells = svgLegend.selectAll('.cell');
-	          var cellHeight = legend.shapeHeight() + legend.shapePadding();
-	          var count = 0;
-	          cells.each(function(cell, i) {
-	            var present = uniqueSteps.indexOf(i) > -1;
-
-	            if (!present) {
-	              // hide cells swatches that aren't in the map
-	              cells[0][i].setAttribute('aria-hidden', true);
-	              count++;
-	            } else  {
-	              // trim spacing between swatches that are visible
-	              var translateHeight = (i * cellHeight) - (count * cellHeight);
-	              cells[0][i].setAttribute('transform',
-	                'translate(0,' + translateHeight + ')');
-	            }
-	          });
-	          // end consolidation
-	          // end map legend
-
-	          // start trim height on map container
-	          var svgContainer = d3.select(this)
-	            .selectAll('.svg-container[data-dimensions]')
-	            .datum(function() {
-	              return (this.getBoundingClientRect().width
-	                * +this.getAttribute('data-dimensions')
-	                / 100)
-	                + 50;
-	            });
-
-	          function pixelize(d) {
-	            return d + 'px';
-	          }
-
-	          svgContainer.style('padding-bottom', pixelize);
-	          // end trim
-
-
-	          // var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
-	          //   .datum(function() {
-	          //     return +this.getAttribute('data-value-swatch') || 0;
-	          //   });
-
-	          // swatches.style('background-color', scale);
-	          // console.log(swatches)
-	        }}
-	      }
-	    )
-	  });
-
-	})(this);
-
-
-/***/ },
-/* 27 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var d3 = __webpack_require__(5);
-
-	d3.legend = __webpack_require__(28);
-
-	module.exports = d3;
-
-
-/***/ },
-/* 28 */
-/***/ function(module, exports, __webpack_require__) {
-
-	module.exports = {
-	  color: __webpack_require__(29),
-	  size: __webpack_require__(31),
-	  symbol: __webpack_require__(32)
-	};
-
-
-/***/ },
-/* 29 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var helper = __webpack_require__(30);
-
-	module.exports = function(){
-
-	  var scale = d3.scale.linear(),
-	    shape = "rect",
-	    shapeWidth = 15,
-	    shapeHeight = 15,
-	    shapeRadius = 10,
-	    shapePadding = 2,
-	    cells = [5],
-	    labels = [],
-	    classPrefix = "",
-	    useClass = false,
-	    title = "",
-	    labelFormat = d3.format(".01f"),
-	    labelOffset = 10,
-	    labelAlign = "middle",
-	    labelDelimiter = "to",
-	    orient = "vertical",
-	    ascending = false,
-	    path,
-	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
-
-	    function legend(svg){
-
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
-	        legendG = svg.selectAll('g').data([scale]);
-
-	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
-
-
-	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
-	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
-	        shapes = cell.select("g." + classPrefix + "cell " + shape);
-
-	      //add event handlers
-	      helper.d3_addEvents(cellEnter, legendDispatcher);
-
-	      cell.exit().transition().style("opacity", 0).remove();
-
-	      helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, path);
-
-	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
-
-	      // sets placement
-	      var text = cell.select("text"),
-	        shapeSize = shapes[0].map( function(d){ return d.getBBox(); });
-
-	      //sets scale
-	      //everything is fill except for line which is stroke,
-	      if (!useClass){
-	        if (shape == "line"){
-	          shapes.style("stroke", type.feature);
-	        } else {
-	          shapes.style("fill", type.feature);
-	        }
-	      } else {
-	        shapes.attr("class", function(d){ return classPrefix + "swatch " + type.feature(d); });
-	      }
-
-	      var cellTrans,
-	      textTrans,
-	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
-
-	      //positions cells and text
-	      if (orient === "vertical"){
-	        cellTrans = function(d,i) { return "translate(0, " + (i * (shapeSize[i].height + shapePadding)) + ")"; };
-	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width + shapeSize[i].x +
-	          labelOffset) + "," + (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
-
-	      } else if (orient === "horizontal"){
-	        cellTrans = function(d,i) { return "translate(" + (i * (shapeSize[i].width + shapePadding)) + ",0)"; }
-	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) +
-	          "," + (shapeSize[i].height + shapeSize[i].y + labelOffset + 8) + ")"; };
-	      }
-
-	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
-	      helper.d3_title(svg, legendG, title, classPrefix);
-
-	      cell.transition().style("opacity", 1);
-
-	    }
-
-
-
-	  legend.scale = function(_) {
-	    if (!arguments.length) return scale;
-	    scale = _;
-	    return legend;
-	  };
-
-	  legend.cells = function(_) {
-	    if (!arguments.length) return cells;
-	    if (_.length > 1 || _ >= 2 ){
-	      cells = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.shape = function(_, d) {
-	    if (!arguments.length) return shape;
-	    if (_ == "rect" || _ == "circle" || _ == "line" || (_ == "path" && (typeof d === 'string')) ){
-	      shape = _;
-	      path = d;
-	    }
-	    return legend;
-	  };
-
-	  legend.shapeWidth = function(_) {
-	    if (!arguments.length) return shapeWidth;
-	    shapeWidth = +_;
-	    return legend;
-	  };
-
-	  legend.shapeHeight = function(_) {
-	    if (!arguments.length) return shapeHeight;
-	    shapeHeight = +_;
-	    return legend;
-	  };
-
-	  legend.shapeRadius = function(_) {
-	    if (!arguments.length) return shapeRadius;
-	    shapeRadius = +_;
-	    return legend;
-	  };
-
-	  legend.shapePadding = function(_) {
-	    if (!arguments.length) return shapePadding;
-	    shapePadding = +_;
-	    return legend;
-	  };
-
-	  legend.labels = function(_) {
-	    if (!arguments.length) return labels;
-	    labels = _;
-	    return legend;
-	  };
-
-	  legend.labelAlign = function(_) {
-	    if (!arguments.length) return labelAlign;
-	    if (_ == "start" || _ == "end" || _ == "middle") {
-	      labelAlign = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.labelFormat = function(_) {
-	    if (!arguments.length) return labelFormat;
-	    labelFormat = _;
-	    return legend;
-	  };
-
-	  legend.labelOffset = function(_) {
-	    if (!arguments.length) return labelOffset;
-	    labelOffset = +_;
-	    return legend;
-	  };
-
-	  legend.labelDelimiter = function(_) {
-	    if (!arguments.length) return labelDelimiter;
-	    labelDelimiter = _;
-	    return legend;
-	  };
-
-	  legend.useClass = function(_) {
-	    if (!arguments.length) return useClass;
-	    if (_ === true || _ === false){
-	      useClass = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.orient = function(_){
-	    if (!arguments.length) return orient;
-	    _ = _.toLowerCase();
-	    if (_ == "horizontal" || _ == "vertical") {
-	      orient = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.ascending = function(_) {
-	    if (!arguments.length) return ascending;
-	    ascending = !!_;
-	    return legend;
-	  };
-
-	  legend.classPrefix = function(_) {
-	    if (!arguments.length) return classPrefix;
-	    classPrefix = _;
-	    return legend;
-	  };
-
-	  legend.title = function(_) {
-	    if (!arguments.length) return title;
-	    title = _;
-	    return legend;
-	  };
-
-	  d3.rebind(legend, legendDispatcher, "on");
-
-	  return legend;
-
-	};
-
-
-/***/ },
-/* 30 */
-/***/ function(module, exports) {
-
-	module.exports = {
-
-	  d3_identity: function (d) {
-	    return d;
-	  },
-
-	  d3_mergeLabels: function (gen, labels) {
-
-	      if(labels.length === 0) return gen;
-
-	      gen = (gen) ? gen : [];
-
-	      var i = labels.length;
-	      for (; i < gen.length; i++) {
-	        labels.push(gen[i]);
-	      }
-	      return labels;
-	    },
-
-	  d3_linearLegend: function (scale, cells, labelFormat) {
-	    var data = [];
-
-	    if (cells.length > 1){
-	      data = cells;
-
-	    } else {
-	      var domain = scale.domain(),
-	      increment = (domain[domain.length - 1] - domain[0])/(cells - 1),
-	      i = 0;
-
-	      for (; i < cells; i++){
-	        data.push(domain[0] + i*increment);
-	      }
-	    }
-
-	    var labels = data.map(labelFormat);
-
-	    return {data: data,
-	            labels: labels,
-	            feature: function(d){ return scale(d); }};
-	  },
-
-	  d3_quantLegend: function (scale, labelFormat, labelDelimiter) {
-	    var labels = scale.range().map(function(d){
-	      var invert = scale.invertExtent(d),
-	      a = labelFormat(invert[0]),
-	      b = labelFormat(invert[1]);
-
-	      // if (( (a) && (a.isNan()) && b){
-	      //   console.log("in initial statement")
-	        return labelFormat(invert[0]) + " " + labelDelimiter + " " + labelFormat(invert[1]);
-	      // } else if (a || b) {
-	      //   console.log('in else statement')
-	      //   return (a) ? a : b;
-	      // }
-
-	    });
-
-	    return {data: scale.range(),
-	            labels: labels,
-	            feature: this.d3_identity
-	          };
-	  },
-
-	  d3_ordinalLegend: function (scale) {
-	    return {data: scale.domain(),
-	            labels: scale.domain(),
-	            feature: function(d){ return scale(d); }};
-	  },
-
-	  d3_drawShapes: function (shape, shapes, shapeHeight, shapeWidth, shapeRadius, path) {
-	    if (shape === "rect"){
-	        shapes.attr("height", shapeHeight).attr("width", shapeWidth);
-
-	    } else if (shape === "circle") {
-	        shapes.attr("r", shapeRadius)//.attr("cx", shapeRadius).attr("cy", shapeRadius);
-
-	    } else if (shape === "line") {
-	        shapes.attr("x1", 0).attr("x2", shapeWidth).attr("y1", 0).attr("y2", 0);
-
-	    } else if (shape === "path") {
-	      shapes.attr("d", path);
-	    }
-	  },
-
-	  d3_addText: function (svg, enter, labels, classPrefix){
-	    enter.append("text").attr("class", classPrefix + "label");
-	    svg.selectAll("g." + classPrefix + "cell text").data(labels).text(this.d3_identity);
-	  },
-
-	  d3_calcType: function (scale, ascending, cells, labels, labelFormat, labelDelimiter){
-	    var type = scale.ticks ?
-	            this.d3_linearLegend(scale, cells, labelFormat) : scale.invertExtent ?
-	            this.d3_quantLegend(scale, labelFormat, labelDelimiter) : this.d3_ordinalLegend(scale);
-
-	    type.labels = this.d3_mergeLabels(type.labels, labels);
-
-	    if (ascending) {
-	      type.labels = this.d3_reverse(type.labels);
-	      type.data = this.d3_reverse(type.data);
-	    }
-
-	    return type;
-	  },
-
-	  d3_reverse: function(arr) {
-	    var mirror = [];
-	    for (var i = 0, l = arr.length; i < l; i++) {
-	      mirror[i] = arr[l-i-1];
-	    }
-	    return mirror;
-	  },
-
-	  d3_placement: function (orient, cell, cellTrans, text, textTrans, labelAlign) {
-	    cell.attr("transform", cellTrans);
-	    text.attr("transform", textTrans);
-	    if (orient === "horizontal"){
-	      text.style("text-anchor", labelAlign);
-	    }
-	  },
-
-	  d3_addEvents: function(cells, dispatcher){
-	    var _ = this;
-
-	      cells.on("mouseover.legend", function (d) { _.d3_cellOver(dispatcher, d, this); })
-	          .on("mouseout.legend", function (d) { _.d3_cellOut(dispatcher, d, this); })
-	          .on("click.legend", function (d) { _.d3_cellClick(dispatcher, d, this); });
-	  },
-
-	  d3_cellOver: function(cellDispatcher, d, obj){
-	    cellDispatcher.cellover.call(obj, d);
-	  },
-
-	  d3_cellOut: function(cellDispatcher, d, obj){
-	    cellDispatcher.cellout.call(obj, d);
-	  },
-
-	  d3_cellClick: function(cellDispatcher, d, obj){
-	    cellDispatcher.cellclick.call(obj, d);
-	  },
-
-	  d3_title: function(svg, cellsSvg, title, classPrefix){
-	    if (title !== ""){
-
-	      var titleText = svg.selectAll('text.' + classPrefix + 'legendTitle');
-
-	      titleText.data([title])
-	        .enter()
-	        .append('text')
-	        .attr('class', classPrefix + 'legendTitle');
-
-	        svg.selectAll('text.' + classPrefix + 'legendTitle')
-	            .text(title)
-
-	      var yOffset = svg.select('.' + classPrefix + 'legendTitle')
-	          .map(function(d) { return d[0].getBBox().height})[0],
-	      xOffset = -cellsSvg.map(function(d) { return d[0].getBBox().x})[0];
-
-	      cellsSvg.attr('transform', 'translate(' + xOffset + ',' + (yOffset + 10) + ')');
-
-	    }
-	  }
-	}
-
-
-/***/ },
-/* 31 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var helper = __webpack_require__(30);
-
-	module.exports =  function(){
-
-	  var scale = d3.scale.linear(),
-	    shape = "rect",
-	    shapeWidth = 15,
-	    shapePadding = 2,
-	    cells = [5],
-	    labels = [],
-	    useStroke = false,
-	    classPrefix = "",
-	    title = "",
-	    labelFormat = d3.format(".01f"),
-	    labelOffset = 10,
-	    labelAlign = "middle",
-	    labelDelimiter = "to",
-	    orient = "vertical",
-	    ascending = false,
-	    path,
-	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
-
-	    function legend(svg){
-
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
-	        legendG = svg.selectAll('g').data([scale]);
-
-	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
-
-
-	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
-	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
-	        shapes = cell.select("g." + classPrefix + "cell " + shape);
-
-	      //add event handlers
-	      helper.d3_addEvents(cellEnter, legendDispatcher);
-
-	      cell.exit().transition().style("opacity", 0).remove();
-
-	      //creates shape
-	      if (shape === "line"){
-	        helper.d3_drawShapes(shape, shapes, 0, shapeWidth);
-	        shapes.attr("stroke-width", type.feature);
-	      } else {
-	        helper.d3_drawShapes(shape, shapes, type.feature, type.feature, type.feature, path);
-	      }
-
-	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
-
-	      //sets placement
-	      var text = cell.select("text"),
-	        shapeSize = shapes[0].map(
-	          function(d, i){
-	            var bbox = d.getBBox()
-	            var stroke = scale(type.data[i]);
-
-	            if (shape === "line" && orient === "horizontal") {
-	              bbox.height = bbox.height + stroke;
-	            } else if (shape === "line" && orient === "vertical"){
-	              bbox.width = bbox.width;
-	            }
-
-	            return bbox;
-	        });
-
-	      var maxH = d3.max(shapeSize, function(d){ return d.height + d.y; }),
-	      maxW = d3.max(shapeSize, function(d){ return d.width + d.x; });
-
-	      var cellTrans,
-	      textTrans,
-	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
-
-	      //positions cells and text
-	      if (orient === "vertical"){
-
-	        cellTrans = function(d,i) {
-	            var height = d3.sum(shapeSize.slice(0, i + 1 ), function(d){ return d.height; });
-	            return "translate(0, " + (height + i*shapePadding) + ")"; };
-
-	        textTrans = function(d,i) { return "translate(" + (maxW + labelOffset) + "," +
-	          (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
-
-	      } else if (orient === "horizontal"){
-	        cellTrans = function(d,i) {
-	            var width = d3.sum(shapeSize.slice(0, i + 1 ), function(d){ return d.width; });
-	            return "translate(" + (width + i*shapePadding) + ",0)"; };
-
-	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) + "," +
-	              (maxH + labelOffset ) + ")"; };
-	      }
-
-	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
-	      helper.d3_title(svg, legendG, title, classPrefix);
-
-	      cell.transition().style("opacity", 1);
-
-	    }
-
-	  legend.scale = function(_) {
-	    if (!arguments.length) return scale;
-	    scale = _;
-	    return legend;
-	  };
-
-	  legend.cells = function(_) {
-	    if (!arguments.length) return cells;
-	    if (_.length > 1 || _ >= 2 ){
-	      cells = _;
-	    }
-	    return legend;
-	  };
-
-
-	  legend.shape = function(_, d) {
-	    if (!arguments.length) return shape;
-	    if (_ == "rect" || _ == "circle" || _ == "line" ){
-	      shape = _;
-	      path = d;
-	    }
-	    return legend;
-	  };
-
-	  legend.shapeWidth = function(_) {
-	    if (!arguments.length) return shapeWidth;
-	    shapeWidth = +_;
-	    return legend;
-	  };
-
-	  legend.shapePadding = function(_) {
-	    if (!arguments.length) return shapePadding;
-	    shapePadding = +_;
-	    return legend;
-	  };
-
-	  legend.labels = function(_) {
-	    if (!arguments.length) return labels;
-	    labels = _;
-	    return legend;
-	  };
-
-	  legend.labelAlign = function(_) {
-	    if (!arguments.length) return labelAlign;
-	    if (_ == "start" || _ == "end" || _ == "middle") {
-	      labelAlign = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.labelFormat = function(_) {
-	    if (!arguments.length) return labelFormat;
-	    labelFormat = _;
-	    return legend;
-	  };
-
-	  legend.labelOffset = function(_) {
-	    if (!arguments.length) return labelOffset;
-	    labelOffset = +_;
-	    return legend;
-	  };
-
-	  legend.labelDelimiter = function(_) {
-	    if (!arguments.length) return labelDelimiter;
-	    labelDelimiter = _;
-	    return legend;
-	  };
-
-	  legend.orient = function(_){
-	    if (!arguments.length) return orient;
-	    _ = _.toLowerCase();
-	    if (_ == "horizontal" || _ == "vertical") {
-	      orient = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.ascending = function(_) {
-	    if (!arguments.length) return ascending;
-	    ascending = !!_;
-	    return legend;
-	  };
-
-	  legend.classPrefix = function(_) {
-	    if (!arguments.length) return classPrefix;
-	    classPrefix = _;
-	    return legend;
-	  };
-
-	  legend.title = function(_) {
-	    if (!arguments.length) return title;
-	    title = _;
-	    return legend;
-	  };
-
-	  d3.rebind(legend, legendDispatcher, "on");
-
-	  return legend;
-
-	};
-
-
-/***/ },
-/* 32 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var helper = __webpack_require__(30);
-
-	module.exports = function(){
-
-	  var scale = d3.scale.linear(),
-	    shape = "path",
-	    shapeWidth = 15,
-	    shapeHeight = 15,
-	    shapeRadius = 10,
-	    shapePadding = 5,
-	    cells = [5],
-	    labels = [],
-	    classPrefix = "",
-	    useClass = false,
-	    title = "",
-	    labelFormat = d3.format(".01f"),
-	    labelAlign = "middle",
-	    labelOffset = 10,
-	    labelDelimiter = "to",
-	    orient = "vertical",
-	    ascending = false,
-	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
-
-	    function legend(svg){
-
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
-	        legendG = svg.selectAll('g').data([scale]);
-
-	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
-
-	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
-	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
-	        shapes = cell.select("g." + classPrefix + "cell " + shape);
-
-	      //add event handlers
-	      helper.d3_addEvents(cellEnter, legendDispatcher);
-
-	      //remove old shapes
-	      cell.exit().transition().style("opacity", 0).remove();
-
-	      helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, type.feature);
-	      helper.d3_addText(legendG, cellEnter, type.labels, classPrefix)
-
-	      // sets placement
-	      var text = cell.select("text"),
-	        shapeSize = shapes[0].map( function(d){ return d.getBBox(); });
-
-	      var maxH = d3.max(shapeSize, function(d){ return d.height; }),
-	      maxW = d3.max(shapeSize, function(d){ return d.width; });
-
-	      var cellTrans,
-	      textTrans,
-	      textAlign = (labelAlign == "start") ? 0 : (labelAlign == "middle") ? 0.5 : 1;
-
-	      //positions cells and text
-	      if (orient === "vertical"){
-	        cellTrans = function(d,i) { return "translate(0, " + (i * (maxH + shapePadding)) + ")"; };
-	        textTrans = function(d,i) { return "translate(" + (maxW + labelOffset) + "," +
-	              (shapeSize[i].y + shapeSize[i].height/2 + 5) + ")"; };
-
-	      } else if (orient === "horizontal"){
-	        cellTrans = function(d,i) { return "translate(" + (i * (maxW + shapePadding)) + ",0)"; };
-	        textTrans = function(d,i) { return "translate(" + (shapeSize[i].width*textAlign  + shapeSize[i].x) + "," +
-	              (maxH + labelOffset ) + ")"; };
-	      }
-
-	      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
-	      helper.d3_title(svg, legendG, title, classPrefix);
-	      cell.transition().style("opacity", 1);
-
-	    }
-
-
-	  legend.scale = function(_) {
-	    if (!arguments.length) return scale;
-	    scale = _;
-	    return legend;
-	  };
-
-	  legend.cells = function(_) {
-	    if (!arguments.length) return cells;
-	    if (_.length > 1 || _ >= 2 ){
-	      cells = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.shapePadding = function(_) {
-	    if (!arguments.length) return shapePadding;
-	    shapePadding = +_;
-	    return legend;
-	  };
-
-	  legend.labels = function(_) {
-	    if (!arguments.length) return labels;
-	    labels = _;
-	    return legend;
-	  };
-
-	  legend.labelAlign = function(_) {
-	    if (!arguments.length) return labelAlign;
-	    if (_ == "start" || _ == "end" || _ == "middle") {
-	      labelAlign = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.labelFormat = function(_) {
-	    if (!arguments.length) return labelFormat;
-	    labelFormat = _;
-	    return legend;
-	  };
-
-	  legend.labelOffset = function(_) {
-	    if (!arguments.length) return labelOffset;
-	    labelOffset = +_;
-	    return legend;
-	  };
-
-	  legend.labelDelimiter = function(_) {
-	    if (!arguments.length) return labelDelimiter;
-	    labelDelimiter = _;
-	    return legend;
-	  };
-
-	  legend.orient = function(_){
-	    if (!arguments.length) return orient;
-	    _ = _.toLowerCase();
-	    if (_ == "horizontal" || _ == "vertical") {
-	      orient = _;
-	    }
-	    return legend;
-	  };
-
-	  legend.ascending = function(_) {
-	    if (!arguments.length) return ascending;
-	    ascending = !!_;
-	    return legend;
-	  };
-
-	  legend.classPrefix = function(_) {
-	    if (!arguments.length) return classPrefix;
-	    classPrefix = _;
-	    return legend;
-	  };
-
-	  legend.title = function(_) {
-	    if (!arguments.length) return title;
-	    title = _;
-	    return legend;
-	  };
-
-	  d3.rebind(legend, legendDispatcher, "on");
-
-	  return legend;
-
-	};
 
 
 /***/ },

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11102,10 +11102,13 @@
 
 	  var setYear = function(year) {
 
+	    var root = d3.select(this);
+
 	    var year = year || '2013';
-	    var bars = d3.select(this).selectAll('[data-value]')
-	    var texts = d3.select(this).selectAll('[data-value-text]')
-	    var swatches = d3.select(this).selectAll('[data-value-swatch]')
+	    var bars = root.selectAll('[data-value]');
+	    var texts = root.selectAll('[data-value-text]');
+	    var swatches = root.selectAll('[data-value-swatch]');
+	    var label = d3.select(this.parentElement).select('label');
 
 	    bars.datum(function() {
 	        var yearVals = this.getAttribute('data-year-values') &&
@@ -11171,6 +11174,10 @@
 	          return that.eitiDataMap.scale(d);
 	        }
 	      });
+
+	    label.select('[data-year]')
+	      .attr('data-year', year)
+	      .text(year)
 	  }
 
 	  var update = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11094,8 +11094,96 @@
 	    this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
 	    this._cells = this._cells.concat(this.nested_cells)
 
-	    this.update();
+	    // this.update();
+	    this.setYear();
 	  };
+
+	  var setYear = function(year) {
+	    var updateValues = function(year, context, attr, text) {
+	      var values = JSON.parse(context.getAttribute('data-year-values'));
+	      // var format = d3.format(context.attr('data-format') || ',');
+	      if (values) {
+	        console.log(values)
+	        context.setAttribute(attr, values[year])
+	        if (text) {
+	          context.innerHTML = values[year];
+	        }
+	      }
+	    }
+	    var year = year || '2013';
+	    var bars = d3.select(this).selectAll('[data-value]')
+	    var texts = d3.select(this).selectAll('[data-value-text]')
+	    var swatches = d3.select(this).selectAll('[data-value-swatch]')
+
+	    if (bars.attr('data-year-values')) {
+	      bars.datum(function() {
+	          if (this.getAttribute('data-year-values')) {
+	            var data = JSON.parse(this.getAttribute('data-year-values') || null);
+	            if (data) {
+	              return data[year] || 0;
+	            }
+
+	          }
+	        })
+	        .attr('data-value', function(d) {
+	          return d;
+	        });
+	    }
+
+	    if (texts.attr('data-year-values')) {
+	      texts.datum(function() {
+	          if (this.getAttribute('data-year-values')) {
+	            var data = JSON.parse(this.getAttribute('data-year-values') || null);
+	            if (data) {
+	              return data[year] || 0;
+	            }
+
+	          }
+	        })
+	        .text(function(d) {
+	          var format = d3.format(this.getAttribute('data-format') || ',')
+	          if (format) {
+	            return format(d);
+	          } else {
+	            return d;
+	          }
+
+	        });
+	    }
+
+	    if (swatches.attr('data-year-values')) {
+	      swatches.datum(function() {
+	          if (this.getAttribute('data-year-values')) {
+	            var data = JSON.parse(this.getAttribute('data-year-values') || null);
+	            if (data) {
+	              return data[year] || 0;
+	            }
+
+	          }
+	        })
+	        .attr('data-value-swatch', function(d) {
+	          return d;
+	        });
+	    }
+
+
+	    this.update();
+	      // .each(function(){
+	      //   // updateValues(year, this, 'data-value')
+
+	      //   var values = JSON.parse(this.attr('data-year-values')
+	      // });
+
+	    // var texts = d3.select(this).selectAll('[data-value-text]')
+	    //   .each(function(){
+	    //     updateValues(year, this, 'data-value-text', true)
+	    //   });
+
+	    // var swatches = d3.select(this).selectAll('[data-value-swatch]')
+	    //   .each(function(){
+	    //     updateValues(year, this, 'data-value-swatch')
+	    //   });
+	  }
 
 	  var update = function() {
 	    if (!this._cells.length) {
@@ -11256,6 +11344,8 @@
 
 	        update: {value: update},
 
+	        setYear: {value: setYear},
+
 	        orient: {
 	          get: function() {
 	            return this.getAttribute('orient');
@@ -11340,6 +11430,7 @@
 	            .domain(domain)
 	            .range(colors);
 
+	          this.setAttribute('scale', scale);
 
 	          marks.attr('fill', scale);
 
@@ -11406,22 +11497,31 @@
 	          // end consolidation
 	          // end map legend
 
-	           // start trim height on map container
-	           var svgContainer = d3.select(this)
-	             .selectAll('.svg-container[data-dimensions]')
-	             .datum(function() {
-	               return (this.getBoundingClientRect().width
-	                 * +this.getAttribute('data-dimensions')
-	                 / 100)
-	                 + 50;
-	             });
+	          // start trim height on map container
+	          var svgContainer = d3.select(this)
+	            .selectAll('.svg-container[data-dimensions]')
+	            .datum(function() {
+	              return (this.getBoundingClientRect().width
+	                * +this.getAttribute('data-dimensions')
+	                / 100)
+	                + 50;
+	            });
 
-	           function pixelize(d) {
-	             return d + 'px';
-	           }
+	          function pixelize(d) {
+	            return d + 'px';
+	          }
 
-	           svgContainer.style('padding-bottom', pixelize);
-	           // end trim
+	          svgContainer.style('padding-bottom', pixelize);
+	          // end trim
+
+
+	          var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
+	            .datum(function() {
+	              return +this.getAttribute('data-value-swatch') || 0;
+	            });
+
+	          swatches.style('background-color', scale);
+	          console.log(swatches)
 	        }}
 	      }
 	    )
@@ -12506,6 +12606,7 @@
 	    var select = root.selectAll('select.chart-selector');
 	    var charts = root.selectAll('eiti-bar-chart');
 	    var maps = root.selectAll('eiti-data-map');
+	    var chartTables = maps.selectAll('table[is="bar-chart-table"]')
 
 	    var update = function(year) {
 	      charts.property('x', year);
@@ -12513,6 +12614,9 @@
 	        this.setYear(year);
 	      });
 	      select.property('value',  year);
+	      chartTables.each(function(){
+	        this.setYear(year);
+	      })
 	    };
 
 	    select.on('change.year', function() {

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -2,10 +2,11 @@
   'use strict';
 
   require('./../components/aria-toggle.js');
-  require('./../components/bar-chart-table.js');
   require('./../components/eiti-data-map.js');
+  require('./../components/bar-chart-table.js');
   require('./../components/eiti-bar-chart.js');
   require('./../components/year-switcher-section.js');
+
 
   require('./../components/aria-tabs.js');
   require('./../components/sticky-nav.js');


### PR DESCRIPTION
Fixes issue(s) #1575 , #1524 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/county-tables-changes/states/UT/#revenue)

Changes proposed in this pull request:

- [x] update federal production tables
- [x] add federal revenue county table
- [x] add jobs county map
- [x] year selectors updates charts

Remaining issues (push back to later PR)
- [ ] if scale doesn't exist in the default year that the chart/map is rendered in (2013), then no scale exists and swatches color themselves.
- [ ] county charts order by value 



/cc @meiqimichelle @coreycaitlin 


