### PR TITLE
Montana state revenue and opt-in content

### DIFF
--- a/_data/opt_in_state_streams.yml
+++ b/_data/opt_in_state_streams.yml
@@ -1,0 +1,2 @@
+MT:
+  'Oil & Natural Gas Production Tax': hey there

--- a/_includes/location/opt-in/state-disbursements.html
+++ b/_includes/location/opt-in/state-disbursements.html
@@ -1,0 +1,63 @@
+{% assign revenue_year = '2014' %}
+{% assign funds = site.data.opt_in_state_revenues[include.location_id].funds %}
+
+{% if funds.size > 0 %}
+  {% assign funds_info = site.data.opt_in_state_funds[include.location_id] %}
+  {% assign funds_count = funds.size | minus: 1 %}
+  {% assign revenue_total = funds.Total.All[revenue_year] %}
+
+{% if page.state_disbursements %}
+  {{ page.state_disbursements | markdownify }}
+{% endif %}
+
+<p><strong>
+  In {{ year }}, ${{ revenue_total | default: 0 | intcomma }}
+  in state revenue from natural resource extraction in 
+  {{ state_name }} was disbursed
+  to {{ funds_count }} fund{{ funds_count | plural }}.
+</strong></p>
+
+<table is="bar-chart-table" class="table-basic"
+  {% if include.id %}id="{{ include.id }}"{% endif %}>
+  <thead>
+    <tr>
+      <th>State fund</th>
+      <th class="num">Distribution</th>
+    </tr>
+  </thead>
+
+  {% for _fund in funds %}
+    {% assign fund = _fund[0] %}
+    {% assign fund_name = fund | xml_escape %}
+    {% assign fund_slug = fund | slugify %}
+    {% assign fund_sources = _fund[1] %}
+    {% assign fund_info = funds_info[fund] %}
+    {% assign fund_dollars = fund_sources.All[revenue_year] %}
+  <tbody id="revenue-disbursement-fund-{{ fund_slug }}"
+    class="table-accordion-group">
+    <tr>
+      <td>
+        {% if fund_info %}
+        <button is="aria-toggle" aria-controls="fund-{{ fund_slug }}"
+          aria-expanded="false" class="not-button-like">
+          <strong>{{ fund_name }}</strong>
+        </button>
+        {% else %}
+        <strong>{{ fund_name }}</strong>
+        {% endif %}
+      </td>
+      <td data-value="{{ fund_dollars }}"
+        data-year-values='{{ fund_sources.All | jsonify }}'>
+        ${{ fund_dollars | default: 0 | intcomma }}
+      </td>
+    </tr>
+    {% if fund_info %}
+    <tr id="fund-{{ fund_slug }}">
+      <td colspan="2">{{ fund_info }}</td>
+    </tr>
+    {% endif %}
+  </tbody>
+  {% endfor %}
+</table>
+{% endif %}
+

--- a/_includes/location/opt-in/state-revenues.html
+++ b/_includes/location/opt-in/state-revenues.html
@@ -6,16 +6,24 @@
   {% assign streams_count = streams.size | minus: 1 %}
   {% assign revenue_total = streams.All.Total[revenue_year] %}
 
-{% if page.state_disbursements %}
-  {{ page.state_disbursements | markdownify }}
+{% if page.state_revenue %}
+  {{ page.state_revenue | markdownify }}
 {% endif %}
 
-<p><strong>
-  In {{ year }}, ${{ revenue_total | default: 0 | intcomma }}
-  in state revenue from natural resource extraction in 
-  {{ state_name }} was disbursed
-  from {{ streams_count }} revenue stream{{ streams_count | plural }}.
-</strong></p>
+<p>
+  <strong>
+    In {{ year }}, state and local governments in 
+    {{ state_name }} collected 
+    ${{ revenue_total | default: 0 | intcomma }}
+    in state revenue from natural resource extraction through 
+    {{ streams_count }} revenue stream{{ streams_count | plural }}.
+  </strong>
+  This includes both tax and non-tax revenue.
+</p>
+
+{% if page.state_revenue_sustainability %}
+  {{ page.state_revenue_sustainability | markdownify }}
+{% endif %}
 
 <table is="bar-chart-table" class="table-basic"
   {% if include.id %}id="{{ include.id }}"{% endif %}>

--- a/_includes/location/opt-in/state-revenues.html
+++ b/_includes/location/opt-in/state-revenues.html
@@ -1,10 +1,10 @@
 {% assign revenue_year = '2014' %}
-{% assign funds = site.data.opt_in_state_revenues[include.location_id].funds %}
+{% assign streams = site.data.opt_in_state_revenues[include.location_id].streams %}
 
-{% if funds.size > 0 %}
-  {% assign funds_info = site.data.opt_in_state_funds[include.location_id] %}
-  {% assign funds_count = funds.size | minus: 1 %}
-  {% assign revenue_total = funds.Total.All[revenue_year] %}
+{% if streams.size > 0 %}
+  {% assign streams_info = site.data.opt_in_state_streams[include.location_id] %}
+  {% assign streams_count = streams.size | minus: 1 %}
+  {% assign revenue_total = streams.All.Total[revenue_year] %}
 
 {% if page.state_disbursements %}
   {{ page.state_disbursements | markdownify }}
@@ -14,46 +14,49 @@
   In {{ year }}, ${{ revenue_total | default: 0 | intcomma }}
   in state revenue from natural resource extraction in 
   {{ state_name }} was disbursed
-  to {{ funds_count }} fund{{ funds_count | plural }}.
+  from {{ streams_count }} revenue stream{{ streams_count | plural }}.
 </strong></p>
 
 <table is="bar-chart-table" class="table-basic"
   {% if include.id %}id="{{ include.id }}"{% endif %}>
   <thead>
     <tr>
-      <th>State fund</th>
-      <th class="num">Distribution</th>
+      <th>Revenue stream</th>
+      <th class="num">Amount collected</th>
     </tr>
   </thead>
 
-  {% for _fund in funds %}
-    {% assign fund = _fund[0] %}
-    {% assign fund_name = fund | xml_escape %}
-    {% assign fund_slug = fund | slugify %}
-    {% assign fund_sources = _fund[1] %}
-    {% assign fund_info = funds_info[fund] %}
-    {% assign fund_dollars = fund_sources.All[revenue_year] %}
-  <tbody id="revenue-disbursement-fund-{{ fund_slug }}"
+  {% for _stream in streams %}
+    {% assign stream = _stream[0] %}
+    {% assign stream_name = stream | xml_escape %}
+    {% if stream_name == 'All' %}
+      {% assign stream_name = 'Total' %}
+    {% endif %}
+    {% assign stream_slug = stream | slugify %}
+    {% assign stream_sources = _stream[1] %}
+    {% assign stream_info = streams_info[stream] %}
+    {% assign stream_dollars = stream_sources.Total[revenue_year] %}
+  <tbody id="revenue-disbursement-stream-{{ stream_slug }}"
     class="table-accordion-group">
     <tr>
       <td>
-        {% if fund_info %}
-        <button is="aria-toggle" aria-controls="fund-{{ fund_slug }}"
+        {% if stream_info %}
+        <button is="aria-toggle" aria-controls="stream-{{ stream_slug }}"
           aria-expanded="false" class="not-button-like">
-          <strong>{{ fund_name }}</strong>
+          <strong>{{ stream_name }}</strong>
         </button>
         {% else %}
-        <strong>{{ fund_name }}</strong>
+        <strong>{{ stream_name }}</strong>
         {% endif %}
       </td>
-      <td data-value="{{ fund_dollars }}"
-        data-year-values='{{ fund_sources.All | jsonify }}'>
-        ${{ fund_dollars | default: 0 | intcomma }}
+      <td data-value="{{ stream_dollars }}"
+        data-year-values='{{ stream_sources.Total | jsonify }}'>
+        ${{ stream_dollars | default: 0 | intcomma }}
       </td>
     </tr>
-    {% if fund_info %}
-    <tr id="fund-{{ fund_slug }}">
-      <td colspan="2">{{ fund_info }}</td>
+    {% if stream_info %}
+    <tr id="stream-{{ stream_slug }}">
+      <td colspan="2">{{ stream_info }}</td>
     </tr>
     {% endif %}
   </tbody>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -9,20 +9,20 @@
 
   <h2>Revenue</h2>
 
-  <p class="full-width-text">Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
+  <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
 
 
   <section id="federal-revenue">
 
     <h3>Federal revenue</h3>
 
-    <p class="full-width-text">TEST PARAGRAPH FOR THE AWESOME COREY M</p>
+    <p>Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.</p>
     
     <h4>Revenue from extraction on federal land by resource</h4>
     
-    <p class="full-width-text">Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
+    <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
-    <p class="full-width-text">The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
+    <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
 
     <div id="fee-summaries" class="tab-interface">
       <ul class="eiti-tabs info-tabs" role="tablist">
@@ -103,7 +103,7 @@
 
     <h4>Federal tax revenue</h4>
 
-    <div class="full-width-text">
+    <div>
       <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to romote other policy goals.</p>
       <p>Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
     </div>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -114,8 +114,10 @@
   <section id="state-local-revenue" class="state revenue">
     <h3>State revenue</h3>
 
-    <div class="full-width-text">
+    {% if page.opt_in == true %}
+      {% include location/opt-in/state-revenues.html location_id=state_id %}
+    {% else %}
       <p>We don't have detailed data about federal, state, or local revenue from natural resource extraction on land owned by the state of {{ state_name }}, corporations, or individuals. However, all companies must pay state, local, and federal taxes.</p>
-    </div>
+    {% endif %}
   </section>
 </section>

--- a/_includes/location/section-state-governance.html
+++ b/_includes/location/section-state-governance.html
@@ -8,10 +8,6 @@
 
   <p>The state of {{ state_name }} participated in additional reporting. As part of the USEITI process, the {{ "Independent Administrator" | term:"Independent Administrator (IA)" }} gathered information about state and local natural resource governance, revenues, and disbursements in {{ state_name }}.</p>
 
-  {% if page.state_land %}
-	  {{ page.state_land | markdownify }}
-  {% endif %}
-
   {{ regulations | markdownify }}
 
 </section>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -111,7 +111,7 @@ nav_items:
         <h3>State disbursements</h2>
 
         {% if page.opt_in == true %}
-          {% include location/opt-in/state-revenues.html location_id=state_id %}
+          {% include location/opt-in/state-disbursements.html location_id=state_id %}
         {% else %}
           <p>We don't know how states spent their money. CONTENT TK</p>
         {% endif %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -10,6 +10,8 @@ nav_items:
         title: Entire state
       - name: federal-production
         title: Federal land
+      - name: state-production
+        title: State land
   - name: revenue
     title: Revenue
     subnav_items:
@@ -86,6 +88,15 @@ nav_items:
       {% include location/section-all-production.html %}
 
       {% include location/section-federal-production.html %}
+
+      <h3 id="state-production">Production on state land in Montana</h3>
+      {% if page.state_land %}
+        {{ page.state_land | markdownify }}
+      {% endif %}
+      {% if page.state_land_production %}
+        {{ page.state_land_production | markdownify }}
+      {% endif %}
+
     </section>
 
     {% include location/section-revenue.html %}
@@ -93,6 +104,9 @@ nav_items:
     {% unless page.offshore == true %}
     <section id="economic-impact">
       <h2>Economic impact</h2>
+      {% if page.state_impact %}
+        {{ page.state_impact | markdownify }}
+      {% endif %}
 
       {% include location/section-gdp.html %}
 
@@ -113,7 +127,7 @@ nav_items:
         {% if page.opt_in == true %}
           {% include location/opt-in/state-disbursements.html location_id=state_id %}
         {% else %}
-          <p>We don't know how states spent their money. CONTENT TK</p>
+          <p>We don't have detailed data about how states or local governments distribute revenue from natural resource extraction.</p>
         {% endif %}
       </section>
 

--- a/_states/MT.md
+++ b/_states/MT.md
@@ -7,24 +7,25 @@ opt_in: true
 
 state_land: |
     The state government of Montana administers 5.2 million surface acres of land (about 5.6% of the state) and 6.2 million mineral acres. For detailed information about land ownership in each county, the Montana State Library maintains [public and private land ownership maps](https://mslservices.mt.gov/Geographic_Information/Maps/Land_Ownership/Default).
-state_revenue: |
-    Revenue from natural resource extraction on federal, state, and private land is a significant source of revenue for state and local governments in Montana. In 2014, natural resource revenue streams accounted for 17.4% of revenue collected by the Montana Department of Revenue. Over the last four years, Montana’s overall revenue has increased while revenue from natural resources has stayed relatively flat.
+state_land_production: |
+    In FY 2014, the following resources were extracted on state land in Montana:
 
-    In FY2014, the state of Montana and county tax collectors collected $446 million. The Oil & Natural Gas Production tax accounts for roughly half of Montana’s revenue from natural resource extraction.
+    * 1,505,356 barrels of crude oil
+    * 3,561 million cubic feet of natural gas
+    * 4,465,582 short tons of coal
+    
+    For details about natural resource extraction on state-owned land, see annual reports produced by the [Mineral Management Bureau](http://dnrc.mt.gov/index/divisions/trust/minerals-management). 
+state_revenue: |
+    Revenue from natural resource extraction on federal, state, and private land is a significant source of revenue for state and local governments in Montana.
+state_revenue_sustainability: |
+    **Revenue sustainability:** In 2014, natural resource revenue streams accounted for 17.4% of revenue collected by the Montana Department of Revenue. Over the last four years, Montana’s overall revenue has increased while revenue from natural resources has stayed relatively flat; the percentage of revenue from natural resources has decreased from 13.5% of total revenue that went to the state general fund in 2010 to 11.3% in 2014.
 state_disbursements: |
     [State agencies](#state-agencies) distribute revenue according to the [Montana State Code](http://leg.mt.gov/bills/mca_toc/), which is defined by the legislature.
+state_impact: |
+    The extractive industries play an important role in Montana’s economy — particularly in eastern Montana, where economic activity in the Bakken oil fields has a strong impact on local economies. To read more about the impact of extractive industries on Montana’s economy, see the [Labor Day Report (PDF)](http://lmi.mt.gov/Portals/135/Publications/LMI-Pubs/Labor%20Market%20Publications/LDR-15.pdf) from the [Montana Department of Labor and Industry](http://dli.mt.gov/).
+
+    Because of relatively high annual wages (compared to other industries), extractive industries contribute a greater percentage of personal income than jobs. In 2014, personal income from extractive industries made up about 4.8% (or $1.2 billion) of all personal income in the state. The average annual wage in Montana in 2014 was $86,496, which represented  4.9% growth from 2013.
 ---
-
-<!-- State overview
-
-- Where is production happening? (production context)
-- Personal income
-
-State revenue and disbursements
-
-- Revenue from production on state land
-- State and local taxes
-- Revenue sustainability -->
 
 <!-- State governance -->
 


### PR DESCRIPTION
Fixes issue(s) #1654 and #1467 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/opt-in-state-revenue/states/MT/)

Changes proposed in this pull request:

- Adds opt-in state revenue data!
- Adds Production on state land section for opt-in states
- Adds intro to economic impact section for opt-in states
- Adds Revenue sustainability section for opt-in states
- Replaces several instances of placeholder content

/cc @meiqimichelle @shawnbot 🎉 🎈 
