### PR TITLE
Normalize subnav order on profiles

### DIFF
--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -21,6 +21,13 @@ nav_items:
         title: State and local revenue
       - name: tax-expenditures
         title: Tax expenditures
+  - name: disbursements
+    title: Disbursements
+    subnav_items:
+      - name: federal-disbursements
+        title: Federal disbursements
+      - name: state-disbursements
+        title: State disbursements
   - name: economic-impact
     title: Economic impact
     subnav_items:
@@ -32,13 +39,6 @@ nav_items:
         title: Self-employment
       - name: exports
         title: Exports
-  - name: disbursements
-    title: Disbursements
-    subnav_items:
-      - name: federal-disbursements
-        title: Federal disbursements
-      - name: state-disbursements
-        title: State disbursements
   - name: state-governance
     title: State governance
     subnav_items:
@@ -111,22 +111,7 @@ nav_items:
       </section>
 
       {% include location/section-revenue.html %}
-
-      {% unless page.offshore == true %}
-      <section id="economic-impact">
-        <h2>Economic impact</h2>
-        {% if page.state_impact %}
-          {{ page.state_impact | markdownify }}
-        {% endif %}
-
-        {% include location/section-gdp.html %}
-
-        {% include location/section-jobs.html %}
-
-        {% include location/section-exports.html %}
-      </section>
-      {% endunless %}
-
+      
       <section id="disbursements" class="disbursements">
         <h2>Disbursements</h2>
 
@@ -143,6 +128,21 @@ nav_items:
         </section>
 
       </section>
+
+      {% unless page.offshore == true %}
+      <section id="economic-impact">
+        <h2>Economic impact</h2>
+        {% if page.state_impact %}
+          {{ page.state_impact | markdownify }}
+        {% endif %}
+
+        {% include location/section-gdp.html %}
+
+        {% include location/section-jobs.html %}
+
+        {% include location/section-exports.html %}
+      </section>
+      {% endunless %}
 
       <section>
         {% include location/section-state-governance.html %}

--- a/states/index.html
+++ b/states/index.html
@@ -12,14 +12,16 @@ nav_items:
     title: Production
     subnav_items:
       - name: all-production
-        title: All land
+        title: Nationwide
       - name: federal-production
-        title: Federal land
+        title: Federal lands and waters
   - name: revenue
     title: Revenue
     subnav_items:
       - name: federal-revenue
         title: Federal land
+      - name: federal-tax-revenue
+        title: Federal tax revenue
   - name: federal-disbursements
     title: Disbursements
   - name: economic-impact


### PR DESCRIPTION
Fixes issue(s) #1519 .

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/normalize-order-on-profiles/)

Changes proposed in this pull request:

- Updates words in subnav on national profile page
- Switches order of disbursements and economic impact sections on state profiles because they should be that way, and were only switched originally because disbursements was commented out for so long 😁 

/cc @coreycaitlin 
