### PR TITLE
Add pagination to search results

### DIFF
--- a/js/components/search.js
+++ b/js/components/search.js
@@ -118,7 +118,7 @@ $( document ).ready(function() {
         $('.search-no-results').remove();
       }
 
-      $.each(json.hits.hits, function(i, hit){
+      var hits = json.hits.hits.map(function(hit) {
         var tags = (hit._source.tag || [])
           .map(function(tag) {
             return (
@@ -128,21 +128,22 @@ $( document ).ready(function() {
                 '</a>&nbsp;' +
               '</span>'
             );
-          })
-          .join('');
+          });
 
         var contentType = getContentTypeGlyph(hit._source.content_type);
 
-        $('.search-results-container').append(
+        return (
           '<article class="search-result-list">' +
             '<h1><a href="' + hit._source.url + '" target="_blank">' +
               hit._source.title +
             '</a></h1>' +
             '<p>' + hit._source.description + '</p>' +
-            '<p>Tagged&nbsp;/' + tags + '</p>' +
+            '<p>Tagged&nbsp;/' + tags.join('') + '</p>' +
           '</article>'
         );
       });
+
+      $('.search-results-container').append( hits.join('') );
 
       var paging = {
         needsPrevLink: from > 0,

--- a/js/components/search.js
+++ b/js/components/search.js
@@ -5,85 +5,165 @@ $( document ).ready(function() {
   //
   // By Sean Herron <sean@herron.io>
   //
-  function GetURLParameter(sParam) {
-    var sPageURL = window.location.search.substring(1);
-    var sURLVariables = sPageURL.split('&');
-    for (var i = 0; i < sURLVariables.length; i++) {
-      var sParameterName = sURLVariables[i].split('=');
-      if (sParameterName[0] == sParam) {
-        return sParameterName[1];
-      }
-    }
+
+  /**
+   * Returns parameter from GET query string
+   *
+   * Note that in application/x-www-form-urlencoded strings
+   * (such as the GET query), a `+` will replace `%20` so we
+   * need to _untranslate_ that back into `%20` before decoding.
+   * The _actual_ `+` is safely encoded as `%2B`, however, so
+   * we do not have to worry about losing `+`s
+   *
+   * @param {string} param - Which value to extract by name in name=value
+   * @returns {string} Value of first requested param else ''
+   */
+  function getQueryParam(param) {
+    return decodeURIComponent(window.location.search
+      .slice(1) // drop the leading '?'
+      .split('&') // split into name=value pairs
+      .map(function(pair) { return pair.split('=') }) // split pairs into [name, value]
+      .filter(function(pair) { return pair[0] === param }) // return matching pairs
+      .map(function(pair) { return pair[1] }) // but only return the value
+      .concat( '' ) // add a default in case didn't find any
+      .shift() // return first match or empty string if none available
+      .replace(/[+]/g, '%20') // untranslate `+` into `%20` (see above)
+    );
   }
 
-  var query = GetURLParameter('q') || '',
-    apiKEY = eiti.beckleyApiKey;
+  /**
+   * Returns URL for search request
+   *
+   * @param {string} query - Raw string holding search terms/query
+   * @param {string} apiKey - Raw string holding API key for api.data.gov
+   * @param {object} [options] - Optional search parameters
+   * @param {number} [options.size=10] - How many results to fetch
+   * @param {number} [options.from=0] - Offset to start from for paging
+   * @returns {string} URL for desired search
+   */
+  function apiSearchUrl( query, apiKey, options ) {
+    var q = encodeURIComponent( query );
+    var size = (options && options.size) || 10;
+    var from = (options && options.from) || 0;
 
-  $('.search-string').append(query.replace(/%20/g,' '));
-  $('.site-search-text').attr('value',query.replace(/%20/g,' '));
-  if (query) {
-    $('input.q').val(query);
-    $('.search-result-list').append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
-    var url = 'https://api.data.gov/beckley-federalist/v0/resources/eiti/?q=' + query + '&size=50&from=0&api_key=' + apiKEY;
-    $.ajax({
-      url: url,
-      cache: false,
-      dataType: 'json'
-    })
-      .done(function(json) {
-        $('.loading').remove();
-        $('.search-results-count').append( json.hits.total + ' search results');
-        if (json.hits.total == 0){
-          $('.search-no-results').show();
-        }
-        else{
-          $('.search-no-results').remove();
-        }
-
-        $.each(json.hits.hits, function(i, hit){
-
-        var result_description = hit._source.description;
-
-          var tags = '';
-          if(hit._source.tag) {
-
-            $.each(hit._source.tag, function(i, tag) {
-              tags += '<span class="search-result-list-tag">&nbsp;<a href="../search-results/?q='
-              + tag + '" title="Search for '
-              + tag +'">'
-              + tag + '</a>&nbsp;/</span>';
-            });
-          }
-
-          var content_type = '';
-          if(hit._source.content_type == 'text/html') {
-            content_type = '<span class="glyphicon glyphicon-link"></span> Website';
-          }
-          else if(hit._source.content_type == 'application/pdf') {
-            content_type = '<span class="glyphicon glyphicon-file"></span> PDF';
-          }
-          else {
-            content_type = '<span class="glyphicon glyphicon-file"></span> ' + hit._source.content_type + '';
-          }
-          $('.search-results-container').append('<article class="search-result-list"><h1><a href="'
-            + hit._source.url
-            + '" target="_blank">'
-            + hit._source.title
-            + '</a></h1>'
-            + '<p>'
-            + result_description
-            + '</p>'
-            +'<p>Tagged&nbsp;/'
-            + tags
-            + '</p>'
-            + '</article>');
-        });
-      });
+    return (
+      'https://api.data.gov/beckley-federalist/v0/resources/eiti/?' +
+      'q=' + q + '&size=' + size + '&from=' + from + '&api_key=' + apiKey
+    );
   }
-  else {
+
+  function localSearchUrl( query, options ) {
+    var q = encodeURIComponent( query );
+    var size = (options && options.size) || 10;
+    var from = (options && options.from) || 0;
+
+    return '/search-results/?q=' + q + '&size=' + size + '&from=' + from;
+  }
+
+  /**
+   * Returns HTML string of Glyph for given content type
+   *
+   * @param {string} contentType - given document content type
+   * @returns {string} glyph and label for content type or generic default
+   */
+  function getContentTypeGlyph(contentType) {
+    var contentTypes = {
+      'text/html':       '<span class="glyphicon glyphicon-link"></span> Website',
+      'application/pdf': '<span class="glyphicon glyphicon-file"></span> PDF',
+      'default':         '<span class="glyphicon glyphicon-file"></span> ' + contentType
+    };
+
+    return contentTypes[contentType]
+      ? contentTypes[contentType]
+      : contentTypes['default']
+  }
+
+  var query = getQueryParam('q'),
+      size  = parseInt(getQueryParam('size'), 10) || 10,
+      from  = parseInt(getQueryParam('from'), 10) || 0;
+
+  $('.search-string').text( query );
+  $('.site-search-text').attr('value', query );
+
+  if ( ! query ) {
     $('.search-no-results').show();
     $('.loading').remove();
     $('.search-results-count').append( 0 + ' search results');
-
+    return;
   }
+
+  $('input.q').val( query );
+  $('.search-result-list').html(
+    '<div class="loading">' +
+      '<span class="glyphicon glyphicon-refresh"></span> Loading' +
+    '</div>'
+  );
+
+  $.ajax({
+    url: apiSearchUrl( query, eiti.beckleyApiKey, {
+      size: size,
+      from: from
+    }),
+    cache: false,
+    dataType: 'json'
+  })
+    .done(function(json) {
+      $('.loading').remove();
+      $('.search-results-count').append( json.hits.total + ' search results');
+
+      if (json.hits.total == 0){
+        $('.search-no-results').show();
+      }
+      else{
+        $('.search-no-results').remove();
+      }
+
+      $.each(json.hits.hits, function(i, hit){
+        var tags = (hit._source.tag || [])
+          .map(function(tag) {
+            return (
+              '<span class="search-result-list-tag">&nbsp;' +
+                '<a href="' + localSearchUrl(tag, {size: size, from: from}) + '" title="Search for ' + tag + '">' +
+                  tag +
+                '</a>&nbsp;' +
+              '</span>'
+            );
+          })
+          .join('');
+
+        var contentType = getContentTypeGlyph(hit._source.content_type);
+
+        $('.search-results-container').append(
+          '<article class="search-result-list">' +
+            '<h1><a href="' + hit._source.url + '" target="_blank">' +
+              hit._source.title +
+            '</a></h1>' +
+            '<p>' + hit._source.description + '</p>' +
+            '<p>Tagged&nbsp;/' + tags + '</p>' +
+          '</article>'
+        );
+      });
+
+      var paging = {
+        needsPrevLink: from > 0,
+        needsNextLink: (from + size) < json.hits.total,
+        urlPrev: localSearchUrl(query, { size: size, from: Math.max(0, from - size - 1) }),
+        urlNext: localSearchUrl(query, { size: size, from: Math.min(json.hits.total - 1, from + size + 1) }),
+        titlePrev: 'Previous page of search results',
+        titleNext: 'Next page of search results'
+      };
+
+      $('.search-results-container .search-results-container').append(
+        [ 'Prev', 'Next' ]
+          .filter(function(link){ return paging[ 'needs' + link + 'Link' ] })
+          .map(function(link){
+            return (
+              '<a href="' + paging['url' + link] + '" title="' + paging['title' + link] + '">' +
+                link +
+              '</a>'
+            )
+          })
+          .join(' | ')
+      );
+    });
 });


### PR DESCRIPTION
**Not ready for merging!**

Resolves #1172

Modifies [search.js](https://github.com/18F/doi-extractives-data/blob/5692a68023b921dcb82fc22ba1ea690acc8db5ea/js/components/search.js) to add previous and next buttons to search results when there are
sufficient results to allow it.

While working on the code to add the previous and next links, I took
considerable liberty in refactoring the existing code. Since I have only
begun to jump into contributions of any scale here, I would really
appreciate feedback on which such liberties I can take and how my
personal style choices mesh with the project/team. It is not my
intention to overrule existing style guidelines, but I hope to learn
them better through this PR.

**The API call is a blocker to this PR**
The search at api.data.gov was consistently returning a `504 Gateway
Timeout` while I was working. Since I could not see the actual search
results, I have guessed at certain elements when writing my code.

For example, with `size=10&from=13`, the code expects to get the 14th
through 24th elements from the search results (14 vs. 13 due to
zero-based-indexing).

Also, with no results, there is no way to see the prev and next links
that I am adding without fidgeting with the code to fib the results. To
test, I fibbed the results by settings `timeout: 200` on the `$.ajax()`
query so that it would quickly fail. Then, I placed a `.fail()` handler
on the query with my paging code and a made up value for the
`json.hits.total` value. The links appeared to work fine under these
conditions.

## Previews

You might notice some oddities in these previews. First of all, Chrome has been started with `web-security` disabled, allowing unauthorized CORS requests (had to do this to ping api.data.gov from `localhost`). Next, there are no search results yet there are links; this is due to the "fibbing" I described above. Further, the tooltips are active because I was hovering over the links when I took the screenies. Finally, you can see the new parameters in the query string: `size` and `from`, which coordinate the paging.

**On first page**
![nextlink](https://cloud.githubusercontent.com/assets/5431237/17276161/22500d6c-56d5-11e6-8c67-373748b046ef.png)

**On a "middle" page**
![bothlinks](https://cloud.githubusercontent.com/assets/5431237/17276165/2b7b53ce-56d5-11e6-95f3-c2de244b11c0.png)

**On last page**
![prevlink](https://cloud.githubusercontent.com/assets/5431237/17276168/30cba36a-56d5-11e6-8a68-9119a7b3368f.png)


cc: @meiqimichelle @gemfarmer 