### PR TITLE
Fix collection default layouts in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,23 +81,16 @@ collections:
 defaults:
   - scope:
       path: ''
-      collection: company-data
+      type: federal-revenue-by-company
     values:
       layout: federal-revenue-by-company
 
   - scope:
       path: ''
-      collection: states
+      type: states
     values:
       layout: state-page
       offshore: false
-
-  - scope:
-      path: ''
-      collection: offshore_regions
-    values:
-      layout: state-page
-      offshore: true
 
 shruggie:
   - d8394cf27efbf8ae2f96ee12788eb257f4358a42


### PR DESCRIPTION
Fixes issue(s) #1640 by updating the Jekyll config with the correct [collection defaults](https://jekyllrb.com/docs/collections/).

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-collection-layouts/explore/federal-revenue-by-company/2015/)

Changes proposed in this pull request:

* Specifies collection scopes in `defaults[n].scope.type` instead of `defaults[n].scope.collection`
* Fixes an incorrect layout specified in the `federal-revenue-by-company` collection: was `company-data`.


/cc @gemfarmer @coreycaitlin 

