### PR TITLE
Wyoming opt-in content

### DIFF
--- a/_includes/location/opt-in/state-disbursements.html
+++ b/_includes/location/opt-in/state-disbursements.html
@@ -10,13 +10,6 @@
   {{ page.state_disbursements | markdownify }}
 {% endif %}
 
-<p>
-  In {{ revenue_year }}, <strong>${{ revenue_total | default: 0 | intcomma }}
-  in state revenue from natural resource extraction in
-  {{ state_name }} was disbursed</strong>
-  to {{ funds_count }} fund{{ funds_count | plural }}.
-</p>
-
 <table is="bar-chart-table" class="table-basic"
   {% if include.id %}id="{{ include.id }}"{% endif %}>
   <thead>
@@ -63,5 +56,7 @@
 
 {% if page.state_saving_spending %}
   <h4>Saving and spending revenue from extraction</h4>
+  <p>Many states choose to establish permanent mineral trust funds, which can help governments dependent on revenue from natural resources smooth revenue and investments across boom and bust cycles.</p>
+  
   {{ page.state_saving_spending | markdownify }}
 {% endif %}

--- a/_states/MT.md
+++ b/_states/MT.md
@@ -34,8 +34,6 @@ state_tax_expenditures: |
 state_disbursements: |
     [State agencies](#state-agencies) distribute revenue according to the [Montana State Code](http://leg.mt.gov/bills/mca_toc/), which is defined by the legislature. In addition to receiving distributions from the state, counties also collect and distribute revenue from local taxes.
 state_saving_spending: |
-    Many states choose to establish permanent mineral trust funds, which can help governments dependent on revenue from natural resources smooth revenue and investments across boom and bust cycles.
-
     In Montana, the coal trust fund is the primary way that revenue from extractive industries is saved for future use. The fund was established by the Montana State Constitution, which also requires that 50% of coal severance tax revenues go to the trust fund. The coal trust fund had an estimated balance of $963 million at the end of FY 2014. Interest from the fund goes to economic development, water, and infrastructure projects. For more information, see the Montana Department of Revenue's [biennial reports](https://revenue.mt.gov/home/publications/biennial_reports).
 state_impact: |
     The extractive industries play an important role in Montana’s economy — particularly in eastern Montana, where economic activity in the Bakken oil fields has a strong impact on local economies. To read more about the impact of extractive industries on Montana’s economy, see the [Labor Day Report (PDF)](http://lmi.mt.gov/Portals/135/Publications/LMI-Pubs/Labor%20Market%20Publications/LDR-15.pdf) from the [Montana Department of Labor and Industry](http://dli.mt.gov/).

--- a/_states/WY.md
+++ b/_states/WY.md
@@ -43,6 +43,8 @@ state_disbursements: |
     At the local level, county tax collectors collect all property taxes on production and distribute them within their own jurisdictions.
 
     _Note: The Wyoming Department of Revenue reports revenue distribution by fiscal year._
+state_saving_spending: |
+    The state of Wyoming saves about 68% of severance tax revenue and 39% of federal mineral royalty revenues. These two revenue streams are Wyoming's two largest sources of revenue from natural resource extraction. Wyoming saves revenue by contributing to the Budget Reserve Account and the Permanent Wyoming Mineral Trust Fund. Interest from the Permanent Wyoming Mineral Trust Fund goes to the General Fund.
 state_impact: |
     The extractive industries play an important role in Wyoming’s economy — particularly in Campbell County's Powder River Basin and in Sublette County. For more information about employment in Wyoming, the [Department of Workforce Services](http://www.wyomingworkforce.org/) has published [long-term industry and occupational projections for 2014 to 2024](http://doe.state.wy.us/lmi/projections/2016/projections_2014-2024.htm).
 

--- a/_states/WY.md
+++ b/_states/WY.md
@@ -9,6 +9,14 @@ state_revenue_year: 2015
 
 case_study_link: |
     For a detailed view of how coal mining affects communities in Wyoming, read more about [Campbell County](../../case-studies/campbell/).
+state_production: |
+    Most of Wyoming's natural resource extraction takes place on federal land, including a majority of coal production and two thirds of natural gas production. Much of this federal land is managed by the Bureau of Land Management.
+
+    Northeastern Wyoming holds the Powder River Basin, which contains eight of the ten largest coal mines in the country. Wyoming's natural gas production is centered in the Green River Basin in southwestern Wyoming. Crude oil production takes place in the Niobrara Shale (in southeastern Wyoming), the Powder River Basin, and the Green River oil shale.
+
+    Wyoming produces about 70% of the uranium mined in the U.S. To learn more about uranium mining nationwide, see the EIA’s [annual domestic uranium production report](http://www.eia.gov/uranium/production/annual/). 
+
+    **Nonenergy minerals:** In 2011, Wyoming's nonenergy mineral production was valued at over $2.14 billion. Notably, Wyoming produces more trona (the chief source of [soda ash](http://minerals.usgs.gov/minerals/pubs/commodity/soda_ash/)) than any other state, and the largest deposit of trona in the world sits under Sweetwater County in Wyoming. For details about what other minerals are extracted, see the [USGS Minerals Yearbook for Wyoming](http://minerals.usgs.gov/minerals/pubs/state/wy.html).
 state_land: |
     The state government of Wyoming administers 3.4 million surface acres of land (about 5.5% of the state) and 3.9 million mineral acres. For detailed information about land ownership in each county, see the [Wyoming Statewide Parcel Viewer](http://gis.wyo.gov/parcels/).
 state_land_production: |


### PR DESCRIPTION
Fixes issue(s) #1798 

[:horse: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/wyoming-additions/explore/WY/)

Changes proposed in this pull request:

- Add production intro for Wyoming profile
- Add Saving & spending section for Wyoming profile
- Remove disbursements total/summary sentence, since it was redundant with the revenue summary and created some Production Year v. Fiscal Year issues

/cc @meiqimichelle 
