### PR TITLE
Normalize year ranges and current year

### DIFF
--- a/_data/years.yml
+++ b/_data/years.yml
@@ -1,1 +1,6 @@
+# XXX this must be a string to use it as an index into other data!
+now: '2013'
+
 default: [2006, 2015]
+
+exports: [2011, 2014]

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -1,6 +1,6 @@
 {% assign all_products = site.data.national_all_production[state_id].products %}
 {% assign units_map = site.data.production_units %}
-{% assign year_range = '[2006, 2015]' %}
+{% assign year_range = site.data.years.all_production | default: site.data.years.default | jsonify %}
 {% assign year_list = year_range | to_list %}
 
 <section id="all-production" is="year-switcher-section" class="all-lands production">

--- a/_includes/location/national-exports.html
+++ b/_includes/location/national-exports.html
@@ -1,6 +1,5 @@
 {% assign export_commodities = site.data.national_exports[state_id].commodities %}
-
-{% assign year_range = '[2011, 2014]' %}
+{% assign year_range = site.data.years.exports | default: site.data.years.default | jsonify %}
 
 <section id="exports" is="year-switcher-section" class="economic exports">
 

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -1,5 +1,4 @@
 {% assign gdp = site.data.national_gdp.US %}
-
 {% assign year_range = site.data.years.gdp | default: site.data.years.default | jsonify %}
 
 <section id="gdp" is="year-switcher-section" class="economic gdp">

--- a/_includes/location/national-jobs.html
+++ b/_includes/location/national-jobs.html
@@ -1,11 +1,8 @@
 {% assign jobs = site.data.national_jobs[state_id] %}
-
 {% assign self_employment_jobs = site.data.national_self_employment[state_id] %}
-
 {% assign jobs_count = jobs[year].count | default: 0 %}
 {% assign jobs_percent = jobs[year].percent | default: 0 %}
-
-{% assign year_range = site.data.years.default | jsonify %}
+{% assign year_range = site.data.years.jobs | default: site.data.years.default | jsonify %}
 
 <section id="employment" class="economic employment">
 

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -1,7 +1,7 @@
 {% assign revenue_commodities = site.data.national_revenues[state_id].commodities %}
 {% assign revenue_total = revenue_commodities.All[year].revenue %}
+{% assign year_range = site.data.years.revenue | default: site.data.years.default | jsonify %}
 {% assign units = '$' %}
-{% assign year_range = '[2006, 2015]' %}
 
 <section id="revenue" is="year-switcher-section" class="federal revenue">
 

--- a/_includes/location/offshore-area-federal-production.html
+++ b/_includes/location/offshore-area-federal-production.html
@@ -1,22 +1,16 @@
 {% assign region_name_caps = region_name | capitalize %}
-
 {% assign federal_product_dir = site.data.offshore_federal_production_areas %}
-
 {% for product in federal_product_dir %}
   {% if product[0] == region_name_caps %}
     {% assign federal_products = product[1][area_id].products %}
     {% break %}
   {% endif %}
 {% endfor %}
-
-{% assign year_range = '[2004, 2013]' %}
-
 {% assign federal_products_num = federal_products | size %}
 {% assign units_map = site.data.production_units %}
+{% assign year_range = site.data.years.federal_production | default: site.data.years.default | jsonify %}
 
 <section id="offshore-area-federal-production" is="year-switcher-section" class="federal production">
-
-
 
   <section class="county-map-table" is="year-switcher-section">
 

--- a/_includes/location/offshore-area-revenue.html
+++ b/_includes/location/offshore-area-revenue.html
@@ -1,15 +1,13 @@
 {% assign offshore_revenue_dir = site.data.offshore_revenue_areas %}
-
 {% for revenue_area in offshore_revenue_dir %}
   {% if revenue_area[0] == area_id %}
     {% assign revenue_commodities = revenue_area[1][area_id].commodities %}
     {% break %}
   {% endif %}
 {% endfor %}
-
 {% assign revenue_total = revenue_commodities.All[year].revenue %}
+{% assign year_range = site.data.years.revenue | default: site.data.years.default | jsonify %}
 {% assign units = '$' %}
-{% assign year_range = '[2004, 2013]' %}
 
 <section id="revenue" is="year-switcher-section" class="offshore-area-revenue">
 

--- a/_includes/location/offshore-federal-revenue-area.html
+++ b/_includes/location/offshore-federal-revenue-area.html
@@ -1,17 +1,8 @@
 {% assign area_revenue = include.area_revenue %}
 {% assign state_revenue = include.state_revenue %}
-
-{% if include.year %}
-  {% assign year = include.year %}
-{% endif %}
-
-{% if include.year_range %}
-  {% assign year_range = include.year_range %}
-{% endif %}
-
 {% assign state_revenue_all = state_revenue.All %}
 {% assign current_revenue = state_revenue_all[year].revenue %}
-
+{% assign year_range = site.data.years.revenue | default: site.data.years.default | jsonify %}
 
 <section id="federal-revenue-county" class="product chart-item full-width">
 

--- a/_includes/location/offshore-region-federal-production.html
+++ b/_includes/location/offshore-region-federal-production.html
@@ -1,15 +1,11 @@
 {% assign region_name = include.region_name | default: region_name %}
 {% assign region_id = include.region_id | default: region_id %}
 {% assign region_name_caps = region_name | capitalize %}
-
 {% assign offshore_region_federal_products = site.data.offshore_federal_production_regions[region_name].products %}
-
 {% assign federal_product_dir = site.data.offshore_federal_production_areas %}
-
-{% assign year_range = '[2004, 2013]' %}
-
 {% assign federal_products_num = offshore_region_federal_products | size %}
 {% assign units_map = site.data.production_units %}
+{% assign year_range = site.data.years.federal_production | default: site.data.years.default | jsonify %}
 
 <section id="federal-production" class="federal production">
 

--- a/_includes/location/offshore-region-revenue.html
+++ b/_includes/location/offshore-region-revenue.html
@@ -1,19 +1,15 @@
-{% assign revenue_total = revenue_commodities.All[year].revenue %}
-{% assign units = '$' %}
-{% assign year_range = '[2004, 2013]' %}
 {% assign revenue_commodities = site.data.offshore_revenue_regions[region_name].commodities %}
 {% assign area_revenue = site.data.offshore_revenue_areas[region_name] %}
 {% assign revenue_total = revenue_commodities.All[year].revenue %}
-{% assign units = '$' %}
-{% assign year_range = '[2004, 2013]' %}
+{% assign year_range = site.data.years.revenue | default: site.data.years.default | jsonify %}
 {% assign year_list = year_range | to_list %}
+{% assign units = '$' %}
 
 <section id="revenue" is="year-switcher-section" class="federal revenue">
 
   <h2>Revenue</h2>
 
   <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
-
 
   <section id="federal-revenue">
 

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -1,6 +1,6 @@
 {% assign all_products = site.data.state_all_production[state_id].products %}
 {% assign units_map = site.data.production_units %}
-{% assign year_range = '[2006, 2015]' %}
+{% assign year_range = site.data.years.all_production | default: site.data.years.default | jsonify %}
 {% assign year_list = year_range | to_list %}
 
 {%

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -1,11 +1,10 @@
 {% assign export_commodities = site.data.state_exports[state_id].commodities %}
 {% assign exports_total = exports.All[include.year].dollars %}
 {% assign exports_commodities_num = exports | size %}
-
-{% assign year_range = '[2011, 2014]' %}
+{% assign year_range = site.data.years.exports | default: site.data.years.default | jsonify %}
 {% assign year_list = year_range | to_list %}
+{% assign empty_years = '' | split: '' %}
 
-{% assign empty_years = ',' | split:',' %}
 <section id="exports" is="year-switcher-section" class="economic exports">
 
   <h3>Exports</h3>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -1,11 +1,8 @@
 {% assign federal_products = site.data.state_federal_production[state_id].products %}
-{% assign year_range = '[2006, 2015]' %}
-
 {% assign federal_products_num = federal_products | size %}
 {% assign units_map = site.data.production_units %}
-
 {% assign county_federal_products = site.data.federal_county_production[state_id] %}
-
+{% assign year_range = site.data.years.federal_production | default: site.data.years.default | jsonify %}
 
 <section id="federal-production" class="federal production">
 

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -1,5 +1,4 @@
 {% assign gdp = site.data.state_gdp[state_id] %}
-
 {% assign year_range = site.data.years.gdp | default: site.data.years.default | jsonify %}
 
 <section id="gdp" is="year-switcher-section" class="economic gdp">

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -1,12 +1,9 @@
 {% assign jobs = site.data.state_jobs[state_id] %}
 {% assign county_jobs = site.data.county_jobs[state_id] %}
-
 {% assign self_employment_jobs = site.data.state_self_employment[state_id] %}
-
 {% assign jobs_count = jobs[year].count | default: 0 %}
 {% assign jobs_percent = jobs[year].percent | default: 0 %}
-
-{% assign year_range = site.data.years.default | jsonify %}
+{% assign year_range = site.data.years.jobs | default: site.data.years.default | jsonify %}
 {% assign year_list = year_range | to_list %}
 
 <section id="employment" class="economic employment">

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -1,16 +1,15 @@
 {% assign revenue_commodities = site.data.state_revenues[state_id].commodities %}
 {% assign county_revenue = site.data.county_revenue[state_id] %}
 {% assign revenue_total = revenue_commodities.All[year].revenue %}
-{% assign units = '$' %}
-{% assign year_range = '[2006, 2015]' %}
+{% assign year_range = site.data.years.revenue | default: site.data.years.default | jsonify %}
 {% assign year_list = year_range | to_list %}
+{% assign units = '$' %}
 
 <section id="revenue" is="year-switcher-section" class="federal revenue">
 
   <h2>Revenue</h2>
 
   <p>Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The types and amounts of payments differ, depending on who owns the natural resources. Payments are often called &ldquo;revenue&rdquo; because they represent revenue to the American public.</p>
-
 
   <section id="federal-revenue">
 

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -1,17 +1,8 @@
 {% assign county_revenue = include.county_revenue %}
 {% assign state_revenue = include.state_revenue %}
-
-{% if include.year %}
-  {% assign year = include.year %}
-{% endif %}
-
-{% if include.year_range %}
-  {% assign year_range = include.year_range %}
-{% endif %}
-
 {% assign state_revenue_all = state_revenue.All %}
 {% assign current_revenue = state_revenue_all[year].revenue %}
-
+{% assign year_range = site.data.years.revenue | default: site.data.years.default | jsonify %}
 
 <section id="federal-revenue-county" class="product chart-item full-width">
 

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -55,7 +55,7 @@ nav_items:
 {% assign locality_name = page.locality_name | default:'County' %}
 
 {% assign state_ref = page.id | upcase %}
-{% assign year = '2013' %}
+{% assign year = site.data.years.now %}
 {% assign oilgas = 'Oil & Gas (Non-Royalty)' %}
 {% assign commodity_names = site.data.commodity_names %}
 {% assign top_products = 10 %}

--- a/explore/index.html
+++ b/explore/index.html
@@ -38,7 +38,7 @@ nav_items:
 {% assign state_id = page.id %}
 
 {% assign state_ref = page.id | upcase %}
-{% assign year = '2013' %}
+{% assign year = site.data.years.now %}
 {% assign oilgas = 'Oil & Gas (Non-Royalty)' %}
 {% assign commodity_names = site.data.commodity_names %}
 {% assign top_products = 10 %}


### PR DESCRIPTION
This is a stepping stone to #1795. The next step will be to change the current year from 2013 to 2015, and after that to get the self-employment data updated (#1850).

### :sunglasses: Previews
* [Explore](https://federalist.18f.gov/preview/18F/doi-extractives-data/normalize-years/explore/)
* [Montana (opt-in)](https://federalist.18f.gov/preview/18F/doi-extractives-data/normalize-years/explore/MT/)
* [Utah](https://federalist.18f.gov/preview/18F/doi-extractives-data/normalize-years/explore/UT/)

Changes proposed in this pull request:
* Replace all hard-coded year range values to reference either a dataset-specific range in [_data/years.yml], or the `default` year range
* Replace both hard-coded 2013 ("current" year) values (in the Explore page and state profiles) to reference `site.data.years.now` (also in [_data/years.yml])

/cc @gemfarmer @meiqimichelle 

[_data/years.yml]: https://github.com/18F/doi-extractives-data/blob/normalize-years/_data/years.yml