### PR TITLE
fix stray Montana heading

### DIFF
--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -88,8 +88,8 @@ nav_items:
 
       {% include location/section-federal-production.html %}
 
-      <h3 id="state-production">Production on state land in Montana</h3>
       {% if page.state_land %}
+        <h3 id="state-production">Production on state land in {{ state_name }}</h3>
         {{ page.state_land | markdownify }}
       {% endif %}
       {% if page.state_land_production %}


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-land-fix/)

Changes proposed in this pull request:

- Removes stray header — the "Production on state land in STATE" name should now only show if it's a priority state, and it will use the state name instead of Montana

/cc @meiqimichelle 

