### PR TITLE
WIP: Use Mercator projection for states and offshore regions

### DIFF
--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -149,7 +149,7 @@ permalink: /explore/federal-revenue-by-location/
       <section id="{{ region.id }}" class="region onshore">
         <div class="map-wrapper">
           <eiti-map id="{{ region.id }}-map" class="region-map" simplify="1e-2"
-            projection="albersCustom" data-path="{{ site.baseurl }}/data/geo/" zoom-to="{{ region.id }}">
+            projection="mercator" data-path="{{ site.baseurl }}/data/geo/" zoom-to="{{ region.id }}">
             <svg class="region-map">
               <g class="onshore states" data-url="us-topology.json"
                 data-object="states"
@@ -182,7 +182,7 @@ permalink: /explore/federal-revenue-by-location/
 
         <div class="map-wrapper">
           <eiti-map id="{{ region.id }}-map" class="region-map" simplify="1e-2"
-            projection="albersCustom" data-path="{{ site.baseurl }}/data/geo/"
+            projection="mercator" data-path="{{ site.baseurl }}/data/geo/"
             zoom-to="{{ region.id }}">
             <svg class="region-map">
               <g class="onshore states reference" data-url="us-topology.json"


### PR DESCRIPTION
**Not ready to merge!**

Resolves #1605 

Previously, every projection for the data explorer was set to a custom
Albers conical projection.

This change swaps out to Mercator for the state and offshort region
maps. The Mercator should not only horizontally level the smaller
regions, but also produce something more familiar at the larger scales
than the Albers.

Seemingly strange to me, I did not find what I was looking for - web mercator auxiliary sphere (EPSG:3857). As popular as it is online, allowing for trivial overlay from other map providers, I was surprised that it didn't appear to be in the default projection set for `d3.geo`, but I don't know `d3` that well, so maybe I overlooked it?

**Issues**:
 - Some states don't look right at all (see Alaska). The sizes and positioning is off, and I wonder if it's not related to the code generating the bounding box. In one screenshot of Alaska, it looked like maybe some data from more than just Alaska was being rendered; possibly a cause of this error?

 - The padding around the state borders is significantly larger than it ought to be. I believe this is related to the problem of size and positioning in general. Perhaps some assumptions were made based off of the custom Albers projection?

<img src="https://cloud.githubusercontent.com/assets/5431237/17276638/a0a15a8c-56e3-11e6-84ea-c6e5d28bca20.png" width="250"/>

<img src="https://cloud.githubusercontent.com/assets/5431237/17276639/a8c1f1d6-56e3-11e6-959a-ad485871535a.png" width="250"/>


Notwithstanding these issues, this should provide a good boost to the maps when it's ready for merging in.

I have not started looking into the bounding box code since I'm unfamiliar with it on a whole and wanted to see if anyone might have some advice before I dive in; perchance while reading this, something will "click" that won't be obvious to me.

cc: @ericronne @gemfarmer @shawnbot 