### PR TITLE
Iconic nav

### DIFF
--- a/_includes/icon-map.html
+++ b/_includes/icon-map.html
@@ -1,0 +1,22 @@
+{% assign _viewbox = include.viewbox | default: site.data.viewboxes.all %}
+{% assign highlighted_state = include.highlighted_state %}
+{% assign offshore = include.offshore %}
+
+<div class="state svg-container map-container"{% if _viewbox %} style="padding-bottom: {{ _viewbox | svg_viewbox_padding }}%;"{% endif %}>
+  <a href="{{ site.baseurl }}/states/" title="Explore data main page">
+  <svg class="states map icon"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
+    {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
+    <g class="states features">
+      <use xlink:href="{{ states_svg }}#states"></use>
+    </g>
+    {% for state in site.data.states %}
+      {% if state_id == state.id %}
+      <g class="state feature">
+        <use xlink:href="{{ states_svg }}#state-{{ state.id }}"></use>
+      </g>
+    {% endif %}
+    {% endfor %}
+  </svg>
+  </a>
+</div>
+

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -99,6 +99,20 @@ nav_items:
 
   <div class="container-right-3">
     <div class="sticky_nav">
+      <h3 class="state-page-nav-title container">
+
+        <div class="nav-title">{{ state_name }}</div>
+        <figure is="data-map">
+
+          {%
+            include icon-map.html
+            state=state_id
+            highlighted_state=state_id
+            offshore=true
+          %}
+        </figure>
+        <label class="nav-prompt">Explore data main page</label>
+      </h3>
       <nav class="sticky_nav-nav">
         {% include case-studies/_nav-list.html %}
       </nav>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -54,13 +54,12 @@ nav_items:
 
 
 <main id="state-{{ state_id }}" class="container-outer layout-state-pages">
-  <div>
-    <a class="breadcrumb" href="{{ site.baseurl }}/states/">State Profiles</a>
-    /
-  </div>
-  <h1 id="title">{{ state_name }}</h1>
-
   <div class="container-left-9">
+    <div>
+      <a class="breadcrumb" href="{{ site.baseurl }}/states/">State Profiles</a>
+      /
+    </div>
+    <h1 id="title">{{ state_name }}</h1>
 
     {% include location/section-overview.html %}
 
@@ -98,7 +97,7 @@ nav_items:
   </div>
 
   <div class="container-right-3">
-    <div class="sticky_nav">
+    <div class="sticky_nav" data-sticky-offset="50">
       <h3 class="state-page-nav-title container">
 
         <div class="nav-title">{{ state_name }}</div>

--- a/_sass/blocks/_all.scss
+++ b/_sass/blocks/_all.scss
@@ -39,6 +39,7 @@
 // Styleguide blocks.state-pages
 @import 'state-pages/info-tabs';
 @import 'state-pages/arrow-box';
+@import 'state-pages/iconic-nav';
 
 // About
 //

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -18,17 +18,10 @@
   }
 
   .chart-title {
-    @include heading(para-lg);
+    @include heading(large-caps);
 
     border-bottom: 1px solid $mid-gray;
     flex: 1 0 auto;
-    font-size: inherit;
-    font-weight: $weight-book;
-    letter-spacing: 1px;
-    line-height: $standard-padding;
-    margin-bottom: $base-padding-lite;
-    padding-bottom: $base-padding-lite;
-    text-transform: uppercase;
   }
 
   .chart-list-intro {

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -11,7 +11,7 @@
     padding-bottom: $standard-padding-lite;
   }
 
-  h3:not(.chart-title) {
+  h3:not(.chart-title):not(.state-page-nav-title) {
     border-bottom: 2px solid $light-green;
     margin-bottom: $standard-padding;
     padding-bottom: $standard-padding-lite;

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -9,7 +9,7 @@
   position: relative;
 
   &:hover,
-  &:focus
+  &:focus,
   &:active {
     svg.map .states.features {
       fill: $blackest-black;
@@ -25,10 +25,11 @@
     }
 
     .states.features {
+      @include transition(all, 0.3s);
+
       fill: $neutral-gray;
       fill-opacity: 1;
       stroke: $neutral-gray;
-      @include transition(all, 0.3s);
     }
   }
 
@@ -38,10 +39,10 @@
     width: 33%;
 
     &:hover,
-    &:focus
+    &:focus,
     &:active {
 
-      &+ .nav-prompt {
+      + .nav-prompt {
         visibility: visible;
       }
 

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -1,0 +1,76 @@
+.state-page-nav-title {
+  @include heading(large-caps);
+
+  align-items: center;
+  border-bottom: 1px solid $mid-gray;
+  display: flex;
+  justify-content: flex-start;
+  margin: 0;
+  position: relative;
+
+  &:hover,
+  &:focus
+  &:active {
+    svg.map .states.features {
+      fill: $blackest-black;
+      fill-opacity: 1;
+      stroke: $blackest-black;
+    }
+  }
+
+  svg.map {
+    .state.feature {
+      fill: $blackest-black;
+      fill-opacity: 1;
+    }
+
+    .states.features {
+      fill: $neutral-gray;
+      fill-opacity: 1;
+      stroke: $neutral-gray;
+      @include transition(all, 0.3s);
+    }
+  }
+
+  figure {
+    align-self: flex-end;
+    margin: 0;
+    width: 33%;
+
+    &:hover,
+    &:focus
+    &:active {
+
+      &+ .nav-prompt {
+        visibility: visible;
+      }
+
+      svg.map .states.features {
+        fill: $blackest-black;
+        fill-opacity: 1;
+        stroke: $blackest-black;
+      }
+    }
+
+    svg.map {
+      padding: 0;
+    }
+  }
+
+  .nav-title {
+    align-self: center;
+    width: 67%;
+  }
+
+  .nav-prompt {
+    @include font-size(0.8);
+    @include transition(visibility, 0.3s);
+
+    font-style: italic;
+    position: absolute;
+    right: 0;
+    text-transform: capitalize;
+    top: -20px;
+    visibility: hidden;
+  }
+}

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -50,3 +50,4 @@
 .sticky_nav-nav_item-sub {
   border-left: 3px solid $neutral-gray;
 }
+

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -1,6 +1,6 @@
 .sticky_nav {
-  padding-left: $base-padding-extra;
-  padding-top: $base-padding-extra;
+  padding-left: $standard-padding-extra;
+  padding-top: $standard-padding-extra;
   top: 0;
 
   @include respond-to(medium-down) {

--- a/_sass/mixins/_type-mixins.scss
+++ b/_sass/mixins/_type-mixins.scss
@@ -62,6 +62,17 @@
     margin-bottom: 0.75rem; // 12px
   }
 
+  @if $level == 'large-caps' {
+    // light 18/27 (12px bottom margin)
+    font-size: inherit;
+    font-weight: $weight-book;
+    letter-spacing: 1px;
+    line-height: $standard-padding;
+    margin-bottom: $base-padding-lite;
+    padding-bottom: $base-padding-lite;
+    text-transform: uppercase;
+  }
+
   @if $level == 'para-md' {
     // light 16/22 (10px bottom margin)
     font-size: $base-font-size; // 16px

--- a/states/index.html
+++ b/states/index.html
@@ -40,13 +40,13 @@ nav_items:
 {% assign steps=9 %}
 
 <main id="states" class="container-outer layout-state-pages">
-  <div>
-    <a class="breadcrumb" href="{{ site.baseurl }}/states/">State Profiles</a>
-    /
-  </div>
-  <h1 id="title">{{ state_name }}</h1>
 
   <div class="container-left-9">
+    <div>
+      <a class="breadcrumb" href="{{ site.baseurl }}/states/">State Profiles</a>
+      /
+    </div>
+    <h1 id="title">{{ state_name }}</h1>
 
     <figure is="data-map" color-scheme="Reds" steps="9">
       {%
@@ -93,7 +93,11 @@ nav_items:
   </div>
 
   <div class="container-right-3">
-    <div class="sticky_nav">
+    <div class="sticky_nav" data-sticky-offset="50">
+      <h3 class="state-page-nav-title container">
+
+        <div class="nav-title">{{ state_name }}</div>
+      </h3>
       <nav class="sticky_nav-nav">
         {% include case-studies/_nav-list.html %}
       </nav>


### PR DESCRIPTION
Fixes issue(s) #1610, #1586 

design: #1589 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/iconic-nav/states/UT)

Changes proposed in this pull request:
- added iconic nav for state page view
- routes back to homepage
- fixed sticky nav on state pages

__NOTE: ignore the remaining hound bugs. The map selector specificity is really high, so I needed to use a high specificity to override it.__

/cc @ericronne @meiqimichelle @coreycaitlin 
