### PR TITLE
National page ribbon

### DIFF
--- a/_includes/location_selector.html
+++ b/_includes/location_selector.html
@@ -11,7 +11,7 @@
     {% for state in site.data.states %}
     <option
       {% if location_selector_selected == state.id %}selected="selected"{% endif %}
-      value="onshore/{{ state.id }}">{{ state.name }}</option>
+      value="states/{{ state.id }}">{{ state.name }}</option>
     {% endfor %}
   </optgroup>
   <optgroup label="Offshore Areas">

--- a/_includes/location_selector.html
+++ b/_includes/location_selector.html
@@ -9,5 +9,6 @@
   <optgroup label="Offshore Areas">
     {% for area in site.data.offshore_areas %}
     <option value="offshore/{{ area.id }}">{{ area.name }}</option>
+    {% endfor %}
   </optgroup>
 </select>

--- a/_includes/location_selector.html
+++ b/_includes/location_selector.html
@@ -1,24 +1,13 @@
 <select
-  id="{{ location_selector_id }}"
-  {% if location_selector_url_prefix %}
-  onchange="window.location = '{{ site.baseurl }}{{ location_selector_url_prefix }}' + this.value"
-  {% endif %}
-  data-selected="{{ location_selector_selected }}">
-  {% if location_selector_none %}
-  <option value="{{ location_selector_none_value }}">{{ location_selector_none }}</option>
-  {% endif %}
+  id="location-selector"
+  onchange="window.location = '{{ site.baseurl }}/' + this.value">
   <optgroup label="States">
     {% for state in site.data.states %}
-    <option
-      {% if location_selector_selected == state.id %}selected="selected"{% endif %}
-      value="states/{{ state.id }}">{{ state.name }}</option>
+    <option value="states/{{ state.id }}">{{ state.name }}</option>
     {% endfor %}
   </optgroup>
   <optgroup label="Offshore Areas">
     {% for area in site.data.offshore_areas %}
-    <option
-      {% if location_selector_selected == area.id %}selected="selected"{% endif %}
-      value="offshore/{{ area.id }}">{{ area.name }}</option>
-    {% endfor %}
+    <option value="offshore/{{ area.id }}">{{ area.name }}</option>
   </optgroup>
 </select>

--- a/_includes/state-map.html
+++ b/_includes/state-map.html
@@ -2,7 +2,7 @@
 {% assign states_svg = '/maps/states/all.svg' %}
 {% assign offshore_svg = '/maps/offshore/all.svg' %}
 <div class="state svg-container map-container wide"{% if _viewbox %} style="padding-bottom: {{ _viewbox | svg_viewbox_padding }}%;"{% endif %}>
-  <svg class="states map{% if include.ownership %} ownership {% endif %}"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
+  <svg class="states map{% if include.ownership %} ownership {% endif %}{% if include.outline %} outline {% endif %}"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
 
     {% if include.states %}
       {% assign _states_href = include.states_href | default: include.href %}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -65,7 +65,8 @@ $light-black: #303030;
 
 // State pages
 $green-land: #d5e5cb;
-$green-mint: #d2e2cc;
+$green-land: #69995A;
+$green-mint: #cde3c3;
 $green-sea: #b1d39c;
 $green-dark: #657c60;
 $chart-green: #a5d78a;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -64,7 +64,6 @@ $dark-gray: #4a4a4a;
 $light-black: #303030;
 
 // State pages
-$green-land: #d5e5cb;
 $green-land: #69995A;
 $green-mint: #cde3c3;
 $green-sea: #b1d39c;

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -7,7 +7,7 @@
   }
 
   p + section,
-  p + h3, 
+  p + h3,
   p + h4 {
     padding-top: $standard-padding-extra;
   }
@@ -17,7 +17,7 @@
     padding-bottom: $standard-padding-lite;
   }
 
-  h3:not(.chart-title):not(.state-page-nav-title), 
+  h3:not(.chart-title):not(.state-page-nav-title),
   h4:not(.chart-title):not(.state-page-nav-title):not(.details-container) {
     @include heading('h5');
 
@@ -25,7 +25,7 @@
     margin-bottom: $base-padding-base;
     padding-bottom: $standard-padding-lite;
   }
-  
+
   h4:not(.chart-title):not(.state-page-nav-title):not(.details-container) {
     border-bottom: 1px solid $neutral-gray;
     font-weight: $weight-light;
@@ -51,7 +51,7 @@
   p {
     @include heading('para-md');
   }
-  
+
   ul {
     @include heading('para-md');
   }
@@ -65,10 +65,6 @@
       border-top: none;
       margin-top: 0;
     }
-  }
-
-  svg.ownership {
-    border: 1px solid $mid-light-gray;
   }
 
   .tab-interface {

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -24,6 +24,10 @@ svg.map {
     fill: $light-gray;
   }
 
+  .feature.offshore-area {
+    fill: $green-land;
+  }
+
   .feature:not([fill]) {
     fill-opacity: 0;
   }
@@ -68,6 +72,10 @@ svg.map {
   .ownership {
     opacity: 0.05;
     pointer-events: none;
+
+    &.federal {
+      opacity: $opacity-state;
+    }
   }
 
   // To make land ownership more green!
@@ -90,4 +98,19 @@ svg.map {
       fill: $green-land;
     }
   }
+}
+
+svg.ownership {
+  border: 1px solid $mid-light-gray;
+
+  &.outline {
+    border: 0;
+
+    .states.mesh {
+      stroke: $pale-blue;
+      stroke-width: 1.5px;
+    }
+  }
+
+
 }

--- a/states/index.html
+++ b/states/index.html
@@ -4,6 +4,7 @@ permalink: /states/
 id: US
 title: Explore data
 national_page: true
+selector: location
 nav_items:
   - name: title
     title: Overview
@@ -42,89 +43,94 @@ nav_items:
 {% assign steps=9 %}
 
 
-<main id="national" class="container-outer layout-state-pages">
-
-  <div class="container-left-9">
-    <div>
-      <a class="breadcrumb" href="{{ site.baseurl }}/">Home</a>
-      /
+<main id="national" class="layout-state-pages">
+  
+  <section class="slab-delta">
+    <div class="container-page-wrapper landing-section_top ribbon ribbon-column">
+      <div class="container-left-8 ribbon-hero ribbon-hero-column">
+        <h1 id="title">Explore data</h1>
+        <figure is="data-map" color-scheme="Reds" steps="9">
+          {%
+            include state-map.html
+            states=site.data.state_revenues
+            offshore_areas=site.data.offshore_federal_production_areas
+            href=':url'
+          %}
+        </figure>
+      </div>
+      <div class="container-right-4 ribbon-card-column ribbon-card-has-image ribbon-card">
+        <figure class="ribbon-card-top">
+          <a href="{{site.baseurl}}/explore/federal-revenue-by-location/">
+            <img class="ribbon-card-image" src="{{ site.baseurl }}/img/explore-landing-intro.png" alt="Map of the US with the Gulf of Mexico highlighted. Total U.S. revenue: 12,261,828,343. Gulf of Mexico revenue: 7,572,080,117. Calendar year 2013.">
+          </a>
+        </figure>
+        <figcaption class="ribbon-card-bottom">
+          {% include selector.html %}
+        </figcaption>
+      </div>
     </div>
-    <h1 id="title">Explore data</h1>
+  </section>
+  
+  <section class="container-page-wrapper">
 
-    <p>Natural resource extraction — and particularly federal revenue from extraction — varies widely across the country. The scope and source of data about natural resource extraction often depends on property ownership, as well as the type of resource.</p>
+      <section id="production">
 
-    <figure is="data-map" color-scheme="Reds" steps="9">
-      {%
-        include state-map.html
-        states=site.data.state_revenues
-        offshore_areas=site.data.offshore_federal_production_areas
-        href=':url'
-      %}
-    </figure>
+        <h2>Production</h2>
 
-<!--     <p>The USEITI Multi-Stakeholder Group gathered additional information to help illuminate the role of extractive industries in areas with significant extractive activities:</p>
-    <ul>
-      <li>For 18 states, we've included links to state agencies and data, which can help understand the laws and regulations governing extraction on state and local land.</li>
-      <li>A few states have opted in to the USEITI process by providing additional data and contextual information about natural resource extraction on state and local land. Montana is the first of these states, and Wyoming and Alaska are also participating.</li>
-      <li>For 12 communities in 10 states, there are <a href="{{ site.baseurl }}/case-studies/"></a>case studies that shed light on the economic and fiscal effects of oil, gas, and mineral extraction in those communities.</li>
-    </ul> -->
+        <p>The U.S. produces more <a href="#all-production-natural-gas-mcf">natural gas</a> and <a href="#all-production-oil-bbl">oil</a> than any other country. The U.S. also ranks second in the world for production of <a href="#all-production-coal-short-tons">coal</a> and renewable energy, and third in the world for gold production.</p>
 
-    <section id="production">
+        {% include location/national-all-production.html %}
 
-      <h2>Production</h2>
+        <section id="federal-production" is="year-switcher-section" class="federal production">
 
-      <p>The U.S. produces more <a href="#all-production-natural-gas-mcf">natural gas</a> and <a href="#all-production-oil-bbl">oil</a> than any other country. The U.S. also ranks second in the world for production of <a href="#all-production-coal-short-tons">coal</a> and renewable energy, and third in the world for gold production.</p>
+        <h3>Land ownership</h3>
 
-      {% include location/national-all-production.html %}
+        {% include location/national-ownership.html %}
 
-      <section id="federal-production" is="year-switcher-section" class="federal production">
+        {% include location/national-federal-production.html %}
 
-      <h3>Land ownership</h3>
+      </section>
 
-      {% include location/national-ownership.html %}
+      {% include location/national-revenue.html %}
 
-      {% include location/national-federal-production.html %}
+      {% include location/national-disbursements.html %}
 
-    </section>
+      <section id="economic-impact">
+      
+      <h2>Economic impact</h2>
 
-    {% include location/national-revenue.html %}
+      {% include location/national-gdp.html %}
 
-    {% include location/national-disbursements.html %}
+      {% include location/national-jobs.html %}
 
-    <section id="economic-impact">
-    
-    <h2>Economic impact</h2>
+      </section>
 
-    {% include location/national-gdp.html %}
-
-    {% include location/national-jobs.html %}
-
-    </section>
-
-    <!-- XXX setting display: none on this prevents the mask from working -->
-    <svg width="0" height="0">
-      <defs>
-        <clipPath id="state-outline">
-          <use xlink:href="{{ site.baseurl }}/maps/states/all.svg#state-{{ state_id }}"></use>
-        </clipPath>
-      </defs>
-    </svg>
+      <!-- XXX setting display: none on this prevents the mask from working -->
+      <svg width="0" height="0">
+        <defs>
+          <clipPath id="state-outline">
+            <use xlink:href="{{ site.baseurl }}/maps/states/all.svg#state-{{ state_id }}"></use>
+          </clipPath>
+        </defs>
+      </svg>
 
 
 
-  </div>
-
-  <div class="container-right-3">
-    <div class="sticky_nav" data-sticky-offset="50">
-      <h3 class="state-page-nav-title container">
-
-        <div class="nav-title">National data</div>
-      </h3>
-      <nav class="sticky_nav-nav">
-        {% include case-studies/_nav-list.html %}
-      </nav>
     </div>
-  </div>
+
+    <div class="container-right-3">
+      <div class="sticky_nav" data-sticky-offset="50">
+        <h3 class="state-page-nav-title container">
+
+          <div class="nav-title">National data</div>
+        </h3>
+        <nav class="sticky_nav-nav">
+          {% include case-studies/_nav-list.html %}
+        </nav>
+      </div>
+    </div>
+  
+  </section>
 
 </main>
 

--- a/states/index.html
+++ b/states/index.html
@@ -72,6 +72,8 @@ nav_items:
   </section>
   
   <section class="container-page-wrapper">
+    
+    <div class="container-left-9">
 
       <section id="production">
 
@@ -81,13 +83,15 @@ nav_items:
 
         {% include location/national-all-production.html %}
 
-        <section id="federal-production" is="year-switcher-section" class="federal production">
-
         <h3>Land ownership</h3>
 
         {% include location/national-ownership.html %}
 
-        {% include location/national-federal-production.html %}
+        <section id="federal-production" is="year-switcher-section" class="federal production">
+          
+          {% include location/national-federal-production.html %}
+          
+        </section>
 
       </section>
 
@@ -113,8 +117,6 @@ nav_items:
           </clipPath>
         </defs>
       </svg>
-
-
 
     </div>
 

--- a/states/index.html
+++ b/states/index.html
@@ -44,7 +44,7 @@ nav_items:
 
 
 <main id="national" class="layout-state-pages">
-  
+
   <section class="slab-delta">
     <div class="container-page-wrapper landing-section_top ribbon ribbon-column">
       <div class="container-left-8 ribbon-hero ribbon-hero-column">
@@ -55,14 +55,14 @@ nav_items:
             states=site.data.state_revenues
             offshore_areas=site.data.offshore_federal_production_areas
             href=':url'
+            ownership=true
+            outline=true
           %}
         </figure>
       </div>
       <div class="container-right-4 ribbon-card-column ribbon-card-has-image ribbon-card">
-        <figure class="ribbon-card-top">
-          <a href="{{site.baseurl}}/explore/federal-revenue-by-location/">
-            <img class="ribbon-card-image" src="{{ site.baseurl }}/img/explore-landing-intro.png" alt="Map of the US with the Gulf of Mexico highlighted. Total U.S. revenue: 12,261,828,343. Gulf of Mexico revenue: 7,572,080,117. Calendar year 2013.">
-          </a>
+        <figure>
+          Natural resource extraction — and particularly federal revenue from extraction — varies widely across the country.
         </figure>
         <figcaption class="ribbon-card-bottom">
           {% include selector.html %}
@@ -70,9 +70,9 @@ nav_items:
       </div>
     </div>
   </section>
-  
+
   <section class="container-page-wrapper">
-    
+
     <div class="container-left-9">
 
       <section id="production">
@@ -88,9 +88,9 @@ nav_items:
         {% include location/national-ownership.html %}
 
         <section id="federal-production" is="year-switcher-section" class="federal production">
-          
+
           {% include location/national-federal-production.html %}
-          
+
         </section>
 
       </section>
@@ -100,7 +100,7 @@ nav_items:
       {% include location/national-disbursements.html %}
 
       <section id="economic-impact">
-      
+
       <h2>Economic impact</h2>
 
       {% include location/national-gdp.html %}
@@ -131,7 +131,7 @@ nav_items:
         </nav>
       </div>
     </div>
-  
+
   </section>
 
 </main>


### PR DESCRIPTION
Fixes issue(s) # ?

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/national-page-top-ribbbon/)

Working off [this image](https://cloud.githubusercontent.com/assets/9259185/17782864/16e1c53c-653b-11e6-9bd0-6a0f5134f121.png)

Changes proposed in this pull request:
- changes ownership palette
- adds framwork for top ribbon
- adds working state selector


/cc @meiqimichelle @ericronne 
