### PR TITLE
Interactive chart map

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -35,6 +35,9 @@
     <g class="counties features">
       <use xlink:href="{{ state_svg }}#counties"></use>
     </g>
+    <g class="counties mesh">
+      <use xlink:href="{{ state_svg }}#counties-mesh"></use>
+    </g>
 
     {% if include.counties %}
       {% assign keys = include.value %}
@@ -64,9 +67,6 @@
     {% endif %}
 
     {% include maps/federal_land_ownership.svg %}
-    <g class="counties mesh">
-      <use xlink:href="{{ state_svg }}#counties-mesh"></use>
-    </g>
     <g class="state feature overlay">
       <use xlink:href="{{ states_svg }}#state-{{ include.state }}"></use>
     </g>

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -56,6 +56,7 @@
 
         {% if year_values %}
           <g class="county feature"
+            data-fips="{{ fips }}"
             data-value='{{ value | default: 0 | jsonify }}'
             data-year-values='{{ year_values | jsonify }}'>
             <title>{{ county[1].name }}</title>

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -1,6 +1,5 @@
 {% assign product_ref = include.product_ref %}
 {% assign caption = include.caption %}
-{% assign sentence = include.sentence %}
 
 {% assign units = county[1].products[1].units %}
 {% if include.long_units %}
@@ -36,7 +35,10 @@
             data-year-values='{{ years_values | jsonify }}'>{{ product_volume | intcomma }}</td>
       </tr>
       <tr data-fips='{{ fips }}'>
-        <td colspan='3' data-year-values='{{ years_values | jsonify }}' data-sentence='{{ product_volume }}' aria-hidden='true'><span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span></td>
+        <td colspan='3'
+            data-year-values='{{ years_values | jsonify }}'
+            data-sentence='{{ product_volume }}'
+            aria-hidden='true'><span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ county[1].name }} from <span data-year='{{ year }}'>{{ year }}</span></td>
       </tr>
     {% endif %}
   {% endfor %}

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -21,8 +21,9 @@
     {% assign product_volume = county[1].products[product_ref].volume[include.year] %}
 
     {% assign years_values =  county[1].products[product_ref].volume %}
+    {% assign fips = county[0] | pad_left: 5, '0' %}
     {% if years_values != 'null' years_values != null %}
-      <tr data-year-values='{{ years_values | jsonify }}'>
+      <tr data-fips="{{ fips }}" data-year-values='{{ years_values | jsonify }}'>
         <td><div class='swatch'
                  data-value-swatch='{{ product_volume }}'
                  data-year-values='{{ years_values | jsonify }}'></div>{{ county[1].name }}</td>
@@ -32,6 +33,9 @@
             data-series='volume'
             data-value='{{ product_volume }}'
             data-year-values='{{ years_values | jsonify }}'>{{ product_volume | intcomma }}</td>
+      </tr>
+      <tr data-fips="{{ fips }}" aria-hidden="true">
+        <td colspan="3">Additional text that fills all the columns</td>
       </tr>
     {% endif %}
   {% endfor %}

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -1,5 +1,6 @@
 {% assign product_ref = include.product_ref %}
 {% assign caption = include.caption %}
+{% assign sentence = include.sentence %}
 
 {% assign units = county[1].products[1].units %}
 {% if include.long_units %}
@@ -9,11 +10,11 @@
 
 <table is='bar-chart-table'
        data-percent-max='100'
-       class="county-table">
+       class='county-table'>
   <thead>
     <tr>
       <th>{{ locality_name }}</th>
-      <th colspan="2" class='numeric' data-series='volume'>{{ units | capitalize }} of {{ product_name | downcase | suffix:units_suffix }}</th>
+      <th colspan='2' class='numeric' data-series='volume'>{{ units | capitalize }} of {{ product_name | downcase | suffix:units_suffix }}</th>
     </tr>
   </thead>
   <tbody>
@@ -23,7 +24,7 @@
     {% assign years_values =  county[1].products[product_ref].volume %}
     {% assign fips = county[0] | pad_left: 5, '0' %}
     {% if years_values != 'null' years_values != null %}
-      <tr data-fips="{{ fips }}" data-year-values='{{ years_values | jsonify }}'>
+      <tr data-fips='{{ fips }}' data-year-values='{{ years_values | jsonify }}'>
         <td><div class='swatch'
                  data-value-swatch='{{ product_volume }}'
                  data-year-values='{{ years_values | jsonify }}'></div>{{ county[1].name }}</td>
@@ -34,8 +35,8 @@
             data-value='{{ product_volume }}'
             data-year-values='{{ years_values | jsonify }}'>{{ product_volume | intcomma }}</td>
       </tr>
-      <tr data-fips="{{ fips }}" aria-hidden="true">
-        <td colspan="3">Additional text that fills all the columns</td>
+      <tr data-fips='{{ fips }}'>
+        <td colspan='3' data-year-values='{{ years_values | jsonify }}' data-sentence='{{ product_volume }}' aria-hidden='true'><span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span></td>
       </tr>
     {% endif %}
   {% endfor %}

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -1,29 +1,36 @@
 {% assign caption = include.caption %}
 
-<table is="bar-chart-table" data-percent-max="100" class="county-table">
+<table is='bar-chart-table' data-percent-max='100' class='county-table'>
   <thead>
     <tr>
       <th>{{ locality_name }}</th>
-      <th colspan="2" class="numeric" data-series="volume">Revenue</th>
+      <th colspan='2' class='numeric' data-series='volume'>Revenue</th>
     </tr>
   </thead>
   <tbody>
   {% for county in include.values %}
     {% assign revenue_amount = county[1].revenue[include.year] %}
     {% assign years_values =  county[1].revenue %}
+    {% assign fips = county[0] | pad_left: 5, '0' %}
     {% if revenue_amount > 0 %}
-    <tr data-year-values='{{ years_values | jsonify }}'>
+    <tr data-fips='{{ fips }}' data-year-values='{{ years_values | jsonify }}'>
       <td><div class='swatch'
                  data-value-swatch='{{ revenue_amount }}'
                  data-year-values='{{ years_values | jsonify }}'></div>{{ county[1].name }}</td>
       <td data-value-text='{{ revenue_amount }}'
           data-year-values='{{ years_values | jsonify }}'
-          data-format="$,">${{ revenue_amount | intcomma }}</td>
+          data-format='$,'>${{ revenue_amount | intcomma }}</td>
       <td class='numberless'
             data-series='volume'
             data-value='{{ revenue_amount }}'
             data-year-values='{{ years_values | jsonify }}'>{{ revenue_amount | intcomma }}</td>
     </tr>
+    <tr data-fips='{{ fips }}'>
+        <td colspan='3'
+            data-year-values='{{ years_values | jsonify }}'
+            data-sentence='{{ revenue_amount }}'
+            aria-hidden='true'><span data-value='{{ revenue_amount }}' data-format='$,'>${{ revenue_amount | intcomma }}</span> was collected from {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span></td>
+      </tr>
     {% endif %}
   {% endfor %}
   </tbody>

--- a/_includes/location/display-jobs-county.html
+++ b/_includes/location/display-jobs-county.html
@@ -11,11 +11,11 @@
   <tbody>
   {% for county in include.values %}
     {% assign years_values = county[1].employment %}
-
+    {% assign fips = county[0] | pad_left: 5, '0' %}
     {% assign jobs_percent = county[1].employment[year].percent %}
     {% assign jobs_count = county[1].employment[year].count %}
 
-    <tr data-year-values='{{ years_values | jsonify }}' data-years-property='count'>
+    <tr data-fips='{{ fips }}' data-year-values='{{ years_values | jsonify }}' data-years-property='count'>
       <td><div class='swatch'
                data-value-swatch='{{ jobs_count }}'
                data-year-values='{{ years_values | jsonify }}'
@@ -34,6 +34,13 @@
           data-format='%'
           class="numeric">{{ jobs_percent }}%</td>
     </tr>
+    <tr data-fips='{{ fips }}'>
+        <td colspan='3'
+            data-year-values='{{ years_values | jsonify }}'
+            data-sentence='{{ jobs_count }}'
+            data-years-property='count'
+            aria-hidden='true'>In <span data-year='{{ year }}'>{{ year }}</span>, there were <span data-value='{{ jobs_count }}'>{{ jobs_count | intcomma }}</span> self-employed people working in {{ county[1].name }}</td>
+      </tr>
   {% endfor %}
   </tbody>
 </table>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -41,14 +41,6 @@
       {% assign units_title = units_map[units].title %}
 
 
-      {% capture sentence %}
-      <span class="eiti-bar-chart-y-value"
-              data-format=",">{{ volume | default: 0 | intcomma }}</span>
-      {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
-      produced on federal land in {{ state_name }} in
-      <span class="eiti-bar-chart-x-value">{{ year }}</span>
-      {% endcapture %}
-
       <section id="federal-production-{{ product_slug }}" class="product chart-item full-width">
 
         <div class="row-container">
@@ -65,7 +57,11 @@
             <figure class="chart">
               <figcaption id="federal-production-figures-{{ product_slug }}">
 
-              {{ sentence }}
+              <span class="eiti-bar-chart-y-value"
+                    data-format=",">{{ volume | default: 0 | intcomma }}</span>
+              {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
+              produced on federal land in {{ state_name }} in
+              <span class="eiti-bar-chart-x-value">{{ year }}</span>
 
               </figcaption>
               <eiti-bar-chart

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -40,6 +40,15 @@
       {% assign units_suffix = units_map[units].suffix | default '' %}
       {% assign units_title = units_map[units].title %}
 
+
+      {% capture sentence %}
+      <span class="eiti-bar-chart-y-value"
+              data-format=",">{{ volume | default: 0 | intcomma }}</span>
+      {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
+      produced on federal land in {{ state_name }} in
+      <span class="eiti-bar-chart-x-value">{{ year }}</span>
+      {% endcapture %}
+
       <section id="federal-production-{{ product_slug }}" class="product chart-item full-width">
 
         <div class="row-container">
@@ -55,11 +64,8 @@
 
             <figure class="chart">
               <figcaption id="federal-production-figures-{{ product_slug }}">
-              <span class="eiti-bar-chart-y-value"
-                      data-format=",">{{ volume | default: 0 | intcomma }}</span>
-              {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
-              produced on federal land in {{ state_name }} in
-              <span class="eiti-bar-chart-x-value">{{ year }}</span>
+
+              {{ sentence }}
 
               </figcaption>
               <eiti-bar-chart
@@ -118,6 +124,7 @@
                   product_ref=product_ref
                   long_units=long_units
                   caption=caption
+                  sentence=sentence
                 %}
               </div><!-- /.table-container -->
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -82,7 +82,7 @@
 
 
             {% capture toggle %}federal-production-{{ product_slug }}-counties{% endcapture %}
-            <figure>
+            <figure is="eiti-data-map-table">
               {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
               {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
               {% assign _width ='inherit' %}

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -83,7 +83,7 @@
             {{ locality_name }} wage and salary jobs
           </h4>
 
-          <figure class="container">
+          <figure is="eiti-data-map-table" class="container">
             <eiti-data-map color-scheme="Reds" steps="{{ steps }}">
               {% capture value_key %}employment.{{ year }}.count{% endcapture %}
 

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -50,7 +50,7 @@
 
 
       {% capture toggle %}federal-revenue-All-counties{% endcapture %}
-      <figure>
+      <figure is="eiti-data-map-table">
         {% capture value_key %}revenue.{{ year }}{% endcapture %}
         {% capture years_key %}revenue{% endcapture %}
         {% assign _width ='inherit' %}

--- a/_sass/blocks/_county-bar-table.scss
+++ b/_sass/blocks/_county-bar-table.scss
@@ -3,6 +3,10 @@
     float: left;
   }
 
+  tbody > tr {
+  	cursor: pointer;
+  }
+
   [is="bar-chart-table"] {
     @extend .table-basic;
   }

--- a/_sass/blocks/_county-bar-table.scss
+++ b/_sass/blocks/_county-bar-table.scss
@@ -4,7 +4,7 @@
   }
 
   tbody > tr {
-  	cursor: pointer;
+    cursor: pointer;
   }
 
   [is="bar-chart-table"] {

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -12,6 +12,14 @@
     background: $white;
   }
 
+  tbody > tr.selected {
+    font-weight: $weight-book;
+
+    &[data-year-values] {
+      border-bottom: 0;
+    }
+  }
+
   .bar {
     background: $light-gray;
   }
@@ -34,6 +42,12 @@
 
   [data-year-values="null"] {
     display: none;
+  }
+
+  [data-sentence] {
+    font-weight: $weight-book;
+    padding-left: calc(#{$standard-padding-lite} + 5px + 1rem);
+    padding-top: 0;
   }
 
   .swatch {

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -90,6 +90,18 @@ eiti-data-map {
       text-align: left;
     }
   }
+
+  .feature.county {
+    cursor: pointer;
+
+    &:hover,
+    &:active,
+    &:focus {
+      stroke: $green-dark-chart;
+      stroke-width: 3px;
+    }
+  }
+
 }
 
 .legend-svg,

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -94,6 +94,7 @@ eiti-data-map {
   .feature.county {
     cursor: pointer;
 
+    &.selected,
     &:hover,
     &:active,
     &:focus {

--- a/js/components/aria-toggle.js
+++ b/js/components/aria-toggle.js
@@ -51,6 +51,10 @@
           return toggle(this, expanded);
         }},
 
+        expand: {value: function(expanded) {
+          return expand(this);
+        }},
+
         detachedCallback: {value: function() {
           this.removeEventListener('click', click);
         }},

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -110,6 +110,22 @@
     }
   }
 
+  var show = function(fips) {
+    var rows = d3.select(this).selectAll('tbody > tr');
+
+    var hiddenRows = rows.filter(function(row) {
+      return !this.hasAttribute('data-year-values');
+    })
+
+    hiddenRows.attr('aria-hidden', true);
+
+    // show matching row
+    hiddenRows.filter(function(row) {
+      return this.getAttribute('data-fips') === fips;
+    }).attr('aria-hidden', false)
+
+  }
+
   var update = function() {
     if (!this._cells.length) {
       return;
@@ -277,6 +293,8 @@
         update: {value: update},
 
         setYear: {value: setYear},
+
+        show: {value: show},
 
         orient: {
           get: function() {

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -12,14 +12,16 @@
 
     var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
 
-    var row = chartTables.selectAll('tr[data-year-values]')
+    var chartRows = chartTables.selectAll('tr[data-fips]')
 
     var toggleTable = function(d, i) {
-      console.log(this, d, i)
       var countyName = this.querySelector('title').textContent;
       var countyFIPS = this.getAttribute('data-fips');
       console.log('county name:', countyName)
       console.log('county fips:', countyFIPS)
+
+      highlightCounty(countyFIPS);
+
       mapToggles.each(function(){
         this.expand();
       });
@@ -29,12 +31,29 @@
       })
     };
 
-    var toggleMap = function() {
-      counties.classed('selected', true)
+    var highlightCounty = function(fips) {
+      counties.classed('selected', false);
+
+      counties.each(function(d, i){
+        var county = d3.select(this);
+        if (+county.attr('data-fips') === +fips) {
+          county.classed('selected', true);
+        }
+      });
     }
 
-    chartTables.on('click.countyTable', toggleMap)
-    counties.on('click.county', toggleTable)
+    var toggleMap = function() {
+      var fips = this.getAttribute('data-fips');
+
+      highlightCounty(fips);
+
+      chartTables.each(function(){
+        this.show(fips);
+      });
+    }
+
+    chartRows.on('click.countyTable', toggleMap);
+    counties.on('click.county', toggleTable);
   };
 
   var detached = function() {

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -1,0 +1,51 @@
+(function(exports) {
+
+  var attached = function() {
+    var root = d3.select(this);
+
+    var select = root.selectAll('select.chart-selector');
+    var maps = root.selectAll('eiti-data-map');
+    var mapToggle = maps.selectAll('button[is="aria-toggle"]');
+    var counties = maps.selectAll('.county.feature');
+    var mapTables = root.selectAll('.eiti-data-map-table');
+
+    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
+
+    // var update = function(year) {
+    //   charts.property('x', year);
+    //   maps.each(function() {
+    //     this.setYear(year);
+    //   });
+    //   select.property('value', year);
+    //   chartTables.each(function(){
+    //     this.setYear(year);
+    //     this.update();
+    //   })
+    // };
+
+    counties.on('click.county', function() {
+      console.log(this)
+      // update('county')
+    });
+
+    // charts.selectAll('g.bar')
+    //   .on('click.year', function(d) {
+    //     update(d.x);
+    //   });
+  };
+
+  var detached = function() {
+  };
+
+  exports.EITIDataMapTable = document.registerElement('eiti-data-map-table', {
+    'extends': 'figure',
+    prototype: Object.create(
+      HTMLElement.prototype,
+      {
+        attachedCallback: {value: attached},
+        detachdCallback: {value: detached}
+      }
+    )
+  })
+
+})(this);

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -17,8 +17,6 @@
     var toggleTable = function(d, i) {
       var countyName = this.querySelector('title').textContent;
       var countyFIPS = this.getAttribute('data-fips');
-      console.log('county name:', countyName)
-      console.log('county fips:', countyFIPS)
 
       highlightCounty(countyFIPS);
 

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -2,36 +2,39 @@
 
   var attached = function() {
     var root = d3.select(this);
+    var self = d3.select(this);
 
     var select = root.selectAll('select.chart-selector');
     var maps = root.selectAll('eiti-data-map');
-    var mapToggle = maps.selectAll('button[is="aria-toggle"]');
-    var counties = maps.selectAll('.county.feature');
+    var mapToggles = maps.selectAll('button[is="aria-toggle"]');
     var mapTables = root.selectAll('.eiti-data-map-table');
+    var counties = maps.selectAll('.county.feature')
 
     var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
 
-    // var update = function(year) {
-    //   charts.property('x', year);
-    //   maps.each(function() {
-    //     this.setYear(year);
-    //   });
-    //   select.property('value', year);
-    //   chartTables.each(function(){
-    //     this.setYear(year);
-    //     this.update();
-    //   })
-    // };
+    var row = chartTables.selectAll('tr[data-year-values]')
 
-    counties.on('click.county', function() {
-      console.log(this)
-      // update('county')
-    });
+    var toggleTable = function(d, i) {
+      console.log(this, d, i)
+      var countyName = this.querySelector('title').textContent;
+      var countyFIPS = this.getAttribute('data-fips');
+      console.log('county name:', countyName)
+      console.log('county fips:', countyFIPS)
+      mapToggles.each(function(){
+        this.expand();
+      });
 
-    // charts.selectAll('g.bar')
-    //   .on('click.year', function(d) {
-    //     update(d.x);
-    //   });
+      chartTables.each(function(){
+        this.show(countyFIPS);
+      })
+    };
+
+    var toggleMap = function() {
+      counties.classed('selected', true)
+    }
+
+    chartTables.on('click.countyTable', toggleMap)
+    counties.on('click.county', toggleTable)
   };
 
   var detached = function() {
@@ -49,3 +52,4 @@
   })
 
 })(this);
+

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11094,6 +11094,10 @@
 	          return toggle(this, expanded);
 	        }},
 
+	        expand: {value: function(expanded) {
+	          return expand(this);
+	        }},
+
 	        detachedCallback: {value: function() {
 	          this.removeEventListener('click', click);
 	        }},
@@ -12295,6 +12299,22 @@
 	    }
 	  }
 
+	  var show = function(fips) {
+	    var rows = d3.select(this).selectAll('tbody > tr');
+
+	    var hiddenRows = rows.filter(function(row) {
+	      return !this.hasAttribute('data-year-values');
+	    })
+
+	    hiddenRows.attr('aria-hidden', true);
+
+	    // show matching row
+	    hiddenRows.filter(function(row) {
+	      return this.getAttribute('data-fips') === fips;
+	    }).attr('aria-hidden', false)
+
+	  }
+
 	  var update = function() {
 	    if (!this._cells.length) {
 	      return;
@@ -12462,6 +12482,8 @@
 	        update: {value: update},
 
 	        setYear: {value: setYear},
+
+	        show: {value: show},
 
 	        orient: {
 	          get: function() {
@@ -12907,36 +12929,39 @@
 
 	  var attached = function() {
 	    var root = d3.select(this);
+	    var self = d3.select(this);
 
 	    var select = root.selectAll('select.chart-selector');
 	    var maps = root.selectAll('eiti-data-map');
-	    var mapToggle = maps.selectAll('button[is="aria-toggle"]');
-	    var counties = maps.selectAll('.county.feature');
+	    var mapToggles = maps.selectAll('button[is="aria-toggle"]');
 	    var mapTables = root.selectAll('.eiti-data-map-table');
+	    var counties = maps.selectAll('.county.feature')
 
 	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
 
-	    // var update = function(year) {
-	    //   charts.property('x', year);
-	    //   maps.each(function() {
-	    //     this.setYear(year);
-	    //   });
-	    //   select.property('value', year);
-	    //   chartTables.each(function(){
-	    //     this.setYear(year);
-	    //     this.update();
-	    //   })
-	    // };
+	    var row = chartTables.selectAll('tr[data-year-values]')
 
-	    counties.on('click.county', function() {
-	      console.log(this)
-	      // update('county')
-	    });
+	    var toggleTable = function(d, i) {
+	      console.log(this, d, i)
+	      var countyName = this.querySelector('title').textContent;
+	      var countyFIPS = this.getAttribute('data-fips');
+	      console.log('county name:', countyName)
+	      console.log('county fips:', countyFIPS)
+	      mapToggles.each(function(){
+	        this.expand();
+	      });
 
-	    // charts.selectAll('g.bar')
-	    //   .on('click.year', function(d) {
-	    //     update(d.x);
-	    //   });
+	      chartTables.each(function(){
+	        this.show(countyFIPS);
+	      })
+	    };
+
+	    var toggleMap = function() {
+	      counties.classed('selected', true)
+	    }
+
+	    chartTables.on('click.countyTable', toggleMap)
+	    counties.on('click.county', toggleTable)
 	  };
 
 	  var detached = function() {
@@ -12954,6 +12979,7 @@
 	  })
 
 	})(this);
+
 
 
 /***/ }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -52,6 +52,7 @@
 	  __webpack_require__(32);
 	  __webpack_require__(33);
 	  __webpack_require__(34);
+	  __webpack_require__(35);
 
 	  __webpack_require__(4);
 	  __webpack_require__(1);
@@ -12886,6 +12887,63 @@
 
 	  exports.EITIYearSwitcherSection = document.registerElement('year-switcher-section', {
 	    'extends': 'section',
+	    prototype: Object.create(
+	      HTMLElement.prototype,
+	      {
+	        attachedCallback: {value: attached},
+	        detachdCallback: {value: detached}
+	      }
+	    )
+	  })
+
+	})(this);
+
+
+/***/ },
+/* 35 */
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  var attached = function() {
+	    var root = d3.select(this);
+
+	    var select = root.selectAll('select.chart-selector');
+	    var maps = root.selectAll('eiti-data-map');
+	    var mapToggle = maps.selectAll('button[is="aria-toggle"]');
+	    var counties = maps.selectAll('.county.feature');
+	    var mapTables = root.selectAll('.eiti-data-map-table');
+
+	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
+
+	    // var update = function(year) {
+	    //   charts.property('x', year);
+	    //   maps.each(function() {
+	    //     this.setYear(year);
+	    //   });
+	    //   select.property('value', year);
+	    //   chartTables.each(function(){
+	    //     this.setYear(year);
+	    //     this.update();
+	    //   })
+	    // };
+
+	    counties.on('click.county', function() {
+	      console.log(this)
+	      // update('county')
+	    });
+
+	    // charts.selectAll('g.bar')
+	    //   .on('click.year', function(d) {
+	    //     update(d.x);
+	    //   });
+	  };
+
+	  var detached = function() {
+	  };
+
+	  exports.EITIDataMapTable = document.registerElement('eiti-data-map-table', {
+	    'extends': 'figure',
 	    prototype: Object.create(
 	      HTMLElement.prototype,
 	      {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12966,8 +12966,6 @@
 	    var toggleTable = function(d, i) {
 	      var countyName = this.querySelector('title').textContent;
 	      var countyFIPS = this.getAttribute('data-fips');
-	      console.log('county name:', countyName)
-	      console.log('county fips:', countyFIPS)
 
 	      highlightCounty(countyFIPS);
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12223,9 +12223,31 @@
 	        }
 	      }
 
+	      function formatText(context, value) {
+	        var format = d3.format(context.getAttribute('data-format') || ',')
+
+	        if (context.getAttribute('data-format') === '%') {
+	          format = function(d) {
+	            if (d === 0) {
+	              return 0;
+	            } else if (d < 1) {
+	              return '<1%';
+	            }
+	            return d3.format('%')(d / 100);
+	          }
+	        }
+
+	        if (format) {
+	          return format(value);
+	        } else {
+	          return value;
+	        }
+	      }
+
 	      var year = year || '2013';
 	      var bars = root.selectAll('[data-value]');
 	      var texts = root.selectAll('[data-value-text]');
+	      var sentences = root.selectAll('[data-sentence]');
 	      var swatches = root.selectAll('[data-value-swatch]');
 	      var label = d3.select(this.parentElement).select('label');
 
@@ -12240,6 +12262,20 @@
 	          return d;
 	        });
 
+	      sentences.datum(function() {
+	          var data = parseYearVals(this)
+	          var property = this.getAttribute('data-years-property');
+	          return cellData(data, year, property);
+	        })
+	        .attr('data-sentence', function(d) {
+	          return d;
+	        })
+	        .select('[data-value]').attr('data-value', function(d) {
+	          return d;
+	        }).text(function(d) {
+	          return formatText(this, d);
+	        })
+
 	      texts.datum(function() {
 	          var data = parseYearVals(this)
 	          var property = this.getAttribute('data-years-property');
@@ -12249,30 +12285,12 @@
 	          return d;
 	        })
 	        .text(function(d) {
-	          var format = d3.format(this.getAttribute('data-format') || ',')
-
-	          if (this.getAttribute('data-format') === '%') {
-	            format = function(d) {
-	              if (d === 0) {
-	                return 0;
-	              } else if (d < 1) {
-	                return '<1%';
-	              }
-
-	              return d3.format('%')(d / 100);
-	            }
-	          }
-
-	          if (format) {
-	            return format(d);
-	          } else {
-	            return d;
-	          }
+	          return formatText(this, d);
 	        });
 
 	      var that = this;
 	      swatches.datum(function() {
-	          var data = parseYearVals(this)
+	          var data = parseYearVals(this);
 	          var property = this.getAttribute('data-years-property');
 	          return cellData(data, year, property);
 	        })
@@ -12289,6 +12307,10 @@
 	        .attr('data-year', year)
 	        .text(year)
 
+	      sentences.select('[data-year]')
+	        .attr('data-year', year)
+	        .text(year)
+
 	      rows.datum(function(){
 	        var data = parseYearVals(this);
 	        return data[year] || 0;
@@ -12301,17 +12323,17 @@
 
 	  var show = function(fips) {
 	    var rows = d3.select(this).selectAll('tbody > tr');
+	    rows.classed('selected', false);
 
-	    var hiddenRows = rows.filter(function(row) {
-	      return !this.hasAttribute('data-year-values');
-	    })
-
-	    hiddenRows.attr('aria-hidden', true);
+	    rows.selectAll('[data-sentence]').attr('aria-hidden', true);
 
 	    // show matching row
-	    hiddenRows.filter(function(row) {
+	    rows.filter(function(row) {
 	      return this.getAttribute('data-fips') === fips;
-	    }).attr('aria-hidden', false)
+	    })
+	    .classed('selected', true)
+	    .select('[data-sentence]')
+	    .attr('aria-hidden', false);
 
 	  }
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12939,14 +12939,16 @@
 
 	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
 
-	    var row = chartTables.selectAll('tr[data-year-values]')
+	    var chartRows = chartTables.selectAll('tr[data-fips]')
 
 	    var toggleTable = function(d, i) {
-	      console.log(this, d, i)
 	      var countyName = this.querySelector('title').textContent;
 	      var countyFIPS = this.getAttribute('data-fips');
 	      console.log('county name:', countyName)
 	      console.log('county fips:', countyFIPS)
+
+	      highlightCounty(countyFIPS);
+
 	      mapToggles.each(function(){
 	        this.expand();
 	      });
@@ -12956,12 +12958,29 @@
 	      })
 	    };
 
-	    var toggleMap = function() {
-	      counties.classed('selected', true)
+	    var highlightCounty = function(fips) {
+	      counties.classed('selected', false);
+
+	      counties.each(function(d, i){
+	        var county = d3.select(this);
+	        if (+county.attr('data-fips') === +fips) {
+	          county.classed('selected', true);
+	        }
+	      });
 	    }
 
-	    chartTables.on('click.countyTable', toggleMap)
-	    counties.on('click.county', toggleTable)
+	    var toggleMap = function() {
+	      var fips = this.getAttribute('data-fips');
+
+	      highlightCounty(fips);
+
+	      chartTables.each(function(){
+	        this.show(fips);
+	      });
+	    }
+
+	    chartRows.on('click.countyTable', toggleMap);
+	    counties.on('click.county', toggleTable);
 	  };
 
 	  var detached = function() {

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -6,6 +6,7 @@
   require('./../components/bar-chart-table.js');
   require('./../components/eiti-bar-chart.js');
   require('./../components/year-switcher-section.js');
+  require('./../components/eiti-data-map-table.js');
 
   require('./../components/aria-tabs.js');
   require('./../components/sticky-nav.js');


### PR DESCRIPTION
Fixes issue(s) #1695

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/interactive-chart-map/states/UT)

Changes proposed in this pull request:
- Interactively connects the county-level chart  with the county-level map and year selectors for the following sets of data:
  - [x] federal production
  - [x] revenue
  - [x] jobs

NOTES: 
- there is a visible bug in the jobs data, but it is related to #1673, not the result of this issue
- The county outlines don't always look great. This is caused by the SVGs overlapping and will be pushed into a spillover issue.

/cc @ericronne @meiqimichelle 
