### PR TITLE
More visual bugs

### DIFF
--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -17,7 +17,7 @@
 
     <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production.
       <br>
-      <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
+      <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/" class="data-downloads">
         <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
       </a>
     </p>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -149,8 +149,8 @@ $form-border-radius: $base-border-radius;
 $form-box-shadow-focus: 0 0 0 2px $form-border-color-hover;
 
 // Map legend
-$opacity-federal: 0.5;
-$opacity-state: 0.25;
+$opacity-federal: 0.35;
+$opacity-state: 0.2;
 $legend-row-height: 1em;
 
 $greener-land-lightness-bump: lightness($green-land) * $opacity-state;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -72,7 +72,7 @@ $mid-blue-opaque: rgba(198, 233, 255, 0.93);
 $dark-blue: #4b9bbf;
 
 // State pages
-$green-land: #69995A;
+$green-land: #69995a;
 $green-mint: #cde3c3;
 $green-sea: #b1d39c;
 $green-dark: #657c60;

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -113,7 +113,7 @@
     @include span-columns(2);
     @include font-size(7 / 8);
 
-    background-color: $gray-light;
+    background-color: $gray-lighter;
     border: 0;
     font-weight: $weight-book;
     margin-right: $standard-padding;

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -31,7 +31,7 @@
     }
 
     .bar {
-      background-color: transparent
+      background-color: transparent;
     }
 
     &[data-value^="-"] .bar {
@@ -83,7 +83,7 @@
     }
 
     .bar {
-      background: $mid-gray;
+      background: $gray-lighter;
       display: block;
       height: 1em;
 

--- a/_sass/components/_ribbon.scss
+++ b/_sass/components/_ribbon.scss
@@ -24,7 +24,7 @@
 // Styleguide components.ribbon
 
 .ribbon-card {
-  background-color: $pale-blue;
+  background-color: $gray-pale;
   border: 0;
   padding-bottom: 0;
   padding-top: $base-padding-extra;
@@ -49,7 +49,7 @@
       padding-top: 0;
 
       .ribbon-card-image {
-        background-color: $pale-blue;
+        background-color: $gray-pale;
         border: 0;
         padding-left: 20%;
         padding-right: 20%;
@@ -66,7 +66,7 @@
 }
 
 .ribbon-card-top {
-  background-color: $pale-blue;
+  background-color: $gray-pale;
   border-bottom: 0;
   flex: 1 0 auto;
   padding-left: $base-padding;
@@ -102,7 +102,7 @@
 .ribbon-card-bottom {
   @include heading('para-sm');
 
-  background-color: $mid-blue;
+  background-color: $gray-light;
   color: $dark-gray;
   font-weight: $weight-book;
   margin-bottom: 0;

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -26,7 +26,7 @@ svg.map {
   }
 
   .feature.offshore-area use {
-    fill: #446237;
+    fill: $greenest-land;
   }
 
   .feature:not([fill]) use {

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -26,7 +26,7 @@ svg.map {
   }
 
   .feature.offshore-area use {
-    fill: $green-land;
+    fill: #354d2d;
   }
 
   .feature:not([fill]) use {

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -26,7 +26,7 @@ svg.map {
   }
 
   .feature.offshore-area use {
-    fill: #354d2d;
+    fill: #446237;
   }
 
   .feature:not([fill]) use {

--- a/_sass/layout/_slabs.scss
+++ b/_sass/layout/_slabs.scss
@@ -8,7 +8,7 @@
 // .slab-alpha - full width slab of $white
 // .slab-beta - full width slab of $light-gray
 // .slab-charlie - full width slab of $mid-gray
-// .slab-delta - full width slab of $light-blue
+// .slab-delta - full width slab of $gray-pale
 // .slab-echo - full width slab of $pale-blue
 // .slab-foxtrot - full width slab of $mid-blue
 //
@@ -40,7 +40,7 @@
 }
 
 .slab-delta {
-  background-color: $light-blue;
+  background-color: $gray-pale;
 }
 
 .slab-echo {

--- a/explore/index.html
+++ b/explore/index.html
@@ -64,12 +64,12 @@ nav_items:
         <figure class="ribbon-card-top">
           <h2 class="ribbon-card-top-text-header">Land ownership</h2>
           <p>
-            Natural resource ownership, governance, and revenues in the United States are closely tied to land ownership, and many USEITI datasets only cover natural resource extraction on {{ "federal lands and waters" | term_end:"federal land" }}.
+            Natural resource ownership, governance, and revenues are closely tied to land ownership. Federal land represents
+            {{ site.data.land_stats[state_id].federal_percent | percent }}%
+            of all land in the U.S., mostly concentrated in western states.
           </p>
           <p>
-            Federal land represents
-            {{ site.data.land_stats[state_id].federal_percent | percent }}%
-            of all land in the U.S., mostly concentrated in the American West. All offshore drilling and energy generation takes place in federal waters, because the {{ "Outer Continental Shelf" | term }} is entirely administered by the federal government.
+            Many USEITI datasets only cover natural resource extraction on {{ "federal lands and waters" | term_end:"federal land" }}.
           </p>
         </figure>
         <figcaption class="ribbon-card-bottom state_pages-select">


### PR DESCRIPTION
Moar visual bug squash.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/ribbons-gibbons/)

- Updates ribbon colors to latest designs
- Changes offshore area color to match federal land
- Lightens land ownership color scheme in general
- Lightens select drop-down color
- Lightens megachart bars
