### PR TITLE
Fix revenue years

### DIFF
--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -60,18 +60,13 @@
 
         {% if revenue_commodities %}
           {% assign empty_years = '' | split:'' %}
-          {% for y in year_list %}
-            {% assign s_y = y | to_s %}
-            {% for _commodity in revenue_commodities %}
-              {% unless _commodity[1][s_y].size %}
-                {% if _commodity[0] != "All" %}
-                  {% assign empty_years = empty_years | push:s_y %}
-                {% endif %}
-              {% endunless %}
-            {% endfor %}
+          {% for _year in year_list %}
+            {% assign _year_string = _year | to_s %}
+            {% unless revenue_commodities.All[_year_string].revenue %}
+              {% assign empty_years = empty_years | push: _year_string %}
+            {% endunless %}
           {% endfor %}
 
-          {% assign empty_years = empty_years | join:',' %}
           {% include year-selector.html year_range=year_range empty_years=empty_years %}
         {% endif %}
 

--- a/_includes/year-selector.html
+++ b/_includes/year-selector.html
@@ -1,24 +1,12 @@
-{% if include.empty_years %}
-  {% assign empty_years = include.empty_years %}
-{% endif %}
-
 {% if include.year_range %}
-  {% assign year_range = include.year_range %}
-{% endif %}
-
-{% if year_range %}
-  {% assign year_list = year_range | to_list %}
+  {% assign _year_list = include.year_range | to_list %}
 
   <select class="chart-selector">
-    {% for _year in year_list %}
+    {% for _year in _year_list %}
       {% assign __year = year | to_i %}
       {% assign s_year = _year | to_s %}
-      {% if include.empty_years.size > 0 %}
-        {% if empty_years contains s_year %}
-          <option disabled value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }} no data</option>
-        {% else %}
-          <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
-        {% endif %}
+      {% if include.empty_years contains s_year %}
+        <option disabled value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }} no data</option>
       {% else %}
         <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
       {% endif %}

--- a/_includes/year-selector.html
+++ b/_includes/year-selector.html
@@ -2,6 +2,7 @@
   {% assign _year_list = include.year_range | to_list %}
 
   <select class="chart-selector">
+    {% if include.empty_years %}<!-- empty years: {{ include.empty_years | jsonify }} -->{% endif %}
     {% for _year in _year_list %}
       {% assign __year = year | to_i %}
       {% assign s_year = _year | to_s %}


### PR DESCRIPTION
There's no issue for this yet, but what it fixes is a problem with the years listed as "no data" in the federal revenue year selectors on state pages.

### :sunglasses: PREVIEW

Compare:
* California: [broken](https://federalist.18f.gov/preview/18F/doi-extractives-data/dev/explore/CA/#federal-revenue) vs. [fixed](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-revenue-years/explore/CA/#revenue)

  ![image](https://cloud.githubusercontent.com/assets/113896/18065045/1d3988fc-6de7-11e6-8901-f1cad817fcad.png) ![image](https://cloud.githubusercontent.com/assets/113896/18065060/27419c5e-6de7-11e6-997a-25b4cf9d1c5a.png)


* Indiana: [broken](https://federalist.18f.gov/preview/18F/doi-extractives-data/dev/explore/IN/#federal-revenue) vs. [fixed](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-revenue-years/explore/IN/#federal-revenue)

  ![image](https://cloud.githubusercontent.com/assets/113896/18065007/e7790d6e-6de6-11e6-9a0b-187da316eb9e.png) ![image](https://cloud.githubusercontent.com/assets/113896/18065026/058820f6-6de7-11e6-8520-f87d5600713f.png)

Changes proposed in this pull request:
- Only use `All` commodities totals to determine which years are "empty" in the federal revenue year selector on state pages.
- Simplify logic on both the state pages and the year selector include.

/cc @gemfarmer @meiqimichelle 
