### PR TITLE
Empty state cleanup

### DIFF
--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -42,7 +42,7 @@
             aria-hidden='true'
             data-witheld="false">
             <span class="withheld" aria-hidden="true">
-              Data about {{ product_name | downcase }} extraction in {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span> is withheld.
+              Data about {{ product_name | downcase }} extraction on federal land in {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span> is withheld.
             </span>
             <span class="has-data">
               <span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ county[1].name }} from <span data-year='{{ year }}'>{{ year }}</span>

--- a/_includes/location/display-jobs-county.html
+++ b/_includes/location/display-jobs-county.html
@@ -4,7 +4,7 @@
   <thead>
     <tr>
       <th>{{ locality_name }}</th>
-      <th colspan="2" class='numeric' data-series='jobs'>Extracives jobs</th>
+      <th colspan="2" class='numeric' data-series='jobs'>Extractives jobs</th>
       <th class='numeric' data-series='percent'>% of all jobs in {{ locality_name | downcase }}</th>
     </tr>
   </thead>

--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -5,7 +5,7 @@
   <h2>Federal disbursements</h2>
 
   <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
-  <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. Funds disbursed directly to state governments account for about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction.</p>
+  <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works.</p>
   <p>
     <a href="{{site.baseurl}}/downloads/disbursements/">
       <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -3,8 +3,8 @@
   <h3>Federal disbursements</h2>
 
   <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called &ldquo;disbursement.&rdquo;</p>
-  <p>Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. While these disbursements are tracked nationally, we don't have detailed data that specifies which expenditures and projects from those national funds are in {{ state_name }}.</p>
-  <p>We do have data about disbursements to state governments, which respresent about 38% of federal revenue from onshore natural resource extraction and less than 1% of revenue from offshore natural resource extraction. 
+  <p>
+    Most federal revenue goes to the General Fund of the Treasury, infrastructure and operational funds, and funds that support public works. While these disbursements are tracked <a href="{{ site.baseurl }}/explore/#federal-disbursements">nationally</a>, we don't have detailed data that specifies which expenditures and projects from those national funds are in {{ state_name }}.
     <br>
     <a href="{{site.baseurl}}/downloads/disbursements/">
       <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
@@ -13,24 +13,31 @@
 
   {% assign disbursements = site.data.federal_disbursements[state_id] %}
 
-  <p><strong>
-    In {{ year }}, ONRR disbursed
-    {% if disbursements %}
-      ${{ disbursements.All.All[year] | round | intcomma }}
-    {% else %}
-      did not receive any
-    {% endif %}
-     to the state of {{ state_name }}.
-  </strong></p>
+  {% if disbursements %}
 
-  <p>
-    {% if disbursements %}
+    <p>
+      ONRR also disburses some revenue from natural resource extraction to state governments.
+      <strong>
+        In {{ year }}, ONRR disbursed
+          ${{ disbursements.All.All[year] | round | intcomma }}
+         to the state of {{ state_name }}.
+      </strong>
+    </p>
+
+    <p>
       {%
         include location/display-disbursements.html
         values=disbursements
         state_name=state_name
       %}
-    {% endif %}
-  </p>
+    </p>
+
+  {% else %} 
+  <!-- If no disbursements -->
+    <p><strong>
+      In {{ year }}, ONRR did not disburse
+      any revenue from natural resource extraction on federal land to the state government of {{ state_name }}.
+    </strong></p>
+  {% endif %}
 
 </section>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -69,7 +69,7 @@
                   <span class="eiti-bar-chart-y-value"
                         data-format=",">{{ volume | default: 0 | intcomma }}</span>
                   {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
-                  produced on federal land in {{ state_name }} in
+                  extracted on federal land in {{ state_name }} in
                   <span class="eiti-bar-chart-x-value">{{ year }}</span>
                 </span>
                 <span class="caption-no-data" aria-hidden="true">
@@ -77,7 +77,7 @@
                   <span class="eiti-bar-chart-x-value">{{ year }}</span>
                 </span>
                 <span class="caption-withheld" aria-hidden="true">
-                  Data about how much {{ product_name | downcase }} was extracted in {{ state_name }} in <span class="eiti-bar-chart-x-value">{{ year }}</span> is {{ "withheld" | term_end }}.
+                  Data about how much {{ product_name | downcase }} was extracted on federal land in {{ state_name }} in <span class="eiti-bar-chart-x-value">{{ year }}</span> is {{ "withheld" | term_end }}.
                 </span>
 
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -14,7 +14,13 @@
     <h3>Production on federal land in {{ state_name }}</h3>
 
     {% if federal_products_num == 0 %}
-      <p>No natural resources were produced on federal land in {{  state_name }} in {{ year }}.</p>
+      <p>
+        ONRR collects detailed data about natural resources produced on federal land. According to that data, there was no natural resource production on federal land in {{  state_name }} in {{ year }}.
+        <br>
+        <a href="{{site.baseurl}}/downloads/federal-production/">
+          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+        </a>
+      </p>
     {% else %}
       <div class="chart-selector-wrapper">
 

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -16,10 +16,18 @@
 
     <h3>Federal revenue</h3>
 
-    <p>Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.</p>
+    <p>
+      Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.
+      <br>
+      <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
+        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation 
+      </a>
+    </p>
     
     <h4>Revenue from extraction on federal land by resource</h4>
     
+{% if revenue_commodities %}
+
     <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on federal land. For details, read more about the processes for awarding rights and collecting revenue for each kind of resource: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
     <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue was collected in {{ year}} for production or potential production of natural resources on federal land in {{ state_name }}, broken down by phase of production.</p>
@@ -51,58 +59,45 @@
       </article>
     </div>
 
-
     <h4>Revenue from extraction on federal land by county</h4>
 
     <section class="chart-list">
 
       <div class="chart-selector-wrapper">
+        {% assign empty_years = '' | split:'' %}
+        {% for _year in year_list %}
+          {% assign _year_string = _year | to_s %}
+          {% unless revenue_commodities.All[_year_string].revenue %}
+            {% assign empty_years = empty_years | push: _year_string %}
+          {% endunless %}
+        {% endfor %}
 
-        {% if revenue_commodities %}
-          {% assign empty_years = '' | split:'' %}
-          {% for _year in year_list %}
-            {% assign _year_string = _year | to_s %}
-            {% unless revenue_commodities.All[_year_string].revenue %}
-              {% assign empty_years = empty_years | push: _year_string %}
-            {% endunless %}
-          {% endfor %}
+        {% include year-selector.html year_range=year_range empty_years=empty_years %}
 
-          {% include year-selector.html year_range=year_range empty_years=empty_years %}
-        {% endif %}
-
-        {% if revenue_commodities %}
-          <p class="chart-description">
-            In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. 
-            <br>
-            <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
-              <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-            </a>
-          </p>
-        {% else %}
-          <p class="chart-description{% unless revenue_commodities %} no-selector{% endunless %}">
-            In {{ year }}, the federal government didn't receive any payment for extraction of natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. 
-            <br>
-            <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
-              <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation 
-            </a>
-          </p>
-        {% endif %}
+        <p class="chart-description">
+          In {{ year }}, companies paid the federal government a total of ${{ revenue_total | intcomma }} to extract natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}.
+        </p>
       </div>
 
-      {% if revenue_commodities %}
-        <section class="county-map-table">
-          {%
-            include location/state-federal-revenue-county.html
-            county_revenue=county_revenue
-            state_revenue=revenue_commodities
-            year=year
-            year_range=year_range
-          %}
-        </section>
-      {% endif %}
+      <section class="county-map-table">
+        {%
+          include location/state-federal-revenue-county.html
+          county_revenue=county_revenue
+          state_revenue=revenue_commodities
+          year=year
+          year_range=year_range
+        %}
+      </section>
     </section>
     <!-- .chart-list -->
 
+{% else %}
+
+        <p class="chart-description{% unless revenue_commodities %} no-selector{% endunless %}">
+          In {{ year }}, ONRR did not receive any payment for extraction of natural resources on federal land (or leasing of federal land for that purpose) in {{ state_name }}.
+        </p>
+
+{% endif %}
 
     <h4>Federal tax revenue</h4>
 


### PR DESCRIPTION
Goes to #1806, and helps prep light-data states for sharing with co-chairs.

[:sailboat: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/empty-state-cleanup/explore/ME/)

[:bear: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/empty-state-cleanup/explore/MT/)

[:office: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/empty-state-cleanup/explore/DC/)

Changes proposed in this pull request:

- Reduces confusing content and empty tables on state profile pages for states without federal production
- Fixes spelling of `extractives` in county tables
- Adds `on federal land` to sentences about withheld data
- Probably some other stuff

/cc @gemfarmer @meiqimichelle — please check a couple of states to make sure I didn't accidentally remove anything! 😁 
