### PR TITLE
Map and chart adjustments

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -34,16 +34,19 @@
         {% assign fips = county[0] | pad_left: 5, '0' %}
         {% if include.href %}<a xlink:href="{{ include.href | replace: '%', fips }}">{% endif %}
         {% assign value = county[1] | get: keys %}
-        {% if value != nil %}
+
+        {% assign year_values = null %}
+        {% if include.years %}
+          {% assign year_values = county[1] | get: include.years %}
+          {% if include.years_property %}
+            {% assign year_values = year_values | map_hash: include.years_property %}
+          {% endif %}
+        {% endif %}
+
+        {% if year_values != nil and year_values != null %}
         <g class="county feature"
           data-value='{{ value | default: 0 | jsonify }}'
-          {% if include.years %}
-            {% assign year_values = county[1] | get: include.years %}
-            {% if include.years_property %}
-              {% assign year_values = year_values | map_hash: include.years_property %}
-            {% endif %}
-            data-year-values='{{ year_values | jsonify }}'
-          {% endif %} >
+          data-year-values='{{ year_values | jsonify }}'>
           <title>{{ county[1].name }}</title>
           <use xlink:href="{{ state_svg }}#county-{{ fips }}"></use>
         </g>

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -78,8 +78,12 @@
 
 <div class="legend-container">
   {% if include.caption %}
-    <figcaption>
+    <figcaption class="legend-data">
       {{ include.caption }}
+    </figcaption>
+    <figcaption class="legend-no-data" aria-hidden="true">
+      There is no data for {{ state_name }} in <span data-year="{{ year }}" >{{ year}}</span>.
+      Select a new year to populate the map.
     </figcaption>
   {% endif %}
 

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -43,13 +43,13 @@
           {% endif %}
         {% endif %}
 
-        {% if year_values != nil and year_values != null %}
-        <g class="county feature"
-          data-value='{{ value | default: 0 | jsonify }}'
-          data-year-values='{{ year_values | jsonify }}'>
-          <title>{{ county[1].name }}</title>
-          <use xlink:href="{{ state_svg }}#county-{{ fips }}"></use>
-        </g>
+        {% if year_values %}
+          <g class="county feature"
+            data-value='{{ value | default: 0 | jsonify }}'
+            data-year-values='{{ year_values | jsonify }}'>
+            <title>{{ county[1].name }}</title>
+            <use xlink:href="{{ state_svg }}#county-{{ fips }}"></use>
+          </g>
         {% endif %}
         {% if include.href %}</a>{% endif %}
       {% endfor %}

--- a/_includes/location/revenue-type-row-oilgas.html
+++ b/_includes/location/revenue-type-row-oilgas.html
@@ -20,7 +20,7 @@
   <td data-value="{{
     revenue_types.Oil.Royalties[include.year] | default: 0
   }}">
-    <span class="tester" data-value="{{
+    <span data-value="{{
     revenue_types.Gas.Royalties[include.year] | default: 0
   }}"></span>
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -90,7 +90,7 @@
               {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
               {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
               {% assign _width ='inherit' %}
-              {% capture caption %}Local production of {{ product_name | downcase | suffix:units_suffix }} in <span data-year="{{ year }}">{{ year }}</span>{% endcapture %}
+              {% capture caption %}Local production of {{ product_name | downcase | suffix:units_suffix }} in <span data-year="{{ year }}">{{ year }}</span>{% if units %} ({{ short_units | default:units }}){% endif %}{% endcapture %}
 
               <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
                 {% assign federal_county_production = site.data.federal_county_production[state_id] %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -97,7 +97,7 @@ nav_items:
   </div>
 
   <div class="container-right-3">
-    <div class="sticky_nav" data-sticky-offset="50">
+    <div class="sticky_nav" data-sticky-offset="100">
       <h3 class="state-page-nav-title container">
 
         <div class="nav-title">{{ state_name }}</div>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -97,7 +97,7 @@ nav_items:
   </div>
 
   <div class="container-right-3">
-    <div class="sticky_nav" data-sticky-offset="100">
+    <div class="sticky_nav" data-sticky-offset="50">
       <h3 class="state-page-nav-title container">
 
         <div class="nav-title">{{ state_name }}</div>

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -148,5 +148,13 @@
       @include span-columns(4);
       @include omega();
     }
+
+    .legend-container,
+    .no-data-container {
+      &[aria-hidden='true'] {
+        display: none;
+      }
+    }
+
   }
 }

--- a/js/components/aria-toggle.js
+++ b/js/components/aria-toggle.js
@@ -46,12 +46,11 @@
         }},
 
         attributeChangedCallback: {value: function(attr, old, value) {
-          value = JSON.parse(value);
           switch (attr) {
             case 'aria-expanded':
-              if (value === false) {
+              if (value === 'false') {
                 collapse(this);
-              } else if (value === true) {
+              } else if (value === 'true') {
                 expand(this);
               }
           }

--- a/js/components/aria-toggle.js
+++ b/js/components/aria-toggle.js
@@ -55,18 +55,7 @@
                 expand(this);
               }
           }
-        }},
-
-        'aria-expanded': {
-          get: function() {
-            return this.getAttribute('aria-expanded');
-          },
-          set: function(value) {
-            if (value !== this['aria-expanded']) {
-              this.setAttribute('aria-expanded', value);
-            }
-          }
-        }
+        }}
       }
     )
   });

--- a/js/components/aria-toggle.js
+++ b/js/components/aria-toggle.js
@@ -13,6 +13,18 @@
     target.setAttribute(HIDDEN, !expanded);
   };
 
+  var collapse = function(button) {
+    var target = document.getElementById(button.getAttribute(CONTROLS));
+    button.setAttribute(EXPANDED, false);
+    target.setAttribute(HIDDEN, true);
+  }
+
+  var expand = function(button) {
+    var target = document.getElementById(button.getAttribute(CONTROLS));
+    button.setAttribute(EXPANDED, true);
+    target.setAttribute(HIDDEN, false);
+  }
+
   var click = function(event) {
     toggle(event.target);
   };
@@ -31,7 +43,30 @@
 
         detachedCallback: {value: function() {
           this.removeEventListener('click', click);
-        }}
+        }},
+
+        attributeChangedCallback: {value: function(attr, old, value) {
+          value = JSON.parse(value);
+          switch (attr) {
+            case 'aria-expanded':
+              if (value === false) {
+                collapse(this);
+              } else if (value === true) {
+                expand(this);
+              }
+          }
+        }},
+
+        'aria-expanded': {
+          get: function() {
+            return this.getAttribute('aria-expanded');
+          },
+          set: function(value) {
+            if (value !== this['aria-expanded']) {
+              this.setAttribute('aria-expanded', value);
+            }
+          }
+        }
       }
     )
   });

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -119,6 +119,12 @@
 
     this._cells.forEach(function(cell) {
       var key = cell.dataset.series || 'default';
+
+      if (key === 'volume' && +cell.getAttribute('data-year-values')) {
+        console.log(series, key, cell)
+      }
+
+
       if (key in series) {
         series[key].push(cell);
       } else {
@@ -220,6 +226,8 @@
           }
         }
 
+
+
         if (childCell) {
           var childBar = document.createElement('div');
           childBar.className = 'bar';
@@ -228,6 +236,12 @@
 
         var value = +cell.dataset.value;
         var size = width(value);
+
+        // if (+cell.dataset.yearValues) {
+        //   console.log('bar:', bar)
+        //   console.log('-----------')
+
+        // }
 
         if (childCell) {
           var childValue = +childCell.dataset.value;
@@ -239,6 +253,12 @@
           bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
           childBar.style.setProperty(sizeProperty, Math.abs(largerSize) + '%');
         } else {
+          if (!size) {
+            console.log(size)
+          } else {
+
+          }
+
           bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
         }
 

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -120,11 +120,6 @@
     this._cells.forEach(function(cell) {
       var key = cell.dataset.series || 'default';
 
-      if (key === 'volume' && +cell.getAttribute('data-year-values')) {
-        console.log(series, key, cell)
-      }
-
-
       if (key in series) {
         series[key].push(cell);
       } else {
@@ -231,8 +226,6 @@
           }
         }
 
-
-
         if (childCell) {
           var childBar = document.createElement('div');
           childBar.className = 'bar';
@@ -241,12 +234,6 @@
 
         var value = +cell.dataset.value;
         var size = width(value);
-
-        // if (+cell.dataset.yearValues) {
-        //   console.log('bar:', bar)
-        //   console.log('-----------')
-
-        // }
 
         if (childCell) {
           var childValue = +childCell.dataset.value;
@@ -258,12 +245,6 @@
           bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
           childBar.style.setProperty(sizeProperty, Math.abs(largerSize) + '%');
         } else {
-          if (!size) {
-            console.log(size)
-          } else {
-
-          }
-
           bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
         }
 

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -191,8 +191,6 @@
         var childCell = cell.querySelector('[data-value]');
 
         // TODO only do this if autolabel="true"?
-
-
         if (cell.childNodes.length === 1 && cell.firstChild.nodeType === Node.TEXT_NODE) {
           if (autolabel) {
             cell.setAttribute('aria-label', cell.firstChild.textContent);

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -225,8 +225,6 @@
               cell.appendChild(barExtent);
             }
             barExtent.appendChild(bar);
-          } else {
-            console.log(cell)
           }
         }
 

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -5,6 +5,7 @@
     this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
     this._cells = this._cells.concat(this.nested_cells)
     this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
+    this.isCountyTable = d3.select(this).classed('county-table');
 
     this.setYear();
     this.update();
@@ -180,6 +181,7 @@
         offsetProperty = 'bottom';
       }
 
+      var that = this;
       cells.forEach(function(cell, i) {
         if (!cell) {
           console.warn('no cell @', i);
@@ -188,6 +190,7 @@
           console.warn('cell is child', i);
         }
 
+        var cellAlwaysEmpty = JSON.parse(cell.getAttribute('data-year-values'));
         var childCell = cell.querySelector('[data-value]');
 
         // TODO only do this if autolabel="true"?
@@ -201,9 +204,6 @@
             span.className = 'text';
             span.appendChild(text);
           }
-        } else {
-          var span = cell.appendChild(document.createElement('span'));
-          span.className = 'text';
         }
 
 
@@ -218,9 +218,15 @@
           bar = document.createElement('div');
           bar.className = 'bar';
           var span = cell.querySelector('span');
-          if (span && barExtent && bar) {
-            cell.insertBefore(barExtent,span);
+          if (barExtent && bar) {
+            if (span) {
+              cell.insertBefore(barExtent,span);
+            } else if (that.isCountyTable && cellAlwaysEmpty) {
+              cell.appendChild(barExtent);
+            }
             barExtent.appendChild(bar);
+          } else {
+            console.log(cell)
           }
         }
 

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -190,7 +190,7 @@
           console.warn('cell is child', i);
         }
 
-        var cellAlwaysEmpty = JSON.parse(cell.getAttribute('data-year-values'));
+        var cellAlwaysEmpty = cell.getAttribute('data-year-values') === 'null';
         var childCell = cell.querySelector('[data-value]');
 
         // TODO only do this if autolabel="true"?
@@ -221,7 +221,7 @@
           if (barExtent && bar) {
             if (span) {
               cell.insertBefore(barExtent,span);
-            } else if (that.isCountyTable && cellAlwaysEmpty) {
+            } else if (that.isCountyTable && !cellAlwaysEmpty) {
               cell.appendChild(barExtent);
             }
             barExtent.appendChild(bar);

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -196,6 +196,8 @@
         var childCell = cell.querySelector('[data-value]');
 
         // TODO only do this if autolabel="true"?
+
+
         if (cell.childNodes.length === 1 && cell.firstChild.nodeType === Node.TEXT_NODE) {
           if (autolabel) {
             cell.setAttribute('aria-label', cell.firstChild.textContent);
@@ -206,6 +208,9 @@
             span.className = 'text';
             span.appendChild(text);
           }
+        } else {
+          var span = cell.appendChild(document.createElement('span'));
+          span.className = 'text';
         }
 
 

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -27,18 +27,47 @@
               return d;
             });
 
-          d3.select(this).select('figcaption [data-year]')
+          // update legend caption
+          d3.select(this).selectAll('figcaption [data-year]')
+            .attr('data-year', year)
             .text(year)
 
           this.update();
         }},
 
         update: {value: function() {
+
+          var noData = this.marks.data().every(function(d){
+            return d == 0;
+          });
+
+          var root = d3.select(this);
+
+          if (noData) {
+            root.select('.legend-no-data')
+              .attr('aria-hidden', false);
+            root.select('.legend-data')
+              .attr('aria-hidden', true);
+            root.select('.details-container')
+              .attr('aria-hidden', true);
+            root.select('.eiti-data-map-table')
+              .attr('aria-hidden', true);
+          } else {
+            root.select('.legend-no-data')
+              .attr('aria-hidden', true);
+            root.select('.legend-data')
+              .attr('aria-hidden', false);
+            root.select('.details-container')
+              .attr('aria-hidden', false);
+            root.select('.eiti-data-map-table')
+              .attr('aria-hidden', false);
+          }
+
           var type = this.getAttribute('scale-type') || 'quantize';
           var scheme = this.getAttribute('color-scheme') || 'Blues';
           var steps = this.getAttribute('steps') || 5;
           var units = this.getAttribute('units') || '';
-
+          var legendDelimiter = '–';
 
           var colors = colorbrewer[scheme][steps];
           if (!colors) {
@@ -56,6 +85,7 @@
           if (domain[0] > 0) {
             domain[0] = 0;
           } else if (domain[0] < 0) {
+            legendDelimiter = 'to';
             domain[1] = Math.max(0, domain[1]);
           }
 
@@ -98,7 +128,7 @@
               .labelFormat(format.si)
               .useClass(false)
               .ascending(true)
-              .labelDelimiter('–')
+              .labelDelimiter(legendDelimiter)
               .shapePadding(6)
               .scale(scale);
 

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -26,6 +26,10 @@
             .attr('data-value', function(d) {
               return d;
             });
+
+          d3.select(this).select('figcaption [data-year]')
+            .text(year)
+
           this.update();
         }},
 
@@ -90,22 +94,22 @@
 
           if (!svgLegend.empty()) {
 
-            var legendScale = svgLegend.select('.legendScale');
-
-            if (legendScale.empty()) {
-              svgLegend.append('g')
-              .attr('class', 'legendScale');
-            }
-
             var legend = d3.legend.color()
               .labelFormat(format.si)
               .useClass(false)
               .ascending(true)
-              .labelDelimiter('-')
+              .labelDelimiter('–')
               .shapePadding(6)
               .scale(scale);
 
-            legendScale.call(legend);
+
+            if (svgLegend.select('.legendScale').empty()) {
+              svgLegend.append('g')
+                .attr('class', 'legendScale');
+            }
+
+            svgLegend.select('.legendScale')
+              .call(legend);
 
             // reverse because the scale is in ascending order
             var _steps = d3.range(0, 9).reverse();

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -87,9 +87,15 @@
           var svgLegend = d3.select(this)
             .select('.legend-svg');
 
+
           if (!svgLegend.empty()) {
-            svgLegend.append('g')
+
+            var legendScale = svgLegend.select('.legendScale');
+
+            if (legendScale.empty()) {
+              svgLegend.append('g')
               .attr('class', 'legendScale');
+            }
 
             var legend = d3.legend.color()
               .labelFormat(format.si)
@@ -99,8 +105,7 @@
               .shapePadding(6)
               .scale(scale);
 
-            svgLegend.select('.legendScale')
-              .call(legend);
+            legendScale.call(legend);
 
             // reverse because the scale is in ascending order
             var _steps = d3.range(0, 9).reverse();
@@ -120,10 +125,12 @@
                 cells[0][i].setAttribute('aria-hidden', true);
                 count++;
               } else  {
+
                 // trim spacing between swatches that are visible
                 var translateHeight = (i * cellHeight) - (count * cellHeight);
                 cells[0][i].setAttribute('transform',
                   'translate(0,' + translateHeight + ')');
+                cells[0][i].setAttribute('aria-hidden', false);
               }
             });
             // end consolidation

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -49,17 +49,15 @@
             root.select('.legend-data')
               .attr('aria-hidden', true);
             root.select('.details-container')
-              .attr('aria-hidden', true);
-            root.select('.eiti-data-map-table')
-              .attr('aria-hidden', true);
+              .attr('aria-hidden', true)
+              .select('button')
+                .attr('aria-expanded', false); // unexpand county-chart
           } else {
             root.select('.legend-no-data')
               .attr('aria-hidden', true);
             root.select('.legend-data')
               .attr('aria-hidden', false);
             root.select('.details-container')
-              .attr('aria-hidden', false);
-            root.select('.eiti-data-map-table')
               .attr('aria-hidden', false);
           }
 

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -131,13 +131,13 @@
               .scale(scale);
 
 
-            if (svgLegend.select('.legendScale').empty()) {
-              svgLegend.append('g')
+            var legendScale = svgLegend.select('.legendScale');
+            if (legendScale.empty()) {
+              legendScale = svgLegend.append('g')
                 .attr('class', 'legendScale');
             }
 
-            svgLegend.select('.legendScale')
-              .call(legend);
+            legendScale.call(legend);
 
             // reverse because the scale is in ascending order
             var _steps = d3.range(0, 9).reverse();

--- a/js/components/year-switcher-section.js
+++ b/js/components/year-switcher-section.js
@@ -18,7 +18,6 @@
       });
       select.property('value', year);
       chartTables.each(function(){
-        console.log(this)
         this.setYear(year);
         this.update();
       })

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11058,6 +11058,18 @@
 	    target.setAttribute(HIDDEN, !expanded);
 	  };
 
+	  var collapse = function(button) {
+	    var target = document.getElementById(button.getAttribute(CONTROLS));
+	    button.setAttribute(EXPANDED, false);
+	    target.setAttribute(HIDDEN, true);
+	  }
+
+	  var expand = function(button) {
+	    var target = document.getElementById(button.getAttribute(CONTROLS));
+	    button.setAttribute(EXPANDED, true);
+	    target.setAttribute(HIDDEN, false);
+	  }
+
 	  var click = function(event) {
 	    toggle(event.target);
 	  };
@@ -11076,7 +11088,30 @@
 
 	        detachedCallback: {value: function() {
 	          this.removeEventListener('click', click);
-	        }}
+	        }},
+
+	        attributeChangedCallback: {value: function(attr, old, value) {
+	          value = JSON.parse(value);
+	          switch (attr) {
+	            case 'aria-expanded':
+	              if (value === false) {
+	                collapse(this);
+	              } else if (value === true) {
+	                expand(this);
+	              }
+	          }
+	        }},
+
+	        'aria-expanded': {
+	          get: function() {
+	            return this.getAttribute('aria-expanded');
+	          },
+	          set: function(value) {
+	            if (value !== this['aria-expanded']) {
+	              this.setAttribute('aria-expanded', value);
+	            }
+	          }
+	        }
 	      }
 	    )
 	  });
@@ -11139,17 +11174,15 @@
 	            root.select('.legend-data')
 	              .attr('aria-hidden', true);
 	            root.select('.details-container')
-	              .attr('aria-hidden', true);
-	            root.select('.eiti-data-map-table')
-	              .attr('aria-hidden', true);
+	              .attr('aria-hidden', true)
+	              .select('button')
+	                .attr('aria-expanded', false); // unexpand county-chart
 	          } else {
 	            root.select('.legend-no-data')
 	              .attr('aria-hidden', true);
 	            root.select('.legend-data')
 	              .attr('aria-hidden', false);
 	            root.select('.details-container')
-	              .attr('aria-hidden', false);
-	            root.select('.eiti-data-map-table')
 	              .attr('aria-hidden', false);
 	          }
 
@@ -12071,6 +12104,7 @@
 	    this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
 	    this._cells = this._cells.concat(this.nested_cells)
 	    this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
+	    this.isCountyTable = d3.select(this).classed('county-table');
 
 	    this.setYear();
 	    this.update();
@@ -12246,6 +12280,7 @@
 	        offsetProperty = 'bottom';
 	      }
 
+	      var that = this;
 	      cells.forEach(function(cell, i) {
 	        if (!cell) {
 	          console.warn('no cell @', i);
@@ -12254,6 +12289,7 @@
 	          console.warn('cell is child', i);
 	        }
 
+	        var cellAlwaysEmpty = JSON.parse(cell.getAttribute('data-year-values'));
 	        var childCell = cell.querySelector('[data-value]');
 
 	        // TODO only do this if autolabel="true"?
@@ -12267,9 +12303,6 @@
 	            span.className = 'text';
 	            span.appendChild(text);
 	          }
-	        } else {
-	          var span = cell.appendChild(document.createElement('span'));
-	          span.className = 'text';
 	        }
 
 
@@ -12284,9 +12317,15 @@
 	          bar = document.createElement('div');
 	          bar.className = 'bar';
 	          var span = cell.querySelector('span');
-	          if (span && barExtent && bar) {
-	            cell.insertBefore(barExtent,span);
+	          if (barExtent && bar) {
+	            if (span) {
+	              cell.insertBefore(barExtent,span);
+	            } else if (that.isCountyTable && cellAlwaysEmpty) {
+	              cell.appendChild(barExtent);
+	            }
 	            barExtent.appendChild(bar);
+	          } else {
+	            console.log(cell)
 	          }
 	        }
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11091,12 +11091,11 @@
 	        }},
 
 	        attributeChangedCallback: {value: function(attr, old, value) {
-	          value = JSON.parse(value);
 	          switch (attr) {
 	            case 'aria-expanded':
-	              if (value === false) {
+	              if (value === 'false') {
 	                collapse(this);
-	              } else if (value === true) {
+	              } else if (value === 'true') {
 	                expand(this);
 	              }
 	          }
@@ -11245,13 +11244,13 @@
 	              .scale(scale);
 
 
-	            if (svgLegend.select('.legendScale').empty()) {
-	              svgLegend.append('g')
+	            var legendScale = svgLegend.select('.legendScale');
+	            if (legendScale.empty()) {
+	              legendScale = svgLegend.append('g')
 	                .attr('class', 'legendScale');
 	            }
 
-	            svgLegend.select('.legendScale')
-	              .call(legend);
+	            legendScale.call(legend);
 
 	            // reverse because the scale is in ascending order
 	            var _steps = d3.range(0, 9).reverse();
@@ -12278,7 +12277,7 @@
 	          console.warn('cell is child', i);
 	        }
 
-	        var cellAlwaysEmpty = JSON.parse(cell.getAttribute('data-year-values'));
+	        var cellAlwaysEmpty = cell.getAttribute('data-year-values') === 'null';
 	        var childCell = cell.querySelector('[data-value]');
 
 	        // TODO only do this if autolabel="true"?
@@ -12309,7 +12308,7 @@
 	          if (barExtent && bar) {
 	            if (span) {
 	              cell.insertBefore(barExtent,span);
-	            } else if (that.isCountyTable && cellAlwaysEmpty) {
+	            } else if (that.isCountyTable && !cellAlwaysEmpty) {
 	              cell.appendChild(barExtent);
 	            }
 	            barExtent.appendChild(bar);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11177,9 +11177,15 @@
 	          var svgLegend = d3.select(this)
 	            .select('.legend-svg');
 
+
 	          if (!svgLegend.empty()) {
-	            svgLegend.append('g')
+
+	            var legendScale = svgLegend.select('.legendScale');
+
+	            if (legendScale.empty()) {
+	              svgLegend.append('g')
 	              .attr('class', 'legendScale');
+	            }
 
 	            var legend = d3.legend.color()
 	              .labelFormat(format.si)
@@ -11189,8 +11195,7 @@
 	              .shapePadding(6)
 	              .scale(scale);
 
-	            svgLegend.select('.legendScale')
-	              .call(legend);
+	            legendScale.call(legend);
 
 	            // reverse because the scale is in ascending order
 	            var _steps = d3.range(0, 9).reverse();
@@ -11210,10 +11215,12 @@
 	                cells[0][i].setAttribute('aria-hidden', true);
 	                count++;
 	              } else  {
+
 	                // trim spacing between swatches that are visible
 	                var translateHeight = (i * cellHeight) - (count * cellHeight);
 	                cells[0][i].setAttribute('transform',
 	                  'translate(0,' + translateHeight + ')');
+	                cells[0][i].setAttribute('aria-hidden', false);
 	              }
 	            });
 	            // end consolidation

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12144,6 +12144,12 @@
 
 	    this._cells.forEach(function(cell) {
 	      var key = cell.dataset.series || 'default';
+
+	      if (key === 'volume' && +cell.getAttribute('data-year-values')) {
+	        console.log(series, key, cell)
+	      }
+
+
 	      if (key in series) {
 	        series[key].push(cell);
 	      } else {
@@ -12245,6 +12251,8 @@
 	          }
 	        }
 
+
+
 	        if (childCell) {
 	          var childBar = document.createElement('div');
 	          childBar.className = 'bar';
@@ -12253,6 +12261,12 @@
 
 	        var value = +cell.dataset.value;
 	        var size = width(value);
+
+	        // if (+cell.dataset.yearValues) {
+	        //   console.log('bar:', bar)
+	        //   console.log('-----------')
+
+	        // }
 
 	        if (childCell) {
 	          var childValue = +childCell.dataset.value;
@@ -12264,6 +12278,12 @@
 	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
 	          childBar.style.setProperty(sizeProperty, Math.abs(largerSize) + '%');
 	        } else {
+	          if (!size) {
+	            console.log(size)
+	          } else {
+
+	          }
+
 	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
 	        }
 
@@ -12636,7 +12656,6 @@
 	      });
 	      select.property('value', year);
 	      chartTables.each(function(){
-	        console.log(this)
 	        this.setYear(year);
 	        this.update();
 	      })

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11116,6 +11116,10 @@
 	            .attr('data-value', function(d) {
 	              return d;
 	            });
+
+	          d3.select(this).select('figcaption [data-year]')
+	            .text(year)
+
 	          this.update();
 	        }},
 
@@ -11180,22 +11184,22 @@
 
 	          if (!svgLegend.empty()) {
 
-	            var legendScale = svgLegend.select('.legendScale');
-
-	            if (legendScale.empty()) {
-	              svgLegend.append('g')
-	              .attr('class', 'legendScale');
-	            }
-
 	            var legend = d3.legend.color()
 	              .labelFormat(format.si)
 	              .useClass(false)
 	              .ascending(true)
-	              .labelDelimiter('-')
+	              .labelDelimiter('–')
 	              .shapePadding(6)
 	              .scale(scale);
 
-	            legendScale.call(legend);
+
+	            if (svgLegend.select('.legendScale').empty()) {
+	              svgLegend.append('g')
+	                .attr('class', 'legendScale');
+	            }
+
+	            svgLegend.select('.legendScale')
+	              .call(legend);
 
 	            // reverse because the scale is in ascending order
 	            var _steps = d3.range(0, 9).reverse();
@@ -12228,6 +12232,8 @@
 	        var childCell = cell.querySelector('[data-value]');
 
 	        // TODO only do this if autolabel="true"?
+
+
 	        if (cell.childNodes.length === 1 && cell.firstChild.nodeType === Node.TEXT_NODE) {
 	          if (autolabel) {
 	            cell.setAttribute('aria-label', cell.firstChild.textContent);
@@ -12238,6 +12244,9 @@
 	            span.className = 'text';
 	            span.appendChild(text);
 	          }
+	        } else {
+	          var span = cell.appendChild(document.createElement('span'));
+	          span.className = 'text';
 	        }
 
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11100,18 +11100,7 @@
 	                expand(this);
 	              }
 	          }
-	        }},
-
-	        'aria-expanded': {
-	          get: function() {
-	            return this.getAttribute('aria-expanded');
-	          },
-	          set: function(value) {
-	            if (value !== this['aria-expanded']) {
-	              this.setAttribute('aria-expanded', value);
-	            }
-	          }
-	        }
+	        }}
 	      }
 	    )
 	  });

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12324,8 +12324,6 @@
 	              cell.appendChild(barExtent);
 	            }
 	            barExtent.appendChild(bar);
-	          } else {
-	            console.log(cell)
 	          }
 	        }
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12257,8 +12257,6 @@
 	        var childCell = cell.querySelector('[data-value]');
 
 	        // TODO only do this if autolabel="true"?
-
-
 	        if (cell.childNodes.length === 1 && cell.firstChild.nodeType === Node.TEXT_NODE) {
 	          if (autolabel) {
 	            cell.setAttribute('aria-label', cell.firstChild.textContent);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11117,18 +11117,47 @@
 	              return d;
 	            });
 
-	          d3.select(this).select('figcaption [data-year]')
+	          // update legend caption
+	          d3.select(this).selectAll('figcaption [data-year]')
+	            .attr('data-year', year)
 	            .text(year)
 
 	          this.update();
 	        }},
 
 	        update: {value: function() {
+
+	          var noData = this.marks.data().every(function(d){
+	            return d == 0;
+	          });
+
+	          var root = d3.select(this);
+
+	          if (noData) {
+	            root.select('.legend-no-data')
+	              .attr('aria-hidden', false);
+	            root.select('.legend-data')
+	              .attr('aria-hidden', true);
+	            root.select('.details-container')
+	              .attr('aria-hidden', true);
+	            root.select('.eiti-data-map-table')
+	              .attr('aria-hidden', true);
+	          } else {
+	            root.select('.legend-no-data')
+	              .attr('aria-hidden', true);
+	            root.select('.legend-data')
+	              .attr('aria-hidden', false);
+	            root.select('.details-container')
+	              .attr('aria-hidden', false);
+	            root.select('.eiti-data-map-table')
+	              .attr('aria-hidden', false);
+	          }
+
 	          var type = this.getAttribute('scale-type') || 'quantize';
 	          var scheme = this.getAttribute('color-scheme') || 'Blues';
 	          var steps = this.getAttribute('steps') || 5;
 	          var units = this.getAttribute('units') || '';
-
+	          var legendDelimiter = '–';
 
 	          var colors = colorbrewer[scheme][steps];
 	          if (!colors) {
@@ -11146,6 +11175,7 @@
 	          if (domain[0] > 0) {
 	            domain[0] = 0;
 	          } else if (domain[0] < 0) {
+	            legendDelimiter = 'to';
 	            domain[1] = Math.max(0, domain[1]);
 	          }
 
@@ -11188,7 +11218,7 @@
 	              .labelFormat(format.si)
 	              .useClass(false)
 	              .ascending(true)
-	              .labelDelimiter('–')
+	              .labelDelimiter(legendDelimiter)
 	              .shapePadding(6)
 	              .scale(scale);
 
@@ -12156,11 +12186,6 @@
 	    this._cells.forEach(function(cell) {
 	      var key = cell.dataset.series || 'default';
 
-	      if (key === 'volume' && +cell.getAttribute('data-year-values')) {
-	        console.log(series, key, cell)
-	      }
-
-
 	      if (key in series) {
 	        series[key].push(cell);
 	      } else {
@@ -12267,8 +12292,6 @@
 	          }
 	        }
 
-
-
 	        if (childCell) {
 	          var childBar = document.createElement('div');
 	          childBar.className = 'bar';
@@ -12277,12 +12300,6 @@
 
 	        var value = +cell.dataset.value;
 	        var size = width(value);
-
-	        // if (+cell.dataset.yearValues) {
-	        //   console.log('bar:', bar)
-	        //   console.log('-----------')
-
-	        // }
 
 	        if (childCell) {
 	          var childValue = +childCell.dataset.value;
@@ -12294,12 +12311,6 @@
 	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
 	          childBar.style.setProperty(sizeProperty, Math.abs(largerSize) + '%');
 	        } else {
-	          if (!size) {
-	            console.log(size)
-	          } else {
-
-	          }
-
 	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
 	        }
 


### PR DESCRIPTION
For #1597 and #1626.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/remaining-chart-issues/states/UT/)

Changes proposed in this pull request:

- chart and map legends update year
- chart and map legends include units
- map description displays "no data text"
- map legend adjusts without gaps in scaling
- county chart table closes when a year has no data
- change delimiter to `to` from `-` in instances where there are negative values
- when years don't have values on 2013, map and chart values for other years still populate when the year is updated


/cc @meiqimichelle @coreycaitlin @shawnbot 
