### PR TITLE
Layout refinements

### DIFF
--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -28,7 +28,7 @@
 
     <section id="all-production-{{ product_slug }}" class="chart-item">
 
-      <h3 class="chart-title">{{ product_name }}</h3>
+      <h3 class="chart-title"><span>{{ product_name }}</span></h3>
 
       <figure class="chart">
         <figcaption id="all-production-figures-{{ product_slug }}">

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -35,13 +35,14 @@
           <span class="eiti-bar-chart-y-value" data-format=","">{{ volume | default: 0 | intcomma }}</span>
           {{ long_units | term }} of
           {{ product_name | downcase | suffix:units_suffix }} was extracted in {{ state_name }} in
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+          <span class="eiti-bar-chart-x-value">{{ year }}</span>
         </figcaption>
         <eiti-bar-chart
           aria-controls="all-production-figures-{{ product_slug }}"
           data='{{ production_values | map_hash: "volume" | jsonify }}'
           x-range="{{ year_range }}"
-          x-value="{{ year }}">
+          x-value="{{ year }}"
+          data-units="{{ long_units }}">
         </eiti-bar-chart>
       </figure>
       <!-- <h4>

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -5,7 +5,7 @@
 
 <section id="all-production" is="year-switcher-section" class="all-lands production">
 
-  <h2>Natural resource production in {{ state_name }}</h2>
+  <h3>Production on all land nationwide</h3>
 
   <div class="chart-selector-wrapper">
 

--- a/_includes/location/national-exports.html
+++ b/_includes/location/national-exports.html
@@ -35,13 +35,14 @@
                 ${{ exports[year].dollars | intcomma }}
               </span>
               of {{ commodity[0] }} was exported from {{ state_name }}
-              in <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+              in <span class="eiti-bar-chart-x-value">{{ year }}</span>
             </figcaption>
             <eiti-bar-chart
               aria-controls="exports-figures-{{ commodity_slug }}"
               data='{{ exports | map_hash: _metric | jsonify }}'
               x-range="{{ year_range }}"
-              x-value="{{ year }}">
+              x-value="{{ year }}"
+              data-units="$">
             </eiti-bar-chart>
 
           </figure>

--- a/_includes/location/national-exports.html
+++ b/_includes/location/national-exports.html
@@ -27,7 +27,7 @@
       {% if commodity[0] != "Total" and commodity[0] != "All" %}
         <section class="chart-item">
 
-          <h3 class="chart-title">{{ commodity[0] }}</h3>
+          <h3 class="chart-title"><span>{{ commodity[0] }}</span></h3>
 
           <figure class="chart chart-{{ _metric }}">
             <figcaption id="exports-figures-{{ commodity_slug }}">

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -59,14 +59,15 @@
                   data-format=",">{{ volume | default: 0 | intcomma }}</span>
           {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
           produced on federal land in {{ state_name }} in
-          <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+          <span class="eiti-bar-chart-x-value">{{ year }}</span>
 
           </figcaption>
           <eiti-bar-chart
             aria-controls="national-federal-production-figures-{{ product_slug }}"
             data='{{ production_values | map_hash: "volume" | jsonify }}'
             x-range="{{ year_range }}"
-            x-value="{{ year }}">
+            x-value="{{ year }}"
+            data-units="{{ long_units }}">
           </eiti-bar-chart>
 
         </figure>

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -47,8 +47,10 @@
       <section id="national-federal-production-{{ product_slug }}" class="product chart-item">
 
         <h4 class="chart-title">
-          {{ product_name }}
-          {% if units_title %} ({{ units_title }}){% endif %}
+          <span>
+            {{ product_name }}
+            {% if units_title %} ({{ units_title }}){% endif %}
+          </span>
         </h4>
 
         <figure class="chart">

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -12,7 +12,7 @@
 
   <section class="county-map-table" is="year-switcher-section">
 
-    <h3>Natural resources extracted on federal land</h3>
+    <h3>Production on federal land nationwide</h3>
 
     {% if federal_products_num == 0 %}
       <p>No natural resources were produced on federal land in {{  state_name }} in {{ year }}.</p>

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -46,7 +46,8 @@
           aria-controls="gdp-figures-{{ _metric }}"
           data='{{ gdp | map_hash: _metric | jsonify }}'
           x-range="{{ year_range }}"
-          x-value="{{ year }}">
+          x-value="{{ year }}"
+          data-units="{{ _format }}">
         </eiti-bar-chart>
 
       </figure>

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -71,7 +71,7 @@
     </section><!-- /.chart-item -->
     {% endfor %}
 
-  </div><!-- /.chart-list.has-intro -->
+  </div><!-- /.chart-list -->
 
   <a href="{{site.baseurl}}/downloads/#gdp">
     <icon class="fa fa-file-text-o u-padding-right"></icon>GDP data comes from the U.S. Bureau of Economic Analysis

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -27,7 +27,7 @@
       {% endif %}
 
     <section class="chart-item">
-      <h3 class="chart-title">GDP ({{ _metric }})</h3>
+      <h3 class="chart-title"><span>GDP ({{ _metric }})</span></h3>
 
       <figure class="chart chart-{{ _metric }}">
         <figcaption id="gdp-figures-{{ _metric }}">

--- a/_includes/location/national-jobs.html
+++ b/_includes/location/national-jobs.html
@@ -28,7 +28,7 @@
     {% assign _metrics = 'count' | split: ' ' %}
     {% for _metric in _metrics %}
     <section class="chart-item"
-      <h3 class="chart-title">Wage and salary jobs</h3>
+      <h3 class="chart-title"><span>Wage and salary jobs</span></h3>
 
       <figure class="chart">
         <figcaption id="jobs-figures-{{ _metric }}">
@@ -88,7 +88,7 @@
     {% for _metric in _metrics %}
     <section class="chart-item">
 
-      <h3 class="chart-title">Self-employment jobs</h3>
+      <h3 class="chart-title"><span>Self-employment jobs</span></h3>
 
       <figure class="chart">
         <figcaption id="self-employment-figures-{{ _metric }}">

--- a/_includes/location/national-jobs.html
+++ b/_includes/location/national-jobs.html
@@ -38,29 +38,16 @@
             {{ jobs[year].jobs | intcomma }}
           </span>
           jobs in extractive industries that paid a wage or salary in
-          {{ state_name }}.
+          {{ state_name }}
         </figcaption>
         <eiti-bar-chart
           aria-controls="jobs-figures-{{ _metric }}"
           data='{{ jobs | map_hash: _metric | jsonify }}'
           x-range="{{ year_range }}"
-          x-value="{{ year }}">
+          x-value="{{ year }}"
+          data-units="jobs">
         </eiti-bar-chart>
       </figure><!-- /.chart -->
-
-        {% if forloop.last %}
-        <!-- <h4>
-          <button is="aria-toggle"
-            aria-controls="employment-detail-{{ _metric }}">&plus; Detail</button>
-        </h4>
-        <div id="employment-detail-{{ _metric }}" aria-hidden="true">
-          {%
-            include location/display-jobs.html
-            values=jobs
-            percent=true
-          %}
-        </div> -->
-        {% endif %}
     </section><!-- /.chart-item -->
       {% endfor %}
   </section><!-- /.chart-list -->
@@ -98,13 +85,14 @@
             {{ self_employment_jobs[year].jobs | intcomma }}
           </span>
           self-employed extractive industries professionals in
-          {{ state_name }}.
+          {{ state_name }}
         </figcaption>
         <eiti-bar-chart
           aria-controls="self-employment-figures-{{ _metric }}"
           data='{{ self_employment_jobs | map_hash: _metric | jsonify }}'
           x-range="{{ year_range }}"
-          x-value="{{ year }}">
+          x-value="{{ year }}"
+          data-units="jobs">
         </eiti-bar-chart>
 
       </figure>

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -90,32 +90,18 @@
             <figcaption id="revenue-figures-{{ commodity_slug }}">
               In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
                 companies paid the federal government <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year].revenue | default: 0 | intcomma }}</span> to extract
-              {{ commodity_name | downcase }} on federal land in {{ state_name }}.
+              {{ commodity_name | downcase }} on federal land in {{ state_name }}
 
             </figcaption>
             <eiti-bar-chart
               data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
               aria-controls="revenue-figures-{{ commodity_slug }}"
               x-range="{{ year_range }}"
-              x-value="{{ year }}">
+              x-value="{{ year }}"
+              data-units="$,">
             </eiti-bar-chart>
 
           </figure>
-
-          <!-- <h4>
-            <button is="aria-toggle"
-              aria-controls="revenue-detail-{{ commodity_slug }}">&plus; Details</button>
-          </h4>
-          <div id="revenue-detail-{{ commodity_slug }}" aria-hidden="true">
-            {% assign revenue_values = commodity[1] %}
-            {%
-              include location/display-revenue.html
-              year=year
-              values=revenue_values
-              percent=false
-              rank=false
-            %}
-          </div> -->
 
         </section>
 

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -83,7 +83,7 @@
 
         <section id="revenue-{{ commodity_slug }}" class="chart-item">
 
-          <h3 class="chart-title">{{ commodity_name }}</h3>
+          <h3 class="chart-title"><span>{{ commodity_name }}</span></h3>
 
           <figure class="chart">
             {% assign annual_revenue = commodity[1] %}

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -30,18 +30,18 @@
       {% assign long_units = units_map[units].long | default 'units' %}
       {% assign units_suffix = units_map[units].suffix | default '' %}
 
-      <section id="national-all-production-{{ product_slug }}" class="chart-item">
+      <section id="state-all-production-{{ product_slug }}" class="chart-item">
 
         <h3 class="chart-title"><span>{{ product_name }}</span></h3>
         <figure class="chart">
-          <figcaption id="national-all-production-figures-{{ product_slug }}">
+          <figcaption id="state-all-production-figures-{{ product_slug }}">
             <span class="eiti-bar-chart-y-value" data-format=","">{{ volume | default: 0 | intcomma }}</span>
             {{ long_units | term }} of
             {{ product_name | downcase | suffix:units_suffix }} was produced in {{ state_name }} in
             <span class="eiti-bar-chart-x-value">{{ year }}</span>
           </figcaption>
           <eiti-bar-chart
-            aria-controls="national-all-production-figures-{{ product_slug }}"
+            aria-controls="state-all-production-figures-{{ product_slug }}"
             data='{{ production_values | map_hash: "volume" | jsonify }}'
             x-range="{{ year_range }}"
             x-value="{{ year }}"

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -38,13 +38,14 @@
             <span class="eiti-bar-chart-y-value" data-format=","">{{ volume | default: 0 | intcomma }}</span>
             {{ long_units | term }} of
             {{ product_name | downcase | suffix:units_suffix }} was produced in {{ state_name }} in
-            <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+            <span class="eiti-bar-chart-x-value">{{ year }}</span>
           </figcaption>
           <eiti-bar-chart
             aria-controls="national-all-production-figures-{{ product_slug }}"
             data='{{ production_values | map_hash: "volume" | jsonify }}'
             x-range="{{ year_range }}"
-            x-value="{{ year }}">
+            x-value="{{ year }}"
+            data-units="{{ long_units }}">
           </eiti-bar-chart>
         </figure>
 

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -32,7 +32,7 @@
 
       <section id="national-all-production-{{ product_slug }}" class="chart-item">
 
-        <h3 class="chart-title">{{ product_name }}</h3>
+        <h3 class="chart-title"><span>{{ product_name }}</span></h3>
         <figure class="chart">
           <figcaption id="national-all-production-figures-{{ product_slug }}">
             <span class="eiti-bar-chart-y-value" data-format=","">{{ volume | default: 0 | intcomma }}</span>

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -5,7 +5,7 @@
 
 <section id="all-production" is="year-switcher-section" class="all-lands production">
 
-  <h2>Natural resource production in {{ state_name }}</h2>
+  <h3>Production in the entire state of {{ state_name }}</h3>
 
   <div class="chart-selector-wrapper">
 

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -51,13 +51,14 @@
                 ${{ exports[year].dollars | intcomma }}
               </span>
               of {{ commodity[0] }} was exported from {{ state_name }}
-              in <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+              in <span class="eiti-bar-chart-x-value">{{ year }}</span>
             </figcaption>
             <eiti-bar-chart
               aria-controls="exports-figures-{{ commodity_slug }}"
               data='{{ exports | map_hash: _metric | jsonify }}'
               x-range="{{ year_range }}"
-              x-value="{{ year }}">
+              x-value="{{ year }}"
+              data-units="{{ _format }}">
             </eiti-bar-chart>
 
           </figure>

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -43,7 +43,7 @@
       {% if commodity[0] != "Total" and commodity[0] != "All" %}
         <section class="chart-item">
 
-          <h3 class="chart-title">{{ commodity[0] }}</h3>
+          <h3 class="chart-title"><span>{{ commodity[0] }}</span></h3>
 
           <figure class="chart chart-{{ _metric }}">
             <figcaption id="exports-figures-{{ commodity_slug }}">

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -59,14 +59,15 @@
                       data-format=",">{{ volume | default: 0 | intcomma }}</span>
               {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
               produced on federal land in {{ state_name }} in
-              <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+              <span class="eiti-bar-chart-x-value">{{ year }}</span>
 
               </figcaption>
               <eiti-bar-chart
                 aria-controls="federal-production-figures-{{ product_slug }}"
                 data='{{ production_values | map_hash: "volume" | jsonify }}'
                 x-range="{{ year_range }}"
-                x-value="{{ year }}">
+                x-value="{{ year }}"
+                data-units="{{ long_units }}">
               </eiti-bar-chart>
 
             </figure>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -11,7 +11,7 @@
 
   <section class="county-map-table" is="year-switcher-section">
 
-    <h3>Natural resources extracted on federal land</h3>
+    <h3>Production on federal land in {{ state_name }}</h3>
 
     {% if federal_products_num == 0 %}
       <p>No natural resources were produced on federal land in {{  state_name }} in {{ year }}.</p>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -86,7 +86,7 @@
               {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
               {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
               {% assign _width ='inherit' %}
-              {% capture caption %}Local production of {{ product_name | downcase | suffix:units_suffix }} in <span data-year="{{ year }}">{{ year }}</span>{% if units %} ({{ short_units | default:units }}){% endif %}{% endcapture %}
+              {% capture caption %}Local production of {{ product_name | downcase | suffix:units_suffix }} in <span data-year="{{ year }}">{{ year }}</span>{% if units %} <span class="legend-units">({{ short_units | default:units }})</span>{% endif %}{% endcapture %}
 
               <eiti-data-map color-scheme="Blues" steps="{{ steps }}" units="{{ units }}">
                 {% assign federal_county_production = site.data.federal_county_production[state_id] %}

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -47,8 +47,10 @@
           <div class="chart-container">
 
             <h4 class="chart-title">
-              {{ product_name }}
-              {% if units_title %} ({{ units_title }}){% endif %}
+              <span>
+                {{ product_name }}
+                {% if units_title %} ({{ units_title }}){% endif %}
+              </span>
             </h4>
 
             <figure class="chart">
@@ -74,7 +76,7 @@
           <div class="map-container">
 
             <h4 class="chart-title">
-              Local production
+              <span>Local production</span>
             </h4>
 
 

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -67,6 +67,6 @@
       </section><!-- /.chart-item -->
       {% endfor %}
 
-    </div><!-- /.chart-list.has-intro -->
+    </div><!-- /.chart-list -->
   {% endif %}
 </section>

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -58,7 +58,8 @@
             aria-controls="gdp-figures-{{ _metric }}"
             data='{{ gdp | map_hash: _metric | jsonify }}'
             x-range="{{ year_range }}"
-            x-value="{{ year }}">
+            x-value="{{ year }}"
+            data-units="{{ _metric }}">
           </eiti-bar-chart>
 
         </figure>

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -39,7 +39,7 @@
         {% endif %}
 
       <section class="chart-item">
-        <h3 class="chart-title">GDP ({{ _metric }})</h3>
+        <h3 class="chart-title"><span>GDP ({{ _metric }})</span></h3>
 
         <figure class="chart chart-{{ _metric }}">
           <figcaption id="gdp-figures-{{ _metric }}">

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -61,13 +61,14 @@
                 {{ jobs[year].jobs | intcomma }}
               </span>
               jobs in extractive industries that paid a wage or salary in
-              {{ state_name }}.
+              {{ state_name }}
             </figcaption>
             <eiti-bar-chart
               aria-controls="jobs-figures-{{ _metric }}"
               data='{{ jobs | map_hash: _metric | jsonify }}'
               x-range="{{ year_range }}"
-              x-value="{{ year }}">
+              x-value="{{ year }}"
+              data-units="jobs">
             </eiti-bar-chart>
           </figure><!-- /.chart -->
 
@@ -159,13 +160,14 @@
             {{ self_employment_jobs[year].jobs | intcomma }}
           </span>
           of people were self-employed in the extractive industries
-          {{ state_name }}.
+          {{ state_name }}
         </figcaption>
         <eiti-bar-chart
           aria-controls="self-employment-figures-{{ _metric }}"
           data='{{ self_employment_jobs | map_hash: _metric | jsonify }}'
           x-range="{{ year_range }}"
-          x-value="{{ year }}">
+          x-value="{{ year }}"
+          data-units="jobs">
         </eiti-bar-chart>
 
       </figure>

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -51,7 +51,7 @@
 
           {% assign _metrics = 'count' | split: ' ' %}
           {% for _metric in _metrics %}
-          <h3 class="chart-title">Wage and salary jobs</h3>
+          <h3 class="chart-title"><span>Wage and salary jobs</span></h3>
 
           <figure class="chart">
             <figcaption id="jobs-figures-{{ _metric }}">
@@ -80,7 +80,7 @@
         <div class="map-container">
 
           <h4 class="chart-title">
-            Local wage and salary jobs
+            <span>Local wage and salary jobs</span>
           </h4>
 
           <figure class="container">
@@ -150,7 +150,7 @@
     {% for _metric in _metrics %}
     <section class="chart-item">
 
-      <h3 class="chart-title">Self-employment</h3>
+      <h3 class="chart-title"><span>Self-employment</span></h3>
 
       <figure class="chart">
         <figcaption id="self-employment-figures-{{ _metric }}">

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -87,7 +87,7 @@
           <figure class="container">
             <eiti-data-map color-scheme="Reds" steps="{{ steps }}">
               {% capture value_key %}employment.{{ year }}.count{% endcapture %}
-              {% capture caption %}Local employment in extractive industries (jobs, <span data-year="{{ year }}">{{ year }}</span>){% endcapture %}
+              {% capture caption %}Local employment in extractive industries <span class="legend-units">(jobs, <span data-year="{{ year }}">{{ year }}</span>)</span>{% endcapture %}
 
               {%
                 include county-map.html

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -50,7 +50,7 @@
 
     <h3>Federal revenue by county</h3>
 
-    <section class="chart-list has-intro">
+    <section class="chart-list">
 
       <div class="chart-selector-wrapper">
 

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -20,7 +20,7 @@
     <div class="chart-container">
 
       <h4 class="chart-title">
-        All commodities
+        <span>All commodities</span>
       </h4>
 
       <figure class="chart">
@@ -44,7 +44,7 @@
     <div class="map-container">
 
       <h4 class="chart-title">
-        Revenue collected by locality
+        <span>Revenue collected by locality</span>
       </h4>
 
 

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -28,14 +28,15 @@
         <span class="eiti-bar-chart-y-value"
                 data-format="$,">${{ current_revenue | intcomma }}</span>
         was collected from federal land in {{ state_name }} in
-        <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+        <span class="eiti-bar-chart-x-value">{{ year }}</span>
 
         </figcaption>
         <eiti-bar-chart
           aria-controls="federal-revenue-county-figures-All"
           data='{{ state_revenue_all | map_hash: "revenue" | jsonify }}'
           x-range="{{ year_range }}"
-          x-value="{{ year }}">
+          x-value="{{ year }}"
+          data-units="$,">
         </eiti-bar-chart>
 
       </figure>

--- a/_includes/year-selector.html
+++ b/_includes/year-selector.html
@@ -14,14 +14,12 @@
       {% assign __year = year | to_i %}
       {% assign s_year = _year | to_s %}
       {% if include.empty_years.size > 0 %}
-        <!-- {{ empty_years }} -->
         {% if empty_years contains s_year %}
           <option disabled value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }} (no data)</option>
         {% else %}
           <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
         {% endif %}
       {% else %}
-      <!-- {{ year_list }} {{ _year }} -->
         <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
       {% endif %}
     {% endfor %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -7,7 +7,7 @@ nav_items:
     title: Production
     subnav_items:
       - name: all-production
-        title: All energy production
+        title: Entire state
       - name: federal-production
         title: Federal land
       - name: state-local-production
@@ -66,6 +66,8 @@ nav_items:
     {% include location/section-overview.html %}
 
     <section id="production">
+      <h2>Production</h2>
+
       {% include location/section-all-production.html %}
 
       {% include location/section-ownership.html %}
@@ -81,7 +83,7 @@ nav_items:
     -->
 
     <section id="economic-impact">
-    <h2>Economic Impact</h2>
+      <h2>Economic Impact</h2>
 
       {% include location/section-gdp.html %}
 

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -19,11 +19,13 @@
 
   .chart-title {
     @include heading(large-caps);
-
+    -ms-align-items: flex-end;
+    -webkit-align-items: flex-end;
     align-items: flex-end;
-    border-bottom: 1px solid $mid-gray;
+    border-bottom: 1px solid $neutral-gray;
     display: flex;
     flex: 1 0 auto;
+    min-height: 40px;
   }
 
   .chart-list-intro {
@@ -91,6 +93,7 @@
     padding: $base-padding-lite;
     padding-left: 0;
     padding-right: 0;
+    padding-top: 0;
 
     > :last-child {
       text-align: right;
@@ -145,8 +148,24 @@
 .row-container {
   @include outer-container();
 
+  display: flex;
+  -ms-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-justify-content: flex-start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+
   > * {
     @include span-columns(4);
+
+    display: flex;
+    -ms-flex-direction: column;
+    -webkit-flex-direction: column;
+    flex-direction: column;
+    -ms-align-self: flex-start;
+    -webkit-align-self: flex-start;
+    align-self: flex-start;
 
     &[aria-hidden=true] {
       display: none;

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -20,7 +20,9 @@
   .chart-title {
     @include heading(large-caps);
 
+    align-items: flex-end;
     border-bottom: 1px solid $mid-gray;
+    display: flex;
     flex: 1 0 auto;
   }
 

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -3,11 +3,7 @@
   @include outer-container();
 
   display: flex;
-  -ms-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
   flex-wrap: wrap;
-  -ms-justify-content: flex-start;
-  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 
 
@@ -19,8 +15,6 @@
 
   .chart-title {
     @include heading(large-caps);
-    -ms-align-items: flex-end;
-    -webkit-align-items: flex-end;
     align-items: flex-end;
     border-bottom: 1px solid $neutral-gray;
     display: flex;
@@ -37,8 +31,6 @@
 
     border-top: none;
     display: flex;
-    -ms-flex-direction: column;
-    -webkit-flex-direction: column;
     flex-direction: column;
     margin-bottom: $base-padding;
     margin-top: 0;
@@ -149,22 +141,14 @@
   @include outer-container();
 
   display: flex;
-  -ms-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
   flex-wrap: wrap;
-  -ms-justify-content: flex-start;
-  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 
   > * {
     @include span-columns(4);
 
-    -ms-align-self: flex-start;
-    -webkit-align-self: flex-start;
     align-self: flex-start;
     display: flex;
-    -ms-flex-direction: column;
-    -webkit-flex-direction: column;
     flex-direction: column;
 
     &[aria-hidden=true] {

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -46,7 +46,7 @@
   .chart-item,
   .details-container {
     button {
-      @include font-size(0.8);
+      @include font-size(0.75); // 12px
 
       background-color: $white;
       color: $dark-gray;
@@ -58,17 +58,24 @@
     @include omega();
   }
 
-  &.has-intro {
-    .chart-item:first-of-type,
-    .chart-item:nth-of-type(3n + 1) {
-      @include omega();
-    }
-  }
-
   &:not(.has-intro) {
+    .chart-item:nth-of-type(n) {
+      padding-right: 2 * $base-padding-lite;
+    }
+
     .chart-item:nth-of-type(3n) {
       @include omega();
+
+      padding-left: 2 * $base-padding-lite;
+      padding-right: 0;
     }
+
+    .chart-item:nth-of-type(2n) {
+      padding-left: $base-padding-lite;
+      padding-right: $base-padding-lite;
+    }
+
+
   }
 
   figure {
@@ -76,11 +83,14 @@
   }
 
   figcaption {
-    @include font-size(0.9);
+    @include font-size(7/8); // 14px
 
     font-weight: $weight-light;
-    min-height: 90px;
+    line-height: 20px;
+    min-height: 85px;
     padding: $base-padding-lite;
+    padding-left: 0;
+    padding-right: 0;
 
     > :last-child {
       text-align: right;
@@ -93,6 +103,7 @@
     font-weight: $weight-bold;
     margin: 0;
     min-height: inherit;
+    padding: $base-padding-lite;
   }
 
   .county-map-table {
@@ -107,6 +118,7 @@
 
   .chart-selector {
     @include span-columns(2);
+    @include font-size(7/8);
 
     background-color: $mid-gray;
     border: 0;
@@ -116,6 +128,7 @@
   }
 
   .chart-description {
+    @include heading('para-md');
     border-left: 1px solid $mid-gray;
     float: left;
     padding-left: 1.25rem;
@@ -165,6 +178,9 @@
         display: none;
       }
     }
-
   }
+}
+
+.legend-units {
+  font-weight: $weight-book;
 }

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -87,7 +87,7 @@
 
     font-weight: $weight-light;
     line-height: 20px;
-    min-height: 85px;
+    min-height: 90px;
     padding: $base-padding-lite;
     padding-left: 0;
     padding-right: 0;

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -76,10 +76,10 @@
   }
 
   figcaption {
-    @include font-size(1);
+    @include font-size(0.9);
 
     font-weight: $weight-light;
-    min-height: 100px;
+    min-height: 90px;
     padding: $base-padding-lite;
 
     > :last-child {

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -83,7 +83,7 @@
   }
 
   figcaption {
-    @include font-size(7/8); // 14px
+    @include font-size(7 / 8); // 14px
 
     font-weight: $weight-light;
     line-height: 20px;
@@ -118,7 +118,7 @@
 
   .chart-selector {
     @include span-columns(2);
-    @include font-size(7/8);
+    @include font-size(7 / 8);
 
     background-color: $mid-gray;
     border: 0;

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -87,7 +87,7 @@
 
     font-weight: $weight-light;
     line-height: 20px;
-    min-height: 90px;
+    min-height: 100px;
     padding: $base-padding-lite;
     padding-left: 0;
     padding-right: 0;

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -159,13 +159,13 @@
   > * {
     @include span-columns(4);
 
+    -ms-align-self: flex-start;
+    -webkit-align-self: flex-start;
+    align-self: flex-start;
     display: flex;
     -ms-flex-direction: column;
     -webkit-flex-direction: column;
     flex-direction: column;
-    -ms-align-self: flex-start;
-    -webkit-align-self: flex-start;
-    align-self: flex-start;
 
     &[aria-hidden=true] {
       display: none;

--- a/_sass/blocks/_county-bar-table.scss
+++ b/_sass/blocks/_county-bar-table.scss
@@ -25,3 +25,7 @@
     }
   }
 }
+
+.county-table {
+  @include heading('para-sm');
+}

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -2,8 +2,13 @@
   padding-bottom: $standard-padding-fluffed;
 
   section + section,
-  h2 + section {
+  h2 + section, {
     padding-top: $standard-padding-fluffed;
+  }
+
+  p + section,
+  p + h3 {
+    padding-top: $standard-padding-extra;
   }
 
   h2 {
@@ -12,6 +17,8 @@
   }
 
   h3:not(.chart-title):not(.state-page-nav-title) {
+    @include heading('h5');
+
     border-bottom: 2px solid $light-green;
     margin-bottom: $standard-padding;
     padding-bottom: $standard-padding-lite;
@@ -32,6 +39,10 @@
   h3 + [class*='panel-'] {
     margin-bottom: $standard-padding;
     margin-top: $standard-padding;
+  }
+
+  p {
+    @include heading('para-md');
   }
 
   figure {

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -1,9 +1,12 @@
 .state-page-nav-title {
   @include heading(large-caps);
-
+  -ms-align-items: center;
+  -webkit-align-items: center;
   align-items: center;
   border-bottom: 1px solid $mid-gray;
   display: flex;
+  -ms-justify-content: flex-start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   margin: 0;
   position: relative;
@@ -34,6 +37,8 @@
   }
 
   figure {
+    -ms-align-self: flex-end;
+    -webkit-align-self: flex-end;
     align-self: flex-end;
     margin: 0;
     width: 33%;

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -1,12 +1,8 @@
 .state-page-nav-title {
   @include heading(large-caps);
-  -ms-align-items: center;
-  -webkit-align-items: center;
   align-items: center;
   border-bottom: 1px solid $mid-gray;
   display: flex;
-  -ms-justify-content: flex-start;
-  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   margin: 0;
   position: relative;
@@ -37,8 +33,6 @@
   }
 
   figure {
-    -ms-align-self: flex-end;
-    -webkit-align-self: flex-end;
     align-self: flex-end;
     margin: 0;
     width: 33%;

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -75,6 +75,6 @@ data-map {
   }
 
   .cell text {
-    @include font-size(3/4);
+    @include font-size(3 / 4);
   }
 }

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -52,7 +52,6 @@ data-map {
       fill: $blackest-black;
       opacity: $opacity-state;
     }
-
   }
 }
 
@@ -73,5 +72,9 @@ data-map {
   .swatch {
     stroke: $neutral-gray;
     stroke-width: 1;
+  }
+
+  .cell text {
+    @include font-size(3/4);
   }
 }

--- a/_sass/components/_eiti-bar-chart.scss
+++ b/_sass/components/_eiti-bar-chart.scss
@@ -73,7 +73,7 @@ eiti-bar-chart {
 
 .eiti-bar-chart-x-value,
 .eiti-bar-chart-y-value {
-  @include font-size(15/16); // 15px
+  @include font-size(15 / 16); // 15px
   color: $green-dark-chart;
   font-weight: $weight-bold;
 }

--- a/_sass/components/_eiti-bar-chart.scss
+++ b/_sass/components/_eiti-bar-chart.scss
@@ -73,6 +73,7 @@ eiti-bar-chart {
 
 .eiti-bar-chart-x-value,
 .eiti-bar-chart-y-value {
+  @include font-size(15/16); // 15px
   color: $green-dark-chart;
   font-weight: $weight-bold;
 }

--- a/_sass/components/_eiti-bar-chart.scss
+++ b/_sass/components/_eiti-bar-chart.scss
@@ -30,7 +30,7 @@ eiti-bar-chart {
   .bar-mask {
     fill: transparent;
     stroke: $white;
-    stroke-width: 2;
+    stroke-width: 4;
   }
 
   .axis {
@@ -91,12 +91,13 @@ eiti-bar-chart {
 .extent-line {
   text {
     @include font-size(0.9);
+    fill: $neutral-gray;
   }
 
   line {
-    stroke: $green-dark-chart;
-    stroke-dasharray: 3,5;
-    stroke-width: 2;
+    stroke: $neutral-gray;
+    stroke-dasharray: 5,5;
+    stroke-width: 1;
   }
 }
 

--- a/_sass/components/_eiti-bar-chart.scss
+++ b/_sass/components/_eiti-bar-chart.scss
@@ -73,11 +73,8 @@ eiti-bar-chart {
 
 .eiti-bar-chart-x-value,
 .eiti-bar-chart-y-value {
-  @include font-size(1.1);
-
   color: $green-dark-chart;
   font-weight: $weight-bold;
-
 }
 
 .x-axis-label {
@@ -87,6 +84,18 @@ eiti-bar-chart {
     @include font-size(1);
 
     text-anchor: middle;
+  }
+}
+
+.extent-line {
+  text {
+    @include font-size(0.9);
+  }
+
+  line {
+    stroke: $green-dark-chart;
+    stroke-dasharray: 3,5;
+    stroke-width: 2;
   }
 }
 

--- a/_sass/mixins/_type-mixins.scss
+++ b/_sass/mixins/_type-mixins.scss
@@ -66,7 +66,7 @@
     font-size: 0.8125rem; // 13px
     font-weight: $weight-book;
     letter-spacing: 1px;
-    line-height: $standard-padding;
+    line-height: 1rem;
     margin-bottom: $base-padding-lite;
     padding-bottom: $base-padding-lite;
     text-transform: uppercase;

--- a/_sass/mixins/_type-mixins.scss
+++ b/_sass/mixins/_type-mixins.scss
@@ -63,8 +63,7 @@
   }
 
   @if $level == 'large-caps' {
-    // light 18/27 (12px bottom margin)
-    font-size: inherit;
+    font-size: 0.8125rem; // 13px
     font-weight: $weight-book;
     letter-spacing: 1px;
     line-height: $standard-padding;

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -9,7 +9,7 @@
 
   // global dimensions
   var width = 300;
-  var height = 150;
+  var height = 160;
 
   var textMargin = 18;
   var baseMargin = 2;
@@ -26,11 +26,20 @@
   var right = width - margin.right;
   var top = margin.top;
   var bottom = height - margin.bottom;
+  var barHeight = bottom - top;
+
+  var extentPercent = 0.05; // 5%
+  var extentMargin = barHeight * extentPercent;
+  var extentLessTop = top;
+  top = top + extentMargin;
+  var extentTop = top - extentMargin;
+
 
   var xAxisLabel = 'years';
   var labelOffset = width / 2;
 
-  var fullHeight = height + textMargin + tickPadding - (2 * baseMargin);
+  var fullHeight = height + textMargin + extentMargin + tickPadding - (2 * baseMargin);
+  var extentlessHeight = fullHeight - extentMargin;
 
   var attached = function() {
     var svg = d3.select(this)
@@ -65,6 +74,13 @@
   };
 
   var update = function() {
+
+    // conditional used as proxy for having an extent line
+    if (!this.hasAttribute('data-units')) {
+      top = extentlessHeight;
+      fullHeight = extentlessHeight;
+    }
+
     var data = this.data;
     var values = data;
 
@@ -106,6 +122,9 @@
       }
     });
 
+    var barWidth = x.rangeBand();
+    var barHeight = bottom - top;
+
     // filter the data so that only values within the domain
     // are included in calculations and rendering
     data = data.filter(function(d) {
@@ -119,9 +138,6 @@
     data.sort(function(a, b) {
       return d3.ascending(+a.x, +b.x);
     });
-
-    var barWidth = x.rangeBand();
-    var barHeight = bottom - top;
 
     var height = d3.scale.linear()
       .domain([ymin, ymax])
@@ -190,33 +206,37 @@
         .attr('x2', width)
         .attr('transform', 'translate(' + [0, bottom] + ')');
 
+    // conditional used as proxy for having an extent line
+    if (this.hasAttribute('data-units')) {
     var extentLine = svg.append('g')
-      .attr('class', 'extent-line')
+        .attr('class', 'extent-line')
 
-    var dataUnits = this.getAttribute('data-units'),
-    dataFormat = this.getAttribute('data-format') || '';
+      var dataUnits = this.getAttribute('data-units'),
+      dataFormat = this.getAttribute('data-format') || '';
 
-    if (dataUnits.indexOf('$') > -1) {
-      dataFormat = eiti.format.dollars;
-      dataUnits = null;
-    } else {
-      dataFormat = eiti.format.si;
+      if (dataUnits.indexOf('$') > -1) {
+        dataFormat = eiti.format.dollars;
+        dataUnits = null;
+      } else {
+        dataFormat = eiti.format.si;
+      }
+
+      var dataText = dataFormat(Math.ceil(+ymax * (1 + extentPercent)));
+      var extentText = [ dataText, dataUnits ].join(' ');
+
+      extentLine.append('text')
+        .text(extentText)
+        .attr('transform', 'translate(' + [0, extentTop - 5] + ')');
+
+      extentLine.append('line')
+        .attr('x1', 0)
+        .attr('x2', width)
+        .attr('transform', 'translate(' + [0, extentTop] + ')');
+
+      var xAxis = svg.select('.x-axis')
+        .attr('transform', 'translate(' + [0, bottom] + ')')
+        .call(axis);
     }
-
-    var extentText = [ dataFormat(ymax), dataUnits ].join(' ');
-
-    extentLine.append('text')
-      .text(extentText)
-      .attr('transform', 'translate(' + [0, top - 5] + ')');
-
-    extentLine.append('line')
-      .attr('x1', 0)
-      .attr('x2', width)
-      .attr('transform', 'translate(' + [0, top] + ')');
-
-    var xAxis = svg.select('.x-axis')
-      .attr('transform', 'translate(' + [0, bottom] + ')')
-      .call(axis);
 
     function isInSet (year, vals) {
       var vals = vals || values;

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -14,6 +14,7 @@
   var textMargin = 18;
   var baseMargin = 2;
   var extentMargin = 18;
+  var tickPadding = 10;
   var margin = {
     top: extentMargin,
     right: baseMargin,
@@ -27,10 +28,9 @@
   var bottom = height - margin.bottom;
 
   var xAxisLabel = 'years';
-  var xAxisBottom = height + margin.bottom;
   var labelOffset = width / 2;
 
-  var fullHeight = height + textMargin;
+  var fullHeight = height + textMargin + tickPadding - (2 * baseMargin);
 
   var attached = function() {
     var svg = d3.select(this)
@@ -160,7 +160,7 @@
 
     svg.selectAll('.bar-mask')
       // extend all the way to the bottom of the screen
-      .attr('height', barHeight + textMargin)
+      .attr('height', barHeight + textMargin + tickPadding)
       .attr('width', barWidth);
 
     selection.call(updateSelected, this.x);
@@ -178,7 +178,7 @@
       .scale(x)
       .ticks(xdomain.length)
       .tickSize(0)
-      .tickPadding(4)
+      .tickPadding(tickPadding)
       .tickFormat(function(x) {
         return String(x).substr(2);
       });
@@ -242,7 +242,7 @@
       .append('text')
         .text(xAxisLabel)
         .attr('transform', function(d) {
-          return 'translate(' + [labelOffset, xAxisBottom] + ')';
+          return 'translate(' + [labelOffset, fullHeight] + ')';
         });
   };
 

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -1,5 +1,6 @@
 (function(exports) {
 
+  var eiti = require('./../eiti');
   // symbols for "private" variables
   var DATA = '__es_data__';
   var X = '__es_x__';
@@ -12,8 +13,9 @@
 
   var textMargin = 18;
   var baseMargin = 2;
+  var extentMargin = 18;
   var margin = {
-    top: 0,
+    top: extentMargin,
     right: baseMargin,
     bottom: textMargin,
     left: baseMargin
@@ -144,7 +146,7 @@
     bars.exit().remove();
 
     bars.attr('transform', function(d) {
-      return 'translate(' + [x(d.x), 0] + ')';
+      return 'translate(' + [x(d.x), top] + ')';
     });
 
     bars.select('.bar-value')
@@ -187,6 +189,30 @@
         .attr('x1', 0)
         .attr('x2', width)
         .attr('transform', 'translate(' + [0, bottom] + ')');
+
+    var extentLine = svg.append('g')
+      .attr('class', 'extent-line')
+
+    var dataUnits = this.getAttribute('data-units'),
+    dataFormat = this.getAttribute('data-format') || '';
+
+    if (dataUnits.indexOf('$') > -1) {
+      dataFormat = eiti.format.dollars;
+      dataUnits = null;
+    } else {
+      dataFormat = eiti.format.si;
+    }
+
+    var extentText = [ dataFormat(ymax), dataUnits ].join(' ');
+
+    extentLine.append('text')
+      .text(extentText)
+      .attr('transform', 'translate(' + [0, top - 5] + ')');
+
+    extentLine.append('line')
+      .attr('x1', 0)
+      .attr('x2', width)
+      .attr('transform', 'translate(' + [0, top] + ')');
 
     var xAxis = svg.select('.x-axis')
       .attr('transform', 'translate(' + [0, bottom] + ')')

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -103,7 +103,7 @@
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
 	  var d3 = {
-	    version: "3.5.16"
+	    version: "3.5.17"
 	  };
 	  var d3_arraySlice = [].slice, d3_array = function(list) {
 	    return d3_arraySlice.call(list);
@@ -3628,7 +3628,7 @@
 	        λ0 = λ, sinφ0 = sinφ, cosφ0 = cosφ, point0 = point;
 	      }
 	    }
-	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ winding & 1;
+	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ winding & 1;
 	  }
 	  function d3_geo_clipCircle(radius) {
 	    var cr = Math.cos(radius), smallRadius = cr > 0, notHemisphere = abs(cr) > ε, interpolate = d3_geo_circleInterpolate(radius, 6 * d3_radians);
@@ -10835,7 +10835,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
-	 * jQuery JavaScript Library v1.12.3
+	 * jQuery JavaScript Library v1.12.4
 	 * http://jquery.com/
 	 *
 	 * Includes Sizzle.js
@@ -10845,7 +10845,7 @@
 	 * Released under the MIT license
 	 * http://jquery.org/license
 	 *
-	 * Date: 2016-04-05T19:16Z
+	 * Date: 2016-05-20T17:17Z
 	 */
 
 	(function( global, factory ) {
@@ -10901,7 +10901,7 @@
 
 
 	var
-		version = "1.12.3",
+		version = "1.12.4",
 
 		// Define a local copy of jQuery
 		jQuery = function( selector, context ) {
@@ -17508,6 +17508,7 @@
 			if ( reliableHiddenOffsetsVal ) {
 				div.style.display = "";
 				div.innerHTML = "<table><tr><td></td><td>t</td></tr></table>";
+				div.childNodes[ 0 ].style.borderCollapse = "separate";
 				contents = div.getElementsByTagName( "td" );
 				contents[ 0 ].style.cssText = "margin:0;border:0;padding:0;display:none";
 				reliableHiddenOffsetsVal = contents[ 0 ].offsetHeight === 0;
@@ -17831,19 +17832,6 @@
 			styles = getStyles( elem ),
 			isBorderBox = support.boxSizing &&
 				jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
-
-		// Support: IE11 only
-		// In IE 11 fullscreen elements inside of an iframe have
-		// 100x too small dimensions (gh-1764).
-		if ( document.msFullscreenElement && window.top !== window ) {
-
-			// Support: IE11 only
-			// Running getBoundingClientRect on a disconnected node
-			// in IE throws an error.
-			if ( elem.getClientRects().length ) {
-				val = Math.round( elem.getBoundingClientRect()[ name ] * 100 );
-			}
-		}
 
 		// some non-html elements return undefined for offsetWidth, so check for null/undefined
 		// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
@@ -20835,6 +20823,11 @@
 	}
 
 	function filterHidden( elem ) {
+
+		// Disconnected elements are considered hidden
+		if ( !jQuery.contains( elem.ownerDocument || document, elem ) ) {
+			return true;
+		}
 		while ( elem && elem.nodeType === 1 ) {
 			if ( getDisplay( elem ) === "none" || elem.type === "hidden" ) {
 				return true;

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12404,6 +12404,7 @@
 	  var textMargin = 18;
 	  var baseMargin = 2;
 	  var extentMargin = 18;
+	  var tickPadding = 10;
 	  var margin = {
 	    top: extentMargin,
 	    right: baseMargin,
@@ -12417,10 +12418,9 @@
 	  var bottom = height - margin.bottom;
 
 	  var xAxisLabel = 'years';
-	  var xAxisBottom = height + margin.bottom;
 	  var labelOffset = width / 2;
 
-	  var fullHeight = height + textMargin;
+	  var fullHeight = height + textMargin + tickPadding - (2 * baseMargin);
 
 	  var attached = function() {
 	    var svg = d3.select(this)
@@ -12550,7 +12550,7 @@
 
 	    svg.selectAll('.bar-mask')
 	      // extend all the way to the bottom of the screen
-	      .attr('height', barHeight + textMargin)
+	      .attr('height', barHeight + textMargin + tickPadding)
 	      .attr('width', barWidth);
 
 	    selection.call(updateSelected, this.x);
@@ -12568,7 +12568,7 @@
 	      .scale(x)
 	      .ticks(xdomain.length)
 	      .tickSize(0)
-	      .tickPadding(4)
+	      .tickPadding(tickPadding)
 	      .tickFormat(function(x) {
 	        return String(x).substr(2);
 	      });
@@ -12632,7 +12632,7 @@
 	      .append('text')
 	        .text(xAxisLabel)
 	        .attr('transform', function(d) {
-	          return 'translate(' + [labelOffset, xAxisBottom] + ')';
+	          return 'translate(' + [labelOffset, fullHeight] + ')';
 	        });
 	  };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12399,7 +12399,7 @@
 
 	  // global dimensions
 	  var width = 300;
-	  var height = 150;
+	  var height = 160;
 
 	  var textMargin = 18;
 	  var baseMargin = 2;
@@ -12416,11 +12416,20 @@
 	  var right = width - margin.right;
 	  var top = margin.top;
 	  var bottom = height - margin.bottom;
+	  var barHeight = bottom - top;
+
+	  var extentPercent = 0.05; // 5%
+	  var extentMargin = barHeight * extentPercent;
+	  var extentLessTop = top;
+	  top = top + extentMargin;
+	  var extentTop = top - extentMargin;
+
 
 	  var xAxisLabel = 'years';
 	  var labelOffset = width / 2;
 
-	  var fullHeight = height + textMargin + tickPadding - (2 * baseMargin);
+	  var fullHeight = height + textMargin + extentMargin + tickPadding - (2 * baseMargin);
+	  var extentlessHeight = fullHeight - extentMargin;
 
 	  var attached = function() {
 	    var svg = d3.select(this)
@@ -12455,6 +12464,13 @@
 	  };
 
 	  var update = function() {
+
+	    // conditional used as proxy for having an extent line
+	    if (!this.hasAttribute('data-units')) {
+	      top = extentlessHeight;
+	      fullHeight = extentlessHeight;
+	    }
+
 	    var data = this.data;
 	    var values = data;
 
@@ -12496,6 +12512,9 @@
 	      }
 	    });
 
+	    var barWidth = x.rangeBand();
+	    var barHeight = bottom - top;
+
 	    // filter the data so that only values within the domain
 	    // are included in calculations and rendering
 	    data = data.filter(function(d) {
@@ -12509,9 +12528,6 @@
 	    data.sort(function(a, b) {
 	      return d3.ascending(+a.x, +b.x);
 	    });
-
-	    var barWidth = x.rangeBand();
-	    var barHeight = bottom - top;
 
 	    var height = d3.scale.linear()
 	      .domain([ymin, ymax])
@@ -12580,33 +12596,37 @@
 	        .attr('x2', width)
 	        .attr('transform', 'translate(' + [0, bottom] + ')');
 
+	    // conditional used as proxy for having an extent line
+	    if (this.hasAttribute('data-units')) {
 	    var extentLine = svg.append('g')
-	      .attr('class', 'extent-line')
+	        .attr('class', 'extent-line')
 
-	    var dataUnits = this.getAttribute('data-units'),
-	    dataFormat = this.getAttribute('data-format') || '';
+	      var dataUnits = this.getAttribute('data-units'),
+	      dataFormat = this.getAttribute('data-format') || '';
 
-	    if (dataUnits.indexOf('$') > -1) {
-	      dataFormat = eiti.format.dollars;
-	      dataUnits = null;
-	    } else {
-	      dataFormat = eiti.format.si;
+	      if (dataUnits.indexOf('$') > -1) {
+	        dataFormat = eiti.format.dollars;
+	        dataUnits = null;
+	      } else {
+	        dataFormat = eiti.format.si;
+	      }
+
+	      var dataText = dataFormat(Math.ceil(+ymax * (1 + extentPercent)));
+	      var extentText = [ dataText, dataUnits ].join(' ');
+
+	      extentLine.append('text')
+	        .text(extentText)
+	        .attr('transform', 'translate(' + [0, extentTop - 5] + ')');
+
+	      extentLine.append('line')
+	        .attr('x1', 0)
+	        .attr('x2', width)
+	        .attr('transform', 'translate(' + [0, extentTop] + ')');
+
+	      var xAxis = svg.select('.x-axis')
+	        .attr('transform', 'translate(' + [0, bottom] + ')')
+	        .call(axis);
 	    }
-
-	    var extentText = [ dataFormat(ymax), dataUnits ].join(' ');
-
-	    extentLine.append('text')
-	      .text(extentText)
-	      .attr('transform', 'translate(' + [0, top - 5] + ')');
-
-	    extentLine.append('line')
-	      .attr('x1', 0)
-	      .attr('x2', width)
-	      .attr('transform', 'translate(' + [0, top] + ')');
-
-	    var xAxis = svg.select('.x-axis')
-	      .attr('transform', 'translate(' + [0, bottom] + ')')
-	      .call(axis);
 
 	    function isInSet (year, vals) {
 	      var vals = vals || values;

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12386,10 +12386,11 @@
 
 /***/ },
 /* 33 */
-/***/ function(module, exports) {
+/***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
 
+	  var eiti = __webpack_require__(12);
 	  // symbols for "private" variables
 	  var DATA = '__es_data__';
 	  var X = '__es_x__';
@@ -12402,8 +12403,9 @@
 
 	  var textMargin = 18;
 	  var baseMargin = 2;
+	  var extentMargin = 18;
 	  var margin = {
-	    top: 0,
+	    top: extentMargin,
 	    right: baseMargin,
 	    bottom: textMargin,
 	    left: baseMargin
@@ -12534,7 +12536,7 @@
 	    bars.exit().remove();
 
 	    bars.attr('transform', function(d) {
-	      return 'translate(' + [x(d.x), 0] + ')';
+	      return 'translate(' + [x(d.x), top] + ')';
 	    });
 
 	    bars.select('.bar-value')
@@ -12577,6 +12579,30 @@
 	        .attr('x1', 0)
 	        .attr('x2', width)
 	        .attr('transform', 'translate(' + [0, bottom] + ')');
+
+	    var extentLine = svg.append('g')
+	      .attr('class', 'extent-line')
+
+	    var dataUnits = this.getAttribute('data-units'),
+	    dataFormat = this.getAttribute('data-format') || '';
+
+	    if (dataUnits.indexOf('$') > -1) {
+	      dataFormat = eiti.format.dollars;
+	      dataUnits = null;
+	    } else {
+	      dataFormat = eiti.format.si;
+	    }
+
+	    var extentText = [ dataFormat(ymax), dataUnits ].join(' ');
+
+	    extentLine.append('text')
+	      .text(extentText)
+	      .attr('transform', 'translate(' + [0, top - 5] + ')');
+
+	    extentLine.append('line')
+	      .attr('x1', 0)
+	      .attr('x2', width)
+	      .attr('transform', 'translate(' + [0, top] + ')');
 
 	    var xAxis = svg.select('.x-axis')
 	      .attr('transform', 'translate(' + [0, bottom] + ')')

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -443,7 +443,7 @@
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
 	  var d3 = {
-	    version: "3.5.16"
+	    version: "3.5.17"
 	  };
 	  var d3_arraySlice = [].slice, d3_array = function(list) {
 	    return d3_arraySlice.call(list);
@@ -3968,7 +3968,7 @@
 	        λ0 = λ, sinφ0 = sinφ, cosφ0 = cosφ, point0 = point;
 	      }
 	    }
-	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < 0) ^ winding & 1;
+	    return (polarAngle < -ε || polarAngle < ε && d3_geo_areaRingSum < -ε) ^ winding & 1;
 	  }
 	  function d3_geo_clipCircle(radius) {
 	    var cr = Math.cos(radius), smallRadius = cr > 0, notHemisphere = abs(cr) > ε, interpolate = d3_geo_circleInterpolate(radius, 6 * d3_radians);
@@ -11370,7 +11370,7 @@
 
 
 	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6),
 	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
 	        shapes = cell.select("g." + classPrefix + "cell " + shape);
 
@@ -11749,7 +11749,7 @@
 
 
 	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6),
 	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
 	        shapes = cell.select("g." + classPrefix + "cell " + shape);
 
@@ -11954,7 +11954,7 @@
 	      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
 
 	      var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
-	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
+	        cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6),
 	        shapeEnter = cellEnter.append(shape).attr("class", classPrefix + "swatch"),
 	        shapes = cell.select("g." + classPrefix + "cell " + shape);
 

--- a/states/index.html
+++ b/states/index.html
@@ -10,6 +10,8 @@ nav_items:
   - name: production
     title: Production
     subnav_items:
+      - name: all-production
+        title: All land
       - name: federal-production
         title: Federal land
   - name: revenue
@@ -59,6 +61,8 @@ nav_items:
     </figure>
 
     <section id="production">
+      <h2>Production</h2>
+
       {% include location/national-all-production.html %}
 
       {% include location/national-federal-production.html %}


### PR DESCRIPTION

Fixes issue(s) #1597 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/layout-refinements/states/)

Changes proposed in this pull request:

- [x] improve `.chart-title` vertical alignment
- [x] added extent line with units and SI units to _all_ bar charts
- [x] removed period from bar chart sentence.
- [x] improved spacing between bars and words
- [x] per @ericronne's suggestion, made Production an h2 heading and added a subheading for all production
- [x] made font and spacing changes per Eric's suggestions

<img width="390" alt="screen shot 2016-07-29 at 11 46 45 am" src="https://cloud.githubusercontent.com/assets/4803473/17256212/29884d14-5582-11e6-8c6a-a7c66d234847.png">


/cc @ericronne @meiqimichelle 

