### PR TITLE
Add minimum Ruby version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
+ruby "> 2.1.0"
+
 gem 'jekyll', '3.0.5'
 gem 'scss_lint', require: false
 gem 'html-proofer'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
-ruby "~> 2.1"
+raise 'Need ruby > 2.1 to run' unless RUBY_VERSION.to_f > 2.1
 
 gem 'jekyll', '3.0.5'
 gem 'scss_lint', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
-ruby "> 2.1.0"
+ruby "~> 2.1"
 
 gem 'jekyll', '3.0.5'
 gem 'scss_lint', require: false


### PR DESCRIPTION
Previously, while attempting to build the site, I could not get the
build to complete without error. It complained of `to_h` not existing.

After tracking down this problem, I realized that my system was running
a late Ruby 2.0-release and `to_h` requires `2.1`

This patch adds a specifier in the Gemfile to require a minimum version.

cc: @shawnbot @gemfarmer 