### PR TITLE
Legends handle wide maps

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,9 +70,9 @@ collections:
     output: true
     permalink: /how-it-works/:path/
   offshore_areas:
-    output: false
+    output: true
   offshore_regions:
-    output: false
+    output: true
     permalink: /offshore/:path/
   states:
     output: true
@@ -90,7 +90,12 @@ defaults:
       type: states
     values:
       layout: state-page
-      offshore: false
+
+  - scope:
+      path: ''
+      type: offshore_regions
+    values:
+      layout: offshore-region
 
 shruggie:
   - d8394cf27efbf8ae2f96ee12788eb257f4358a42

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -13,7 +13,17 @@
   {% endcapture %}
 {% endif %}
 
-<div class="svg-container county map-container"{% if _viewbox %}
+{% if _viewbox %}
+  {% assign _viewbox_list = _viewbox | split:' ' | to_f %}
+  {% assign breakpoint_width = _viewbox_list[2] %}
+  {% assign breakpoint_height = _viewbox_list[3] | times:1.5 %}
+  {% capture is_wide %}
+    {% if breakpoint_width > breakpoint_height %}wide{% endif %}
+  {% endcapture %}
+  {% assign is_wide = is_wide | strip %}
+{% endif %}
+
+<div class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }}; padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _viewbox | svg_viewbox_padding: _width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
@@ -78,7 +88,7 @@
   {% endif %}
 </div>
 
-<div class="legend-container">
+<div class="legend-container {{ is_wide }}">
   {% if include.caption %}
     <figcaption class="legend-data">
       {{ include.caption }}
@@ -90,4 +100,15 @@
   {% endif %}
 
   <svg class="legend-svg"></svg>
+
+  {% if include.toggle %}
+    <h4 class="details-container">
+      <button is="aria-toggle"
+        aria-controls="{{ include.toggle }}">&plus;
+        {% if include.toggle_text %}
+          {{ include.toggle_text}}
+        {% else %}Show table{% endif %}
+      </button>
+    </h4>
+  {% endif %}
 </div>

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -79,7 +79,8 @@
   {% if include.toggle %}
     <h4 class="details-container">
       <button is="aria-toggle"
-        aria-controls="{{ include.toggle }}">&plus;
+        aria-controls="{{ include.toggle }}">
+        <i class="icon icon-plus-sm"></i>
         {% if include.toggle_text %}
           {{ include.toggle_text}}
         {% else %}Show table{% endif %}
@@ -104,7 +105,8 @@
   {% if include.toggle %}
     <h4 class="details-container">
       <button is="aria-toggle"
-        aria-controls="{{ include.toggle }}">&plus;
+        aria-controls="{{ include.toggle }}">
+        <i class="icon icon-plus-sm"></i>
         {% if include.toggle_text %}
           {{ include.toggle_text}}
         {% else %}Show table{% endif %}

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -7,14 +7,13 @@
 {% endif %}
 
 
-<label>{{ caption }}</label>
 <table is='bar-chart-table'
        data-percent-max='100'
        class="county-table">
   <thead>
     <tr>
-      <th>Locality</th>
-      <th colspans="2" class='numeric' data-series='volume'>{{ units | capitalize }}</th>
+      <th>{{ locality_name }}</th>
+      <th colspan="2" class='numeric' data-series='volume'>{{ units | capitalize }} of {{ product_name | downcase | suffix:units_suffix }}</th>
     </tr>
   </thead>
   <tbody>

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -1,11 +1,10 @@
 {% assign caption = include.caption %}
 
-<label>{{ caption }}</label>
 <table is="bar-chart-table" data-percent-max="100" class="county-table">
   <thead>
     <tr>
-      <th>Locality</th>
-      <th colspans="2" class="numeric" data-series="volume">Revenue</th>
+      <th>{{ locality_name }}</th>
+      <th colspan="2" class="numeric" data-series="volume">Revenue</th>
     </tr>
   </thead>
   <tbody>

--- a/_includes/location/display-jobs-county.html
+++ b/_includes/location/display-jobs-county.html
@@ -1,12 +1,11 @@
 {% assign caption = include.caption %}
 
-<label>{{ caption }}</label>
 <table is='bar-chart-table' data-percent-max='100' class="county-table">
   <thead>
     <tr>
-      <th>Locality</th>
-      <th colspans="2" class='numeric' data-series='jobs'>Jobs</th>
-      <th class='numeric' data-series='percent'>Percent</th>
+      <th>{{ locality_name }}</th>
+      <th colspan="2" class='numeric' data-series='jobs'>Extracives jobs</th>
+      <th class='numeric' data-series='percent'>% of all jobs in {{ locality_name | downcase }}</th>
     </tr>
   </thead>
   <tbody>
@@ -32,7 +31,8 @@
       <td data-value-text='{{ jobs_percent }}'
           data-year-values='{{ years_values | jsonify }}'
           data-years-property='percent'
-          data-format='%'>{{ jobs_percent }}%</td>
+          data-format='%'
+          class="numeric">{{ jobs_percent }}%</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/_includes/location/display-jobs-county.html
+++ b/_includes/location/display-jobs-county.html
@@ -6,7 +6,7 @@
     <tr>
       <th>Locality</th>
       <th colspans="2" class='numeric' data-series='jobs'>Jobs</th>
-      <th class='numeric' data-series='percent'>Locality %</th>
+      <th class='numeric' data-series='percent'>Percent</th>
     </tr>
   </thead>
   <tbody>

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -45,20 +45,6 @@
           data-units="{{ long_units }}">
         </eiti-bar-chart>
       </figure>
-      <!-- <h4>
-        <button is="aria-toggle"
-          aria-controls="all-production-detail-{{ product_slug }}">&plus; Historical details</button>
-      </h4>
-      <div id="all-production-detail-{{ product_slug }}" aria-hidden="true">
-        {%
-          include location/display-production.html
-          units=units
-          year=year
-          values=production_values
-          percent=false
-          rank=false
-        %}
-      </div> -->
     </section>
   {% endfor %}
 

--- a/_includes/location/national-exports.html
+++ b/_includes/location/national-exports.html
@@ -46,20 +46,6 @@
             </eiti-bar-chart>
 
           </figure>
-
-        <!--   <h4>
-            <button is="aria-toggle" aria-controls="exports-detail-{{ commodity_slug }}">
-              &plus; Details
-            </button>
-          </h4>
-          <div id="exports-detail-{{ commodity_slug }}" aria-hidden="true">
-            {%
-              include location/display-exports.html
-              values=exports
-              percent=false
-            %}
-          </div> -->
-
         </section><!-- /.chart-item -->
       {% endif %}
     {% endfor %}

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -55,22 +55,6 @@
 
       </figure>
 
-      {% if forloop.last %}
-      <!-- <h4>
-        <button is="aria-toggle" aria-controls="gdp-detail-{{ _metric }}">
-          &plus; Details
-        </button>
-      </h4>
-      <div id="gdp-detail-{{ _metric }}" aria-hidden="true">
-        {%
-          include location/display-gdp.html
-          values=gdp
-          percent=true
-        %}
-      </div> -->
-      <!-- /#gdp-years -->
-      {% endif %}
-
     </section><!-- /.chart-item -->
     {% endfor %}
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -77,7 +77,7 @@
           <div class="map-container">
 
             <h4 class="chart-title">
-              <span>Local production</span>
+              {{ locality_name }} production
             </h4>
 
 
@@ -86,7 +86,9 @@
               {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
               {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
               {% assign _width ='inherit' %}
-              {% capture caption %}Local production of {{ product_name | downcase | suffix:units_suffix }} in <span data-year="{{ year }}">{{ year }}</span>{% if units %} <span class="legend-units">({{ short_units | default:units }})</span>{% endif %}{% endcapture %}
+
+              {% capture caption %}{{ locality_name }} production of {{ product_name | downcase | suffix:units_suffix }} in <span data-year="{{ year }}">{{ year }}</span>{% if units %} <span class="legend-units">({{ short_units | default:units }})</span>{% endif %}{% endcapture %}
+
 
               <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
                 {% assign federal_county_production = site.data.federal_county_production[state_id] %}

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -81,13 +81,14 @@
         <div class="map-container">
 
           <h4 class="chart-title">
-            <span>Local wage and salary jobs</span>
+            {{ locality_name }} wage and salary jobs
           </h4>
 
           <figure class="container">
             <eiti-data-map color-scheme="Reds" steps="{{ steps }}">
               {% capture value_key %}employment.{{ year }}.count{% endcapture %}
-              {% capture caption %}Local employment in extractive industries <span class="legend-units">(jobs, <span data-year="{{ year }}">{{ year }}</span>)</span>{% endcapture %}
+
+              {% capture caption %}{{ locality_name }} employment in extractive industries <span class="legend-units">(jobs, <span data-year="{{ year }}">{{ year }}</span>)</span>{% endcapture %}
 
               {%
                 include county-map.html

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -17,7 +17,18 @@
   <aside class="map-container">
     <figure>
       {% assign _viewbox = site.data.viewboxes[state_id] %}
-      <div class="svg-container county map-container"{% if _viewbox %}
+      {% assign _viewbox_list = _viewbox | split:' ' | to_f %}
+      {% assign breakpoint_width = _viewbox_list[2] %}
+      {% assign breakpoint_height = _viewbox_list[3] | times:1.5 %}
+      {% capture is_wide %}
+        {% if breakpoint_width > breakpoint_height %}wide{% endif %}
+      {% endcapture %}
+
+      {% assign is_wide = is_wide | strip %}
+
+
+
+      <div class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
         style="padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %}>
         <svg class="county ownership map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
           <g class="states features">
@@ -46,8 +57,8 @@
       </div>
 
     </figure>
-    <aside class="legend-container">
-      {% include maps/federal_land_ownership_legend.svg %}
+    <aside class="legend-container {{ is_wide }}">
+      {% include maps/federal_land_ownership_legend.svg is_wide=is_wide %}
     </aside>
 
 

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -23,10 +23,7 @@
       {% capture is_wide %}
         {% if breakpoint_width > breakpoint_height %}wide{% endif %}
       {% endcapture %}
-
       {% assign is_wide = is_wide | strip %}
-
-
 
       <div class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
         style="padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %}>
@@ -51,16 +48,12 @@
             <use xlink:href="{{ states_svg }}#state-{{ state_id }}"></use>
           </g>
         </svg>
-
-
-
       </div>
 
     </figure>
     <aside class="legend-container {{ is_wide }}">
       {% include maps/federal_land_ownership_legend.svg is_wide=is_wide %}
     </aside>
-
 
   </aside>
 </section>

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -45,7 +45,7 @@
     <div class="map-container">
 
       <h4 class="chart-title">
-        <span>Revenue collected by locality</span>
+        <span>Revenue collected by {{ locality_name }}</span>
       </h4>
 
 
@@ -54,7 +54,7 @@
         {% capture value_key %}revenue.{{ year }}{% endcapture %}
         {% capture years_key %}revenue{% endcapture %}
         {% assign _width ='inherit' %}
-        {% capture caption %}Local revenue in <span data-year="{{ year }}">{{ year }}</span>{% endcapture %}
+        {% capture caption %}{{ locality_name }} revenue in <span data-year="{{ year }}">{{ year }}</span>{% endcapture %}
 
         <eiti-data-map color-scheme="Reds" steps="{{ steps }}" units="{{ units }}" format="$">
 

--- a/_includes/maps/federal_land_ownership_legend.svg
+++ b/_includes/maps/federal_land_ownership_legend.svg
@@ -1,45 +1,45 @@
 {% assign cell_padding = include.cell_padding | default:6 %}
 
 <svg class="legend-ownership-svg">
-	<g class="legendQuant">
-		<g class="legendCells">
-			{% if include.is_wide == 'wide' %}
-				<g class="cell federal" transform="translate(0,0)" style="opacity: 1;">
-					<rect class="swatch" height="12" width="100"></rect>
-					<rect class="swatch" height="12" width="100"></rect>
-					<text class="label"
-						    transform="translate(50,27)"
-						    style="font-size: 12px; text-anchor:middle;">Federally owned</text>
-				</g>
-				<g class="cell state" transform="translate({{ cell_padding | plus: 100 }}, 0)" style="opacity: 1;">
-					<rect class="swatch" height="12" width="100"></rect>
-					<rect class="swatch" height="12" width="100"></rect>
-					<text class="label"
-						    transform="translate(50,27)"
-						    style="font-size: 12px; text-anchor:middle;">State owned</text>
-				</g>
-				<g class="cell" transform="translate({{ cell_padding | times: 2 | plus: 200 }}, 0)" style="opacity: 1;">
-					<rect class="swatch" height="12" width="100"></rect>
-					<text class="label"
-						    transform="translate(50,27)"
-						    style="font-size: 12px; text-anchor:middle;">Private</text>
-				</g>
-			{% else %}
-				<g class="cell federal" transform="translate(0,0)" style="opacity: 1;">
-					<rect class="swatch" height="15" width="15"></rect>
-					<rect class="swatch" height="15" width="15"></rect>
-					<text class="label" transform="translate(25,12.5)">Federally owned</text>
-				</g>
-				<g class="cell state" transform="translate(0, {{ cell_padding | plus: 15 }})" style="opacity: 1;">
-					<rect class="swatch" height="15" width="15"></rect>
-					<rect class="swatch" height="15" width="15"></rect>
-					<text class="label" transform="translate(25,12.5)">State owned</text>
-				</g>
-				<g class="cell" transform="translate(0, {{ cell_padding | times: 2 | plus: 30 }})" style="opacity: 1;">
-					<rect class="swatch" height="15" width="15"></rect>
-					<text class="label" transform="translate(25,12.5)">Private</text>
-				</g>
-			{% endif %}
-		</g>
-	</g>
+  <g class="legendQuant">
+    <g class="legendCells">
+      {% if include.is_wide == 'wide' %}
+        <g class="cell federal" transform="translate(0,0)" style="opacity: 1;">
+          <rect class="swatch" height="12" width="100"></rect>
+          <rect class="swatch" height="12" width="100"></rect>
+          <text class="label"
+                transform="translate(50,27)"
+                style="font-size: 12px; text-anchor:middle;">Federally owned</text>
+        </g>
+        <g class="cell state" transform="translate({{ cell_padding | plus: 100 }}, 0)" style="opacity: 1;">
+          <rect class="swatch" height="12" width="100"></rect>
+          <rect class="swatch" height="12" width="100"></rect>
+          <text class="label"
+                transform="translate(50,27)"
+                style="font-size: 12px; text-anchor:middle;">State owned</text>
+        </g>
+        <g class="cell" transform="translate({{ cell_padding | times: 2 | plus: 200 }}, 0)" style="opacity: 1;">
+          <rect class="swatch" height="12" width="100"></rect>
+          <text class="label"
+                transform="translate(50,27)"
+                style="font-size: 12px; text-anchor:middle;">Private</text>
+        </g>
+      {% else %}
+        <g class="cell federal" transform="translate(0,0)" style="opacity: 1;">
+          <rect class="swatch" height="15" width="15"></rect>
+          <rect class="swatch" height="15" width="15"></rect>
+          <text class="label" transform="translate(25,12.5)">Federally owned</text>
+        </g>
+        <g class="cell state" transform="translate(0, {{ cell_padding | plus: 15 }})" style="opacity: 1;">
+          <rect class="swatch" height="15" width="15"></rect>
+          <rect class="swatch" height="15" width="15"></rect>
+          <text class="label" transform="translate(25,12.5)">State owned</text>
+        </g>
+        <g class="cell" transform="translate(0, {{ cell_padding | times: 2 | plus: 30 }})" style="opacity: 1;">
+          <rect class="swatch" height="15" width="15"></rect>
+          <text class="label" transform="translate(25,12.5)">Private</text>
+        </g>
+      {% endif %}
+    </g>
+  </g>
 </svg>

--- a/_includes/maps/federal_land_ownership_legend.svg
+++ b/_includes/maps/federal_land_ownership_legend.svg
@@ -3,20 +3,43 @@
 <svg class="legend-ownership-svg">
 	<g class="legendQuant">
 		<g class="legendCells">
-			<g class="cell federal" transform="translate(0,0)" style="opacity: 1;">
-				<rect class="swatch" height="15" width="15"></rect>
-				<rect class="swatch" height="15" width="15"></rect>
-				<text class="label" transform="translate(25,12.5)">Federally owned</text>
-			</g>
-			<g class="cell state" transform="translate(0, {{ cell_padding | plus: 15 }})" style="opacity: 1;">
-				<rect class="swatch" height="15" width="15"></rect>
-				<rect class="swatch" height="15" width="15"></rect>
-				<text class="label" transform="translate(25,12.5)">Indian lands</text>
-			</g>
-			<g class="cell" transform="translate(0, {{ cell_padding | times: 2 | plus: 30 }})" style="opacity: 1;">
-				<rect class="swatch" height="15" width="15"></rect>
-				<text class="label" transform="translate(25,12.5)">Private</text>
-			</g>
+			{% if include.is_wide == 'wide' %}
+				<g class="cell federal" transform="translate(0,0)" style="opacity: 1;">
+					<rect class="swatch" height="12" width="100"></rect>
+					<rect class="swatch" height="12" width="100"></rect>
+					<text class="label"
+						    transform="translate(50,27)"
+						    style="font-size: 12px; text-anchor:middle;">Federally owned</text>
+				</g>
+				<g class="cell state" transform="translate({{ cell_padding | plus: 100 }}, 0)" style="opacity: 1;">
+					<rect class="swatch" height="12" width="100"></rect>
+					<rect class="swatch" height="12" width="100"></rect>
+					<text class="label"
+						    transform="translate(50,27)"
+						    style="font-size: 12px; text-anchor:middle;">State owned</text>
+				</g>
+				<g class="cell" transform="translate({{ cell_padding | times: 2 | plus: 200 }}, 0)" style="opacity: 1;">
+					<rect class="swatch" height="12" width="100"></rect>
+					<text class="label"
+						    transform="translate(50,27)"
+						    style="font-size: 12px; text-anchor:middle;">Private</text>
+				</g>
+			{% else %}
+				<g class="cell federal" transform="translate(0,0)" style="opacity: 1;">
+					<rect class="swatch" height="15" width="15"></rect>
+					<rect class="swatch" height="15" width="15"></rect>
+					<text class="label" transform="translate(25,12.5)">Federally owned</text>
+				</g>
+				<g class="cell state" transform="translate(0, {{ cell_padding | plus: 15 }})" style="opacity: 1;">
+					<rect class="swatch" height="15" width="15"></rect>
+					<rect class="swatch" height="15" width="15"></rect>
+					<text class="label" transform="translate(25,12.5)">State owned</text>
+				</g>
+				<g class="cell" transform="translate(0, {{ cell_padding | times: 2 | plus: 30 }})" style="opacity: 1;">
+					<rect class="swatch" height="15" width="15"></rect>
+					<text class="label" transform="translate(25,12.5)">Private</text>
+				</g>
+			{% endif %}
 		</g>
 	</g>
 </svg>

--- a/_includes/maps/federal_land_ownership_legend.svg
+++ b/_includes/maps/federal_land_ownership_legend.svg
@@ -8,21 +8,18 @@
           <rect class="swatch" height="12" width="100"></rect>
           <rect class="swatch" height="12" width="100"></rect>
           <text class="label"
-                transform="translate(50,27)"
-                style="font-size: 12px; text-anchor:middle;">Federally owned</text>
+                transform="translate(50,27)">Federally owned</text>
         </g>
         <g class="cell state" transform="translate({{ cell_padding | plus: 100 }}, 0)" style="opacity: 1;">
           <rect class="swatch" height="12" width="100"></rect>
           <rect class="swatch" height="12" width="100"></rect>
           <text class="label"
-                transform="translate(50,27)"
-                style="font-size: 12px; text-anchor:middle;">State owned</text>
+                transform="translate(50,27)">State owned</text>
         </g>
         <g class="cell" transform="translate({{ cell_padding | times: 2 | plus: 200 }}, 0)" style="opacity: 1;">
           <rect class="swatch" height="12" width="100"></rect>
           <text class="label"
-                transform="translate(50,27)"
-                style="font-size: 12px; text-anchor:middle;">Private</text>
+                transform="translate(50,27)">Private</text>
         </g>
       {% else %}
         <g class="cell federal" transform="translate(0,0)" style="opacity: 1;">

--- a/_includes/maps/federal_land_ownership_legend.svg
+++ b/_includes/maps/federal_land_ownership_legend.svg
@@ -8,18 +8,18 @@
           <rect class="swatch" height="12" width="100"></rect>
           <rect class="swatch" height="12" width="100"></rect>
           <text class="label"
-                transform="translate(50,27)">Federally owned</text>
+                transform="translate(0,27)">Federally owned</text>
         </g>
         <g class="cell state" transform="translate({{ cell_padding | plus: 100 }}, 0)" style="opacity: 1;">
           <rect class="swatch" height="12" width="100"></rect>
           <rect class="swatch" height="12" width="100"></rect>
           <text class="label"
-                transform="translate(50,27)">State owned</text>
+                transform="translate(0,27)">State owned</text>
         </g>
         <g class="cell" transform="translate({{ cell_padding | times: 2 | plus: 200 }}, 0)" style="opacity: 1;">
           <rect class="swatch" height="12" width="100"></rect>
           <text class="label"
-                transform="translate(50,27)">Private</text>
+                transform="translate(0,27)">Private</text>
         </g>
       {% else %}
         <g class="cell federal" transform="translate(0,0)" style="opacity: 1;">

--- a/_includes/year-selector.html
+++ b/_includes/year-selector.html
@@ -15,7 +15,7 @@
       {% assign s_year = _year | to_s %}
       {% if include.empty_years.size > 0 %}
         {% if empty_years contains s_year %}
-          <option disabled value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }} (no data)</option>
+          <option disabled value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }} no data</option>
         {% else %}
           <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
         {% endif %}

--- a/_layouts/offshore-region.html
+++ b/_layouts/offshore-region.html
@@ -1,0 +1,42 @@
+---
+layout: default
+---
+
+{% assign region_name = page.title %}
+{% assign region_id = page.id %}
+
+<main id="offshore-region-{{ region_id }}" class="container-outer layout-state-pages">
+  <div class="container-left-9">
+    <div>
+      <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore data</a>
+      /
+    </div>
+    <h1 id="title">{{ region_name }}</h1>
+
+  </div>
+
+  <div class="container-right-3">
+    <div class="sticky_nav" data-sticky-offset="50">
+      <h3 class="state-page-nav-title container">
+
+        <div class="nav-title">{{ region_name }}</div>
+        <figure is="data-map">
+
+          {%
+            include icon-map.html
+            state=region_id
+            highlighted_state=region_id
+            offshore=true
+          %}
+        </figure>
+        <label class="nav-prompt">Explore data main page</label>
+      </h3>
+      <nav class="sticky_nav-nav">
+        {% include case-studies/_nav-list.html %}
+      </nav>
+    </div>
+  </div>
+
+</main>
+
+<script src="{{ site.baseurl }}/js/lib/state-pages.min.js"></script>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -38,6 +38,7 @@ nav_items:
 
 {% assign state_name = page.title %}
 {% assign state_id = page.id %}
+{% assign locality_name = page.locality_name | default:'County' %}
 
 {% assign state_ref = page.id | upcase %}
 {% assign year = '2013' %}
@@ -56,6 +57,7 @@ nav_items:
 
 
 <main id="state-{{ state_id }}" class="container-outer layout-state-pages">
+<!-- {{ locality_name }} -->
   <div class="container-left-9">
     <div>
       <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore data</a>

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -181,10 +181,10 @@
 
       &.wide {
         @include span-columns(12);
-        height: 100px;
+        height: 130px;
+        padding: 0;
 
         .legend-svg {
-          height: 100%;
           width: 100%;
         }
       }

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -184,8 +184,8 @@
         height: 100px;
 
         .legend-svg {
-          width: 100%;
           height: 100%;
+          width: 100%;
         }
       }
     }

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -181,9 +181,11 @@
 
       &.wide {
         @include span-columns(12);
+        height: 100px;
 
         .legend-svg {
           width: 100%;
+          height: 100%;
         }
       }
     }

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -168,11 +168,24 @@
 
     .svg-container {
       @include span-columns(8);
+
+      &.wide {
+        @include span-columns(12);
+        @include omega();
+      }
     }
 
     .legend-container {
       @include span-columns(4);
       @include omega();
+
+      &.wide {
+        @include span-columns(12);
+
+        .legend-svg {
+          width: 100%;
+        }
+      }
     }
 
     .legend-container,

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -19,7 +19,6 @@
 
   svg.map {
     .state.feature {
-      fill: $blackest-black;
       fill-opacity: 1;
     }
 

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -51,6 +51,10 @@
     text-align: left;
   }
 
+  .numeric[colspan="2"] {
+    text-align: center;
+  }
+
   [data-value] {
     min-width: 120px;
     position: relative;
@@ -81,6 +85,10 @@
   [data-value^="-"] .bar {
     background: transparent;
     border: 1px solid;
+  }
+
+  [data-value-text]:not(.numeric) {
+    text-align: right;
   }
 
   &[orient=vertical] {

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -78,3 +78,9 @@ data-map {
     @include font-size(3 / 4);
   }
 }
+
+.legend-svg.horizontal {
+  .cell text {
+    font-size: 10px;
+  }
+}

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -68,6 +68,7 @@ data-map {
   border: none;
   padding: $base-padding-lite;
   width: 200px;
+  height: 215px;
 
   .swatch {
     stroke: $neutral-gray;

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -26,12 +26,21 @@ data-map {
     @include span-columns(8);
     @include omega();
 
-    > * {
+    .svg-container {
       @include span-columns(8);
 
-      &:last-child {
-        @include span-columns(4);
+      &.wide {
+        @include span-columns(12);
         @include omega();
+      }
+    }
+
+    .legend-container {
+      @include span-columns(4);
+      @include omega();
+
+      &.wide {
+        @include span-columns(12);
       }
     }
   }
@@ -77,6 +86,15 @@ data-map {
 
   .cell text {
     @include font-size(3 / 4);
+  }
+}
+
+.legend-container.wide {
+  padding-top: $standard-padding-lite;
+
+  .legend-ownership-svg {
+    width: 100%;
+    height: 100px;
   }
 }
 

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -69,7 +69,7 @@ data-map {
   bottom: 0;
   margin: 0;
   position: absolute;
-  right: $standard-padding-lite;
+  left: $standard-padding-lite;
 }
 
 eiti-data-map {

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -87,7 +87,7 @@ eiti-data-map {
     &.wide .details-container {
       display: block;
       position: static;
-      text-align: right;
+      text-align: left;
     }
   }
 }

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -127,3 +127,10 @@ eiti-data-map {
     font-size: 10px;
   }
 }
+
+.legend-container.wide .legend-ownership-svg {
+  .label {
+    @include font-size(0.75);
+    text-anchor: middle;
+  }
+}

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -131,6 +131,5 @@ eiti-data-map {
 .legend-container.wide .legend-ownership-svg {
   .label {
     @include font-size(0.75);
-    text-anchor: middle;
   }
 }

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -72,6 +72,26 @@ data-map {
   right: $standard-padding-lite;
 }
 
+eiti-data-map {
+  .svg-container.wide {
+    .details-container {
+      display: none;
+    }
+  }
+
+  .legend-container {
+    .details-container {
+      display: none;
+    }
+
+    &.wide .details-container {
+      display: block;
+      position: static;
+      text-align: right;
+    }
+  }
+}
+
 .legend-svg,
 .legend-ownership-svg {
   border: none;
@@ -95,6 +115,10 @@ data-map {
   .legend-ownership-svg {
     width: 100%;
     height: 100px;
+  }
+
+  .legend-svg.horizontal {
+    height: 50px;
   }
 }
 

--- a/_states/AK.md
+++ b/_states/AK.md
@@ -6,6 +6,8 @@ FIPS: '02'
 case_study: true
 opt_in: true
 priority: true
+
+locality_name: 'Borough or Census Area'
 ---
 * The [Alaska Department of Natural Resources Division of Oil and Gas](http://dog.dnr.alaska.gov/index.htm) is responsible for leasing state lands for oil, gas, and geothermal extraction. Its major functions include evaluating oil and gas resources, fielding and issuing exploration permits, conducting royalty audits, and negotiating contracts.
   - [Oil and gas statutes and regulations](http://dog.dnr.alaska.gov/AboutUs/OGStatutes.htm)

--- a/_states/LA.md
+++ b/_states/LA.md
@@ -5,6 +5,8 @@ FIPS: '22'
 
 case_study: true
 priority: true
+
+locality_name: 'Parish'
 ---
 * The Office of Mineral Resources within the [Louisiana Department of Natural Resources](http://dnr.louisiana.gov/) manages natural resource extraction throughout the state and receives revenue from royalties, bonuses, rents, interest, and fees for leases for state-owned lands.
   - [Oil production](http://dnr.louisiana.gov/index.cfm?md=pagebuilderANDtmp=homeANDpid=208)

--- a/data/federal-production/rollup.sql
+++ b/data/federal-production/rollup.sql
@@ -45,9 +45,9 @@ UNION
         END AS units,
         SUM(volume) AS volume
     FROM federal_offshore_production AS offshore
-    INNER JOIN offshore_planning_areas AS area
+    LEFT JOIN offshore_planning_areas AS area
     ON
-        offshore.planning_area = area.name
+        LOWER(TRIM(offshore.planning_area)) = LOWER(TRIM(area.name))
     GROUP BY
         year, product, product_name, units
 ORDER BY

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -107,16 +107,16 @@
 
           var settings = {
             horizontal : {
-              width: 46,
-              height: 12,
-              padding: 4
-            },
-            narrowHorizontal: {
               width: 50,
               height: 12,
               padding: 6
             },
-            vertical : {
+            narrowHorizontal: {
+              width: 60,
+              height: 12,
+              padding: 10
+            },
+            vertical: {
               width: 15,
               height: 15,
               padding: 6
@@ -189,7 +189,7 @@
             ? 'horizontal'
             : 'vertical';
 
-          if (narrowHorizontal) {
+          if (narrowHorizontal && orient === 'horizontal') {
             shapeWidth = settings.narrowHorizontal.width;
             shapeHeight = settings.narrowHorizontal.height;
             shapePadding = settings.narrowHorizontal.padding;
@@ -198,6 +198,11 @@
             shapeHeight = settings[orient].height;
             shapePadding = settings[orient].padding;
           }
+
+          console.log('orient', orient)
+          console.log('shapeWidth', shapeWidth)
+          console.log('shapeHeight',  shapeHeight)
+          console.log('shapePadding', shapePadding)
 
           var svgLegend = d3.select(this)
             .select('.legend-svg')

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -66,16 +66,6 @@
               }
 
             }
-
-            // if (svgMapBBox.height < svgMapBBox.width) {
-            //   if (!svgContainer.empty()) {
-            //     svgContainer.classed('wide', true);
-            //   }
-
-            //   if (!legendContainer.empty()) {
-            //     legendContainer.classed('wide', true);
-            //   }
-            // }
           }
         }},
 
@@ -114,14 +104,27 @@
           var legendFormat = format === '$'
             ? eiti.format.dollars
             : eiti.format.si;
-          var orient = this.isWideView
-            ? 'horizontal'
-            : 'vertical';
-          var shapeWidth = this.isWideView
-            ? 40
-            : 15;
 
-          console.log('orient', orient)
+          var settings = {
+            horizontal : {
+              width: 46,
+              height: 12,
+              padding: 4
+            },
+            narrowHorizontal: {
+              width: 50,
+              height: 12,
+              padding: 6
+            },
+            vertical : {
+              width: 15,
+              height: 15,
+              padding: 6
+            }
+          },
+          shapeWidth,
+          shapeHeight,
+          shapePadding;
 
           var colors = colorbrewer[scheme][steps];
           if (!colors) {
@@ -171,20 +174,46 @@
             return values.filter(uniq);
           }
 
+
+          // reverse because the scale is in ascending order
+          var _steps = d3.range(0, 9)
+
+          if (!this.isWideView) {
+            _steps = _steps.reverse();
+          }
+          // find which steps are represented in the map
+          var uniqueSteps = getUnique(marks.data(), _steps, domain);
+          var narrowHorizontal = uniqueSteps.length < 6;
+
+          var orient = this.isWideView
+            ? 'horizontal'
+            : 'vertical';
+
+          if (narrowHorizontal) {
+            shapeWidth = settings.narrowHorizontal.width;
+            shapeHeight = settings.narrowHorizontal.height;
+            shapePadding = settings.narrowHorizontal.padding;
+          } else {
+            shapeWidth = settings[orient].width;
+            shapeHeight = settings[orient].height;
+            shapePadding = settings[orient].padding;
+          }
+
           var svgLegend = d3.select(this)
-            .select('.legend-svg');
+            .select('.legend-svg')
+            .classed(orient, true);
 
           if (!svgLegend.empty()) {
 
             var legend = d3.legend.color()
               .labelFormat(legendFormat)
-              .labelFloor(false)
               .useClass(false)
-              .ascending(true)
+              .ascending(!this.isWideView)
               .orient(orient)
               .shapeWidth(shapeWidth)
+              .shapeHeight(shapeHeight)
               .labelDelimiter(legendDelimiter)
-              .shapePadding(6)
+              .shapePadding(shapePadding)
               .scale(scale);
 
 
@@ -196,32 +225,36 @@
 
             legendScale.call(legend);
 
-            // reverse because the scale is in ascending order
-            var _steps = d3.range(0, 9).reverse();
-
-            // find which steps are represented in the map
-            var uniqueSteps = getUnique(marks.data(), _steps, domain);
-
             // start consolidate (translate) visible cells
-            // var cells = svgLegend.selectAll('.cell');
-            // var cellHeight = legend.shapeHeight() + legend.shapePadding();
-            // var count = 0;
-            // cells.each(function(cell, i) {
-            //   var present = uniqueSteps.indexOf(i) > -1;
+            var cells = svgLegend.selectAll('.cell');
+            var cellHeight = legend.shapeHeight() + legend.shapePadding();
+            var cellWidth = legend.shapeWidth() + legend.shapePadding();
+            var count = 0;
 
-            //   if (!present) {
-            //     // hide cells swatches that aren't in the map
-            //     cells[0][i].setAttribute('aria-hidden', true);
-            //     count++;
-            //   } else  {
+            var that = this;
+            cells.each(function(cell, i) {
+              var present = uniqueSteps.indexOf(i) > -1;
 
-            //     // trim spacing between swatches that are visible
-            //     var translateHeight = (i * cellHeight) - (count * cellHeight);
-            //     cells[0][i].setAttribute('transform',
-            //       'translate(0,' + translateHeight + ')');
-            //     cells[0][i].setAttribute('aria-hidden', false);
-            //   }
-            // });
+              if (!present) {
+                // hide cells swatches that aren't in the map
+                cells[0][i].setAttribute('aria-hidden', true);
+                count++;
+              } else  {
+                if (that.isWideView) {
+                  var translateWidth = (i * cellWidth) - (count * cellWidth);
+                  cells[0][i].setAttribute('transform',
+                    'translate(' + translateWidth + ', 0)');
+                  cells[0][i].setAttribute('aria-hidden', false);
+                } else {
+                  // trim spacing between swatches that are visible
+                  var translateHeight = (i * cellHeight) - (count * cellHeight);
+                  cells[0][i].setAttribute('transform',
+                    'translate(0,' + translateHeight + ')');
+                  cells[0][i].setAttribute('aria-hidden', false);
+                }
+
+              }
+            });
             // end consolidation
             // end map legend
           } else {

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -9,12 +9,16 @@
       HTMLElement.prototype,
       {
         attachedCallback: {value: function() {
-          this.marks = d3.select(this).selectAll('[data-value]')
+          var root = d3.select(this);
+
+          this.marks = root.selectAll('[data-value]')
             .datum(function() {
               return +this.getAttribute('data-value') || 0;
             });
 
-          this.detectWidth();
+          if (!root.select('.svg-container').classed('wide')) {
+            this.detectWidth();
+          }
           this.update();
         }},
 
@@ -42,8 +46,8 @@
           var legendContainer = root.select('.legend-container');
 
           if (!svgMap.empty()) {
-            var svgMapBBox = svgMap.node().getBBox()
-            var svgDimensions = svgMap.attr('viewBox')
+            var svgMapBBox = svgMap.node().getBBox();
+            var svgDimensions = svgMap.attr('viewBox');
 
             if (svgDimensions) {
               svgDimensions = svgDimensions.split(' ');
@@ -54,7 +58,6 @@
                 // then make it a wide view
                 if (width > height * 1.5) {
                   this.isWideView = true;
-                  console.log(this, this.isWideView)
                   if (!svgContainer.empty()) {
                     svgContainer.classed('wide', true);
                   }
@@ -64,7 +67,6 @@
                   }
                 }
               }
-
             }
           }
         }},
@@ -198,11 +200,6 @@
             shapeHeight = settings[orient].height;
             shapePadding = settings[orient].padding;
           }
-
-          console.log('orient', orient)
-          console.log('shapeWidth', shapeWidth)
-          console.log('shapeHeight',  shapeHeight)
-          console.log('shapePadding', shapePadding)
 
           var svgLegend = d3.select(this)
             .select('.legend-svg')

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -18,6 +18,8 @@
 
           if (!root.select('.svg-container').classed('wide')) {
             this.detectWidth();
+          } else {
+            this.isWideView = true;
           }
           this.update();
         }},

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -179,12 +179,8 @@
           }
 
 
-          // reverse because the scale is in ascending order
           var _steps = d3.range(0, 9)
 
-          if (!this.isWideView) {
-            _steps = _steps.reverse();
-          }
           // find which steps are represented in the map
           var uniqueSteps = getUnique(marks.data(), _steps, domain);
           var narrowHorizontal = uniqueSteps.length < 6;
@@ -212,7 +208,6 @@
             var legend = d3.legend.color()
               .labelFormat(legendFormat)
               .useClass(false)
-              .ascending(!this.isWideView)
               .orient(orient)
               .shapeWidth(shapeWidth)
               .shapeHeight(shapeHeight)

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -116,7 +116,7 @@
               padding: 6
             },
             narrowHorizontal: {
-              width: 60,
+              width: 70,
               height: 12,
               padding: 10
             },

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -213,6 +213,7 @@
               .shapeHeight(shapeHeight)
               .labelDelimiter(legendDelimiter)
               .shapePadding(shapePadding)
+              .labelAlign("start")
               .scale(scale);
 
 

--- a/js/components/sticky-nav.js
+++ b/js/components/sticky-nav.js
@@ -198,9 +198,7 @@
   }
 
 
-
   window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
-
   window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 
   // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -260,9 +260,7 @@
 	  }
 
 
-
 	  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
-
 	  window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 
 	  // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -264,9 +264,7 @@
 	  }
 
 
-
 	  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
-
 	  window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 
 	  // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11179,16 +11179,6 @@
 	              }
 
 	            }
-
-	            // if (svgMapBBox.height < svgMapBBox.width) {
-	            //   if (!svgContainer.empty()) {
-	            //     svgContainer.classed('wide', true);
-	            //   }
-
-	            //   if (!legendContainer.empty()) {
-	            //     legendContainer.classed('wide', true);
-	            //   }
-	            // }
 	          }
 	        }},
 
@@ -11227,14 +11217,27 @@
 	          var legendFormat = format === '$'
 	            ? eiti.format.dollars
 	            : eiti.format.si;
-	          var orient = this.isWideView
-	            ? 'horizontal'
-	            : 'vertical';
-	          var shapeWidth = this.isWideView
-	            ? 40
-	            : 15;
 
-	          console.log('orient', orient)
+	          var settings = {
+	            horizontal : {
+	              width: 46,
+	              height: 12,
+	              padding: 4
+	            },
+	            narrowHorizontal: {
+	              width: 50,
+	              height: 12,
+	              padding: 6
+	            },
+	            vertical : {
+	              width: 15,
+	              height: 15,
+	              padding: 6
+	            }
+	          },
+	          shapeWidth,
+	          shapeHeight,
+	          shapePadding;
 
 	          var colors = colorbrewer[scheme][steps];
 	          if (!colors) {
@@ -11284,20 +11287,46 @@
 	            return values.filter(uniq);
 	          }
 
+
+	          // reverse because the scale is in ascending order
+	          var _steps = d3.range(0, 9)
+
+	          if (!this.isWideView) {
+	            _steps = _steps.reverse();
+	          }
+	          // find which steps are represented in the map
+	          var uniqueSteps = getUnique(marks.data(), _steps, domain);
+	          var narrowHorizontal = uniqueSteps.length < 6;
+
+	          var orient = this.isWideView
+	            ? 'horizontal'
+	            : 'vertical';
+
+	          if (narrowHorizontal) {
+	            shapeWidth = settings.narrowHorizontal.width;
+	            shapeHeight = settings.narrowHorizontal.height;
+	            shapePadding = settings.narrowHorizontal.padding;
+	          } else {
+	            shapeWidth = settings[orient].width;
+	            shapeHeight = settings[orient].height;
+	            shapePadding = settings[orient].padding;
+	          }
+
 	          var svgLegend = d3.select(this)
-	            .select('.legend-svg');
+	            .select('.legend-svg')
+	            .classed(orient, true);
 
 	          if (!svgLegend.empty()) {
 
 	            var legend = d3.legend.color()
 	              .labelFormat(legendFormat)
-	              .labelFloor(false)
 	              .useClass(false)
-	              .ascending(true)
+	              .ascending(!this.isWideView)
 	              .orient(orient)
 	              .shapeWidth(shapeWidth)
+	              .shapeHeight(shapeHeight)
 	              .labelDelimiter(legendDelimiter)
-	              .shapePadding(6)
+	              .shapePadding(shapePadding)
 	              .scale(scale);
 
 
@@ -11309,32 +11338,36 @@
 
 	            legendScale.call(legend);
 
-	            // reverse because the scale is in ascending order
-	            var _steps = d3.range(0, 9).reverse();
-
-	            // find which steps are represented in the map
-	            var uniqueSteps = getUnique(marks.data(), _steps, domain);
-
 	            // start consolidate (translate) visible cells
-	            // var cells = svgLegend.selectAll('.cell');
-	            // var cellHeight = legend.shapeHeight() + legend.shapePadding();
-	            // var count = 0;
-	            // cells.each(function(cell, i) {
-	            //   var present = uniqueSteps.indexOf(i) > -1;
+	            var cells = svgLegend.selectAll('.cell');
+	            var cellHeight = legend.shapeHeight() + legend.shapePadding();
+	            var cellWidth = legend.shapeWidth() + legend.shapePadding();
+	            var count = 0;
 
-	            //   if (!present) {
-	            //     // hide cells swatches that aren't in the map
-	            //     cells[0][i].setAttribute('aria-hidden', true);
-	            //     count++;
-	            //   } else  {
+	            var that = this;
+	            cells.each(function(cell, i) {
+	              var present = uniqueSteps.indexOf(i) > -1;
 
-	            //     // trim spacing between swatches that are visible
-	            //     var translateHeight = (i * cellHeight) - (count * cellHeight);
-	            //     cells[0][i].setAttribute('transform',
-	            //       'translate(0,' + translateHeight + ')');
-	            //     cells[0][i].setAttribute('aria-hidden', false);
-	            //   }
-	            // });
+	              if (!present) {
+	                // hide cells swatches that aren't in the map
+	                cells[0][i].setAttribute('aria-hidden', true);
+	                count++;
+	              } else  {
+	                if (that.isWideView) {
+	                  var translateWidth = (i * cellWidth) - (count * cellWidth);
+	                  cells[0][i].setAttribute('transform',
+	                    'translate(' + translateWidth + ', 0)');
+	                  cells[0][i].setAttribute('aria-hidden', false);
+	                } else {
+	                  // trim spacing between swatches that are visible
+	                  var translateHeight = (i * cellHeight) - (count * cellHeight);
+	                  cells[0][i].setAttribute('transform',
+	                    'translate(0,' + translateHeight + ')');
+	                  cells[0][i].setAttribute('aria-hidden', false);
+	                }
+
+	              }
+	            });
 	            // end consolidation
 	            // end map legend
 	          } else {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11220,16 +11220,16 @@
 
 	          var settings = {
 	            horizontal : {
-	              width: 46,
-	              height: 12,
-	              padding: 4
-	            },
-	            narrowHorizontal: {
 	              width: 50,
 	              height: 12,
 	              padding: 6
 	            },
-	            vertical : {
+	            narrowHorizontal: {
+	              width: 60,
+	              height: 12,
+	              padding: 10
+	            },
+	            vertical: {
 	              width: 15,
 	              height: 15,
 	              padding: 6
@@ -11302,7 +11302,7 @@
 	            ? 'horizontal'
 	            : 'vertical';
 
-	          if (narrowHorizontal) {
+	          if (narrowHorizontal && orient === 'horizontal') {
 	            shapeWidth = settings.narrowHorizontal.width;
 	            shapeHeight = settings.narrowHorizontal.height;
 	            shapePadding = settings.narrowHorizontal.padding;
@@ -11311,6 +11311,11 @@
 	            shapeHeight = settings[orient].height;
 	            shapePadding = settings[orient].padding;
 	          }
+
+	          console.log('orient', orient)
+	          console.log('shapeWidth', shapeWidth)
+	          console.log('shapeHeight',  shapeHeight)
+	          console.log('shapePadding', shapePadding)
 
 	          var svgLegend = d3.select(this)
 	            .select('.legend-svg')

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11122,12 +11122,16 @@
 	      HTMLElement.prototype,
 	      {
 	        attachedCallback: {value: function() {
-	          this.marks = d3.select(this).selectAll('[data-value]')
+	          var root = d3.select(this);
+
+	          this.marks = root.selectAll('[data-value]')
 	            .datum(function() {
 	              return +this.getAttribute('data-value') || 0;
 	            });
 
-	          this.detectWidth();
+	          if (!root.select('.svg-container').classed('wide')) {
+	            this.detectWidth();
+	          }
 	          this.update();
 	        }},
 
@@ -11155,8 +11159,8 @@
 	          var legendContainer = root.select('.legend-container');
 
 	          if (!svgMap.empty()) {
-	            var svgMapBBox = svgMap.node().getBBox()
-	            var svgDimensions = svgMap.attr('viewBox')
+	            var svgMapBBox = svgMap.node().getBBox();
+	            var svgDimensions = svgMap.attr('viewBox');
 
 	            if (svgDimensions) {
 	              svgDimensions = svgDimensions.split(' ');
@@ -11167,7 +11171,6 @@
 	                // then make it a wide view
 	                if (width > height * 1.5) {
 	                  this.isWideView = true;
-	                  console.log(this, this.isWideView)
 	                  if (!svgContainer.empty()) {
 	                    svgContainer.classed('wide', true);
 	                  }
@@ -11177,7 +11180,6 @@
 	                  }
 	                }
 	              }
-
 	            }
 	          }
 	        }},
@@ -11311,11 +11313,6 @@
 	            shapeHeight = settings[orient].height;
 	            shapePadding = settings[orient].padding;
 	          }
-
-	          console.log('orient', orient)
-	          console.log('shapeWidth', shapeWidth)
-	          console.log('shapeHeight',  shapeHeight)
-	          console.log('shapePadding', shapePadding)
 
 	          var svgLegend = d3.select(this)
 	            .select('.legend-svg')

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11131,6 +11131,8 @@
 
 	          if (!root.select('.svg-container').classed('wide')) {
 	            this.detectWidth();
+	          } else {
+	            this.isWideView = true;
 	          }
 	          this.update();
 	        }},

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11446,8 +11446,6 @@
 	    labelOffset = 10,
 	    labelAlign = "middle",
 	    labelDelimiter = "to",
-	    labelFloor = true,
-	    labelCeil = true,
 	    orient = "vertical",
 	    ascending = false,
 	    path,
@@ -11455,7 +11453,7 @@
 
 	    function legend(svg){
 
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter, labelFloor, labelCeil),
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
 	        legendG = svg.selectAll('g').data([scale]);
 
 	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
@@ -11595,18 +11593,6 @@
 	    return legend;
 	  };
 
-	  legend.labelFloor = function(_) {
-	    if (!arguments.length) return labelFloor;
-	    labelFloor = _;
-	    return legend;
-	  };
-
-	  legend.labelCeil = function(_) {
-	    if (!arguments.length) return labelCeil;
-	    labelCeil = _;
-	    return legend;
-	  };
-
 	  legend.useClass = function(_) {
 	    if (!arguments.length) return useClass;
 	    if (_ === true || _ === false){
@@ -11695,22 +11681,15 @@
 	            feature: function(d){ return scale(d); }};
 	  },
 
-	  d3_quantLegend: function (scale, labelFormat, labelDelimiter, labelFloor, labelCeil) {
+	  d3_quantLegend: function (scale, labelFormat, labelDelimiter) {
 	    var labels = scale.range().map(function(d){
 	      var invert = scale.invertExtent(d),
 	      a = labelFormat(invert[0]),
 	      b = labelFormat(invert[1]);
 
-	      if (labelFloor && labelCeil || !labelFloor && !labelCeil) {
-	        return a + " " + labelDelimiter + " " + b;
-	      } else if (labelFloor && !labelCeil) {
-	        return a;
-	      } else if (!labelFloor && labelCeil) {
-	        return b;
-	      }
 	      // if (( (a) && (a.isNan()) && b){
 	      //   console.log("in initial statement")
-	        // return labelFormat(invert[0]) + " " + labelDelimiter + " " + labelFormat(invert[1]);
+	        return labelFormat(invert[0]) + " " + labelDelimiter + " " + labelFormat(invert[1]);
 	      // } else if (a || b) {
 	      //   console.log('in else statement')
 	      //   return (a) ? a : b;
@@ -11750,10 +11729,10 @@
 	    svg.selectAll("g." + classPrefix + "cell text").data(labels).text(this.d3_identity);
 	  },
 
-	  d3_calcType: function (scale, ascending, cells, labels, labelFormat, labelDelimiter, labelFloor, labelCeil){
+	  d3_calcType: function (scale, ascending, cells, labels, labelFormat, labelDelimiter){
 	    var type = scale.ticks ?
 	            this.d3_linearLegend(scale, cells, labelFormat) : scale.invertExtent ?
-	            this.d3_quantLegend(scale, labelFormat, labelDelimiter, labelFloor, labelCeil) : this.d3_ordinalLegend(scale);
+	            this.d3_quantLegend(scale, labelFormat, labelDelimiter) : this.d3_ordinalLegend(scale);
 
 	    type.labels = this.d3_mergeLabels(type.labels, labels);
 
@@ -11846,8 +11825,6 @@
 	    labelOffset = 10,
 	    labelAlign = "middle",
 	    labelDelimiter = "to",
-	    labelFloor = true,
-	    labelCeil = true,
 	    orient = "vertical",
 	    ascending = false,
 	    path,
@@ -11855,7 +11832,7 @@
 
 	    function legend(svg){
 
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter, labelFloor, labelCeil),
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
 	        legendG = svg.selectAll('g').data([scale]);
 
 	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
@@ -11998,18 +11975,6 @@
 	    return legend;
 	  };
 
-	  legend.labelFloor = function(_) {
-	    if (!arguments.length) return labelFloor;
-	    labelFloor = _;
-	    return legend;
-	  };
-
-	  legend.labelCeil = function(_) {
-	    if (!arguments.length) return labelCeil;
-	    labelCeil = _;
-	    return legend;
-	  };
-
 	  legend.orient = function(_){
 	    if (!arguments.length) return orient;
 	    _ = _.toLowerCase();
@@ -12067,15 +12032,13 @@
 	    labelAlign = "middle",
 	    labelOffset = 10,
 	    labelDelimiter = "to",
-	    labelFloor = true,
-	    labelCeil = true,
 	    orient = "vertical",
 	    ascending = false,
 	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
 
 	    function legend(svg){
 
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter, labelFloor, labelCeil),
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
 	        legendG = svg.selectAll('g').data([scale]);
 
 	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
@@ -12173,18 +12136,6 @@
 	  legend.labelDelimiter = function(_) {
 	    if (!arguments.length) return labelDelimiter;
 	    labelDelimiter = _;
-	    return legend;
-	  };
-
-	  legend.labelFloor = function(_) {
-	    if (!arguments.length) return labelFloor;
-	    labelFloor = _;
-	    return legend;
-	  };
-
-	  legend.labelCeil = function(_) {
-	    if (!arguments.length) return labelCeil;
-	    labelCeil = _;
 	    return legend;
 	  };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -272,9 +272,7 @@
 	  }
 
 
-
 	  window.addEventListener('scroll', stickyNav.throttle(stickyNav.run, 130, stickyNav));
-
 	  window.addEventListener('resize', stickyNav.throttle(stickyNav.run, 150, stickyNav));
 
 	  // documentation: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
@@ -11229,7 +11227,7 @@
 	              padding: 6
 	            },
 	            narrowHorizontal: {
-	              width: 60,
+	              width: 70,
 	              height: 12,
 	              padding: 10
 	            },

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11326,6 +11326,7 @@
 	              .shapeHeight(shapeHeight)
 	              .labelDelimiter(legendDelimiter)
 	              .shapePadding(shapePadding)
+	              .labelAlign("start")
 	              .scale(scale);
 
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11127,6 +11127,7 @@
 	              return +this.getAttribute('data-value') || 0;
 	            });
 
+	          this.detectWidth();
 	          this.update();
 	        }},
 
@@ -11145,6 +11146,50 @@
 	            .text(year)
 
 	          this.update();
+	        }},
+
+	        detectWidth: {value: function() {
+	          var root = d3.select(this);
+	          var svgMap = root.select('svg.county.map');
+	          var svgContainer = root.select('.svg-container');
+	          var legendContainer = root.select('.legend-container');
+
+	          if (!svgMap.empty()) {
+	            var svgMapBBox = svgMap.node().getBBox()
+	            var svgDimensions = svgMap.attr('viewBox')
+
+	            if (svgDimensions) {
+	              svgDimensions = svgDimensions.split(' ');
+	              if (svgDimensions.length === 4) {
+	                var width = +svgDimensions[2];
+	                var height = +svgDimensions[3];
+	                // if a map's width is more than 50% a map's height
+	                // then make it a wide view
+	                if (width > height * 1.5) {
+	                  this.isWideView = true;
+	                  console.log(this, this.isWideView)
+	                  if (!svgContainer.empty()) {
+	                    svgContainer.classed('wide', true);
+	                  }
+
+	                  if (!legendContainer.empty()) {
+	                    legendContainer.classed('wide', true);
+	                  }
+	                }
+	              }
+
+	            }
+
+	            // if (svgMapBBox.height < svgMapBBox.width) {
+	            //   if (!svgContainer.empty()) {
+	            //     svgContainer.classed('wide', true);
+	            //   }
+
+	            //   if (!legendContainer.empty()) {
+	            //     legendContainer.classed('wide', true);
+	            //   }
+	            // }
+	          }
 	        }},
 
 	        update: {value: function() {
@@ -11182,6 +11227,14 @@
 	          var legendFormat = format === '$'
 	            ? eiti.format.dollars
 	            : eiti.format.si;
+	          var orient = this.isWideView
+	            ? 'horizontal'
+	            : 'vertical';
+	          var shapeWidth = this.isWideView
+	            ? 40
+	            : 15;
+
+	          console.log('orient', orient)
 
 	          var colors = colorbrewer[scheme][steps];
 	          if (!colors) {
@@ -11204,7 +11257,6 @@
 	          }
 
 	          // FIXME: do something with divergent scales??
-
 	          var scale = d3.scale[type]()
 	            .domain(domain)
 	            .range(colors);
@@ -11239,8 +11291,11 @@
 
 	            var legend = d3.legend.color()
 	              .labelFormat(legendFormat)
+	              .labelFloor(false)
 	              .useClass(false)
 	              .ascending(true)
+	              .orient(orient)
+	              .shapeWidth(shapeWidth)
 	              .labelDelimiter(legendDelimiter)
 	              .shapePadding(6)
 	              .scale(scale);
@@ -11261,25 +11316,25 @@
 	            var uniqueSteps = getUnique(marks.data(), _steps, domain);
 
 	            // start consolidate (translate) visible cells
-	            var cells = svgLegend.selectAll('.cell');
-	            var cellHeight = legend.shapeHeight() + legend.shapePadding();
-	            var count = 0;
-	            cells.each(function(cell, i) {
-	              var present = uniqueSteps.indexOf(i) > -1;
+	            // var cells = svgLegend.selectAll('.cell');
+	            // var cellHeight = legend.shapeHeight() + legend.shapePadding();
+	            // var count = 0;
+	            // cells.each(function(cell, i) {
+	            //   var present = uniqueSteps.indexOf(i) > -1;
 
-	              if (!present) {
-	                // hide cells swatches that aren't in the map
-	                cells[0][i].setAttribute('aria-hidden', true);
-	                count++;
-	              } else  {
+	            //   if (!present) {
+	            //     // hide cells swatches that aren't in the map
+	            //     cells[0][i].setAttribute('aria-hidden', true);
+	            //     count++;
+	            //   } else  {
 
-	                // trim spacing between swatches that are visible
-	                var translateHeight = (i * cellHeight) - (count * cellHeight);
-	                cells[0][i].setAttribute('transform',
-	                  'translate(0,' + translateHeight + ')');
-	                cells[0][i].setAttribute('aria-hidden', false);
-	              }
-	            });
+	            //     // trim spacing between swatches that are visible
+	            //     var translateHeight = (i * cellHeight) - (count * cellHeight);
+	            //     cells[0][i].setAttribute('transform',
+	            //       'translate(0,' + translateHeight + ')');
+	            //     cells[0][i].setAttribute('aria-hidden', false);
+	            //   }
+	            // });
 	            // end consolidation
 	            // end map legend
 	          } else {
@@ -11356,6 +11411,8 @@
 	    labelOffset = 10,
 	    labelAlign = "middle",
 	    labelDelimiter = "to",
+	    labelFloor = true,
+	    labelCeil = true,
 	    orient = "vertical",
 	    ascending = false,
 	    path,
@@ -11363,7 +11420,7 @@
 
 	    function legend(svg){
 
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter, labelFloor, labelCeil),
 	        legendG = svg.selectAll('g').data([scale]);
 
 	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
@@ -11503,6 +11560,18 @@
 	    return legend;
 	  };
 
+	  legend.labelFloor = function(_) {
+	    if (!arguments.length) return labelFloor;
+	    labelFloor = _;
+	    return legend;
+	  };
+
+	  legend.labelCeil = function(_) {
+	    if (!arguments.length) return labelCeil;
+	    labelCeil = _;
+	    return legend;
+	  };
+
 	  legend.useClass = function(_) {
 	    if (!arguments.length) return useClass;
 	    if (_ === true || _ === false){
@@ -11591,15 +11660,22 @@
 	            feature: function(d){ return scale(d); }};
 	  },
 
-	  d3_quantLegend: function (scale, labelFormat, labelDelimiter) {
+	  d3_quantLegend: function (scale, labelFormat, labelDelimiter, labelFloor, labelCeil) {
 	    var labels = scale.range().map(function(d){
 	      var invert = scale.invertExtent(d),
 	      a = labelFormat(invert[0]),
 	      b = labelFormat(invert[1]);
 
+	      if (labelFloor && labelCeil || !labelFloor && !labelCeil) {
+	        return a + " " + labelDelimiter + " " + b;
+	      } else if (labelFloor && !labelCeil) {
+	        return a;
+	      } else if (!labelFloor && labelCeil) {
+	        return b;
+	      }
 	      // if (( (a) && (a.isNan()) && b){
 	      //   console.log("in initial statement")
-	        return labelFormat(invert[0]) + " " + labelDelimiter + " " + labelFormat(invert[1]);
+	        // return labelFormat(invert[0]) + " " + labelDelimiter + " " + labelFormat(invert[1]);
 	      // } else if (a || b) {
 	      //   console.log('in else statement')
 	      //   return (a) ? a : b;
@@ -11639,10 +11715,10 @@
 	    svg.selectAll("g." + classPrefix + "cell text").data(labels).text(this.d3_identity);
 	  },
 
-	  d3_calcType: function (scale, ascending, cells, labels, labelFormat, labelDelimiter){
+	  d3_calcType: function (scale, ascending, cells, labels, labelFormat, labelDelimiter, labelFloor, labelCeil){
 	    var type = scale.ticks ?
 	            this.d3_linearLegend(scale, cells, labelFormat) : scale.invertExtent ?
-	            this.d3_quantLegend(scale, labelFormat, labelDelimiter) : this.d3_ordinalLegend(scale);
+	            this.d3_quantLegend(scale, labelFormat, labelDelimiter, labelFloor, labelCeil) : this.d3_ordinalLegend(scale);
 
 	    type.labels = this.d3_mergeLabels(type.labels, labels);
 
@@ -11735,6 +11811,8 @@
 	    labelOffset = 10,
 	    labelAlign = "middle",
 	    labelDelimiter = "to",
+	    labelFloor = true,
+	    labelCeil = true,
 	    orient = "vertical",
 	    ascending = false,
 	    path,
@@ -11742,7 +11820,7 @@
 
 	    function legend(svg){
 
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter, labelFloor, labelCeil),
 	        legendG = svg.selectAll('g').data([scale]);
 
 	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
@@ -11885,6 +11963,18 @@
 	    return legend;
 	  };
 
+	  legend.labelFloor = function(_) {
+	    if (!arguments.length) return labelFloor;
+	    labelFloor = _;
+	    return legend;
+	  };
+
+	  legend.labelCeil = function(_) {
+	    if (!arguments.length) return labelCeil;
+	    labelCeil = _;
+	    return legend;
+	  };
+
 	  legend.orient = function(_){
 	    if (!arguments.length) return orient;
 	    _ = _.toLowerCase();
@@ -11942,13 +12032,15 @@
 	    labelAlign = "middle",
 	    labelOffset = 10,
 	    labelDelimiter = "to",
+	    labelFloor = true,
+	    labelCeil = true,
 	    orient = "vertical",
 	    ascending = false,
 	    legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
 
 	    function legend(svg){
 
-	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
+	      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter, labelFloor, labelCeil),
 	        legendG = svg.selectAll('g').data([scale]);
 
 	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
@@ -12046,6 +12138,18 @@
 	  legend.labelDelimiter = function(_) {
 	    if (!arguments.length) return labelDelimiter;
 	    labelDelimiter = _;
+	    return legend;
+	  };
+
+	  legend.labelFloor = function(_) {
+	    if (!arguments.length) return labelFloor;
+	    labelFloor = _;
+	    return legend;
+	  };
+
+	  legend.labelCeil = function(_) {
+	    if (!arguments.length) return labelCeil;
+	    labelCeil = _;
 	    return legend;
 	  };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11292,12 +11292,8 @@
 	          }
 
 
-	          // reverse because the scale is in ascending order
 	          var _steps = d3.range(0, 9)
 
-	          if (!this.isWideView) {
-	            _steps = _steps.reverse();
-	          }
 	          // find which steps are represented in the map
 	          var uniqueSteps = getUnique(marks.data(), _steps, domain);
 	          var narrowHorizontal = uniqueSteps.length < 6;
@@ -11325,7 +11321,6 @@
 	            var legend = d3.legend.color()
 	              .labelFormat(legendFormat)
 	              .useClass(false)
-	              .ascending(!this.isWideView)
 	              .orient(orient)
 	              .shapeWidth(shapeWidth)
 	              .shapeHeight(shapeHeight)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "custom-event": "^1.0.0",
     "d3": "^3.5.5",
     "d3-queue": "^1.0.7",
-    "d3-svg-legend": "^1.10.0",
+    "d3-svg-legend": "github:gemfarmer/d3-legend",
     "document-register-element": "^0.5.3",
     "immutable": "^3.7.6",
     "jquery": "^1.11.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "custom-event": "^1.0.0",
     "d3": "^3.5.5",
     "d3-queue": "^1.0.7",
-    "d3-svg-legend": "github:gemfarmer/d3-legend",
+    "d3-svg-legend": "^1.10.0",
     "document-register-element": "^0.5.3",
     "immutable": "^3.7.6",
     "jquery": "^1.11.3",


### PR DESCRIPTION
Fixes #1585 

Horizontal stacking display: [MT :sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/wide-maps/states/TN)
Vertical side-by-side display: [UT :sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/wide-maps/states/UT)

legends for the `<eiti-data-map>` component render a legend svg. This PR attempts to make the two column `map | legend` layout a one column layout (map and legend below it). There will also be a few other tweaks to the legend styling

Changes proposed in this pull request:
- [x] Detect if a map should have a "horizontal" or "vertical" layout
- [x] Basic horizontal implimentation 
- [x] make PRs to the [d3-legend](https://github.com/susielu/d3-legend)
  - [x] handle non-delimited quantize scale labels
  - [x] ~~enable a scale to be [filterable based its data](https://github.com/susielu/d3-legend/issues/31)~~ _instead, I added this logic to the data map component. It should eventually be removed, but works for now.
- [x] Make legend in side-by-side display more "fluffed"


/cc @ericronne 

#### Some Examples:
<img width="733" alt="screen shot 2016-07-28 at 12 05 23 pm" src="https://cloud.githubusercontent.com/assets/4803473/17221970/ad0b4b40-54bb-11e6-9074-b659b35a3c7d.png">
<img width="726" alt="screen shot 2016-07-28 at 12 05 14 pm" src="https://cloud.githubusercontent.com/assets/4803473/17221974/ad1ea3fc-54bb-11e6-9a70-5c0f628592e0.png">
<img width="746" alt="screen shot 2016-07-28 at 12 05 00 pm" src="https://cloud.githubusercontent.com/assets/4803473/17221971/ad0c7556-54bb-11e6-966a-a85850989dca.png">
<img width="753" alt="screen shot 2016-07-28 at 12 04 53 pm" src="https://cloud.githubusercontent.com/assets/4803473/17221975/ad1eeb6e-54bb-11e6-930a-c90105e4df6b.png">
<img width="737" alt="screen shot 2016-07-28 at 12 04 38 pm" src="https://cloud.githubusercontent.com/assets/4803473/17221972/ad0e8ae4-54bb-11e6-95ee-ec0395e22680.png">
<img width="760" alt="screen shot 2016-07-28 at 12 04 25 pm" src="https://cloud.githubusercontent.com/assets/4803473/17221973/ad141acc-54bb-11e6-8767-0fec43374bde.png">
<img width="755" alt="screen shot 2016-07-28 at 12 02 28 pm" src="https://cloud.githubusercontent.com/assets/4803473/17221979/ad3bfbb4-54bb-11e6-8650-ce3fafa42356.png">
<img width="752" alt="screen shot 2016-07-28 at 12 02 19 pm" src="https://cloud.githubusercontent.com/assets/4803473/17221977/ad39e0cc-54bb-11e6-9942-ca8353735646.png">
<img width="751" alt="screen shot 2016-07-28 at 12 02 12 pm" src="https://cloud.githubusercontent.com/assets/4803473/17221978/ad3aac28-54bb-11e6-8158-3140dfb740b6.png">
<img width="726" alt="screen shot 2016-07-28 at 12 06 49 pm" src="https://cloud.githubusercontent.com/assets/4803473/17222000/cfa3f2b0-54bb-11e6-9a58-ec259683f96e.png">

