### PR TITLE
Withheld bugs

### DIFF
--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -12,6 +12,7 @@
   };
 
   var WITHHELD_FLAG = 'Withheld';
+  var NO_DATA_FLAG = undefined;
 
   var setYear = function(year) {
     var root = d3.select(this);
@@ -29,12 +30,16 @@
       function coerceNumber(num) {
         return typeof(num) == undefined || typeof(num) == 'undefined'
           ? WITHHELD_FLAG
-          :  num;
+          : num;
       }
 
       function cellData(data, year, property, coerce) {
-        if (data && data[year] && property) {
-          return data[year][property] || coerceNumber(coerce);
+        if (data && property) {
+          if ( data[year] ) {
+            return data[year][property] || coerceNumber(coerce);
+          } else {
+            return NO_DATA_FLAG;
+          }
         } else if (data && !property) {
           return data[year] || coerceNumber(coerce);
         } else {
@@ -56,7 +61,7 @@
           }
         }
 
-        if (value === WITHHELD_FLAG || !format) {
+        if (value === WITHHELD_FLAG || value === NO_DATA_FLAG || !format) {
           return value;
         } else {
           return format(value);
@@ -73,17 +78,22 @@
       var rows = root.selectAll('tr[data-year-values]');
 
       bars.datum(function() {
-          var data = parseYearVals(this)
+          var data = parseYearVals(this);
           var property = this.getAttribute('data-years-property');
-          return cellData(data, year, property, 0);
+
+          // coerce value to 0 so that a bar is rendered,
+          // even in instances where a bar will be initially
+          // hidden
+          return cellData(data, year, property, 0) || 0;
         })
         .attr('data-value', function(d) {
           return d;
         });
 
       var sentencesData = sentences.datum(function() {
-          var data = parseYearVals(this)
+          var data = parseYearVals(this);
           var property = this.getAttribute('data-years-property');
+
           return cellData(data, year, property);
         }).attr('data-sentence', function(d) {
           return d;
@@ -115,9 +125,9 @@
         })
 
       texts.datum(function() {
-          var data = parseYearVals(this)
+          var data = parseYearVals(this);
           var property = this.getAttribute('data-years-property');
-          return cellData(data, year, property);
+          return cellData(data, year, property) || 0;
         })
         .attr('data-value-text', function(d) {
           return d;
@@ -130,7 +140,7 @@
       swatches.datum(function() {
           var data = parseYearVals(this);
           var property = this.getAttribute('data-years-property');
-          return cellData(data, year, property);
+          return cellData(data, year, property) || 0;
         })
         .attr('data-value-swatch', function(d) {
           return d;
@@ -151,11 +161,14 @@
 
       rows.datum(function(){
         var data = parseYearVals(this);
-        return data[year] || WITHHELD_FLAG;
+        if ( data[year] === NO_DATA_FLAG ) {
+          return NO_DATA_FLAG
+        } else {
+          return data[year] || WITHHELD_FLAG;
+        }
       })
       .attr('aria-hidden', function (d) {
         return !d;
-
       });
     }
   }

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -162,7 +162,7 @@
       rows.datum(function(){
         var data = parseYearVals(this);
         if ( data[year] === NO_DATA_FLAG ) {
-          return NO_DATA_FLAG
+          return NO_DATA_FLAG;
         } else {
           return data[year] || WITHHELD_FLAG;
         }

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -14,7 +14,6 @@
 
           this.marks = root.selectAll('[data-value]')
             .datum(function() {
-              // console.log(typeof(this.getAttribute('data-value')))
               if (this.getAttribute('data-value') === null || this.getAttribute('data-value') === 'null') {
 
                 return WITHHELD_FLAG;
@@ -34,7 +33,6 @@
         setYear: {value: function(year) {
           this.marks.datum(function() {
               var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
-
               if (data[year] === null || data[year] === 'null') {
                 return WITHHELD_FLAG;
               } else {
@@ -86,11 +84,6 @@
         }},
 
         update: {value: function() {
-
-          // if (this.innerText.indexOf('County employment') > -1) {
-          //   console.log('marks', this.marks.data())
-          // }
-
           var hasData = [];
           this.marks.data().every(function(d){
             if (d === WITHHELD_FLAG) {
@@ -106,10 +99,6 @@
           });
 
           var root = d3.select(this);
-
-          // if (this.innerText.indexOf('County employment') > -1) {
-          //   console.log('hasData', hasData)
-          // }
 
           if (hasData.indexOf(true) >= 0 || hasData.indexOf(WITHHELD_FLAG) >= 0) {
 

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -87,23 +87,29 @@
 
         update: {value: function() {
 
+          // if (this.innerText.indexOf('County employment') > -1) {
+          //   console.log('marks', this.marks.data())
+          // }
 
           var hasData = [];
           this.marks.data().every(function(d){
             if (d === WITHHELD_FLAG) {
               hasData.push(WITHHELD_FLAG);
-              return WITHHELD_FLAG
+              return true;
             } else if (d && d !== 0) {
               hasData.push(true);
               return true;
             } else {
               hasData.push(false);
-              return false;
+              return true;
             }
-
           });
 
           var root = d3.select(this);
+
+          // if (this.innerText.indexOf('County employment') > -1) {
+          //   console.log('hasData', hasData)
+          // }
 
           if (hasData.indexOf(true) >= 0 || hasData.indexOf(WITHHELD_FLAG) >= 0) {
 

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -25487,7 +25487,7 @@
 	        return root.svg4everybody = factory();
 	    }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : "object" == typeof exports ? module.exports = factory() : root.svg4everybody = factory();
 	}(this, function() {
-	    /*! svg4everybody v2.1.0 | github.com/jonathantneal/svg4everybody */
+	    /*! svg4everybody v2.0.3 | github.com/jonathantneal/svg4everybody */
 	    function embed(node, target) {
 	        // if the target exists
 	        if (target) {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11508,23 +11508,29 @@
 
 	        update: {value: function() {
 
+	          // if (this.innerText.indexOf('County employment') > -1) {
+	          //   console.log('marks', this.marks.data())
+	          // }
 
 	          var hasData = [];
 	          this.marks.data().every(function(d){
 	            if (d === WITHHELD_FLAG) {
 	              hasData.push(WITHHELD_FLAG);
-	              return WITHHELD_FLAG
+	              return true;
 	            } else if (d && d !== 0) {
 	              hasData.push(true);
 	              return true;
 	            } else {
 	              hasData.push(false);
-	              return false;
+	              return true;
 	            }
-
 	          });
 
 	          var root = d3.select(this);
+
+	          // if (this.innerText.indexOf('County employment') > -1) {
+	          //   console.log('hasData', hasData)
+	          // }
 
 	          if (hasData.indexOf(true) >= 0 || hasData.indexOf(WITHHELD_FLAG) >= 0) {
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11435,7 +11435,6 @@
 
 	          this.marks = root.selectAll('[data-value]')
 	            .datum(function() {
-	              // console.log(typeof(this.getAttribute('data-value')))
 	              if (this.getAttribute('data-value') === null || this.getAttribute('data-value') === 'null') {
 
 	                return WITHHELD_FLAG;
@@ -11455,7 +11454,6 @@
 	        setYear: {value: function(year) {
 	          this.marks.datum(function() {
 	              var data = JSON.parse(this.getAttribute('data-year-values') || '{}');
-
 	              if (data[year] === null || data[year] === 'null') {
 	                return WITHHELD_FLAG;
 	              } else {
@@ -11507,11 +11505,6 @@
 	        }},
 
 	        update: {value: function() {
-
-	          // if (this.innerText.indexOf('County employment') > -1) {
-	          //   console.log('marks', this.marks.data())
-	          // }
-
 	          var hasData = [];
 	          this.marks.data().every(function(d){
 	            if (d === WITHHELD_FLAG) {
@@ -11527,10 +11520,6 @@
 	          });
 
 	          var root = d3.select(this);
-
-	          // if (this.innerText.indexOf('County employment') > -1) {
-	          //   console.log('hasData', hasData)
-	          // }
 
 	          if (hasData.indexOf(true) >= 0 || hasData.indexOf(WITHHELD_FLAG) >= 0) {
 
@@ -12543,6 +12532,7 @@
 	  };
 
 	  var WITHHELD_FLAG = 'Withheld';
+	  var NO_DATA_FLAG = undefined;
 
 	  var setYear = function(year) {
 	    var root = d3.select(this);
@@ -12560,12 +12550,16 @@
 	      function coerceNumber(num) {
 	        return typeof(num) == undefined || typeof(num) == 'undefined'
 	          ? WITHHELD_FLAG
-	          :  num;
+	          : num;
 	      }
 
 	      function cellData(data, year, property, coerce) {
-	        if (data && data[year] && property) {
-	          return data[year][property] || coerceNumber(coerce);
+	        if (data && property) {
+	          if ( data[year] ) {
+	            return data[year][property] || coerceNumber(coerce);
+	          } else {
+	            return NO_DATA_FLAG;
+	          }
 	        } else if (data && !property) {
 	          return data[year] || coerceNumber(coerce);
 	        } else {
@@ -12587,7 +12581,7 @@
 	          }
 	        }
 
-	        if (value === WITHHELD_FLAG || !format) {
+	        if (value === WITHHELD_FLAG || value === NO_DATA_FLAG || !format) {
 	          return value;
 	        } else {
 	          return format(value);
@@ -12604,17 +12598,22 @@
 	      var rows = root.selectAll('tr[data-year-values]');
 
 	      bars.datum(function() {
-	          var data = parseYearVals(this)
+	          var data = parseYearVals(this);
 	          var property = this.getAttribute('data-years-property');
-	          return cellData(data, year, property, 0);
+
+	          // coerce value to 0 so that a bar is rendered,
+	          // even in instances where a bar will be initially
+	          // hidden
+	          return cellData(data, year, property, 0) || 0;
 	        })
 	        .attr('data-value', function(d) {
 	          return d;
 	        });
 
 	      var sentencesData = sentences.datum(function() {
-	          var data = parseYearVals(this)
+	          var data = parseYearVals(this);
 	          var property = this.getAttribute('data-years-property');
+
 	          return cellData(data, year, property);
 	        }).attr('data-sentence', function(d) {
 	          return d;
@@ -12646,9 +12645,9 @@
 	        })
 
 	      texts.datum(function() {
-	          var data = parseYearVals(this)
+	          var data = parseYearVals(this);
 	          var property = this.getAttribute('data-years-property');
-	          return cellData(data, year, property);
+	          return cellData(data, year, property) || 0;
 	        })
 	        .attr('data-value-text', function(d) {
 	          return d;
@@ -12661,7 +12660,7 @@
 	      swatches.datum(function() {
 	          var data = parseYearVals(this);
 	          var property = this.getAttribute('data-years-property');
-	          return cellData(data, year, property);
+	          return cellData(data, year, property) || 0;
 	        })
 	        .attr('data-value-swatch', function(d) {
 	          return d;
@@ -12682,11 +12681,14 @@
 
 	      rows.datum(function(){
 	        var data = parseYearVals(this);
-	        return data[year] || WITHHELD_FLAG;
+	        if ( data[year] === NO_DATA_FLAG ) {
+	          return NO_DATA_FLAG
+	        } else {
+	          return data[year] || WITHHELD_FLAG;
+	        }
 	      })
 	      .attr('aria-hidden', function (d) {
 	        return !d;
-
 	      });
 	    }
 	  }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12682,7 +12682,7 @@
 	      rows.datum(function(){
 	        var data = parseYearVals(this);
 	        if ( data[year] === NO_DATA_FLAG ) {
-	          return NO_DATA_FLAG
+	          return NO_DATA_FLAG;
 	        } else {
 	          return data[year] || WITHHELD_FLAG;
 	        }


### PR DESCRIPTION
Fixes issue(s) #1773, #1761

[:sunglasses: PREVIEW UT 🗻 ](https://federalist.18f.gov/preview/18F/doi-extractives-data/withheld-bug/explore/UT)

Changes proposed in this pull request:
- updated filter logic in `eiti-data-map.js` to properly evaluate whether or not the map has values, which allows the toggle to show/hide as expected.
- Discovered that the `Withheld` values that were showing up in the county-level charts, was the product of `bar-chart-table.js` not distinguishing between truly withheld values and instances in which a county has values one year, but not another. I updated the logic to reflect this distinction.
- there should no longer be any data that is flagged as `Withheld` outside of federal production.

/cc @shawnbot @meiqimichelle 
