### PR TITLE
Print stylesheet

### DIFF
--- a/_includes/how-it-works/offshore_oil_gas_steps.html
+++ b/_includes/how-it-works/offshore_oil_gas_steps.html
@@ -1,7 +1,7 @@
 
 <section class="container-outer">
 
-  <div accordion="offshore-oilgas-dkk" accordion-item class="revenues_subpage-dyk">
+  <div accordion="offshore-oilgas-dyk" accordion-item class="revenues_subpage-dyk">
 
     <h2 class="revenues_subpage-dyk_heading">Did you know?</h2>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,7 +51,8 @@
 
     <!-- Styles
     ================================================== -->
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css" type="text/css" media="all">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/print.css" type="text/css" media="print">
 
     <!-- Scripts
     ================================================== -->

--- a/_sass/_print.scss
+++ b/_sass/_print.scss
@@ -1,3 +1,9 @@
-@import 'print/layout';
-@import 'print/home';
-@import 'print/about';
+@media print {
+  @import 'print/layout';
+  @import 'print/home';
+  @import 'print/about';
+  @import 'print/landing';
+  @import 'print/how-it-works';
+  @import 'print/content';
+  @import 'print/state-page';
+}

--- a/_sass/_print.scss
+++ b/_sass/_print.scss
@@ -6,4 +6,5 @@
   @import 'print/how-it-works';
   @import 'print/content';
   @import 'print/state-page';
+  @import 'print/page-breaks';
 }

--- a/_sass/_print.scss
+++ b/_sass/_print.scss
@@ -1,0 +1,3 @@
+@import 'print/layout';
+@import 'print/home';
+@import 'print/about';

--- a/_sass/print/_about.scss
+++ b/_sass/print/_about.scss
@@ -1,0 +1,25 @@
+.bureau img,
+.bureau-img {
+  width: 100px;
+}
+
+
+.article_img-60 {
+  max-width: 30;
+  width: 250px;
+
+
+  &.article_img-centered {
+    margin: 0;
+  }
+}
+
+
+.about_intro-highlight {
+  padding-left: 0;
+  text-align: left;
+}
+
+.about_intro-callout {
+  padding-left: 0;
+}

--- a/_sass/print/_about.scss
+++ b/_sass/print/_about.scss
@@ -3,7 +3,6 @@
   width: 100px;
 }
 
-
 .article_img-60 {
   max-width: 30;
   width: 250px;
@@ -13,7 +12,6 @@
     margin: 0;
   }
 }
-
 
 .about_intro-highlight {
   padding-left: 0;

--- a/_sass/print/_content.scss
+++ b/_sass/print/_content.scss
@@ -1,7 +1,7 @@
 .layout-content {
   .container-left-7 {
-    width: 100%;
     margin: 0;
+    width: 100%;
   }
 
   .case_studies_intro-select {

--- a/_sass/print/_content.scss
+++ b/_sass/print/_content.scss
@@ -1,0 +1,14 @@
+.layout-content {
+  .container-left-7 {
+    width: 100%;
+    margin: 0;
+  }
+
+  .case_studies_intro-select {
+    display: none !important;
+  }
+
+  .case_studies-maps {
+    text-align: left;
+  }
+}

--- a/_sass/print/_home.scss
+++ b/_sass/print/_home.scss
@@ -1,7 +1,8 @@
 .carousel,
 .eiti-tabs,
 .card-image_link,
-.eiti-tab-panel .explore_home-button {
+.eiti-tab-panel .explore_home-button,
+.home-bottom-links {
   display: none !important;
 }
 

--- a/_sass/print/_home.scss
+++ b/_sass/print/_home.scss
@@ -1,0 +1,41 @@
+.carousel,
+.eiti-tabs,
+.card-image_link,
+.eiti-tab-panel .explore_home-button {
+  display: none !important;
+}
+
+.card {
+
+  display: block;
+  float: none;
+  height: inherit !important;
+
+  img {
+    display: none !important;
+  }
+}
+
+.eiti-tab-panel {
+
+  display: block;
+  float: none;
+  margin-bottom: $base-padding-jumbo;
+
+  img {
+    margin: 0;
+    padding: 0;
+  }
+
+  &[aria-hidden=true] {
+    display: block !important;
+  }
+}
+
+.header-image_link,
+.card > a,
+.explore_home-img {
+  &:after {
+    content: '';
+  }
+}

--- a/_sass/print/_home.scss
+++ b/_sass/print/_home.scss
@@ -7,7 +7,6 @@
 }
 
 .card {
-
   display: block;
   float: none;
   height: inherit !important;
@@ -18,7 +17,6 @@
 }
 
 .eiti-tab-panel {
-
   display: block;
   float: none;
   margin-bottom: $base-padding-jumbo;
@@ -36,7 +34,7 @@
 .header-image_link,
 .card > a,
 .explore_home-img {
-  &:after {
+  &::after {
     content: '';
   }
 }

--- a/_sass/print/_how-it-works.scss
+++ b/_sass/print/_how-it-works.scss
@@ -1,0 +1,10 @@
+.revenues_page-footer,
+.revenues_subpage-involved_video,
+.break, {
+  display: none !important;
+}
+
+
+.revenues_subpage-steps_group {
+	width: 100%;
+}

--- a/_sass/print/_how-it-works.scss
+++ b/_sass/print/_how-it-works.scss
@@ -6,5 +6,5 @@
 
 
 .revenues_subpage-steps_group {
-	width: 100%;
+  width: 100%;
 }

--- a/_sass/print/_how-it-works.scss
+++ b/_sass/print/_how-it-works.scss
@@ -1,6 +1,6 @@
 .revenues_page-footer,
 .revenues_subpage-involved_video,
-.break, {
+.break {
   display: none !important;
 }
 

--- a/_sass/print/_landing.scss
+++ b/_sass/print/_landing.scss
@@ -2,9 +2,9 @@
 .landing-section_open {
   margin-top: 0;
 
-  div[class^="landing-"] {
-    height: initial !important;
+  div[class^='landing-'] {
     background: initial !important;
+    height: initial !important;
   }
 }
 
@@ -12,7 +12,7 @@
 .landing-section_open a,
 .hero-right a,
 .landing-wrapper section a {
-  &:after {
+  &::after {
     content: '';
   }
 }

--- a/_sass/print/_landing.scss
+++ b/_sass/print/_landing.scss
@@ -19,6 +19,7 @@
 
 .hero-right_caption {
   padding-left: 0;
+
   a {
     text-decoration: none;
   }

--- a/_sass/print/_landing.scss
+++ b/_sass/print/_landing.scss
@@ -1,0 +1,34 @@
+.landing-section,
+.landing-section_open {
+  margin-top: 0;
+
+  div[class^="landing-"] {
+    height: initial !important;
+    background: initial !important;
+  }
+}
+
+.landing-section a,
+.landing-section_open a,
+.hero-right a,
+.landing-wrapper section a {
+  &:after {
+    content: '';
+  }
+}
+
+.hero-right_caption {
+  padding-left: 0;
+  a {
+    text-decoration: none;
+  }
+}
+
+.hero-right_square {
+  border: 0;
+}
+
+.hero-right_image {
+  text-align: left;
+}
+

--- a/_sass/print/_layout.scss
+++ b/_sass/print/_layout.scss
@@ -27,9 +27,9 @@ img {
   max-width: 500px !important;
 }
 
-a:after{
-  content:" (" attr(href) ") ";
+a::after{
   @include font-size(1);
+  content: ' (' attr(href) ') ';
 }
 
 .term {

--- a/_sass/print/_layout.scss
+++ b/_sass/print/_layout.scss
@@ -4,8 +4,12 @@ section.banner,
 footer,
 #glossary,
 #nav-drawer,
+iframe,
 .term .icon-book,
-.carousel-button {
+.carousel-button,
+[accordion-button],
+.hash_selector,
+.sticky_nav {
   display: none !important;
 }
 
@@ -23,13 +27,33 @@ img {
   max-width: 500px !important;
 }
 
-@media print {
-  a:after{
-    content:" (" attr(href) ") ";
-    @include font-size(1);
-  }
+a:after{
+  content:" (" attr(href) ") ";
+  @include font-size(1);
 }
 
 .term {
   border-bottom: 0;
+}
+
+
+[accordion-content],
+[accordion-item] div[aria-hidden=true] {
+  display: block !important;
+}
+
+section.chart-item,
+.row-container,
+tr,
+figure,
+eiti-data-map,
+eiti-bar-chart,
+img {
+  page-break-inside: avoid;
+}
+
+h1,
+h2,
+h3 {
+  page-break-after: avoid;
 }

--- a/_sass/print/_layout.scss
+++ b/_sass/print/_layout.scss
@@ -1,0 +1,35 @@
+section.banner,
+.header-nav,
+.header-bars,
+footer,
+#glossary,
+#nav-drawer,
+.term .icon-book,
+.carousel-button {
+  display: none !important;
+}
+
+header,
+.container-outer {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+@page {
+  margin: 0.5cm;
+}
+
+img {
+  max-width: 500px !important;
+}
+
+@media print {
+  a:after{
+    content:" (" attr(href) ") ";
+    @include font-size(1);
+  }
+}
+
+.term {
+  border-bottom: 0;
+}

--- a/_sass/print/_layout.scss
+++ b/_sass/print/_layout.scss
@@ -38,6 +38,6 @@ a::after{
 
 
 [accordion-content],
-[accordion-item] div[aria-hidden=true] {
+[accordion-item] div[aria-hidden='true'] {
   display: block !important;
 }

--- a/_sass/print/_layout.scss
+++ b/_sass/print/_layout.scss
@@ -41,19 +41,3 @@ a:after{
 [accordion-item] div[aria-hidden=true] {
   display: block !important;
 }
-
-section.chart-item,
-.row-container,
-tr,
-figure,
-eiti-data-map,
-eiti-bar-chart,
-img {
-  page-break-inside: avoid;
-}
-
-h1,
-h2,
-h3 {
-  page-break-after: avoid;
-}

--- a/_sass/print/_page-breaks.scss
+++ b/_sass/print/_page-breaks.scss
@@ -6,8 +6,8 @@ figcaption,
 eiti-data-map,
 eiti-bar-chart,
 img {
-  page-break-inside: avoid;
   page-break-before: always;
+  page-break-inside: avoid;
 }
 
 h1:not(#title),

--- a/_sass/print/_page-breaks.scss
+++ b/_sass/print/_page-breaks.scss
@@ -1,0 +1,19 @@
+.chart-item,
+.row-container,
+tr,
+figure,
+figcaption,
+eiti-data-map,
+eiti-bar-chart,
+img {
+  page-break-inside: avoid;
+  page-break-before: always;
+}
+
+h1:not(#title),
+h2,
+h3,
+.chart-title {
+  page-break-after: avoid;
+  page-break-before: always;
+}

--- a/_sass/print/_page-breaks.scss
+++ b/_sass/print/_page-breaks.scss
@@ -12,8 +12,6 @@ img {
 
 h1:not(#title),
 h2,
-h3,
-.chart-title {
+h3 {
   page-break-after: avoid;
-  page-break-before: always;
 }

--- a/_sass/print/_state-page.scss
+++ b/_sass/print/_state-page.scss
@@ -1,0 +1,3 @@
+.layout-state-pages figure {
+  min-height: 300px;
+}

--- a/_sass/print/_state-page.scss
+++ b/_sass/print/_state-page.scss
@@ -1,3 +1,7 @@
 .layout-state-pages figure {
   min-height: 300px;
 }
+
+.chart-list {
+  width: 100%;
+}

--- a/css/print.scss
+++ b/css/print.scss
@@ -1,0 +1,22 @@
+---
+# Jekyll only builds Sass files with front matter
+---
+
+// include reset
+@import 'reset';
+
+// include Bourbon & Neat
+@import 'lib/bourbon/bourbon';
+@import 'lib/neat/neat';
+
+// include site specific base styles
+@import 'base';
+
+// include fonts (and @import font-face declarations from /css/fonts)
+@import 'fonts';
+
+// include FontAwesome Sass variables, etc.
+@import 'lib/font-awesome/font-awesome';
+
+// include print stylesheet overrides
+@import 'print';

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@ title: Home
       </div>
     </section>
 
-    <section class="explore_home-main" id="impact" role="tabpanel" aria-hidden="true">
+    <section class="eiti-tab-panel explore_home-main" id="impact" role="tabpanel" aria-hidden="true">
       <div class="container-left-3">
         <p>Extractive industries account for 2.6 percent of the national GDP, and contribute to exports and employment in many parts of the country.</p>
         <a href="{{ site.baseurl }}/explore/#economic-impact" class="button-primary explore_home-button">Explore data</a>


### PR DESCRIPTION
Fixes issue(s) #1509, #1390 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/print-stylesheet/states/)

To review:
---
- open link
- try to print
- check out print preview on various pages

Changes proposed in this pull request:
---
- makes second print.css stylesheet that styles the site when it is printed
- I removed all exclusively interactive features of the site, except for links. 
- links: add URL as text following a link in this format `Some link (www.somelink.com)`
- left-aligned most things
- pages covered
  - all content pages
  - how it works and explore landing pages
  - state and national pages
  - home page
  - about page
- For the most part tried to keep the default spacing, font sizes and alignment
- The hardest part was making the page break in the correct location. The breaks that I have established are far from perfect – there are plenty of messy examples I have found – but this is a good place to start.

__NOTE: I used the `!important` flag quite a bit. Normally I would applaud hound for catching me, but since these are supreme overrides and I don't want to mess around with finding the appropriate specificity for each instance I am trying to override, `!important` is more helpful than harmful IMHO.__

/cc @meiqimichelle @coreycaitlin 