### PR TITLE
Weird FFx/Safari bars bug

### DIFF
--- a/_includes/location/national-exports.html
+++ b/_includes/location/national-exports.html
@@ -40,7 +40,7 @@
             <eiti-bar-chart
               aria-controls="exports-figures-{{ commodity_slug }}"
               data='{{ exports | map_hash: _metric | jsonify }}'
-              data-x-range="{{ year_range }}"
+              x-range="{{ year_range }}"
               x-value="{{ year }}">
             </eiti-bar-chart>
 

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -45,7 +45,7 @@
         <eiti-bar-chart
           aria-controls="gdp-figures-{{ _metric }}"
           data='{{ gdp | map_hash: _metric | jsonify }}'
-          data-x-range="{{ year_range }}"
+          x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
 

--- a/_includes/location/national-jobs.html
+++ b/_includes/location/national-jobs.html
@@ -43,7 +43,7 @@
         <eiti-bar-chart
           aria-controls="jobs-figures-{{ _metric }}"
           data='{{ jobs | map_hash: _metric | jsonify }}'
-          data-x-range="{{ year_range }}"
+          x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
       </figure><!-- /.chart -->
@@ -103,7 +103,7 @@
         <eiti-bar-chart
           aria-controls="self-employment-figures-{{ _metric }}"
           data='{{ self_employment_jobs | map_hash: _metric | jsonify }}'
-          data-x-range="{{ year_range }}"
+          x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
 

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -40,7 +40,7 @@
             <eiti-bar-chart
               aria-controls="exports-figures-{{ commodity_slug }}"
               data='{{ exports | map_hash: _metric | jsonify }}'
-              data-x-range="{{ year_range }}"
+              x-range="{{ year_range }}"
               x-value="{{ year }}">
             </eiti-bar-chart>
 

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -45,7 +45,7 @@
         <eiti-bar-chart
           aria-controls="gdp-figures-{{ _metric }}"
           data='{{ gdp | map_hash: _metric | jsonify }}'
-          data-x-range="{{ year_range }}"
+          x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
 

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -49,7 +49,7 @@
           <eiti-bar-chart
             aria-controls="jobs-figures-{{ _metric }}"
             data='{{ jobs | map_hash: _metric | jsonify }}'
-            data-x-range="{{ year_range }}"
+            x-range="{{ year_range }}"
             x-value="{{ year }}">
           </eiti-bar-chart>
         </figure><!-- /.chart -->
@@ -130,7 +130,7 @@
         <eiti-bar-chart
           aria-controls="self-employment-figures-{{ _metric }}"
           data='{{ self_employment_jobs | map_hash: _metric | jsonify }}'
-          data-x-range="{{ year_range }}"
+          x-range="{{ year_range }}"
           x-value="{{ year }}">
         </eiti-bar-chart>
 

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -71,6 +71,8 @@
         .key(function(d) { return d.x; })
         .rollup(function(d) { return d[0]; })
         .entries(data);
+
+
     } else {
       values = Object.keys(data).reduce(function(map, key) {
         map[key] = {x: +key, y: data[key]};
@@ -81,9 +83,9 @@
       });
     }
 
-    // console.log('data:', data, 'values:', values);
 
     var xrange = this.xrange;
+
     if (!xrange) {
       xrange = d3.extent(data, function(d) {
         return +d.x;
@@ -100,6 +102,12 @@
       if (!values[x]) {
         data.push({x: x, y: 0});
       }
+    });
+
+    // filter the data so that only values within the domain
+    // are included in calculations and rendering
+    data = data.filter(function(d){
+      return xdomain.indexOf(d.x) > -1;
     });
 
     var extent = d3.extent(data, function(d) { return d.y; });
@@ -136,7 +144,11 @@
     bars.exit().remove();
 
     bars.attr('transform', function(d) {
-      return 'translate(' + [x(d.x), 0] + ')';
+      if (x(d.x)) {
+        return 'translate(' + [x(d.x), 0] + ')';
+      } else {
+        console.warn(d.x, 'not in bar chart domain')
+      }
     });
 
     bars.select('.bar-value')

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -106,7 +106,7 @@
 
     // filter the data so that only values within the domain
     // are included in calculations and rendering
-    data = data.filter(function(d){
+    data = data.filter(function(d) {
       return xdomain.indexOf(d.x) > -1;
     });
 
@@ -144,11 +144,7 @@
     bars.exit().remove();
 
     bars.attr('transform', function(d) {
-      if (x(d.x)) {
-        return 'translate(' + [x(d.x), 0] + ')';
-      } else {
-        console.warn(d.x, 'not in bar chart domain')
-      }
+      return 'translate(' + [x(d.x), 0] + ')';
     });
 
     bars.select('.bar-value')

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -87,46 +87,52 @@
           var svgLegend = d3.select(this)
             .select('.legend-svg');
 
-          svgLegend.append('g')
-            .attr('class', 'legendScale');
+          if (svgLegend[0][0]) {
+            svgLegend.append('g')
+              .attr('class', 'legendScale');
 
-          var legend = d3.legend.color()
-            .labelFormat(format.si)
-            .useClass(false)
-            .ascending(true)
-            .labelDelimiter('-')
-            .shapePadding(6)
-            .scale(scale);
+            var legend = d3.legend.color()
+              .labelFormat(format.si)
+              .useClass(false)
+              .ascending(true)
+              .labelDelimiter('-')
+              .shapePadding(6)
+              .scale(scale);
 
-          svgLegend.select('.legendScale')
-            .call(legend);
+            svgLegend.select('.legendScale')
+              .call(legend);
 
-          // reverse because the scale is in ascending order
-          var _steps = d3.range(0, 9).reverse();
+            // reverse because the scale is in ascending order
+            var _steps = d3.range(0, 9).reverse();
 
-          // find which steps are represented in the map
-          var uniqueSteps = getUnique(marks.data(), _steps, domain);
+            // find which steps are represented in the map
+            var uniqueSteps = getUnique(marks.data(), _steps, domain);
 
-          // start consolidate (translate) visible cells
-          var cells = svgLegend.selectAll('.cell');
-          var cellHeight = legend.shapeHeight() + legend.shapePadding();
-          var count = 0;
-          cells.each(function(cell, i) {
-            var present = uniqueSteps.indexOf(i) > -1;
+            // start consolidate (translate) visible cells
+            var cells = svgLegend.selectAll('.cell');
+            var cellHeight = legend.shapeHeight() + legend.shapePadding();
+            var count = 0;
+            cells.each(function(cell, i) {
+              var present = uniqueSteps.indexOf(i) > -1;
 
-            if (!present) {
-              // hide cells swatches that aren't in the map
-              cells[0][i].setAttribute('aria-hidden', true);
-              count++;
-            } else  {
-              // trim spacing between swatches that are visible
-              var translateHeight = (i * cellHeight) - (count * cellHeight);
-              cells[0][i].setAttribute('transform',
-                'translate(0,' + translateHeight + ')');
-            }
-          });
-          // end consolidation
-          // end map legend
+              if (!present) {
+                // hide cells swatches that aren't in the map
+                cells[0][i].setAttribute('aria-hidden', true);
+                count++;
+              } else  {
+                // trim spacing between swatches that are visible
+                var translateHeight = (i * cellHeight) - (count * cellHeight);
+                cells[0][i].setAttribute('transform',
+                  'translate(0,' + translateHeight + ')');
+              }
+            });
+            // end consolidation
+            // end map legend
+          } else {
+            console.warn('<eiti-data-map> does not exist on this page.')
+          }
+
+
 
           // start trim height on map container
           var svgContainer = d3.select(this)
@@ -145,14 +151,6 @@
           svgContainer.style('padding-bottom', pixelize);
           // end trim
 
-
-          // var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
-          //   .datum(function() {
-          //     return +this.getAttribute('data-value-swatch') || 0;
-          //   });
-
-          // swatches.style('background-color', scale);
-          // console.log(swatches)
         }}
       }
     )

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -87,7 +87,7 @@
           var svgLegend = d3.select(this)
             .select('.legend-svg');
 
-          if (svgLegend[0][0]) {
+          if (!svgLegend.empty()) {
             svgLegend.append('g')
               .attr('class', 'legendScale');
 
@@ -129,10 +129,8 @@
             // end consolidation
             // end map legend
           } else {
-            console.warn('<eiti-data-map> does not exist on this page.')
+            console.warn('this <eiti-data-map> element does not have an associated svg legend.');
           }
-
-
 
           // start trim height on map container
           var svgContainer = d3.select(this)

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12424,7 +12424,7 @@
 
 	    // filter the data so that only values within the domain
 	    // are included in calculations and rendering
-	    data = data.filter(function(d){
+	    data = data.filter(function(d) {
 	      return xdomain.indexOf(d.x) > -1;
 	    });
 
@@ -12462,11 +12462,7 @@
 	    bars.exit().remove();
 
 	    bars.attr('transform', function(d) {
-	      if (x(d.x)) {
-	        return 'translate(' + [x(d.x), 0] + ')';
-	      } else {
-	        console.warn(d.x, 'not in bar chart domain')
-	      }
+	      return 'translate(' + [x(d.x), 0] + ')';
 	    });
 
 	    bars.select('.bar-value')

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12391,6 +12391,8 @@
 	        .key(function(d) { return d.x; })
 	        .rollup(function(d) { return d[0]; })
 	        .entries(data);
+
+
 	    } else {
 	      values = Object.keys(data).reduce(function(map, key) {
 	        map[key] = {x: +key, y: data[key]};
@@ -12401,9 +12403,9 @@
 	      });
 	    }
 
-	    // console.log('data:', data, 'values:', values);
 
 	    var xrange = this.xrange;
+
 	    if (!xrange) {
 	      xrange = d3.extent(data, function(d) {
 	        return +d.x;
@@ -12420,6 +12422,12 @@
 	      if (!values[x]) {
 	        data.push({x: x, y: 0});
 	      }
+	    });
+
+	    // filter the data so that only values within the domain
+	    // are included in calculations and rendering
+	    data = data.filter(function(d){
+	      return xdomain.indexOf(d.x) > -1;
 	    });
 
 	    var extent = d3.extent(data, function(d) { return d.y; });
@@ -12456,7 +12464,11 @@
 	    bars.exit().remove();
 
 	    bars.attr('transform', function(d) {
-	      return 'translate(' + [x(d.x), 0] + ')';
+	      if (x(d.x)) {
+	        return 'translate(' + [x(d.x), 0] + ')';
+	      } else {
+	        console.warn(d.x, 'not in bar chart domain')
+	      }
 	    });
 
 	    bars.select('.bar-value')

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11177,46 +11177,52 @@
 	          var svgLegend = d3.select(this)
 	            .select('.legend-svg');
 
-	          svgLegend.append('g')
-	            .attr('class', 'legendScale');
+	          if (svgLegend[0][0]) {
+	            svgLegend.append('g')
+	              .attr('class', 'legendScale');
 
-	          var legend = d3.legend.color()
-	            .labelFormat(format.si)
-	            .useClass(false)
-	            .ascending(true)
-	            .labelDelimiter('-')
-	            .shapePadding(6)
-	            .scale(scale);
+	            var legend = d3.legend.color()
+	              .labelFormat(format.si)
+	              .useClass(false)
+	              .ascending(true)
+	              .labelDelimiter('-')
+	              .shapePadding(6)
+	              .scale(scale);
 
-	          svgLegend.select('.legendScale')
-	            .call(legend);
+	            svgLegend.select('.legendScale')
+	              .call(legend);
 
-	          // reverse because the scale is in ascending order
-	          var _steps = d3.range(0, 9).reverse();
+	            // reverse because the scale is in ascending order
+	            var _steps = d3.range(0, 9).reverse();
 
-	          // find which steps are represented in the map
-	          var uniqueSteps = getUnique(marks.data(), _steps, domain);
+	            // find which steps are represented in the map
+	            var uniqueSteps = getUnique(marks.data(), _steps, domain);
 
-	          // start consolidate (translate) visible cells
-	          var cells = svgLegend.selectAll('.cell');
-	          var cellHeight = legend.shapeHeight() + legend.shapePadding();
-	          var count = 0;
-	          cells.each(function(cell, i) {
-	            var present = uniqueSteps.indexOf(i) > -1;
+	            // start consolidate (translate) visible cells
+	            var cells = svgLegend.selectAll('.cell');
+	            var cellHeight = legend.shapeHeight() + legend.shapePadding();
+	            var count = 0;
+	            cells.each(function(cell, i) {
+	              var present = uniqueSteps.indexOf(i) > -1;
 
-	            if (!present) {
-	              // hide cells swatches that aren't in the map
-	              cells[0][i].setAttribute('aria-hidden', true);
-	              count++;
-	            } else  {
-	              // trim spacing between swatches that are visible
-	              var translateHeight = (i * cellHeight) - (count * cellHeight);
-	              cells[0][i].setAttribute('transform',
-	                'translate(0,' + translateHeight + ')');
-	            }
-	          });
-	          // end consolidation
-	          // end map legend
+	              if (!present) {
+	                // hide cells swatches that aren't in the map
+	                cells[0][i].setAttribute('aria-hidden', true);
+	                count++;
+	              } else  {
+	                // trim spacing between swatches that are visible
+	                var translateHeight = (i * cellHeight) - (count * cellHeight);
+	                cells[0][i].setAttribute('transform',
+	                  'translate(0,' + translateHeight + ')');
+	              }
+	            });
+	            // end consolidation
+	            // end map legend
+	          } else {
+	            console.warn('<eiti-data-map> does not exist on this page.')
+	          }
+
+
 
 	          // start trim height on map container
 	          var svgContainer = d3.select(this)
@@ -11235,14 +11241,6 @@
 	          svgContainer.style('padding-bottom', pixelize);
 	          // end trim
 
-
-	          // var swatches = d3.select(this).selectAll('.swatch[data-value-swatch]')
-	          //   .datum(function() {
-	          //     return +this.getAttribute('data-value-swatch') || 0;
-	          //   });
-
-	          // swatches.style('background-color', scale);
-	          // console.log(swatches)
 	        }}
 	      }
 	    )

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11177,7 +11177,7 @@
 	          var svgLegend = d3.select(this)
 	            .select('.legend-svg');
 
-	          if (svgLegend[0][0]) {
+	          if (!svgLegend.empty()) {
 	            svgLegend.append('g')
 	              .attr('class', 'legendScale');
 
@@ -11219,10 +11219,8 @@
 	            // end consolidation
 	            // end map legend
 	          } else {
-	            console.warn('<eiti-data-map> does not exist on this page.')
+	            console.warn('this <eiti-data-map> element does not have an associated svg legend.');
 	          }
-
-
 
 	          // start trim height on map container
 	          var svgContainer = d3.select(this)


### PR DESCRIPTION
Fixes issue(s) #1602

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/bars-bug/states)

Changes proposed in this pull request:

- fixed bug that was preventing maps and charts to render on safari. This was the result of the `<eiti-data-map>` component script existing on the national page without any elements to reference.
- fixed bar chart bug that was causing some years to have multiple bars. This was the result of an inconsistency between the `year_range` for that chart and the years in its affiliated dataset. I filtered the data so that only years within that range were accounted for and rendered.

/cc @meiqimichelle @shawnbot 
