### PR TITLE
Redirects invalid URLs to parent page if possible

### DIFF
--- a/404.md
+++ b/404.md
@@ -4,8 +4,17 @@ layout: error
 title: 404
 subtitle: Page not found
 ---
+<div id="additional-404-message" />
 
 <script>
+var redirectMessage = function( oldPath, newPath, pathname, remainingDelay ) {
+	return (
+		'No page found at <a href="' + oldPath.href + '">' + oldPath.pathname + '</a>.<br />' +
+		'Automatically redirecting to <a href="' + newPath + '">' + pathname + '</a> ' +
+		'in ' + remainingDelay + ' seconds.'
+	);
+};
+
 var path = document.location;
 var parentPath = path
 	.pathname
@@ -22,7 +31,19 @@ var nextLocation = [
 ].join( '' );
 
 // If we aren't already at a root-level page
+// then redirect to the parent after a short
+// explanatory delay
 if ( parentPath.length ) {
-	document.location.replace( nextLocation );
+	var additionalMessage = document.getElementById( 'additional-404-message' );
+	var countDown = function( seconds ) {
+		if ( 0 === seconds ) {
+			document.location.replace( nextLocation );
+		}
+
+		additionalMessage.innerHTML = redirectMessage( path, nextLocation, parentPath, seconds );
+		setTimeout( countDown.bind( this, seconds - 1 ), 1000 );
+	}
+
+	countDown( 5 );
 }
 </script>

--- a/404.md
+++ b/404.md
@@ -7,6 +7,7 @@ subtitle: Page not found
 <div id="additional-404-message" />
 
 <script>
+(function(){
 var redirectMessage = function( oldPath, newPath, pathname, remainingDelay ) {
 	return (
 		'No page found at <a href="' + oldPath.href + '">' + oldPath.pathname + '</a>.<br />' +
@@ -33,17 +34,16 @@ var nextLocation = [
 // If we aren't already at a root-level page
 // then redirect to the parent after a short
 // explanatory delay
-if ( parentPath.length ) {
-	var additionalMessage = document.getElementById( 'additional-404-message' );
-	var countDown = function( seconds ) {
-		if ( 0 === seconds ) {
-			document.location.replace( nextLocation );
-		}
-
-		additionalMessage.innerHTML = redirectMessage( path, nextLocation, parentPath, seconds );
-		setTimeout( countDown.bind( this, seconds - 1 ), 1000 );
+var additionalMessage = document.getElementById( 'additional-404-message' );
+var countDown = function( seconds ) {
+	if ( 0 === seconds ) {
+		document.location.replace( nextLocation );
 	}
 
-	countDown( 5 );
+	additionalMessage.innerHTML = redirectMessage( path, nextLocation, parentPath || '/', seconds );
+	setTimeout( countDown.bind( this, seconds - 1 ), 1000 );
 }
+
+countDown( 5 );
+})();
 </script>

--- a/404.md
+++ b/404.md
@@ -4,3 +4,25 @@ layout: error
 title: 404
 subtitle: Page not found
 ---
+
+<script>
+var path = document.location;
+var parentPath = path
+	.pathname
+	.replace( /\/$/, '' ) // remove trailing slash
+	.split( '/' )         // separate into path components
+	.slice( 0, -1 )       // remove the last one
+	.join( '/' );         // rejoin to the parent path
+
+var nextLocation = [
+	path.origin,          // e.g. https://useiti.doi.gov/
+	parentPath,           // parent of page path or /
+	path.search,          // ?query=terms&args=14
+	path.hash             // #someModifier
+].join( '' );
+
+// If we aren't already at a root-level page
+if ( parentPath.length ) {
+	document.location.replace( nextLocation );
+}
+</script>


### PR DESCRIPTION
Resolves #1210

Previously, all 404 views showed the 404 error page.

Now, as requested in #1210, the browser will automatically be redirected
to the parent path if indeed it isn't already navigating to a root-level
page.

**Example**:
 - `/explore/reconc/` redirects to `/explore`
 - `/explorer` does not redirect
 - `/explorer/` does not redirect

This was accomplished with a simple JavaScript snippet embedded in the
404 document. It _should_ work regardless of the domain and port being used.

In the second commit in this PR I updated the redirect behavior to switch from instantly redirecting to displaying an explanation message for a few seconds before redirecting. I felt like this was more helpful to a user so they wouldn't have to see a confusing flash of a 404. The message shows the invalid path, the next path after the redirect, and the number of seconds remaining until that redirect.

> For lots of fun, navigate to `/some/very/long/url/with/lots/of/parents/that/do/not/exist`
![countdown404](https://cloud.githubusercontent.com/assets/5431237/16939458/96433b7a-4d36-11e6-90c9-95e0f47a9cc7.gif)


**Normal Behavior**
![normalredirect](https://cloud.githubusercontent.com/assets/5431237/16939446/82355de8-4d36-11e6-8dd5-9d3dd1fc8f6a.gif)

**Notes**
 - This code _could_ be bundled into some JS file, but actually, since it only displays on the 404 page, I figured that it wasn't too bad to embed it right there.
 - The behavior here is pretty flexible. All we're doing is looking at the given location and mogrifying it.
 - I have no design skill and take no blame for poorly designed or worded messages :wink:
 - Although I saw no problems, and this 404 is the end of the line, I did dig deep to try and find if I was causing naming clashes in the global scope - figured it was okay for the reason above, that this is the end of the line for rendering.

cc: @gemfarmer 
