### PR TITLE
National page disbursements

### DIFF
--- a/_data/fund_names.yml
+++ b/_data/fund_names.yml
@@ -1,0 +1,7 @@
+States: Disbursed to states
+'U.S. Treasury': General Fund of the Treasury
+Reclamation: Reclamation fund
+'Land & Water Conservation': Land and Water Conservation Fund
+'Historic Preservation': 'Historic Preservation Fund'
+'American Indian Tribes': 'American Indian tribes'
+Other: 'Other funds'

--- a/_includes/location/display-disbursements.html
+++ b/_includes/location/display-disbursements.html
@@ -1,9 +1,9 @@
 <table is="bar-chart-table">
   <thead>
     <th>Fund</th>
-    <th class="numeric">Total</th>
-    <th class="numeric">Onshore</th>
-    <th class="numeric">Offshore</th>
+    <th class="numeric">All funds</th>
+    <th class="numeric">From onshore revenue</th>
+    <th class="numeric">From offshore revenue</th>
   </thead>
   <tbody>
   {% for _fund in include.values %}
@@ -21,4 +21,3 @@
   {% endfor %}
   </tbody>
 </table>
-

--- a/_includes/location/display-disbursements.html
+++ b/_includes/location/display-disbursements.html
@@ -1,3 +1,5 @@
+{% assign fund_map = site.data.fund_names %}
+
 <table is="bar-chart-table">
   <thead>
     <th>Fund</th>
@@ -12,7 +14,13 @@
     {% assign _values = _fund[1] %}
     {% if _values.All[year] %}
     <tr>
-      <td>{{ _fund_name | xml_escape }}</td>
+
+      {% if include.state_name and _fund_name == 'States'  %}
+        <td>{{ include.state_name }}</td>
+      {% else %}
+        <td>{{ fund_map[_fund_name] | xml_escape | default:_fund_name }}</td>
+      {% endif %}
+
       <td class="numeric" data-value="{{ _values.All[year] | default: 0 }}">${{ _values.All[year] | round | intcomma }}</td>
       <td class="numeric" data-value="{{ _values.Onshore[year] | default: 0 }}">${{ _values.Onshore[year] | round | intcomma }}</td>
       <td class="numeric" data-value="{{ _values.Offshore[year] | default: 0 }}">${{ _values.Offshore[year] | round | intcomma }}</td>

--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -1,18 +1,17 @@
-<!-- TODO: move this to an include! -->
-<p>After collecting revenue from natural resource extraction, the federal government distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
-<p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. While these disbursements are tracked nationally, we don't have detailed data that specifies which expenditures and projects from those national funds are in {{ state_name }}.</p>
-<p>We do have data about disbursements to state governments, which respresent about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction.</p>
-
-<p>
+<section id="federal-disbursements">
   {% assign disbursements = site.data.federal_disbursements.US %}
 
-  In {{ year }}, ONRR disbursed
-  {% if disbursements %}
-    ${{ disbursements.All.All[year] | round | intcomma }}
-  {% else %}
-    did not receive any
-  {% endif %}
-    nationwide.
+  <h2>Federal disbursements</h2>
+
+  <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
+  <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. Funds disbursed directly to state governments account for about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction. <a href="{{site.baseurl}}/downloads/disbursements/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a></p>
+
+  <p><strong>
+    {% if disbursements %}
+    In {{ year }}, ONRR disbursed a total of
+    ${{ disbursements.All.All[year] | round | intcomma }}.
+    {% endif %}
+  </strong></p>
 
   {% if disbursements %}
     {%
@@ -20,8 +19,5 @@
       values=disbursements
     %}
   {% endif %}
-</p>
 
-<a href="{{site.baseurl}}/downloads/disbursements/">
-<icon class="fa fa-file-text-o u-padding-right"></icon>Disbursements data comes from the Office of Natural Resources Revenue
-</a>
+</section>

--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -1,4 +1,5 @@
 <section id="federal-disbursements">
+
   {% assign disbursements = site.data.federal_disbursements.US %}
 
   <h2>Federal disbursements</h2>

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -1,27 +1,31 @@
-<!-- TODO: move this to an include! -->
-<p>After collecting revenue from natural resource extraction, the federal government distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
-<p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. While these disbursements are tracked nationally, we don't have detailed data that specifies which expenditures and projects from those national funds are in {{ state_name }}.</p>
-<p>We do have data about disbursements to state governments, which respresent about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction.</p>
+<section id="federal-disbursements" class="disbursements">
 
-<p>
+  <h2>Federal disbursements</h2>
+
+  <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
+  <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. While these disbursements are tracked nationally, we don't have detailed data that specifies which expenditures and projects from those national funds are in {{ state_name }}.</p>
+  <p>We do have data about disbursements to state governments, which respresent about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction. <a href="{{site.baseurl}}/downloads/disbursements/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a></p>
+
   {% assign disbursements = site.data.federal_disbursements[state_id] %}
 
-  In {{ year }}, ONRR disbursed
-  {% if disbursements %}
-    ${{ disbursements.All.All[year] | round | intcomma }}
-  {% else %}
-    did not receive any
-  {% endif %}
-   to the state of {{ state_name }}.
+  <p><strong>
+    In {{ year }}, ONRR disbursed
+    {% if disbursements %}
+      ${{ disbursements.All.All[year] | round | intcomma }}
+    {% else %}
+      did not receive any
+    {% endif %}
+     to the state of {{ state_name }}.
+  </strong></p>
 
-  {% if disbursements %}
-    {%
-      include location/display-disbursements.html
-      values=disbursements
-    %}
-  {% endif %}
-</p>
+  <p>
+    {% if disbursements %}
+      {%
+        include location/display-disbursements.html
+        values=disbursements
+        state_name=state_name
+      %}
+    {% endif %}
+  </p>
 
-<a href="{{site.baseurl}}/downloads/disbursements/">
-<icon class="fa fa-file-text-o u-padding-right"></icon>Disbursements data comes from the Office of Natural Resources Revenue
-</a>
+</section>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -90,11 +90,7 @@ nav_items:
     </section>
     {% endunless %}
 
-    <section id="federal-disbursements" class="disbursements">
-      <h2>Federal Disbursements</h2>
-
-      {% include location/section-disbursements.html %}
-    </section>
+    {% include location/section-disbursements.html %}
 
     {% if page.opt_in == true %}
     <section id="state-disbursements" class="disbursements">

--- a/states/index.html
+++ b/states/index.html
@@ -28,8 +28,6 @@ nav_items:
       title: GDP
     - name: employment
       title: Jobs
-    - name: exports
-      title: Exports
 ---
 
 {% assign national_page = page.national_page %}
@@ -91,12 +89,10 @@ nav_items:
 
     {% include location/national-revenue.html %}
 
-    <section id="federal-disbursements">
-      <h2>Federal Disbursements</h2>
-      {% include location/national-disbursements.html %}
-    </section>
+    {% include location/national-disbursements.html %}
 
     <section id="economic-impact">
+    
     <h2>Economic impact</h2>
 
     {% include location/national-gdp.html %}


### PR DESCRIPTION
Fixes issue(s) #1519 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/national-content-revision/)

Changes proposed in this pull request:

- Pull some markup into the disbursements includes files, for consistency
- Clarify intro content to make sense on the national page
- Move data and documentation link up to end of intro section
- Fix some header capitalization
- Add a yml file to manage fund names (with much help from @gemfarmer)

/cc @gemfarmer @meiqimichelle 
