### PR TITLE
content fixes and edits

### DIFF
--- a/_case-studies/north-slope.md
+++ b/_case-studies/north-slope.md
@@ -157,7 +157,7 @@ The table below highlights the data sources used to compile this narrative, as w
 
 [^20]: [Comprehensive Annual Financial Report of the North Slope Borough, Alaska (PDF)](http://www.north-slope.org/assets/images/uploads/2013_NSB_CAFR.pdf), 2013.
 
-[^21]: Energy Information Agency, [State severance tax revenues decline as fossil fuel prices drop](http://www.eia.gov/todayinenergy/detail.cfm?id=24512), January 12, 2016
+[^21]: Energy Information Administration, [State severance tax revenues decline as fossil fuel prices drop](http://www.eia.gov/todayinenergy/detail.cfm?id=24512), January 12, 2016
 
 [^22]: [Alaska Department of Revenue Tax Division](http://www.tax.alaska.gov/programs/programs/reports/AnnualReport.aspx?Year=2015)
 

--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -124,10 +124,10 @@ permalink: /explore/reconciliation/
                 <div class="flowchart-stem_left"></div>
               </li>
               <li class="flowchart-dialog flowchart-no_top flowchart-dialog_transparent flowchart-columns_8">
-                <p>For the 2015 USEITI Report, 540 transactions were reconciled. <span class="flowchart-text_bold flowchart-text_large">The Independent Administrator identified and reviewed just 17 material variances, all of which were fully explained.</span> No material variances were found to indicate significant errors or fraud. Here are some of the common explanations:</p>
+                <p><span class="flowchart-text_bold flowchart-text_large">The Independent Administrator identified and reviewed just 17 material variances, all of which were fully explained.</span> No material variances were found to indicate significant errors or fraud. Here are some of the common explanations:</p>
                 <ul class="list-bullet">
                   <li>Differences in accounting systems. Some companies record transactions in their accounting systems differently than the government does, so revenue categories (such as rents, taxes, and royalties) may get lumped differently.</li>
-                  <li>Differences in when payments were recorded. For example: a company might make a payment in December, and that payment doesn't get recorded by the government until January of the next year.</li>
+                  <li>Differences in when payments were recorded. For example: a company may have made a payment and recorded it on December 31, and that payment was then recorded by the government on January 2 of the next year.</li>
                 </ul>
                 <div class="flowchart-stem_left"></div>
               </li>

--- a/_explore/revenue/reconciliation.html
+++ b/_explore/revenue/reconciliation.html
@@ -72,10 +72,15 @@ permalink: /explore/reconciliation/
 
       <div class="container flowchart">
 
-        <h2>What did the reconciliation process find?</h2>
+        <h2>Company participation, reporting, and reconciliation results</h2>
         <ul>
           <li class="flowchart-dialog flowchart-dialog_top">
-            <span class="flowchart-text_large">The USEITI reconciliation process looked at 540 transactions from 45 companies, and found that all <span class="term term-p" data-term="material variance" title="Click to define" tabindex="0">material variances<i class="icon-book"></i></span> were fully explained. No evidence of significant errors or fraud was found.</span>
+            <ul>
+              <li>45 companies were asked to report</li>
+              <li>31 companies reported and reconciled $8.5 billion in Department of the Interior revenue</li>
+              <li>12 out of 41 applicable companies reported $190 million in corporate income taxes</li>
+              <li>100% of 17 <span class="term term-p" data-term="material variance" title="Click to define" tabindex="0">material variances<i class="icon-book"></i></span> have been explained</li>
+            </ul>
           </li>
         </ul>
 
@@ -94,7 +99,10 @@ permalink: /explore/reconciliation/
           </li>
 
           <li class="flowchart-dialog flowchart-dialog_left flowchart-dialog_right flowchart-columns_10">
-            <span class="flowchart-text_bold">Is the percentage difference greater than the <span class="term term-p" data-term="margin of variance" title="Click to define" tabindex="0">margin of variance<i class="icon-book"></i></span>?</span>
+            <span class="flowchart-text_bold">
+              Is the percentage difference greater than the <span class="term term-p" data-term="margin of variance" title="Click to define" tabindex="0">margin of variance<i class="icon-book"></i>?</span><br>AND<br>
+              Is the dollar amount of the discrepancy greater than the <span class="term term-p" data-term="variance floor" title="Click to define" tabindex="0">variance floor<i class="icon-book"></i></span>?
+            </span>
             <div class="flowchart-words_left">yes</div>
             <div class="flowchart-words_right">no</div>
             <div class="flowchart-stem_left"></div>
@@ -102,11 +110,11 @@ permalink: /explore/reconciliation/
           </li>
           <li class="container">
             <ul>
-              <li class="flowchart-dialog flowchart-no_dialog flowchart-columns_8 flowchart-columns_left">
-                <span class="flowchart-text_bold">Is the dollar amount of the discrepancy greater than the <span class="term term-p" data-term="variance floor" title="Click to define" tabindex="0">variance floor<i class="icon-book"></i></span>?</span>
+<!--               <li class="flowchart-dialog flowchart-no_dialog flowchart-columns_8 flowchart-columns_left">
+                <span class="flowchart-text_bold"></span>
                 <div class="flowchart-stem_left"></div>
               </li>
-              <li class="para-sm flowchart-dialog flowchart-no_dialog flowchart-columns_4 flowchart-columns_right">
+ -->              <li class="para-sm flowchart-dialog flowchart-no_dialog flowchart-columns_4 flowchart-columns_right">
                 <span class="flowchart-text_bold">No further reason to review.</span>
 
                 <path class="flowchart-stem_bottom_right_extra_long"></path>
@@ -119,7 +127,7 @@ permalink: /explore/reconciliation/
                 <p>For the 2015 USEITI Report, 540 transactions were reconciled. <span class="flowchart-text_bold flowchart-text_large">The Independent Administrator identified and reviewed just 17 material variances, all of which were fully explained.</span> No material variances were found to indicate significant errors or fraud. Here are some of the common explanations:</p>
                 <ul class="list-bullet">
                   <li>Differences in accounting systems. Some companies record transactions in their accounting systems differently than the government does, so revenue categories (such as rents, taxes, and royalties) may get lumped differently.</li>
-                  <li>Differences in accounting years. For example, companies and government sometimes run on different accounting years, resulting in payments getting recorded in different years.</li>
+                  <li>Differences in when payments were recorded. For example: a company might make a payment in December, and that payment doesn't get recorded by the government until January of the next year.</li>
                 </ul>
                 <div class="flowchart-stem_left"></div>
               </li>
@@ -229,23 +237,23 @@ permalink: /explore/reconciliation/
           <h3>Footnotes</h3>
           <ol>
 
-            <li id="fn:1" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $711,360 was paid by BP America in 2012 and recorded by ONRR in 2013. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
-            <li id="fn:2" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $54,318,974 was paid by Chevron Corporation in 2012 and recorded by ONRR in 2013. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
-            <li id="fn:3" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: Payment transactions for tax refunds totaling $6,345,527 were shown as paid by the IRS in 2013 and recorded by Shell E&amp;P Company in January 2014. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
-            <li id="fn:4" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $11,232,000 was paid by Exxon Mobil Corporation in 2012 and recorded by ONRR in 2013. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
-            <li id="fn:5" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $8,300,214 was paid by Peabody Energy Corporation in 2013 and recorded by ONRR in 2014. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
-            <li id="fn:6" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $91,500 was paid by Anadarko Petroleum Corporation in 2012 and recorded by ONRR in 2013. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
-            <li id="fn:7" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $280,655 was paid by ConocoPhillips in 2013 and recorded by ONRR in 2014. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
-            <li id="fn:8" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $17,000 was paid by ConocoPhillips in 2013 and recorded by ONRR in 2014. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
-            <li id="fn:9" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $240,500 was paid by ConocoPhillips in 2013 and recorded by ONRR in 2014. <a href="#fnref:9" class="reversefootnote">↩</a></p></li>
+            <li id="fn:1" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $711,360 was paid by BP America in 2012 and recorded by ONRR in 2013. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+            <li id="fn:2" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $54,318,974 was paid by Chevron Corporation in 2012 and recorded by ONRR in 2013. <a href="#fnref:2" class="reversefootnote">↩</a></p></li>
+            <li id="fn:3" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: Payment transactions for tax refunds totaling $6,345,527 were shown as paid by the IRS in 2013 and recorded by Shell E&amp;P Company in January 2014. <a href="#fnref:3" class="reversefootnote">↩</a></p></li>
+            <li id="fn:4" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $11,232,000 was paid by Exxon Mobil Corporation in 2012 and recorded by ONRR in 2013. <a href="#fnref:4" class="reversefootnote">↩</a></p></li>
+            <li id="fn:5" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $8,300,214 was paid by Peabody Energy Corporation in 2013 and recorded by ONRR in 2014. <a href="#fnref:5" class="reversefootnote">↩</a></p></li>
+            <li id="fn:6" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $91,500 was paid by Anadarko Petroleum Corporation in 2012 and recorded by ONRR in 2013. <a href="#fnref:6" class="reversefootnote">↩</a></p></li>
+            <li id="fn:7" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $280,655 was paid by ConocoPhillips in 2013 and recorded by ONRR in 2014. <a href="#fnref:7" class="reversefootnote">↩</a></p></li>
+            <li id="fn:8" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $17,000 was paid by ConocoPhillips in 2013 and recorded by ONRR in 2014. <a href="#fnref:8" class="reversefootnote">↩</a></p></li>
+            <li id="fn:9" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $240,500 was paid by ConocoPhillips in 2013 and recorded by ONRR in 2014. <a href="#fnref:9" class="reversefootnote">↩</a></p></li>
             <li id="fn:10" class="hashoffset"><p>The IA investigated this material variance and found that Freeport McMoRan Inc. records rental payment transactions in their accounting system differently from how ONRR records transactions, including different lumping of rents and bonuses. This variance was fully explained by this difference in categorization.<a href="#fnref:10" class="reversefootnote">↩</a></p></li>
-            <li id="fn:11" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $5,520,487 was paid by Statoil Gulf of Mexico in 2013 and recorded by ONRR in 2014. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
-            <li id="fn:12" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $1,086,317 was paid by Ultra Resources in 2012 and recorded in 2013; $47,724 was paid in 2013 and recorded in 2014. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
-            <li id="fn:13" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $31,500 was paid by Noble Energy, Inc. in 2012 and recorded in 2013. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
-            <li id="fn:14" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $19,500 was paid by Noble Energy, Inc. in 2013 and recorded by BLM in 2014. <a href="#fnref:14" class="reversefootnote">↩</a></p></li>
-            <li id="fn:15" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $32,500 was paid by Cimarex Energy in 2013 and recorded by BLM in 2014. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
+            <li id="fn:11" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $5,520,487 was paid by Statoil Gulf of Mexico in 2013 and recorded by ONRR in 2014. <a href="#fnref:11" class="reversefootnote">↩</a></p></li>
+            <li id="fn:12" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $1,086,317 was paid by Ultra Resources in 2012 and recorded in 2013; $47,724 was paid in 2013 and recorded in 2014. <a href="#fnref:12" class="reversefootnote">↩</a></p></li>
+            <li id="fn:13" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $31,500 was paid by Noble Energy, Inc. in 2012 and recorded in 2013. <a href="#fnref:13" class="reversefootnote">↩</a></p></li>
+            <li id="fn:14" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $19,500 was paid by Noble Energy, Inc. in 2013 and recorded by BLM in 2014. <a href="#fnref:14" class="reversefootnote">↩</a></p></li>
+            <li id="fn:15" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $32,500 was paid by Cimarex Energy in 2013 and recorded by BLM in 2014. <a href="#fnref:15" class="reversefootnote">↩</a></p></li>
             <li id="fn:16" class="hashoffset"><p>The IA investigated this material variance and found that BLM included revenue for permit fees collected for activity they administered on multiple tribal leases. However, Newfield Exploration Company did not include this revenue in this category, as it was not for federal leases. This variance was fully explained by this difference in categorization.<a href="#fnref:16" class="reversefootnote">↩</a></p></li>
-            <li id="fn:17" class="hashoffset"><p>This material variance was fully explained by a difference in accounting years: $1,383,084 was paid by ANKOR Energy LLC in 2012 and recorded in 2013. <a href="#fnref:17" class="reversefootnote">↩</a></p></li>
+            <li id="fn:17" class="hashoffset"><p>This material variance was fully explained by a difference in when payments were recorded: $1,383,084 was paid by ANKOR Energy LLC in 2012 and recorded in 2013. <a href="#fnref:17" class="reversefootnote">↩</a></p></li>
           </ol>
         </div>
       </div>

--- a/_how-it-works/coal-excise-tax.md
+++ b/_how-it-works/coal-excise-tax.md
@@ -11,7 +11,7 @@ selector: list
 
 In the United States, one of the taxes coal producers must pay is an excise tax when they mine coal. Producers pay the tax when the coal is first sold or used.[^1] The tax does not apply to lignite or to coal mined in the U.S. for export. Learn more about [how coal revenues work]({{site.baseurl}}/how-it-works/coal/).
 
-This tax originated in 1977 with the Black Lung Revenue Act. The excise tax is the chief source of revenue for the [Black Lung Program](https://www.dol.gov/owcp/dcmwc/) and Black Lung Disability Trust Fund (BLTDF), which pays benefits to miners disabled by black lung disease, as well as their eligible survivors and dependents.[^2]
+This tax originated in 1977 with the Black Lung Revenue Act. The excise tax is the chief source of revenue for the [Black Lung Program](https://www.dol.gov/owcp/dcmwc/) and Black Lung Disability Trust Fund (BLDTF), which pays benefits to miners disabled by black lung disease, as well as their eligible survivors and dependents.[^2]
 
 Coal excise tax payments are collected by the Internal Revenue Service and transferred to the BLDTF. Amounts in the BLDTF are available, as provided in appropriation acts, for benefit payments that are administered by the Department of Labor’s Division of Coal Mine Workers’ Compensation.[^3]
 

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -11,7 +11,10 @@
     {% include year-selector.html year_range=year_range %}
 
     <p class="chart-description">
-      A revolutionary description of GDP from extractives could go here. The selector should change only the GDP section
+      Extractive industries accounted for
+      {{ gdp[year].percent | percent }}%
+      of U.S. GDP in {{ year }}.
+      GDP data comes from the U.S. Bureau of Economic Analysis. <a href="{{site.baseurl}}/downloads/#gdp">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
     </p>
   </div><!-- .chart-selector-wrapper -->
 


### PR DESCRIPTION
Fixes issue(s) #1681, #1680, #1683

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/content-fixes/)

Changes proposed in this pull request:

- fix `BLDTF` typo
- add summary sentences to GDP section of the national page
- discovered that 2013 *is* the latest national GDP percentage we have, and didn't edit the case study intro page after all because it was already up-to-date!
- found and corrected one instance of `Energy Information Agency`
- on the reconciliation page, pull in language from pg. 2 of the executive summary
- correct material variance explanations to clarify that it's not about accounting years but about Dec/Jan payments (for instance)

/cc @meiqimichelle 

