### PR TITLE
State page restructuring and Montana content

### DIFF
--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -11,7 +11,8 @@
 
     {% include year-selector.html year_range=year_range %}
 
-    <p class="chart-description">The federal government collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned property in {{ state_name }}.</p>
+    <p class="chart-description">The U.S. Energy Information Administration collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned land in {{ state_name }}. <a href="{{site.baseurl}}/downloads/#production-all">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+    </p>
   </div>
 
   <div class="chart-list">
@@ -49,19 +50,4 @@
 
   </div>
 
-  <a href="{{site.baseurl}}/downloads/#production-all">
-      <icon class="fa fa-file-text-o u-padding-right"></icon>Data about energy production on all lands and waters comes from the Energy Information Administration
-  </a>
-
-</section>
-
-<section id="state-local-production" class="state production">
-  <h3>Production on state land</h3>
-  <p class="full-width-text">Natural resource extraction on land owned by the State of {{ state_name }} is governed by <a href="{{ site.baseurl }}/how-it-works/state-laws-and-regulations/#role-of-state-government-agencies/</a>">state laws and regulations</a>.</p>
-  <p>We don't have detailed data about natural resource extraction on land owned by the state.</p>
-</section>
-
-<section id="private-land-production" class="production">
-  <h3>Production on private land</h3>
-  <p class="full-width-text">We don't have detailed data about natural resource extraction on land owned by individuals or corporations.</p>
 </section>

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -13,7 +13,7 @@
       {% include year-selector.html year_range=year_range %}
 
       <p class="chart-description">
-        {% include location/key-exports.html %}
+        {% include location/key-exports.html %} The U.S. Census Bureau collects information about the top 25 exports in each state. <a href="{{site.baseurl}}/downloads/#exports">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
       </p>
     </div>
 
@@ -51,9 +51,5 @@
     {% endfor %}
 
   </div><!-- /.chart-list -->
-
-  <a href="{{site.baseurl}}/downloads/#exports">
-    <icon class="fa fa-file-text-o u-padding-right"></icon>Exports data comes from the U.S. Census Bureau
-  </a>
 
 </section>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -9,30 +9,23 @@
 
 <section id="federal-production" class="federal production">
 
-  <h3>Production on federal land in {{ state_name }}</h2>
-
-  {% include location/section-ownership.html %}
-
   <section class="county-map-table" is="year-switcher-section">
 
     <h3>Natural resources extracted on federal land</h3>
 
     {% if federal_products_num == 0 %}
       <p>No natural resources were produced on federal land in {{  state_name }} in {{ year }}.</p>
+    {% else %}
+      <div class="chart-selector-wrapper">
+
+        {% include year-selector.html year_range=year_range %}
+
+        <p class="chart-description">
+            ONRR collects detailed data about natural resources produced on federal land in {{ state_name }}.
+            <a href="{{site.baseurl}}/downloads/federal-production/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+        </p>
+      </div>
     {% endif %}
-
-    <div class="chart-selector-wrapper">
-
-      {% include year-selector.html year_range=year_range %}
-
-      <p class="chart-description">
-        {% if federal_products_num == 0 %}
-          No natural resources were produced on federal land in {{  state_name }} in {{ year }}.
-        {% else %}
-          ONRR collects data about what natural resources are produced on federal land in {{ state_name }}. <a href="{{site.baseurl}}/downloads/federal-production/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
-        {% endif %}
-      </p>
-    </div>
 
     <div class="chart-list">
 

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -21,8 +21,8 @@
 
       <div class="chart-description">
         <p><strong>Wage and salary data</strong> describes the number of people employed in natural resource extraction that receive wages or salaries from companies.</p>
-        <p>In {{ year }}, jobs in the extractive industries that paid a wage or salary made up {{ jobs_percent | percent }} % of statewide employment in {{ state_name }}.</p>
-        <p>Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a></p>
+        <p>Employment data comes from the Bureau of Labor Statistics. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a></p>
+        <p>In {{ year }}, jobs in the extractive industries that paid a wage or salary made up {{ jobs_percent | percent }}% of statewide employment in {{ state_name }}.</p>
       </div>
     </div><!-- .chart-selector-wrapper -->
 
@@ -107,7 +107,7 @@
           <strong>Self-employment data</strong> describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.
         </p>
         <p>
-          Employment data comes from the Bureau of Labor Statistics and the Bureau of Economic Analysis. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+          Employment data comes from the Bureau of Economic Analysis. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
         </p>
       </div>
     </div><!-- .chart-selector-wrapper -->

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -2,7 +2,11 @@
 {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ state_id }}.svg{% endcapture %}
 
 <section class="container-outer land-ownership">
+
+  <h3>Land ownership in {{ state_name }}</h2>
+
   <section class="text-container">
+
     <p><strong>In {{ state_name }}, {{ site.data.land_stats[state_id].federal_percent | percent }} percent of land is owned by the federal government.</strong></p>
 
     <p>When companies extract natural resources on federal land, they pay royalties, rents, bonuses, and other fees — much like they would to any landowner.</p>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -10,9 +10,9 @@
   <p class="full-width-text">Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
 
 
-  <h3>Revenue from federal land</h3>
-
   <section id="federal-revenue">
+
+    <h3>Federal revenue from extraction on federal land</h3>
 
     <p class="full-width-text">Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
@@ -47,7 +47,7 @@
 
     <section class="chart-list has-intro">
 
-      <h4>Revenue from resources extracted on federal land in {{ state_name }}</h4>
+      <h4>Federal revenue by county</h4>
 
       <div class="chart-selector-wrapper">
 
@@ -72,28 +72,21 @@
     </section>
     <!-- .chart-list -->
 
+    <h3>Federal tax revenue</h3>
+
+    <div class="full-width-text">
+      <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to romote other policy goals.</p>
+      <p>Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
+    </div>
+
   </section>
   <!-- #federal-revenue -->
 
   <section id="state-local-revenue" class="state revenue">
-    <h3>Revenue from extraction on state land</h3>
+    <h3>State revenue from extraction on state land</h3>
 
     <div class="full-width-text">
-      <p>We don't have detailed data about state revenue from natural resource extraction on land owned by the state of {{ state_name }}.</p>
-
-      <!-- pulls in state fiscal and legal information if the state is one of the MSG-prioritized states -->
-      {% if is_priority_state %}
-        <p>However, the USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern extraction on state land.</p>
-        <p>Learn more about natural resource regulation, production, and revenue in {{ state_name }}:</p>
-
-        {{ regulations | markdownify }}
-
-      {% endif %}
+      <p>We don't have detailed data about federal, state, or local revenue from natural resource extraction on land owned by the state of {{ state_name }}, corporations, or individuals. However, all companies must pay state, local, and federal taxes.</p>
     </div>
-  </section>
-
-  <section id="private-revenue" class="private-lands revenue">
-    <h3>Revenue from extraction on private land</h3>
-    <p class="full-width-text">All companies, including those that extract natural resources on private land, must pay state, local, and federal taxes. Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
   </section>
 </section>

--- a/_includes/location/section-state-governance.html
+++ b/_includes/location/section-state-governance.html
@@ -1,0 +1,17 @@
+<!-- pulls in state fiscal and legal information if the state is one of the MSG-prioritized states -->
+
+{% if is_priority_state %}
+
+<section id="state-governance" class="">
+  
+  <h2>State governance</h2>
+
+  <div class="full-width-text">
+
+	  <p>The USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern natural resource extraction in {{ state_name }}:</p>
+
+	  {{ regulations | markdownify }}
+
+  </div>
+
+{% endif %}

--- a/_includes/location/section-state-governance.html
+++ b/_includes/location/section-state-governance.html
@@ -1,6 +1,18 @@
 <!-- pulls in state fiscal and legal information if the state is one of the MSG-prioritized states -->
 
-{% if is_priority_state %}
+{% if is_opt_in_state %}
+
+<section id="state-governance" class="">
+
+	<h2>State governance</h2>
+
+    <p>The state of {{ state_name }} chose to participate in additional sub-national reporting as part of the USEITI process. The {{ "Independent Administrator" | term:"Independent Administrator (IA)" }} gathered additional information about natural resource governance, revenues, and disbursements in {{ state_name }}.</p>
+
+	{{ regulations | markdownify }}
+
+</section>
+
+{% elsif is_priority_state %}
 
 <section id="state-governance" class="">
   

--- a/_includes/location/section-state-governance.html
+++ b/_includes/location/section-state-governance.html
@@ -1,29 +1,25 @@
 <!-- pulls in state fiscal and legal information if the state is one of the MSG-prioritized states -->
 
-{% if is_opt_in_state %}
-
-<section id="state-governance" class="">
-
+<section id="state-governance">
+	
 	<h2>State governance</h2>
 
-    <p>The state of {{ state_name }} chose to participate in additional sub-national reporting as part of the USEITI process. The {{ "Independent Administrator" | term:"Independent Administrator (IA)" }} gathered additional information about natural resource governance, revenues, and disbursements in {{ state_name }}.</p>
+	{% if is_opt_in_state %}
 
-	{{ regulations | markdownify }}
+	    <p>The state of {{ state_name }} chose to participate in additional sub-national reporting as part of the USEITI process. The {{ "Independent Administrator" | term:"Independent Administrator (IA)" }} gathered additional information about natural resource governance, revenues, and disbursements in {{ state_name }}.</p>
+
+		{{ regulations | markdownify }}
+
+	{% elsif is_priority_state %}
+  
+  		<div class="full-width-text">
+
+			<p>The USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern natural resource extraction in {{ state_name }}:</p>
+
+			{{ regulations | markdownify }}
+
+		</div>
+
+	{% endif %}
 
 </section>
-
-{% elsif is_priority_state %}
-
-<section id="state-governance" class="">
-  
-  <h2>State governance</h2>
-
-  <div class="full-width-text">
-
-	  <p>The USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern natural resource extraction in {{ state_name }}:</p>
-
-	  {{ regulations | markdownify }}
-
-  </div>
-
-{% endif %}

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -59,7 +59,7 @@
     <div class="map-container">
 
       <h4 class="chart-title">
-        Local revenue collected
+        Revenue collected by county
       </h4>
 
 

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -6,6 +6,8 @@ nav_items:
   - name: production
     title: Production
     subnav_items:
+      - name: all-production
+        title: All energy production
       - name: federal-production
         title: Federal land
       - name: state-local-production
@@ -16,11 +18,9 @@ nav_items:
     title: Revenue
     subnav_items:
       - name: federal-revenue
-        title: Federal land
+        title: Federal revenue
       - name: state-local-revenue
-        title: State land
-      - name: private-revenue
-        title: Private land
+        title: State revenue
   - name: economic-impact
     title: Economic impact
     subnav_items:
@@ -32,6 +32,8 @@ nav_items:
       title: Self-employment
     - name: exports
       title: Exports
+  - name: state-governance
+    title: State governance
 ---
 
 {% assign state_name = page.title %}
@@ -66,6 +68,8 @@ nav_items:
     <section id="production">
       {% include location/section-all-production.html %}
 
+      {% include location/section-ownership.html %}
+
       {% include location/section-federal-production.html %}
     </section>
 
@@ -84,6 +88,10 @@ nav_items:
       {% include location/section-jobs.html %}
 
       {% include location/section-exports.html %}
+    </section>
+
+    <section>
+      {% include location/section-state-governance.html %}
     </section>
 
     <!-- XXX setting display: none on this prevents the mask from working -->

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -58,7 +58,7 @@ nav_items:
 <main id="state-{{ state_id }}" class="container-outer layout-state-pages">
   <div class="container-left-9">
     <div>
-      <a class="breadcrumb" href="{{ site.baseurl }}/states/">State Profiles</a>
+      <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore data</a>
       /
     </div>
     <h1 id="title">{{ state_name }}</h1>

--- a/_states/DC.md
+++ b/_states/DC.md
@@ -1,5 +1,5 @@
 ---
 id: DC
-title: District of Columbia
+title: Washington, DC
 FIPS: '11'
 ---

--- a/_states/MT.md
+++ b/_states/MT.md
@@ -90,7 +90,3 @@ To learn more, find Annual Evaluation Reports for Montana in the [Office of Surf
 The Conservation and Resource Development Division of the Department of Natural Resources and Conservation runs the [Reclamation and Development Grants Program](http://dnrc.mt.gov/divisions/cardd/resource-development/reclamation-and-development-grants-program) to fund projects that “compensate Montana citizens for the effects of exploration and mining on Montana lands.”
 
 The [Montana Department of Justice Natural Resources Damage Program](https://dojmt.gov/lands/) administers grants for the restoration of the Upper Clark Fork River Basin’s natural resources “due to mining and mineral processing operations.” Between 2000 and 2011, the governor approved 121 projects totaling $121 million.
-
-
-
-

--- a/_states/MT.md
+++ b/_states/MT.md
@@ -7,7 +7,7 @@ opt_in: true
 priority: true
 ---
 
-State overview
+<!-- State overview
 
 - Where is production happening? (production context)
 - Personal income
@@ -18,7 +18,7 @@ State revenue and disbursements
 - State and local taxes
 - Tax expenditures
 - Revenue sustainability
-- State disbursements
+- State disbursements -->
 
 <!-- State governance -->
 

--- a/_states/MT.md
+++ b/_states/MT.md
@@ -6,10 +6,91 @@ FIPS: '30'
 opt_in: true
 priority: true
 ---
-* The [Montana Department of Revenue](https://revenue.mt.gov/) collects, manages, and distributes the majority of extractives revenues in Montana, and publishes [tax related reports](https://revenue.mt.gov/home/publications). County governments also collect many property taxes.
-* The [Montana Department of Natural Resources and Conservation](http://dnrc.mt.gov/) managed Montana's natural resources, including administering state trust lands.
-  - The [Minerals Management Bureau](http://dnrc.mt.gov/divisions/trust/minerals-management) manages and issues leases and permits for oil, gas, coal, and other natural resources on state lands.
-  - The [Montana Board of Oil and Gas Conservation](http://bogc.dnrc.mt.gov/BoardSummaries.asp) protects citizens and the environment from the negative effects of oil and gas extraction by issuing permits, inspecting wells, and conducting environmental remediation programs.
-    - [Rules and regulations](http://bogc.dnrc.mt.gov/rulesregs.asp)
-    - [Wells, production, and leases data](http://bogc.dnrc.mt.gov/WebApps/DataMiner/)
-+ The [Montana Department of Environmental Quality](http://deq.mt.gov/) leads Montana's planning, permitting, compliance, enforcement, and remediation efforts for projects and incidents related to air, water, land, and energy.
+
+State overview
+
+- Where is production happening? (production context)
+- Personal income
+
+State revenue and disbursements
+
+- Revenue from production on state land
+- State and local taxes
+- Tax expenditures
+- Revenue sustainability
+- State disbursements
+
+<!-- State governance -->
+
+The state of Montana regulates extraction and interacts with extractive industry companies in Montana, particularly when they are operating on state and private lands. For extraction on federal land, state agencies may be involved, but federal agencies are primarily responsible for managing the land. Learn more about how [oil and gas]({{site.baseurl}}/how-it-works/onshore-oil-gas/), [coal]({{site.baseurl}}/how-it-works/coal/), and [hardrock minerals]({{site-baseurl}}/how-it-works/hardrock-minerals/) are managed on federal lands.
+
+### State agencies
+
+The [Montana Department of Revenue](https://revenue.mt.gov/) collects, manages, and distributes  revenue from companies engaged in extraction of oil, natural gas, coal, and non-energy minerals in Montana. It publishes [biennial reports](https://revenue.mt.gov/home/publications/biennial_reports) and other [tax related reports](https://revenue.mt.gov/home/publications). County governments also collect many property taxes.
+
+The [Montana Department of Natural Resources and Conservation](http://dnrc.mt.gov/) managed Montana's natural resources, including administering state trust lands.
+
+- The [Montana Board of Oil and Gas Conservation](http://bogc.dnrc.mt.gov/BoardSummaries.asp) is involved in all stages of oil and gas extraction. It permits all oil and gas wells, regulates the underground injecting program, and assists in remediation efforts. It also inspects all oil and gas wells and operations to ensure they comply with all state environmental laws. The board is governed by [rules and regulations](http://bogc.dnrc.mt.gov/rulesregs.asp).
+- The [Reclamation and Development Grant Program](http://dnrc.mt.gov/divisions/cardd/resource-development/reclamation-and-development-grants-program) funds some abandoned mine projects.
+- The [Mineral Management Bureau](http://dnrc.mt.gov/index/divisions/trust/minerals-management) (within the [Trust Land Management Division](http://dnrc.mt.gov/divisions/trust)) permits, regulates, and collects revenue for extraction on state trust lands. Their work complements the work of the Board of Oil and Gas Conservation and Department of Environmental Quality, both of which retain regulatory authority over mines on state lands. State land leasing is governed by state [statutes and rules](http://www.mtrules.org/gateway/chapterhome.asp?chapter=36.25).
+
+The [Montana Department of Environmental Quality](http://deq.mt.gov/) leads Montana's planning, permitting, compliance, enforcement, and remediation efforts for projects and incidents related to air, water, land, and energy.
+
+- The [Air, Energy, and Mining Division](http://deq.mt.gov/DEQAdmin/AEM) is charged with protecting the quality of Montana's air, water, and land. Its responsibilities and roles include:
+  - Issuing air quality permits for oil and gas wells
+  - Issuing permits and monitoring compliance for projects relating to coal and hardrock mines
+  - Determining correct control measures and establishing requirements to ensure compliance with laws and regulations
+  - Providing technical assistance in bringing violations back into compliance
+  - Preparing enforcement requests for the [Enforcement Division](http://deq.mt.gov/DEQAdmin/ENF)
+  - Holding and reviewing reclamation bonds for [coal](http://deq.mt.gov/Land/CoalUranium) and [hardrock mining](http://deq.mt.gov/Land/hardrock)
+
+- The [Waste Management and Remediation Division](http://deq.mt.gov/DEQAdmin/WMR) administers and oversees investigation and cleanup of extraction sites that need remediation.
+
+### State laws and regulations
+
+The [Constitution of the State of Montana](http://leg.mt.gov/bills/mca_toc/Constitution.htm) includes environmental protections, including a right to a “clean and healthful environment,” and provisions for environmental protection, improvement, and reclamation.
+
+The Montana Code Annotated (MCA) has several sections that govern natural resource extraction:
+
++ [Title 82: Minerals, Oil, and Gas](http://leg.mt.gov/bills/mca_toc/82.htm) includes statutes related to minerals, oil, and gas.
++ [Title 15: Taxation](http://leg.mt.gov/bills/mca_toc/15.htm) covers taxation. See chapters 35 (Coal Severance), 36 (Oil & Gas Production Tax), 37 (Mining License Taxes), and 38 (RIGWAT Tax).
++ [Title 77: State Lands](http://leg.mt.gov/bills/mca_toc/77.htm) covers state lands. See Chapter 3 (Rock, Mineral, Coal, Oil, and Gas Resources).
+- The _Montana Environmental Policy Act (MCA §75-1-101, et seq.)_ aims to ensure environmental impacts are considered in state planning (including environmental impact statements).
+- The _Clean Air Act of Montana (MCA § 75-2-101, et seq.)_ seeks to “achieve and maintain levels of air quality that will protect human health and safety and, to the greatest degree possible, prevent injury to plant and animal life.”
+- The _Water Quality Act (MCA §75-5-101, et seq.)_ aims to "conserve water by protecting, maintaining, and improving the quality of water" throughout the state and to "provide a comprehensive program for the prevention, abatement, and control of water pollution."
+- The _Montana Metal Mine Reclamation Act (MCA §82-4-301, et seq.)_ provides for reclamation of hard rock and metal mines.
+
+The Administrative Rules of Montana also regulate natural resource extraction:
+
+- [Title 36: Natural Resources and Conservation](http://www.mtrules.org/Gateway/Department.asp?DeptNo=36) covers the Department of Natural Resources & Conservation. See chapters 19 (Reclamation and Development Grants Program), 22 (Board of Oil & Gas Conservation), and 25 (State Land Leasing).
+- [Title 17 Environmental Quality](http://www.mtrules.org/Gateway/Department.asp?DeptNo=17) covers the Department of Environmental Quality. See chapters 8 (Air Quality), 24 (Reclamation), and 30 (Water Quality).
+
+### Fiscal costs of extractive activity
+
+In addition to generating revenue, extractive industries can bring costs to state and local communities. In Montana, these costs are concentrated in eastern Montana because of extraction from the Bakken Formation in Montana and neighboring North Dakota. For more extractive industries' effect on this region, see the Eastern Montana Impact Coalition's [Regional Impact Analysis (PDF)](http://static1.squarespace.com/static/529fb9b4e4b0edf62d295374/t/55e9eb5be4b098674aefb5fe/1441393499939/Abbreviated+EMIC+Regional+Impact+Analysis+2015.pdf).
+
+The USEITI {{ term | "Multi-Stakeholder Group" }} prioritized four types of fiscal costs in the 2015 USEITI report:
+
+**Transportation:** The Montana Department of Transportation estimates an additional $52 million per year in increased pavement needs for highways in eastern Montana because of extractive industry activity. Local governments in eastern Montana also saw increases in budgets for streets and roads increase 44% to 345% from 2000 to 2013.
+
+To read more, see the [Montana Department of Transportation report (PDF)](http://www.mdt.mt.gov/other/webdata/external/research/docs/research_proj/oil_boom/summary_mdt_efforts.pdf) on efforts to respond to impacts on the state highway system from oil exploration and production in eastern Montana.
+
+**Water:** Surveyed communities in eastern Montana reported that water rates increased an average of 86.4% from 2011 to 2014 and sewage rates increased 302.9%. The Eastern Montana Impact Coalition also estimates that $33.8 million to $80.6 million will be needed for incremental improvements to support growing demand on water, sewage, and transportation systems. These figures don’t include large projects.
+
+The Department of Environmental Quality plans, monitors, assesses, and enforces [water quality](http://deq.mt.gov/Water) in Montana. It performs targeted water quality monitoring related to oil and gas development in eastern Montana and coal mining near Lake Koocanusa, runs the [Montana Ground Water Pollution Control System](http://deq.mt.gov/Water/WQINFO/mgwpcs) and its permitting process, and produces [Clean Water Act Integrated Reports](http://deq.mt.gov/Water/WQPB/cwaic/reports).
+
+**Emergency services:** Increased population near extraction can increase demands on emergency services. Law enforcement at multiple jurisdictional levels in eastern Montana have seen costs rise related to increases in oil and gas activity.
+
+The State Highway Patrol added a new detachment in eastern Montana, county sheriffs' offices have seen costs rise $13.4 million, and surveyed police departments have seen an average budget increase of 128.9% between 2000 and 2013. Surveyed local governments also reported an average increase of 169.2% in emergency spending from 2000 to 2013.
+
+**Reclamation:** Multiple organizations in the Montana state government work on the reclamation and remediation of sites related to extraction. The Department of Environmental Quality Waste Management and Remediation Division administers state and federal superfund sites, as well as Montana’s [abandoned mine land projects](http://deq.mt.gov/Land/AbandonedMines). Montana has been “certified” by the federal Abandoned Mine Land Reclamation program, meaning that it has reclaimed its identified, high-priority abandoned coal mine areas. [Current projects](http://deq.mt.gov/Land/AbandonedMines/CurrentProjects) include addressing acid mine drainage in the Great Falls coal field, which is projected to cost $96 million, and managing subsidence events and potential subsidence in Red Lodge.
+
+To learn more, find Annual Evaluation Reports for Montana in the [Office of Surface Mining Reclamation and Enforcement Oversight Document Database](http://odocs.osmre.gov/) or learn about the bonding of active mines in the [Coal Program Annual Report](http://deq.mt.gov/Land/CoalUranium/annualreports).
+
+The Conservation and Resource Development Division of the Department of Natural Resources and Conservation runs the [Reclamation and Development Grants Program](http://dnrc.mt.gov/divisions/cardd/resource-development/reclamation-and-development-grants-program) to fund projects that “compensate Montana citizens for the effects of exploration and mining on Montana lands.”
+
+The [Montana Department of Justice Natural Resources Damage Program](https://dojmt.gov/lands/) administers grants for the restoration of the Upper Clark Fork River Basin’s natural resources “due to mining and mineral processing operations.” Between 2000 and 2011, the governor approved 121 projects totaling $121 million.
+
+
+
+


### PR DESCRIPTION
Progress toward issue #1467. This is a slightly messy one, and the structure will need more work — but I wanted to get it reviewed & merged before I wander too far.

[:sunglasses: MONTANA PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/montana-addition/states/MT/)

[:sunglasses: OTHER STATE](https://federalist.18f.gov/preview/18F/doi-extractives-data/montana-addition/states/CA/) (so you can see if I broke stuff)

[:sunglasses: DC](https://federalist.18f.gov/preview/18F/doi-extractives-data/montana-addition/states/DC/) (so you can see if I broke stuff)

Changes proposed in this pull request:

- Move several "Data and documentation" links into intro sections
- Remove state/private production sections, because those are covered in all-lands production
- Pull in all governance content for Montana
- Combine state/private revenue sections
- Pull land ownership up a level, since we'll be adding info about state/tribal land
- Change `District of Columbia` --> `Washington, DC`
- A whole buncha other stuff

/cc @gemfarmer @meiqimichelle: Happy to walk through this Monday if it would help!

