### PR TITLE
State pages outline and navigation

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -101,8 +101,7 @@
       Select a new year to populate the map.
     </figcaption>
     <figcaption class="legend-withheld" aria-hidden="true">
-      Data for {{ state_name }} was withheld in <span data-year="{{ year }}" >{{ year}}</span>.
-      Select a new year to populate the map.
+      County-level data for <span data-year="{{ year }}" >{{ year}}</span> is withheld.
     </figcaption>
   {% endif %}
 

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -42,7 +42,7 @@
             aria-hidden='true'
             data-witheld="false">
             <span class="withheld" aria-hidden="true">
-              Data was for {{ county[1].name }} was withheld in <span data-year='{{ year }}'>{{ year }}</span>
+              Data about {{ product_name | downcase }} extraction in {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span> is withheld.
             </span>
             <span class="has-data">
               <span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ county[1].name }} from <span data-year='{{ year }}'>{{ year }}</span>

--- a/_includes/location/opt-in/state-revenues.html
+++ b/_includes/location/opt-in/state-revenues.html
@@ -5,6 +5,7 @@
   {% assign funds_info = site.data.opt_in_state_funds[include.location_id] %}
   {% assign funds_count = funds.size | minus: 1 %}
   {% assign revenue_total = funds.Total.All[revenue_year] %}
+
 <p>
   ${{ revenue_total | default: 0 | intcomma }}
   in state revenue from the extractives industry was disbursed
@@ -55,3 +56,4 @@
   {% endfor %}
 </table>
 {% endif %}
+

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -1,6 +1,6 @@
 <section id="federal-disbursements" class="disbursements">
 
-  <h2>Federal disbursements</h2>
+  <h3>Federal disbursements</h2>
 
   <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
   <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. While these disbursements are tracked nationally, we don't have detailed data that specifies which expenditures and projects from those national funds are in {{ state_name }}.</p>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -69,8 +69,7 @@
                   <span class="eiti-bar-chart-x-value">{{ year }}</span>
                 </span>
                 <span class="caption-withheld" aria-hidden="true">
-                  Data for {{ state_name }} was withheld in
-                  <span class="eiti-bar-chart-x-value">{{ year }}</span>
+                  Data about how much {{ product_name | downcase }} was extracted in {{ state_name }} in <span class="eiti-bar-chart-x-value">{{ year }}</span> is {{ "withheld" | term_end }}.
                 </span>
 
 

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -5,19 +5,6 @@
 
   <h3>Land ownership in {{ state_name }}</h2>
 
-  <section class="text-container">
-
-    <p>In {{ state_name }}, <strong>{{ site.data.land_stats[state_id].federal_percent | percent }}% of land</strong> is owned by the federal government.</p>
-
-    <p>When companies extract natural resources on federal land, they pay royalties, rents, bonuses, and other fees — much like they would to any landowner.</p>
-
-    {% if page.state_land %}
-      {{ page.state_land | markdownify }}
-    {% endif %}
-
-    <p>Learn more about <a href="{{ site.baseurl }}/how-it-works/ownership/">natural resources and land ownership</a> in the U.S.</p>
-  </section>
-
   <aside class="map-container">
     <figure>
       {% assign _viewbox = site.data.viewboxes[state_id] %}

--- a/_includes/location/section-state-governance.html
+++ b/_includes/location/section-state-governance.html
@@ -1,23 +1,27 @@
 <!-- pulls in state fiscal and legal information if the state is one of the MSG-prioritized states -->
 
+{% if is_opt_in_state %}
+
 <section id="state-governance">
 
-	{% if is_opt_in_state %}
+  <h2>State governance</h2>
 
-		<h2>State governance</h2>
+  <p>The state of {{ state_name }} participated in additional reporting. As part of the USEITI process, the {{ "Independent Administrator" | term:"Independent Administrator (IA)" }} gathered information about state and local natural resource governance, revenues, and disbursements in {{ state_name }}.</p>
 
-	    <p>The state of {{ state_name }} participated in additional reporting. As part of the USEITI process, the {{ "Independent Administrator" | term:"Independent Administrator (IA)" }} gathered information about state and local natural resource governance, revenues, and disbursements in {{ state_name }}.</p>
-
-		{{ regulations | markdownify }}
-
-	{% elsif is_priority_state %}
-  
-		<h2>State governance</h2>
-
-		<p>The USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern natural resource extraction in {{ state_name }}:</p>
-
-		{{ regulations | markdownify }}
-
-	{% endif %}
+  {{ regulations | markdownify }}
 
 </section>
+
+{% elsif is_priority_state %}
+
+  <section id="state-governance">
+
+  	<h2>State governance</h2>
+
+	<p>The USEITI Multi-Stakeholder Group identified {{ state_name }} as a priority state and gathered additional information about state agencies and regulations that govern natural resource extraction in {{ state_name }}:</p>
+
+	{{ regulations | markdownify }}
+
+  </section>
+
+{% endif %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -10,30 +10,40 @@ nav_items:
         title: Entire state
       - name: federal-production
         title: Federal land
-      - name: state-local-production
-        title: State land
-      - name: private-land-production
-        title: Private land
   - name: revenue
     title: Revenue
     subnav_items:
       - name: federal-revenue
         title: Federal revenue
       - name: state-local-revenue
-        title: State revenue
+        title: State and local revenue
   - name: economic-impact
     title: Economic impact
     subnav_items:
-    - name: gdp
-      title: GDP
-    - name: employment
-      title: Wage and salary jobs
-    - name: self-employment
-      title: Self-employment
-    - name: exports
-      title: Exports
+      - name: gdp
+        title: GDP
+      - name: employment
+        title: Wage and salary jobs
+      - name: self-employment
+        title: Self-employment
+      - name: exports
+        title: Exports
+  - name: disbursements
+    title: Disbursements
+    subnav_items:
+      - name: federal-disbursements
+        title: Federal disbursements
+      - name: state-disbursements
+        title: State disbursements
   - name: state-governance
     title: State governance
+    subnav_items:
+      - name: state-agencies
+        title: State agencies
+      - name: state-regulations
+        title: State laws and regulations
+      - name: fiscal-costs
+        title: Fiscal costs
 ---
 
 {% assign state_name = page.title %}
@@ -66,12 +76,12 @@ nav_items:
 
     {% include location/section-overview.html %}
 
+    {% include location/section-ownership.html %}
+
     <section id="production">
       <h2>Production</h2>
 
       {% include location/section-all-production.html %}
-
-      {% include location/section-ownership.html %}
 
       {% include location/section-federal-production.html %}
     </section>
@@ -90,15 +100,22 @@ nav_items:
     </section>
     {% endunless %}
 
-    {% include location/section-disbursements.html %}
+    <section id="disbursements" class="disbursements">
+      <h2>Disbursements</h2>
 
-    {% if page.opt_in == true %}
-    <section id="state-disbursements" class="disbursements">
-      <h2>State Disbursements</h2>
+      {% include location/section-disbursements.html %}
 
-      {% include location/opt-in/state-revenues.html location_id=state_id %}
+      <section id="state-disbursements" class="disbursements">
+        <h3>State disbursements</h2>
+
+        {% if page.opt_in == true %}
+          {% include location/opt-in/state-revenues.html location_id=state_id %}
+        {% else %}
+          <p>We don't know how states spent their money. CONTENT TK</p>
+        {% endif %}
+      </section>
+
     </section>
-    {% endif %}
 
     <section>
       {% include location/section-state-governance.html %}


### PR DESCRIPTION
I'm not sure what issue this resolves, but it relates to a bunch of them!

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-nav/states/MT/)

Changes proposed in this pull request:

- Header order and levels
- Changes side nav
- Moves land ownership image up closer to where it will go

/cc @meiqimichelle 

