### PR TITLE
update version to v1.3.4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ description: >
 url: https://useiti.doi.gov
 
 # app version number
-version: v1.3.3
+version: v1.3.4
 
 beckley_api_key: LXJh2PKSC6zxY0YNuBRYgIj2JxSPcDwSPCZuHBG1
 

--- a/_sass/components/_glossary.scss
+++ b/_sass/components/_glossary.scss
@@ -5,7 +5,7 @@
 // // Styleguide components.glossary
 
 $drawer-width: 300px;
-$term-width: 200px;
+$term-width: 180px;
 $term-width-max: 220px;
 
 #glossary {


### PR DESCRIPTION
Fixes issue(s) # .

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/version-bump/)

Changes proposed in this pull request:

- update to verstion `v1.3.4`
- add hotfix that changes `.glossary-item` width (to avoid glossary bug that persists on dev)

/cc relevant people

