### PR TITLE
Fix bad map fills on Firefox

### DIFF
--- a/_includes/icon-map.html
+++ b/_includes/icon-map.html
@@ -23,7 +23,7 @@
       {% endif %}
     {% endfor %}
 
-    {% for _state in site.data.states %}
+    {% for _state in site.states %}
       {% if location_id == _state.id %}
         <g class="state feature">
           <use xlink:href="{{ _states_svg }}#state-{{ _state.id }}"></use>

--- a/_includes/state-map.html
+++ b/_includes/state-map.html
@@ -5,6 +5,16 @@
 <div class="state svg-container map-container wide"{% if _viewbox %} style="padding-bottom: {{ _viewbox | svg_viewbox_padding }}%;"{% endif %}>
   <svg class="states map{% if include.case_studies %} case_studies {% endif %}{% if include.ownership %} ownership {% endif %}{% if include.no_outline %} no-outlines {% endif %}"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
 
+    {% if include.offshore_areas != false %}
+      {%
+        include maps/offshore-areas.html
+        svg=offshore_svg
+        areas=include.offshore_areas
+        value=include.value
+        href=include.href
+      %}
+    {% endif %}
+
     {% if include.states != false %}
       {%
         include maps/state-areas.html
@@ -13,16 +23,6 @@
         value=include.value
         href=include.href
         no_ownership=include.case_studies
-      %}
-    {% endif %}
-
-    {% if include.offshore_areas != false %}
-      {%
-        include maps/offshore-areas.html
-        svg=offshore_svg
-        areas=include.offshore_areas
-        value=include.value
-        href=include.href
       %}
     {% endif %}
 

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -1,3 +1,4 @@
+// scss-lint:disable QualifyingElement, SelectorDepth
 .state-page-nav-title {
   @include heading(large-caps);
   align-items: center;

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -8,14 +8,12 @@
   position: relative;
 
   svg.map {
-    .state.feature,
-    .offshore-area.feature {
+    .state.feature use,
+    .offshore-area.feature use {
       fill-opacity: 1;
     }
 
-
-
-    .states.features {
+    .states.features use {
       @include transition(all, 0.3s);
 
       fill: $neutral-gray;
@@ -23,7 +21,7 @@
       stroke: $neutral-gray;
     }
 
-    .offshore.features {
+    .offshore.features use {
       @include transition(all, 0.3s);
 
       fill: $mid-gray;
@@ -45,13 +43,13 @@
         visibility: visible;
       }
 
-      svg.map .states.features {
+      svg.map .states.features use {
         fill: $blackest-black;
         fill-opacity: 1;
         stroke: $blackest-black;
       }
 
-      svg.map .offshore.features {
+      svg.map .offshore.features use {
         fill: $dark-gray;
         fill-opacity: 1;
         stroke: $dark-gray;

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -1,4 +1,4 @@
-// scss-lint:disable QualifyingElement
+// scss-lint:disable QualifyingElement, SelectorDepth
 svg.map {
   background: none;
   box-sizing: border-box;

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -13,42 +13,42 @@ svg.map {
     stroke-width: inherit;
   }
 
-  .mesh {
+  .mesh use {
     fill: none;
     pointer-events: none;
     stroke: $neutral-gray;
     stroke-width: 0.5;
   }
 
-  .states.features {
+  .states.features use {
     fill: $light-gray;
   }
 
-  .feature.offshore-area {
+  .feature.offshore-area use {
     fill: $green-land;
   }
 
-  .feature:not([fill]) {
+  .feature:not([fill]) use {
     fill-opacity: 0;
   }
 
-  .feature[fill] {
+  .feature[fill] use {
     fill-opacity: 1;
   }
 
-  .counties.features {
+  .counties.features use {
     fill: $white;
   }
 
-  .states.mesh {
+  .states.mesh use {
     stroke: $another-gray;
   }
 
-  .counties.mesh {
+  .counties.mesh use {
     stroke-width: 1;
   }
 
-  .feature.overlay {
+  .feature.overlay use {
     fill: none;
     pointer-events: none;
     stroke: $dark-gray;
@@ -94,7 +94,7 @@ svg.map {
   }
 
   &.states.ownership {
-    .states.features {
+    .states.features use {
       fill: $green-land;
     }
   }
@@ -102,7 +102,7 @@ svg.map {
 
 svg.ownership {
   &.no-outlines {
-    .states.mesh {
+    .states.mesh use {
       stroke: $pale-blue;
       stroke-width: 1.5px;
     }
@@ -110,11 +110,11 @@ svg.ownership {
     &.state-page {
       padding-top: 0;
 
-      .states.features {
+      .states.features use {
         fill: transparent;
       }
 
-      .states.mesh {
+      .states.mesh use {
         stroke: transparent;
       }
     }
@@ -123,17 +123,17 @@ svg.ownership {
 
 svg.case_studies {
   .feature.offshore-area,
-  .feature.state {
+  .feature.state use {
     fill: $mid-blue;
   }
 
   &.no-outlines {
-    .states.mesh {
+    .states.mesh use {
       stroke: $pale-blue;
       stroke-width: 1.5px;
     }
 
-    .states.features {
+    .states.features use {
       fill: $mid-blue;
     }
   }

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -88,7 +88,7 @@ svg.map {
       opacity: $opacity-federal;
     }
 
-    .counties.features {
+    .counties.features use {
       fill: $green-land;
     }
   }
@@ -122,7 +122,7 @@ svg.ownership {
 }
 
 svg.case_studies {
-  .feature.offshore-area,
+  .feature.offshore-area use,
   .feature.state use {
     fill: $mid-blue;
   }


### PR DESCRIPTION
Fixes #1794.

### :sunglasses: Previews
* [Explore](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-svg-use-ffx/explore/)

  ![image](https://cloud.githubusercontent.com/assets/113896/18111681/778d3ad4-6ed6-11e6-8426-195a9173a57e.png)

* [Case Studies](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-svg-use-ffx/explore/)

  ![image](https://cloud.githubusercontent.com/assets/113896/18111691/7f3f8c28-6ed6-11e6-9e35-c84263af471a.png)

Changes proposed in this pull request:
- Qualifies all of the relevant SVG selectors with an additional `use` descendent in order to fix the Firefox issue of invalid (black) fills on map features.

/cc @meiqimichelle