### PR TITLE
State page nitpicks

### DIFF
--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -12,7 +12,11 @@
     {% include year-selector.html year_range=year_range %}
 
     <p class="chart-description">
-      The Energy Information Administration collects data about <strong>energy-related natural resources on all types of land and offshore areas</strong> (including state and private land). This data does not include information about non-energy mineral mining. <a href="{{site.baseurl}}/downloads/#production-all">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+      The Energy Information Administration collects data about <strong>energy-related natural resources on all types of land and offshore areas</strong> (including state and private land). This data does not include information about non-energy mineral mining.
+      <br>
+      <a href="{{site.baseurl}}/downloads/#production-all">
+        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+      </a>
     </p>
   </div>
 

--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -5,7 +5,12 @@
   <h2>Federal disbursements</h2>
 
   <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
-  <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. Funds disbursed directly to state governments account for about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction. <a href="{{site.baseurl}}/downloads/disbursements/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a></p>
+  <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. Funds disbursed directly to state governments account for about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction.</p>
+  <p>
+    <a href="{{site.baseurl}}/downloads/disbursements/">
+      <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+    </a>
+  </p>
 
   <p><strong>
     {% if disbursements %}

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -17,7 +17,9 @@
       <p class="chart-description">
         Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.
         ONRR collects detailed data about natural resources extracted on federal lands and waters.
-        <a href="{{site.baseurl}}/downloads/federal-production/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon>
+        <br>
+        <a href="{{site.baseurl}}/downloads/federal-production/">
+          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation 
         </a>
       </p>
     </div>

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -14,7 +14,11 @@
       Extractive industries accounted for
       {{ gdp[year].percent | percent }}%
       of U.S. GDP in {{ year }}.
-      GDP data comes from the U.S. Bureau of Economic Analysis. <a href="{{site.baseurl}}/downloads/#gdp">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+      GDP data comes from the U.S. Bureau of Economic Analysis. 
+      <br>
+      <a href="{{site.baseurl}}/downloads/#gdp">
+        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+      </a>
     </p>
   </div><!-- .chart-selector-wrapper -->
 

--- a/_includes/location/national-jobs.html
+++ b/_includes/location/national-jobs.html
@@ -19,7 +19,12 @@
       {% include year-selector.html year_range=year_range %}
 
       <div class="chart-description">
-        <p><strong>Wage and salary data</strong>, from the Bureau of Labor Statistics, describes the number of people employed in natural resource extraction that receive wages or salaries from companies. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a></p>
+        <p><strong>Wage and salary data</strong>, from the Bureau of Labor Statistics, describes the number of people employed in natural resource extraction that receive wages or salaries from companies.
+          <br> 
+          <a href="{{site.baseurl}}/downloads/#jobs">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+          </a>
+        </p>
         <p><p>In {{ year }}, jobs in the extractive industries that paid a wage or salary made up {{ jobs_percent | percent }}% of nationwide employment.</p></p>
       </div>
     </div><!-- .chart-selector-wrapper -->
@@ -64,7 +69,11 @@
       {% include year-selector.html year_range=year_range %}
 
       <p class="chart-description">
-          <strong>Self-employment data</strong>, from the Bureau of Economic Analysis, describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+          <strong>Self-employment data</strong>, from the Bureau of Economic Analysis, describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.
+          <br> 
+          <a href="{{site.baseurl}}/downloads/#jobs">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+          </a>
       </p>
     </div><!-- .chart-selector-wrapper -->
 

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -15,7 +15,12 @@
 
     <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
-    <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon> </a></p>
+    <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production.
+      <br>
+      <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
+        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+      </a>
+    </p>
 
     <div id="fee-summaries" class="tab-interface">
       <ul class="eiti-tabs info-tabs" role="tablist">

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -7,15 +7,15 @@
 
   <h2>Revenue</h2>
 
-  <p class="full-width-text">Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
+  <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
 
   <h3>Federal revenue from extraction on federal land</h3>
 
   <section id="federal-revenue">
 
-    <p class="full-width-text">Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
+    <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
-    <p class="full-width-text">The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon> </a></p>
+    <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon> </a></p>
 
     <div id="fee-summaries" class="tab-interface">
       <ul class="eiti-tabs info-tabs" role="tablist">
@@ -102,7 +102,7 @@
 
    <h3 id="federal-tax-revenue">Federal tax revenue</h3>
 
-    <div class="full-width-text">
+    <div>
       <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to romote other policy goals.</p>
       <p>Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
     </div>

--- a/_includes/location/offshore-area-federal-production.html
+++ b/_includes/location/offshore-area-federal-production.html
@@ -29,8 +29,10 @@
       <p class="chart-description">
         Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.
         ONRR collects detailed data about natural resources extracted on federal lands and waters.
-        <a href="{{site.baseurl}}/downloads/federal-production/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon>
-        </a>
+          <br>
+          <a href="{{site.baseurl}}/downloads/federal-production/">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+          </a>
       </p>
     </div>
 

--- a/_includes/location/offshore-area-revenue.html
+++ b/_includes/location/offshore-area-revenue.html
@@ -15,15 +15,15 @@
 
   <h2>Revenue</h2>
 
-  <p class="full-width-text">Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
+  <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
 
   <h3>Federal revenue from extraction on federal land</h3>
 
   <section id="federal-revenue">
 
-    <p class="full-width-text">Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
+    <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
-    <p class="full-width-text">The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon> </a></p>
+    <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon> </a></p>
 
     <div id="fee-summaries" class="tab-interface">
       <ul class="eiti-tabs info-tabs" role="tablist">
@@ -110,7 +110,7 @@
 
    <h3>Federal tax revenue</h3>
 
-    <div class="full-width-text">
+    <div>
       <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to romote other policy goals.</p>
       <p>Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
     </div>

--- a/_includes/location/offshore-area-revenue.html
+++ b/_includes/location/offshore-area-revenue.html
@@ -23,7 +23,12 @@
 
     <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
-    <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon> </a></p>
+    <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production.
+      <br>
+      <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
+        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+      </a>
+    </p>
 
     <div id="fee-summaries" class="tab-interface">
       <ul class="eiti-tabs info-tabs" role="tablist">

--- a/_includes/location/revenue-type-row-oilgas.html
+++ b/_includes/location/revenue-type-row-oilgas.html
@@ -25,7 +25,7 @@
   }}"></span>
 
     <span class="text">
-    <a href="#revenue-oil"><strong>Oil</strong></a>
+    <strong class="text-header text-header-first">Oil</strong>
     ${{
       revenue_types.Oil.Royalties[include.year]
       | default: 0
@@ -33,7 +33,7 @@
     }}</span>
 
     <span class="text">
-    <a href="#revenue-gas"><strong>Gas</strong></a>
+    <strong class="text-header text-header-second">Gas</strong>
     ${{ revenue_types.Gas.Royalties[include.year] | default: 0 | intcomma }}</span>
 
   </td>

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -21,7 +21,11 @@
     {% endif %}
 
     <p class="chart-description{% unless all_products %} no-selector{% endunless %}">
-      The U.S. Energy Information Administration collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned land in {{ state_name }}. <a href="{{site.baseurl}}/downloads/#production-all">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+      The U.S. Energy Information Administration collects data about <strong>energy-related natural resources</strong> produced on federal, state, and privately owned land in {{ state_name }}. 
+        <br>
+        <a href="{{site.baseurl}}/downloads/#production-all">
+          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+        </a>
     </p>
   </div>
 

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -4,7 +4,12 @@
 
   <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
   <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. While these disbursements are tracked nationally, we don't have detailed data that specifies which expenditures and projects from those national funds are in {{ state_name }}.</p>
-  <p>We do have data about disbursements to state governments, which respresent about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction. <a href="{{site.baseurl}}/downloads/disbursements/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a></p>
+  <p>We do have data about disbursements to state governments, which respresent about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction. 
+    <br>
+    <a href="{{site.baseurl}}/downloads/disbursements/">
+      <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+    </a>
+  </p>
 
   {% assign disbursements = site.data.federal_disbursements[state_id] %}
 

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -37,7 +37,11 @@
           In {{ year }}, extractive industries products did not rank among the top 25 exports from {{ state_name }}.
         {% endif %}
 
-        The U.S. Census Bureau collects information about the top 25 exports in each state. <a href="{{site.baseurl}}/downloads/#exports">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+        The U.S. Census Bureau collects information about the top 25 exports in each state.
+          <br>
+          <a href="{{site.baseurl}}/downloads/#exports">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+          </a>
       </p>
     </div>
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -22,7 +22,10 @@
 
         <p class="chart-description">
             ONRR collects detailed data about natural resources produced on federal land in {{ state_name }}.
-            <a href="{{site.baseurl}}/downloads/federal-production/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+            <br>
+            <a href="{{site.baseurl}}/downloads/federal-production/">
+              <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+            </a>
         </p>
       </div>
     {% endif %}

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -22,7 +22,11 @@
 
     {% endif %}
     <p class="chart-description{% unless gdp %} no-selector{% endunless %}">
-      GDP data comes from the U.S. Bureau of Economic Analysis. <a href="{{site.baseurl}}/downloads/#gdp">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+      GDP data comes from the U.S. Bureau of Economic Analysis.
+      <br>
+      <a href="{{site.baseurl}}/downloads/#gdp">
+        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+      </a>
     </p>
   </div><!-- .chart-selector-wrapper -->
 

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -33,7 +33,12 @@
       {% endif %}
 
       <div class="chart-description{% unless jobs %} no-selector{% endunless %}">
-        <p><strong>Wage and salary data</strong>, from the Bureau of Labor Statistics, describes the number of people employed in natural resource extraction that receive wages or salaries from companies. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a></p>
+        <p><strong>Wage and salary data</strong>, from the Bureau of Labor Statistics, describes the number of people employed in natural resource extraction that receive wages or salaries from companies. 
+          <br>
+          <a href="{{site.baseurl}}/downloads/#jobs">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+          </a>
+        </p>
         {% if jobs %}
           <p>In {{ year }}, jobs in the extractive industries that paid a wage or salary made up {{ jobs_percent | percent }}% of statewide employment in {{ state_name }}.</p>
         {% else %}
@@ -145,7 +150,11 @@
 
       <div class="chart-description {% unless self_employment_jobs %} no-selector{% endunless %}">
         <p>
-          <strong>Self-employment data</strong>, from the Bureau of Economic Analysis, describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies. <a href="{{site.baseurl}}/downloads/#jobs">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+          <strong>Self-employment data</strong>, from the Bureau of Economic Analysis, describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.
+          <br>
+          <a href="{{site.baseurl}}/downloads/#jobs">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation 
+          </a>
         </p>
       </div>
     </div><!-- .chart-selector-wrapper -->

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -72,11 +72,19 @@
 
         {% if revenue_commodities %}
           <p class="chart-description">
-            In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+            In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. 
+            <br>
+            <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
+              <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+            </a>
           </p>
         {% else %}
           <p class="chart-description{% unless revenue_commodities %} no-selector{% endunless %}">
-            In {{ year }}, the federal government didn't receive any payment for extraction of natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+            In {{ year }}, the federal government didn't receive any payment for extraction of natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. 
+            <br>
+            <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
+              <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation 
+            </a>
           </p>
         {% endif %}
       </div>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -72,7 +72,7 @@ nav_items:
 {% endcapture %}
 
 <main id="state-{{ state_id }}" class="container-page-wrapper layout-state-pages">
-  <div class="container">
+  <section class="container">
     <div>
       <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore data</a>
       /
@@ -87,7 +87,7 @@ nav_items:
     <div class="container-right-5 container-shift-1">
       {% include location/section-ownership.html %}
     </div>
-  </div>
+  </section>
 
   <section class="container">
     <div class="container-left-9">

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -124,7 +124,7 @@
   }
 
   .chart-description {
-    @include heading('para-md');
+    //@include heading('para-md');
     border-left: 1px solid $mid-gray;
     float: left;
     padding-left: 1.25rem;

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -124,7 +124,6 @@
   }
 
   .chart-description {
-    //@include heading('para-md');
     border-left: 1px solid $mid-gray;
     float: left;
     padding-left: 1.25rem;

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -16,10 +16,6 @@
     border-bottom: 20px solid $light-green;
     padding-bottom: $standard-padding-lite;
   }
-  
-  h2 + p {
-    @include heading('para-lg');
-  }
 
   h3:not(.chart-title):not(.state-page-nav-title),
   h4:not(.chart-title):not(.state-page-nav-title):not(.details-container) {

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -52,14 +52,6 @@
     margin-top: $standard-padding;
   }
 
-  p {
-    @include heading('para-lg');
-  }
-
-  ul {
-    @include heading('para-lg');
-  }
-
   figure {
     margin: 0;
   }

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -16,6 +16,10 @@
     border-bottom: 20px solid $light-green;
     padding-bottom: $standard-padding-lite;
   }
+  
+  h2 + p {
+    @include heading('para-lg');
+  }
 
   h3:not(.chart-title):not(.state-page-nav-title),
   h4:not(.chart-title):not(.state-page-nav-title):not(.details-container) {
@@ -53,11 +57,11 @@
   }
 
   p {
-    @include heading('para-md');
+    @include heading('para-lg');
   }
 
   ul {
-    @include heading('para-md');
+    @include heading('para-lg');
   }
 
   figure {

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -134,3 +134,11 @@ $ab-border-thick: 4px;
 #revenue-process tbody th .bar {
   display: none;
 }
+
+.revenue a[href="#revenue-oil"] {
+  color: $green-darkest;
+}
+
+.revenue a[href="#revenue-gas"] {
+  color: $green-dark;
+}

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -134,11 +134,3 @@ $ab-border-thick: 4px;
 #revenue-process tbody th .bar {
   display: none;
 }
-
-.revenue a[href="#revenue-oil"] {
-  color: $green-darkest;
-}
-
-.revenue a[href="#revenue-gas"] {
-  color: $green-dark;
-}

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -73,6 +73,16 @@
     min-width: 120px;
     position: relative;
 
+    .text-header {
+      &.text-header-first {
+        color: $green-darkest;
+      }
+
+      &.text-header-second {
+        color: $green-dark;
+      }
+    }
+
     .bar {
       background: $mid-gray;
       display: block;

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -12,14 +12,14 @@
   }
 
   ul a {
-      text-decoration: none;
+    text-decoration: none;
 
-      &:hover,
-      &:focus {
-        text-decoration: underline;
-      }
+    &:hover,
+    &:focus {
+      text-decoration: underline;
     }
-  
+  }
+
   nav > ul:first-of-type {
     padding-left: 0;
     padding-top: $base-padding-lite;
@@ -61,7 +61,7 @@
 .sticky_nav-nav_item-sub {
   border-left: 3px solid $neutral-gray;
   padding-left: $base-padding-lite;
-  
+
   &:first-of-type {
     margin-top: $base-padding-lite;
     padding-top: 0;

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -12,13 +12,17 @@
   }
 
   ul a {
-    text-decoration: none;
+      text-decoration: none;
 
-    &:hover,
-    &:focus {
-      text-decoration: underline;
+      &:hover,
+      &:focus {
+        text-decoration: underline;
+      }
     }
-  }
+  
+  nav > ul:first-of-type {
+    padding-left: 0;
+  } 
 }
 
 .sticky_nav-nav_item {

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -23,7 +23,7 @@
   nav > ul:first-of-type {
     padding-left: 0;
     padding-top: $base-padding-lite;
-  } 
+  }
 }
 
 .sticky_nav-nav_item {

--- a/_sass/components/_sticky_nav.scss
+++ b/_sass/components/_sticky_nav.scss
@@ -22,6 +22,7 @@
   
   nav > ul:first-of-type {
     padding-left: 0;
+    padding-top: $base-padding-lite;
   } 
 }
 
@@ -32,6 +33,7 @@
   list-style-type: none;
   margin-bottom: 0;
   padding: $base-padding-lite;
+  padding-left: 0;
   text-decoration: none;
 
   &:hover {
@@ -58,5 +60,11 @@
 
 .sticky_nav-nav_item-sub {
   border-left: 3px solid $neutral-gray;
+  padding-left: $base-padding-lite;
+  
+  &:first-of-type {
+    margin-top: $base-padding-lite;
+    padding-top: 0;
+  }
 }
 


### PR DESCRIPTION
Various layout bugs.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/state-page-nitpicks/explore)

Changes proposed in this pull request:

- Fixes spacing after state profile intro section (needed to be the same 5em as the rest of the spacing before h2)
- Removes indentation from the first level of sticky nav on state pages (should have been flush with left)
- Fixes other small padding bugs in sticky nav
- Makes paragraph text on state pages the same size as paragraph text on the rest of the site (ie, `para-lg`)
- Makes `.chart-description` the same side as rest of paragraph text
- Moves data and downloads icon on the state profile pages before the text, and chunks onto its own line to match rest of site
- Makes oil and gas in revenues mega chart the same colors as their bars. Note: the approach here will need to be changed once the rest of #1713 is addressed as it won't work if there aren't links there, and we're supposed to remove the links.

/cc @ericronne @gemfarmer 
