### PR TITLE
Final batch of opt-in sections

### DIFF
--- a/_includes/location/opt-in/state-disbursements.html
+++ b/_includes/location/opt-in/state-disbursements.html
@@ -61,3 +61,7 @@
 </table>
 {% endif %}
 
+{% if page.state_saving_spending %}
+  <h4>Saving and spending revenue from extraction</h4>
+  {{ page.state_saving_spending | markdownify }}
+{% endif %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -95,6 +95,13 @@ nav_items:
       <section id="production">
         <h2>Production</h2>
 
+        <p>
+          The U.S. Energy Information Administration (EIA) publishes a profile of <a href="http://www.eia.gov/state/?sid={{ state_ref }}">{{ state_name }}'s energy production and usage</a>.
+        </p>
+        {% if page.state_production %}
+          {{ page.state_production | markdownify }}
+        {% endif %}
+
         {% include location/section-all-production.html %}
 
         {% include location/section-federal-production.html %}

--- a/_states/MT.md
+++ b/_states/MT.md
@@ -7,6 +7,14 @@ opt_in: true
 
 state_revenue_year: 2014
 
+state_production: |
+    Much of Montana's crude oil and natural gas production is in northeastern Montana, in the Williston Basin, which includes the [Bakken formation](https://www.minneapolisfed.org/publications/special-studies/bakken/oil-production) as well as the Baker/Cedar Creek field, which contains the nation’s largest single underground natural gas storage facility. (There are also natural gas wells in south central Montana.)
+
+    Montana's coal reserves, which are the largest estimated recoverable coal reserves in the U.S., are mostly located in the Powder River Basin in southeastern Montana. Five large surface mines provide the bulk of Montana’s coal production, though it also has one sizable underground mine.  
+
+    Montana has 25 hydroelectric dams and several utility-scale wind farms. The Montana Department of Environmental Quality maintains information about [wind power in Montana](http://deq.mt.gov/Energy/EnergizeMT/Renewable/windweb).
+
+    **Nonenergy minerals:** In 2011, Montana's nonenergy mineral production was valued at over $1.4 billion. For details about what minerals are extracted, see the [USGS Minerals Yearbook for Montana](http://minerals.usgs.gov/minerals/pubs/state/mt.html).
 state_land: |
     The state government of Montana administers 5.2 million surface acres of land (about 5.6% of the state) and 6.2 million mineral acres. For detailed information about land ownership in each county, the Montana State Library maintains [public and private land ownership maps](https://mslservices.mt.gov/Geographic_Information/Maps/Land_Ownership/Default).
 state_land_production: |
@@ -25,6 +33,10 @@ state_tax_expenditures: |
     In FY 2014, Montana had four programs related to the extractive industries, which reduced state or local revenue by a total of $60.5 million. Of that total, a tax holiday on new oil production cost Montana $55.9 million in unrealized tax revenue and tax holiday on new natural gas production holiday cost the state $2 million. The Montana Department of Revenue outlines tax expenditures in its [biennial reports](https://revenue.mt.gov/home/publications/biennial_reports).
 state_disbursements: |
     [State agencies](#state-agencies) distribute revenue according to the [Montana State Code](http://leg.mt.gov/bills/mca_toc/), which is defined by the legislature. In addition to receiving distributions from the state, counties also collect and distribute revenue from local taxes.
+state_saving_spending: |
+    Many states choose to establish permanent mineral trust funds, which can help governments dependent on revenue from natural resources smooth revenue and investments across boom and bust cycles.
+
+    In Montana, the coal trust fund is the primary way that revenue from extractive industries is saved for future use. The fund was established by the Montana State Constitution, which also requires that 50% of coal severance tax revenues go to the trust fund. The coal trust fund had an estimated balance of $963 million at the end of FY 2014. Interest from the fund goes to economic development, water, and infrastructure projects. For more information, see the Montana Department of Revenue's [biennial reports](https://revenue.mt.gov/home/publications/biennial_reports).
 state_impact: |
     The extractive industries play an important role in Montana’s economy — particularly in eastern Montana, where economic activity in the Bakken oil fields has a strong impact on local economies. To read more about the impact of extractive industries on Montana’s economy, see the [Labor Day Report (PDF)](http://lmi.mt.gov/Portals/135/Publications/LMI-Pubs/Labor%20Market%20Publications/LDR-15.pdf) from the [Montana Department of Labor and Industry](http://dli.mt.gov/).
 
@@ -41,7 +53,7 @@ The [Montana Department of Revenue](https://revenue.mt.gov/) collects, manages, 
 
 The [Montana Department of Natural Resources and Conservation](http://dnrc.mt.gov/) manages Montana's natural resources, including administering state trust lands and distributing revenue from state trust lands.
 
-- The [Montana Board of Oil and Gas Conservation](http://bogc.dnrc.mt.gov/BoardSummaries.asp) is involved in all stages of oil and gas extraction. It permits all oil and gas wells, regulates the underground injecting program, and assists in remediation efforts. It also inspects all oil and gas wells and operations to ensure they comply with all state environmental laws. The board is governed by [rules and regulations](http://bogc.dnrc.mt.gov/rulesregs.asp).
+- The [Montana Board of Oil and Gas Conservation](http://bogc.dnrc.mt.gov/BoardSummaries.asp) is involved in all stages of oil and gas extraction. It permits all oil and gas wells, regulates the underground injecting program, and assists in remediation efforts. It also inspects all oil and gas wells and operations to ensure they comply with all state environmental laws. The board is governed by [rules and regulations](http://bogc.dnrc.mt.gov/rulesregs.asp), maintains a [data portal](http://bogc.dnrc.mt.gov/WebApps/DataMiner/), and publishes [annual reviews](http://bogc.dnrc.mt.gov/annualreviews.asp).
 - The [Reclamation and Development Grant Program](http://dnrc.mt.gov/divisions/cardd/resource-development/reclamation-and-development-grants-program) funds some abandoned mine projects.
 - The [Mineral Management Bureau](http://dnrc.mt.gov/index/divisions/trust/minerals-management) (within the [Trust Land Management Division](http://dnrc.mt.gov/divisions/trust)) permits, regulates, and collects revenue for extraction on state trust lands. Their work complements the work of the Board of Oil and Gas Conservation and Department of Environmental Quality, both of which retain regulatory authority over mines on state lands. State land leasing is governed by state [statutes and rules](http://www.mtrules.org/gateway/chapterhome.asp?chapter=36.25).
 


### PR DESCRIPTION
Fixes issue(s) #1467 

[:bear: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/opt-in-additions/explore/MT/)

Changes proposed in this pull request:

- Add "revenue sustainability" section (and content for Montana)
- Add "saving and spending" section (and content for Montana)
- Add Production intro (custom content for Montana + EIA state energy profile links for everyone)

/cc @meiqimichelle or whoever feels like merging!

