### PR TITLE
Visual bug squish squash

### DIFF
--- a/_includes/location/key-all-production-summary.html
+++ b/_includes/location/key-all-production-summary.html
@@ -1,12 +1,10 @@
 {% assign top_all_products = site.data.top_state_products[include.location_id].all_production[include.year] %}
 
 {% if top_all_products.size > 0 %}
-  <p>{{ state_name }} ranks among the top five states in the U.S. for production of:
-    <ul>
+  <p>{{ state_name }} ranks among the top five states in the U.S. for production of:<ul>
       {% for product in top_all_products %}
         <li>{{ product.name }}: #{{ product.rank }} in the nation ({{ product.percent | floor }}% of U.S. production)</li>
         {% if forloop.index == include.top %}{% break %}{% endif %}
       {% endfor %}
-    </ul>
-  </p>
+    </ul></p>
 {% endif %}

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -38,6 +38,13 @@
       <h3 class="chart-title"><span>{{ product_name }}</span></h3>
 
       <figure class="chart">
+        <eiti-bar-chart
+          aria-controls="all-production-figures-{{ product_slug }}"
+          data='{{ production_values | jsonify }}'
+          x-range="{{ year_range }}"
+          x-value="{{ year }}"
+          data-units="{{ long_units }}">
+        </eiti-bar-chart>
         <figcaption id="all-production-figures-{{ product_slug }}">
           <span class="caption-data">
             <span class="eiti-bar-chart-y-value" data-format=",">{{ volume | default: 0 | intcomma }}</span>
@@ -50,13 +57,6 @@
             <span class="eiti-bar-chart-x-value">{{ year }}</span>
           </span>
         </figcaption>
-        <eiti-bar-chart
-          aria-controls="all-production-figures-{{ product_slug }}"
-          data='{{ production_values | jsonify }}'
-          x-range="{{ year_range }}"
-          x-value="{{ year }}"
-          data-units="{{ long_units }}">
-        </eiti-bar-chart>
       </figure>
     </section>
     {% endfor %}

--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -7,7 +7,7 @@
   <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
   <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. Funds disbursed directly to state governments account for about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction.</p>
   <p>
-    <a href="{{site.baseurl}}/downloads/disbursements/">
+    <a href="{{site.baseurl}}/downloads/disbursements/" class="disbursements-data">
       <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
     </a>
   </p>

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -47,23 +47,6 @@
         </h4>
 
         <figure class="chart">
-          <figcaption id="national-federal-production-figures-{{ product_slug }}">
-          <span class="caption-data">
-            <span class="eiti-bar-chart-y-value" data-format=",">{{ volume | default: 0 | intcomma }}</span>
-              {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
-              produced on federal land in
-              <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          </span>
-          <span class="caption-no-data" aria-hidden="true">
-            There is no data for {{ state_name }} in
-            <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          </span>
-          <span class="caption-withheld" aria-hidden="true">
-            Data for {{ state_name }} was withheld in
-            <span class="eiti-bar-chart-x-value">{{ year }}</span>
-          </span>
-
-          </figcaption>
           <eiti-bar-chart
             aria-controls="national-federal-production-figures-{{ product_slug }}"
             data='{{ production_values | map_hash: "volume" | jsonify }}'
@@ -71,7 +54,22 @@
             x-value="{{ year }}"
             data-units="{{ long_units }}">
           </eiti-bar-chart>
-
+          <figcaption id="national-federal-production-figures-{{ product_slug }}">
+            <span class="caption-data">
+              <span class="eiti-bar-chart-y-value" data-format=",">{{ volume | default: 0 | intcomma }}</span>
+                {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
+                produced on federal land in
+                <span class="eiti-bar-chart-x-value">{{ year }}</span>
+            </span>
+            <span class="caption-no-data" aria-hidden="true">
+              There is no data about extracting {{ product_name | downcase | suffix:units_suffix }} on federal land in
+              <span class="eiti-bar-chart-x-value">{{ year }}</span>
+            </span>
+            <span class="caption-withheld" aria-hidden="true">
+              Data about extracting {{ product_name | downcase | suffix:units_suffix }} on federal land was withheld in
+              <span class="eiti-bar-chart-x-value">{{ year }}</span>
+            </span>
+          </figcaption>
         </figure>
 
       </section>

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -37,6 +37,13 @@
       <h3 class="chart-title"><span>GDP ({{ _metric }})</span></h3>
 
       <figure class="chart chart-{{ _metric }}">
+        <eiti-bar-chart
+          aria-controls="gdp-figures-{{ _metric }}"
+          data='{{ gdp | map_hash: _metric | jsonify }}'
+          x-range="{{ year_range }}"
+          x-value="{{ year }}"
+          data-units="{{ _format }}">
+        </eiti-bar-chart>
         <figcaption id="gdp-figures-{{ _metric }}">
           Extractive industries accounted for
           <span class="caption-data">
@@ -54,16 +61,7 @@
             There is no data for {{ state_name }} in
             <span class="eiti-bar-chart-x-value">{{ year }}</span>
           </span>
-
         </figcaption>
-        <eiti-bar-chart
-          aria-controls="gdp-figures-{{ _metric }}"
-          data='{{ gdp | map_hash: _metric | jsonify }}'
-          x-range="{{ year_range }}"
-          x-value="{{ year }}"
-          data-units="{{ _format }}">
-        </eiti-bar-chart>
-
       </figure>
 
     </section><!-- /.chart-item -->

--- a/_includes/location/national-jobs.html
+++ b/_includes/location/national-jobs.html
@@ -35,6 +35,13 @@
       <h3 class="chart-title"><span>Wage and salary jobs</span></h3>
 
       <figure class="chart">
+        <eiti-bar-chart
+          aria-controls="jobs-figures-{{ _metric }}"
+          data='{{ jobs | map_hash: _metric | jsonify }}'
+          x-range="{{ year_range }}"
+          x-value="{{ year }}"
+          data-units="jobs">
+        </eiti-bar-chart>
         <figcaption id="jobs-figures-{{ _metric }}">
           <span class="caption-data">
             In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
@@ -49,13 +56,6 @@
             <span class="eiti-bar-chart-x-value">{{ year }}</span>
           </span>
         </figcaption>
-        <eiti-bar-chart
-          aria-controls="jobs-figures-{{ _metric }}"
-          data='{{ jobs | map_hash: _metric | jsonify }}'
-          x-range="{{ year_range }}"
-          x-value="{{ year }}"
-          data-units="jobs">
-        </eiti-bar-chart>
       </figure><!-- /.chart -->
     </section><!-- /.chart-item -->
       {% endfor %}

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -73,6 +73,13 @@
           <h3 class="chart-title"><span>{{ commodity_name }}</span></h3>
 
           <figure class="chart">
+            <eiti-bar-chart
+              data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
+              aria-controls="revenue-figures-{{ commodity_slug }}"
+              x-range="{{ year_range }}"
+              x-value="{{ year }}"
+              data-units="$,">
+            </eiti-bar-chart>
             {% assign annual_revenue = commodity[1] %}
             <figcaption id="revenue-figures-{{ commodity_slug }}">
               <span class="caption-data">
@@ -81,18 +88,10 @@
                 {{ commodity_name | downcase }} on federal land
               </span>
               <span class="caption-no-data" aria-hidden="true">
-                There is no data for {{ state_name }} in
+                There is no data about {{ commodity_name | downcase }} on federal land in
                 <span class="eiti-bar-chart-x-value">{{ year }}</span>
               </span>
             </figcaption>
-            <eiti-bar-chart
-              data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
-              aria-controls="revenue-figures-{{ commodity_slug }}"
-              x-range="{{ year_range }}"
-              x-value="{{ year }}"
-              data-units="$,">
-            </eiti-bar-chart>
-
           </figure>
 
         </section>

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -49,9 +49,10 @@
       </article>
     </div>
 
-    <section class="chart-list">
 
-      <h4>Revenue by resource</h4>
+    <h4>Revenue by resource</h4>
+
+    <section class="chart-list">
 
       <div class="chart-selector-wrapper">
 

--- a/_includes/location/offshore-area-federal-production.html
+++ b/_includes/location/offshore-area-federal-production.html
@@ -59,6 +59,13 @@
         </h4>
 
         <figure class="chart">
+          <eiti-bar-chart
+            aria-controls="offshore-area-federal-production-figures-{{ product_slug }}"
+            data='{{ production_values | map_hash: "volume" | jsonify }}'
+            x-range="{{ year_range }}"
+            x-value="{{ year }}"
+            data-units="{{ long_units }}">
+          </eiti-bar-chart>
           <figcaption id="offshore-area-federal-production-figures-{{ product_slug }}">
           <span class="caption-data">
             <span class="eiti-bar-chart-y-value"
@@ -75,16 +82,7 @@
             Data for {{ state_name }} was withheld in
             <span class="eiti-bar-chart-x-value">{{ year }}</span>
           </span>
-
           </figcaption>
-          <eiti-bar-chart
-            aria-controls="offshore-area-federal-production-figures-{{ product_slug }}"
-            data='{{ production_values | map_hash: "volume" | jsonify }}'
-            x-range="{{ year_range }}"
-            x-value="{{ year }}"
-            data-units="{{ long_units }}">
-          </eiti-bar-chart>
-
         </figure>
 
       </section>

--- a/_includes/location/offshore-area-revenue.html
+++ b/_includes/location/offshore-area-revenue.html
@@ -81,6 +81,13 @@
           <h3 class="chart-title"><span>{{ commodity_name }}</span></h3>
 
           <figure class="chart">
+            <eiti-bar-chart
+              data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
+              aria-controls="revenue-figures-{{ commodity_slug }}"
+              x-range="{{ year_range }}"
+              x-value="{{ year }}"
+              data-units="$,">
+            </eiti-bar-chart>
             {% assign annual_revenue = commodity[1] %}
             <figcaption id="revenue-figures-{{ commodity_slug }}">
               <span class="caption-data">
@@ -93,16 +100,7 @@
                 <span class="eiti-bar-chart-x-value">{{ year }}</span>
               </span>
             </figcaption>
-            <eiti-bar-chart
-              data='{{ annual_revenue | map_hash: "revenue" | jsonify }}'
-              aria-controls="revenue-figures-{{ commodity_slug }}"
-              x-range="{{ year_range }}"
-              x-value="{{ year }}"
-              data-units="$,">
-            </eiti-bar-chart>
-
           </figure>
-
         </section>
 
       {% endfor %}

--- a/_includes/location/offshore-federal-revenue-area.html
+++ b/_includes/location/offshore-federal-revenue-area.html
@@ -24,6 +24,13 @@
       </h4>
 
       <figure class="chart">
+        <eiti-bar-chart
+          aria-controls="federal-revenue-county-figures-All"
+          data='{{ state_revenue_all | map_hash: "revenue" | jsonify }}'
+          x-range="{{ year_range }}"
+          x-value="{{ year }}"
+          data-units="$,">
+        </eiti-bar-chart>
         <figcaption id="federal-revenue-county-figures-All">
           <span class="caption-data">
             <span class="eiti-bar-chart-y-value"
@@ -35,16 +42,7 @@
             There is no data for {{ state_name }} in
             <span class="eiti-bar-chart-x-value">{{ year }}</span>
           </span>
-
         </figcaption>
-        <eiti-bar-chart
-          aria-controls="federal-revenue-county-figures-All"
-          data='{{ state_revenue_all | map_hash: "revenue" | jsonify }}'
-          x-range="{{ year_range }}"
-          x-value="{{ year }}"
-          data-units="$,">
-        </eiti-bar-chart>
-
       </figure>
     </div><!-- /.chart-container -->
 

--- a/_includes/location/offshore-region-federal-production.html
+++ b/_includes/location/offshore-region-federal-production.html
@@ -58,8 +58,14 @@
             </h4>
 
             <figure class="chart">
+              <eiti-bar-chart
+                aria-controls="federal-production-figures-{{ product_slug }}"
+                data='{{ production_values | map_hash: "volume" | jsonify }}'
+                x-range="{{ year_range }}"
+                x-value="{{ year }}"
+                data-units="{{ long_units }}">
+              </eiti-bar-chart>
               <figcaption id="federal-production-figures-{{ product_slug }}">
-
                 <span class="caption-data">
                   <span class="eiti-bar-chart-y-value"
                         data-format=",">{{ volume | default: 0 | intcomma }}</span>
@@ -74,17 +80,7 @@
                 <span class="caption-withheld" aria-hidden="true">
                   Data about how much {{ product_name | downcase }} was extracted in {{ region_name }} in <span class="eiti-bar-chart-x-value">{{ year }}</span> is {{ "withheld" | term_end }}.
                 </span>
-
-
               </figcaption>
-              <eiti-bar-chart
-                aria-controls="federal-production-figures-{{ product_slug }}"
-                data='{{ production_values | map_hash: "volume" | jsonify }}'
-                x-range="{{ year_range }}"
-                x-value="{{ year }}"
-                data-units="{{ long_units }}">
-              </eiti-bar-chart>
-
             </figure>
 
           </div><!-- /.chart-container -->

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -46,6 +46,13 @@
 
       <h3 class="chart-title"><span>{{ product_name }}</span></h3>
       <figure class="chart">
+        <eiti-bar-chart
+          aria-controls="state-all-production-figures-{{ product_slug }}"
+          data='{{ production_values | map_hash: "volume" | jsonify }}'
+          x-range="{{ year_range }}"
+          x-value="{{ year }}"
+          data-units="{{ long_units }}">
+        </eiti-bar-chart>
         <figcaption id="state-all-production-figures-{{ product_slug }}">
           <span class="caption-data">
             <span class="eiti-bar-chart-y-value" data-format=",">{{ volume | default: 0 | intcomma }}</span>
@@ -58,13 +65,6 @@
             <span class="eiti-bar-chart-x-value">{{ year }}</span>
           </span>
         </figcaption>
-        <eiti-bar-chart
-          aria-controls="state-all-production-figures-{{ product_slug }}"
-          data='{{ production_values | map_hash: "volume" | jsonify }}'
-          x-range="{{ year_range }}"
-          x-value="{{ year }}"
-          data-units="{{ long_units }}">
-        </eiti-bar-chart>
       </figure>
 
     </section>

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -6,7 +6,7 @@
   <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. While these disbursements are tracked nationally, we don't have detailed data that specifies which expenditures and projects from those national funds are in {{ state_name }}.</p>
   <p>We do have data about disbursements to state governments, which respresent about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction. 
     <br>
-    <a href="{{site.baseurl}}/downloads/disbursements/">
+    <a href="{{site.baseurl}}/downloads/disbursements/" class="disbursements-data">
       <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
     </a>
   </p>

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -58,6 +58,13 @@
           <h3 class="chart-title"><span>{{ commodity[0] }}</span></h3>
 
           <figure class="chart chart-{{ _metric }}">
+            <eiti-bar-chart
+              aria-controls="exports-figures-{{ commodity_slug }}"
+              data='{{ exports | map_hash: _metric | jsonify }}'
+              x-range="{{ year_range }}"
+              x-value="{{ year }}"
+              data-units="{{ _format }}">
+            </eiti-bar-chart>
             <figcaption id="exports-figures-{{ commodity_slug }}">
               <span class="caption-data">
                 <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">
@@ -72,14 +79,6 @@
                 <span class="eiti-bar-chart-x-value">{{ year }}</span>
               </span>
             </figcaption>
-            <eiti-bar-chart
-              aria-controls="exports-figures-{{ commodity_slug }}"
-              data='{{ exports | map_hash: _metric | jsonify }}'
-              x-range="{{ year_range }}"
-              x-value="{{ year }}"
-              data-units="{{ _format }}">
-            </eiti-bar-chart>
-
           </figure>
 
         </section><!-- /.chart-item -->

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -57,6 +57,13 @@
             </h4>
 
             <figure class="chart">
+              <eiti-bar-chart
+                aria-controls="federal-production-figures-{{ product_slug }}"
+                data='{{ production_values | map_hash: "volume" | jsonify }}'
+                x-range="{{ year_range }}"
+                x-value="{{ year }}"
+                data-units="{{ long_units }}">
+              </eiti-bar-chart>
               <figcaption id="federal-production-figures-{{ product_slug }}">
                 <span class="caption-data">
                   <span class="eiti-bar-chart-y-value"
@@ -73,13 +80,6 @@
                   Data about how much {{ product_name | downcase }} was extracted in {{ state_name }} in <span class="eiti-bar-chart-x-value">{{ year }}</span> is {{ "withheld" | term_end }}.
                 </span>
               </figcaption>
-              <eiti-bar-chart
-                aria-controls="federal-production-figures-{{ product_slug }}"
-                data='{{ production_values | map_hash: "volume" | jsonify }}'
-                x-range="{{ year_range }}"
-                x-value="{{ year }}"
-                data-units="{{ long_units }}">
-              </eiti-bar-chart>
             </figure>
 
           </div><!-- /.chart-container -->

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -58,7 +58,6 @@
 
             <figure class="chart">
               <figcaption id="federal-production-figures-{{ product_slug }}">
-
                 <span class="caption-data">
                   <span class="eiti-bar-chart-y-value"
                         data-format=",">{{ volume | default: 0 | intcomma }}</span>
@@ -73,8 +72,6 @@
                 <span class="caption-withheld" aria-hidden="true">
                   Data about how much {{ product_name | downcase }} was extracted in {{ state_name }} in <span class="eiti-bar-chart-x-value">{{ year }}</span> is {{ "withheld" | term_end }}.
                 </span>
-
-
               </figcaption>
               <eiti-bar-chart
                 aria-controls="federal-production-figures-{{ product_slug }}"
@@ -83,7 +80,6 @@
                 x-value="{{ year }}"
                 data-units="{{ long_units }}">
               </eiti-bar-chart>
-
             </figure>
 
           </div><!-- /.chart-container -->

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -46,6 +46,13 @@
         <h3 class="chart-title"><span>GDP ({{ _metric }})</span></h3>
 
         <figure class="chart chart-{{ _metric }}">
+          <eiti-bar-chart
+            aria-controls="gdp-figures-{{ _metric }}"
+            data='{{ gdp | map_hash: _metric | jsonify }}'
+            x-range="{{ year_range }}"
+            x-value="{{ year }}"
+            data-units="{{ _metric }}">
+          </eiti-bar-chart>
           <figcaption id="gdp-figures-{{ _metric }}">
             <span class="caption-data">
               Extractive industries accounted for
@@ -64,14 +71,6 @@
                 <span class="eiti-bar-chart-x-value">{{ year }}</span>
               </span>
           </figcaption>
-          <eiti-bar-chart
-            aria-controls="gdp-figures-{{ _metric }}"
-            data='{{ gdp | map_hash: _metric | jsonify }}'
-            x-range="{{ year_range }}"
-            x-value="{{ year }}"
-            data-units="{{ _metric }}">
-          </eiti-bar-chart>
-
         </figure>
 
       </section><!-- /.chart-item -->

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -58,6 +58,13 @@
           <h3 class="chart-title"><span>Wage and salary jobs</span></h3>
 
           <figure class="chart">
+            <eiti-bar-chart
+              aria-controls="jobs-figures-{{ _metric }}"
+              data='{{ jobs | map_hash: _metric | jsonify }}'
+              x-range="{{ year_range }}"
+              x-value="{{ year }}"
+              data-units="jobs">
+            </eiti-bar-chart>
             <figcaption id="jobs-figures-{{ _metric }}">
               <span class="caption-data">
                 In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
@@ -73,13 +80,6 @@
                 <span class="eiti-bar-chart-x-value">{{ year }}</span>
               </span>
             </figcaption>
-            <eiti-bar-chart
-              aria-controls="jobs-figures-{{ _metric }}"
-              data='{{ jobs | map_hash: _metric | jsonify }}'
-              x-range="{{ year_range }}"
-              x-value="{{ year }}"
-              data-units="jobs">
-            </eiti-bar-chart>
           </figure><!-- /.chart -->
 
           {% endfor %}
@@ -166,6 +166,13 @@
       <h3 class="chart-title"><span>Self-employment</span></h3>
 
       <figure class="chart">
+        <eiti-bar-chart
+          aria-controls="self-employment-figures-{{ _metric }}"
+          data='{{ self_employment_jobs | map_hash: _metric | jsonify }}'
+          x-range="{{ year_range }}"
+          x-value="{{ year }}"
+          data-units="jobs">
+        </eiti-bar-chart>
         <figcaption id="self-employment-figures-{{ _metric }}">
           In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
           there were
@@ -175,14 +182,6 @@
           self-employed people working in the extractive industries in
           {{ state_name }}
         </figcaption>
-        <eiti-bar-chart
-          aria-controls="self-employment-figures-{{ _metric }}"
-          data='{{ self_employment_jobs | map_hash: _metric | jsonify }}'
-          x-range="{{ year_range }}"
-          x-value="{{ year }}"
-          data-units="jobs">
-        </eiti-bar-chart>
-
       </figure>
 
     </section><!-- /.chart-item -->

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -35,7 +35,6 @@
             There is no data for {{ state_name }} in
             <span class="eiti-bar-chart-x-value">{{ year }}</span>
           </span>
-
         </figcaption>
         <eiti-bar-chart
           aria-controls="federal-revenue-county-figures-All"
@@ -44,7 +43,6 @@
           x-value="{{ year }}"
           data-units="$,">
         </eiti-bar-chart>
-
       </figure>
     </div><!-- /.chart-container -->
 

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -117,7 +117,7 @@ nav_items:
         {% include location/section-disbursements.html %}
 
         <section id="state-disbursements" class="disbursements">
-          <h3>State disbursements</h2>
+          <h3>State disbursements</h3>
 
           {% if page.opt_in == true %}
             {% include location/opt-in/state-disbursements.html location_id=state_id %}

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -134,6 +134,12 @@
       float: none;
       padding-left: 0;
     }
+
+    a {
+      @include heading(para-sm);
+      
+      color: $blue;
+    }
   }
 }
 

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -121,11 +121,9 @@
 
   .chart-description {
     border-left: 1px solid $mid-gray;
-    color: $blue;
     float: left;
     margin-bottom: 0;
     padding-left: 1.25rem;
-    text-decoration: none;
     width: 75%;
 
     &.no-selector {
@@ -137,6 +135,9 @@
 
     a {
       @include heading(para-sm);
+      
+      color: $blue;
+      text-decoration: none;
 
       &:hover,
       &:active {

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -133,6 +133,9 @@
       width: 100%;
     }
 
+    color: $blue;
+    text-decoration: none;
+
     a {
       @include heading(para-sm);
 
@@ -140,9 +143,6 @@
       &:active {
         text-decoration: underline;
       }
-
-      color: $blue;
-      text-decoration: none;
     }
   }
 }

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -97,7 +97,6 @@
     font-weight: $weight-bold;
     margin: 0;
     min-height: inherit;
-    //padding: $base-padding-lite;
   }
 
   .county-map-table {
@@ -131,6 +130,7 @@
       border: none;
       float: none;
       padding-left: 0;
+      width: 100%;
     }
 
     a {

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -121,9 +121,11 @@
 
   .chart-description {
     border-left: 1px solid $mid-gray;
+    color: $blue;
     float: left;
     margin-bottom: 0;
     padding-left: 1.25rem;
+    text-decoration: none;
     width: 75%;
 
     &.no-selector {
@@ -132,10 +134,6 @@
       padding-left: 0;
       width: 100%;
     }
-
-    color: $blue;
-    text-decoration: none;
-
     a {
       @include heading(para-sm);
 

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -21,6 +21,7 @@
     flex: 1 0 auto;
     margin-bottom: $base-padding-base;
     min-height: 40px;
+    padding-top: 2.5rem;
   }
 
   .chart-list-intro {
@@ -33,7 +34,6 @@
     border-top: none;
     display: flex;
     flex-direction: column;
-    margin-bottom: $base-padding;
     margin-top: 0;
     padding-top: 0;
   }
@@ -69,8 +69,6 @@
       padding-left: $base-padding-lite;
       padding-right: $base-padding-lite;
     }
-
-
   }
 
   figure {
@@ -82,7 +80,7 @@
 
     font-weight: $weight-light;
     line-height: 20px;
-    min-height: 100px;
+    min-height: 65px;
     padding: $base-padding-lite;
     padding-left: 0;
     padding-right: 0;
@@ -99,7 +97,7 @@
     font-weight: $weight-bold;
     margin: 0;
     min-height: inherit;
-    padding: $base-padding-lite;
+    //padding: $base-padding-lite;
   }
 
   .county-map-table {
@@ -110,7 +108,6 @@
 
 .chart-selector-wrapper {
   display: inline-block;
-  margin-bottom: $base-padding-jumbo;
 
   .chart-selector {
     @include span-columns(2);
@@ -126,6 +123,7 @@
   .chart-description {
     border-left: 1px solid $mid-gray;
     float: left;
+    margin-bottom: 0;
     padding-left: 1.25rem;
     width: 75%;
 
@@ -137,8 +135,14 @@
 
     a {
       @include heading(para-sm);
-      
+
+      &:hover,
+      &:active {
+        text-decoration: underline;
+      }
+
       color: $blue;
+      text-decoration: none;
     }
   }
 }

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -135,7 +135,7 @@
 
     a {
       @include heading(para-sm);
-      
+
       color: $blue;
       text-decoration: none;
 

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -134,6 +134,7 @@
       padding-left: 0;
       width: 100%;
     }
+
     a {
       @include heading(para-sm);
 

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -1,20 +1,33 @@
 .layout-state-pages {
   padding-bottom: $standard-padding-fluffed;
 
-  section + section,
-  h2 + section, {
-    padding-top: $standard-padding-fluffed;
-  }
+  // section + section,
+  // h2 + section, {
+  //   padding-top: $standard-padding-fluffed;
+  // }
 
-  p + section,
-  p + h3,
-  p + h4 {
-    padding-top: $standard-padding-extra;
+  // p + section,
+  // p + h3,
+  // p + h4 {
+  //   padding-top: $standard-padding-extra;
+  // }
+  
+  p + section {
+    margin-top: -0.75rem; //to compendate for margin from preceding p
   }
 
   h2 {
     border-bottom: 20px solid $light-green;
     padding-bottom: $standard-padding-lite;
+    padding-top: 6rem;
+  }
+
+  h3 {
+    padding-top: 4rem;
+  }
+
+  h4 {
+    padding-bottom: $standard-padding;
   }
 
   h3:not(.chart-title):not(.state-page-nav-title),
@@ -33,10 +46,6 @@
   h4:not(.chart-title):not(.state-page-nav-title):not(.details-container) {
     border-bottom: 1px solid $neutral-gray;
     font-weight: $weight-light;
-  }
-
-  h4 {
-    padding-bottom: $standard-padding;
   }
 
   hr {

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -94,16 +94,16 @@
       padding-bottom: $base-padding-lite;
     }
   }
-  
+
   .disbursements-data {
     @include heading(para-sm);
+
+    color: $blue;
+    text-decoration: none;
 
     &:hover,
     &:active {
       text-decoration: underline;
     }
-
-    color: $blue;
-    text-decoration: none;
   }
 }

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -1,33 +1,17 @@
 .layout-state-pages {
   padding-bottom: $standard-padding-fluffed;
 
-  // section + section,
-  // h2 + section, {
-  //   padding-top: $standard-padding-fluffed;
-  // }
-
-  // p + section,
-  // p + h3,
-  // p + h4 {
-  //   padding-top: $standard-padding-extra;
-  // }
-  
-  p + section {
-    margin-top: -0.75rem; //to compendate for margin from preceding p
+  p + section,
+  section + section,
+  h2 + section,
+  p + h4 {
+    margin-top: -0.75rem; //to compensate for margin from preceding selectors
   }
 
-  h2 {
+  h2:not(.ribbon-card-top-text-header) {
     border-bottom: 20px solid $light-green;
     padding-bottom: $standard-padding-lite;
     padding-top: 6rem;
-  }
-
-  h3 {
-    padding-top: 4rem;
-  }
-
-  h4 {
-    padding-bottom: $standard-padding;
   }
 
   h3:not(.chart-title):not(.state-page-nav-title),
@@ -38,14 +22,24 @@
     padding-bottom: $standard-padding-lite;
   }
 
-  .title-land-ownership:not(.chart-title):not(.state-page-nav-title) {
-    border-bottom: 1px solid $neutral-gray;
-    margin-bottom: $base-padding-lite * 2;
+  h3:not(.chart-title):not(.title-land-ownership) {
+    padding-top: 4rem;
+  }
+
+  ul + h3:not(.chart-title):not(.title-land-ownership),
+  p + h3:not(.chart-title):not(.title-land-ownership) {
+    margin-top: -0.75rem; //to compensate for margin from preceding selectors
   }
 
   h4:not(.chart-title):not(.state-page-nav-title):not(.details-container) {
     border-bottom: 1px solid $neutral-gray;
     font-weight: $weight-light;
+    padding-top: 2.5rem;
+  }
+
+  .title-land-ownership:not(.chart-title):not(.state-page-nav-title) {
+    border-bottom: 1px solid $neutral-gray;
+    margin-bottom: $base-padding-lite * 2;
   }
 
   hr {
@@ -73,8 +67,7 @@
   }
 
   .tab-interface {
-    margin-bottom: $standard-padding-fluffed;
-    margin-top: $standard-padding-fluffed;
+    margin-top: 2rem;
   }
 
   .full-width-text {
@@ -100,5 +93,17 @@
       margin-bottom: 0;
       padding-bottom: $base-padding-lite;
     }
+  }
+  
+  .disbursements-data {
+    @include heading(para-sm);
+
+    &:hover,
+    &:active {
+      text-decoration: underline;
+    }
+
+    color: $blue;
+    text-decoration: none;
   }
 }

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -94,7 +94,7 @@ $ab-border-thick: 4px;
 
   .table-arrow_box-category {
     border-bottom: $ab-border-thin solid $ab-color-primary;
-    border-top: 40px solid $white;
+    border-top: 25px solid $white;
     color: $green-dark;
     font-weight: $weight-bold;
     letter-spacing: 1px;

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -5,7 +5,6 @@
 
   border-collapse: collapse;
   border-spacing: 0;
-  margin: 0 0 2em;
 
   tbody tr:focus,
   tbody tr:hover {

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -97,7 +97,6 @@ data-map {
 // map legend
 .details-container {
   bottom: 0;
-  left: $standard-padding-lite;
   margin: 0;
   position: absolute;
 }

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -11,7 +11,7 @@
   var width = 300;
   var height = 160;
 
-  var textMargin = 18;
+  var textMargin = 14;
   var baseMargin = 2;
   var extentMargin = 18;
   var tickPadding = 10;

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -34,10 +34,6 @@
   top = top + extentMargin;
   var extentTop = top - extentMargin;
 
-
-  var xAxisLabel = 'years';
-  var labelOffset = width / 2;
-
   var fullHeight = height + textMargin + extentMargin + tickPadding - (2 * baseMargin);
   var extentlessHeight = fullHeight - extentMargin;
 
@@ -205,7 +201,7 @@
       .tickSize(0)
       .tickPadding(tickPadding)
       .tickFormat(function(x) {
-        return String(x).substr(2);
+        return '’' + String(x).substr(2);
       });
 
     svg.append('g')
@@ -268,14 +264,6 @@
 
     xAxis.selectAll('path, line')
         .attr('fill', 'none');
-
-    svg.append('g')
-      .attr('class', 'x-axis-label')
-      .append('text')
-        .text(xAxisLabel)
-        .attr('transform', function(d) {
-          return 'translate(' + [labelOffset, fullHeight] + ')';
-        });
   };
 
   var formatUnits = function(text, units) {


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/visual-bug-squish-squash/explore/)

- Moves summary sentence below instead of above bar charts
- Removes year X axis marker, replaces with apostrophe before two-digit years
- Makes data and documentation links smaller
- Starts to standardize padding on state pages
