### PR TITLE
Links from revenue page to coal excise and AML pages

### DIFF
--- a/_how-it-works/natural-resources/revenues.md
+++ b/_how-it-works/natural-resources/revenues.md
@@ -25,7 +25,6 @@ title_display: Revenues
 selector: hash
 ---
 
-
 > Companies pay a wide range of fees, rates and taxes to extract natural resources in the U.S. The amounts differ depending on what the [ownership]({{ site.baseurl }}/how-it-works/ownership/) of the natural resource looks like. We'll cover some of the major types of payments companies make here. They are usually called &#8216;revenue&#8217; because they represent revenue to the American public.
 
 {% include selector.html %}
@@ -46,13 +45,18 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
 
 Corporations operating in the extractive industries pay taxes to the IRS on their income. These companies pay federal corporate income taxes regardless of whether they extract natural resources from federal, state, or privately held lands, so long as they have a liability. These companies also pay taxes on income from extracting natural resources and processing them into other products and commodities. There are different types of companies operating in these industries, with different ownership structures, and as a result, they are treated as different taxpayers:
 
-
 * C-corporations with many shareholders who own the company; these companies pays corporate income taxes to the IRS
 * S-corporations with 100 shareholders or less who own the company; shareholders pay personal income taxes to the IRS
 * Partnerships where two or more members own the business; members individually pay income taxes to the IRS
 * Sole proprietorships with one individual owner; the individual owner pays personal income tax to the IRS
 
 Only income taxes from C-corporations are included in the 2015 USEITI Report.
+
+### Other taxes and fees
+
+In the U.S., coal producers must pay a federal [coal excise tax]({{ site.baseurl }}/how-it-works/coal-excise-tax/) when they mine coal (a producer is any person or entity that owns the coal after it’s mined from the ground). Producers pay the tax when the coal is first sold or used. The tax does not apply to lignite or to coal mined in the U.S. for export.
+
+The [Abandoned Mine Land (AML) Reclamation Program]({{ site.baseurl }}/how-it-works/aml-fees/) uses fees paid by present-day coal mining companies to {{ "reclaim" | term:"reclamation" }} coal mines abandoned before 1977.
 
 ### Revenue policy provisions
 
@@ -78,7 +82,6 @@ The Treasury estimates the total dollar amount of each tax expenditure in a give
 * **Fossil fuels:** For FY 2013, expensing of exploration and development costs for fuels, totaling $550 million, was the largest of five expenditures. See analysis and estimates of [fossil fuel tax expenditures.]({{ site.baseurl }}/how-it-works/revenues/tax-expenditures/#fossil-fuels)
 * **Renewable energy:** For FY 2013, the energy investment credit, totaling $2 billion, was the largest of four expenditures. The energy production credit was the second largest, totaling $1.7 billion. See analysis and estimates of [renewable energy tax expenditures.]({{ site.baseurl }}/how-it-works/revenues/tax-expenditures/#renewables)
 * **Nonenergy materials:** For FY 2013, the excess of percentage-over-cost depletion for nonenergy minerals, totaling $580 million, was the largest of two expenditures. See analysis and estimates of [nonenergy mineral tax expenditures.]({{ site.baseurl }}/how-it-works/revenues/tax-expenditures/#nonenergy)
-
 
 The federal budget also includes annual estimates of the net revenue effects of eliminating a wider range of fossil fuel related tax expenditures outlined in [United States – Progress Report on Fossil Fuel Subsidies](https://www.treasury.gov/open/Documents/USA%20FFSR%20progress%20report%20to%20G20%202014%20Final.pdf). When added together, eliminating fossil fuel tax expenditures would decrease the U.S. deficit by $4.4 billion a year on average over a 10-year window, per estimates in the White House report, [Fiscal Year 2016 Mid-Session Review: Budget of the U.S. Government](https://www.whitehouse.gov/sites/default/files/omb/budget/fy2016/assets/16msr.pdf). The report did not include estimates of the effects of eliminating renewable and nonenergy mineral tax expenditures.
 


### PR DESCRIPTION
Fixes issue(s) #1755 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/coal-excise-links/how-it-works/revenues/)

