### PR TITLE
Legend bugs

### DIFF
--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -45,7 +45,7 @@
               Data about {{ product_name | downcase }} extraction on federal land in {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span> is withheld.
             </span>
             <span class="has-data">
-              <span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ county[1].name }} from <span data-year='{{ year }}'>{{ year }}</span>
+              <span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> {{ units }} of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ county[1].name }} from <span data-year='{{ year }}'>{{ year }}</span>
             </span>
           </td>
       </tr>

--- a/_includes/location/offshore-area-federal-production-table.html
+++ b/_includes/location/offshore-area-federal-production-table.html
@@ -1,5 +1,6 @@
-{% assign product_ref = include.product_ref %}
-{% assign caption = include.caption %}
+{% assign product_ref = include.product_ref | default: caption %}
+{% assign caption = include.caption | default: caption %}
+{% assign product_name = include.product_name | default: product_name %}
 
 {% assign units = county[1].products[1].units %}
 {% if include.long_units %}
@@ -12,7 +13,7 @@
        class='county-table'>
   <thead>
     <tr>
-      <th>{{ region_name }}</th>
+      <th>{{ locality_name }}</th>
       <th colspan='2' class='numeric' data-series='volume'>{{ units | capitalize }} of {{ product_name | downcase | suffix:units_suffix }}</th>
     </tr>
   </thead>
@@ -45,7 +46,7 @@
               Data about {{ product_name | downcase }} extraction in {{ area[1].name }} in <span data-year='{{ year }}'>{{ year }}</span> is withheld.
             </span>
             <span class="has-data">
-              <span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ area[1].name }} from <span data-year='{{ year }}'>{{ year }}</span>
+              <span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> {{ units }} of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ area[1].name }} from <span data-year='{{ year }}'>{{ year }}</span>
             </span>
           </td>
       </tr>

--- a/_includes/location/offshore-region-federal-production.html
+++ b/_includes/location/offshore-region-federal-production.html
@@ -1,6 +1,8 @@
 {% assign region_name = include.region_name | default: region_name %}
 {% assign region_id = include.region_id | default: region_id %}
 {% assign region_name_caps = region_name | capitalize %}
+{% assign steps = 5 %}
+
 {% assign offshore_region_federal_products = site.data.offshore_federal_production_regions[region_name].products %}
 {% assign federal_product_dir = site.data.offshore_federal_production_areas %}
 {% assign federal_products_num = offshore_region_federal_products | size %}
@@ -125,6 +127,7 @@
                   year=year
                   values=offshore_area_federal_production
                   product_ref=product_ref
+                  product_name=product_name
                   long_units=long_units
                   caption=caption
                   sentence=sentence

--- a/_layouts/offshore-region.html
+++ b/_layouts/offshore-region.html
@@ -15,6 +15,8 @@ nav_items:
 
 {% assign region_name = page.title %}
 {% assign region_id = page.id %}
+{% assign locality_name = 'Region' %}
+
 {% assign commodity_names = site.data.commodity_names %}
 {% assign year = '2013' %}
 {% assign _viewbox = site.data.viewboxes_offshore[region_id] %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -59,7 +59,7 @@ nav_items:
 {% assign oilgas = 'Oil & Gas (Non-Royalty)' %}
 {% assign commodity_names = site.data.commodity_names %}
 {% assign top_products = 10 %}
-{% assign steps=9 %}
+{% assign steps = 5 %}
 
 {% assign is_priority_state = page.priority %}
 {% assign is_case_study_state = page.case_study %}
@@ -68,7 +68,7 @@ nav_items:
 {% assign _viewbox = site.data.viewboxes[state_id] %}
 
 {% capture regulations %}
-{{ page.content }}
+  {{ page.content }}
 {% endcapture %}
 
 <main id="state-{{ state_id }}" class="container-page-wrapper layout-state-pages">
@@ -122,7 +122,7 @@ nav_items:
       </section>
 
       {% include location/section-revenue.html %}
-      
+
       <section id="disbursements" class="disbursements">
         <h2>Disbursements</h2>
 

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -107,11 +107,15 @@
                 .attr('aria-hidden', true);
               root.select('.legend-withheld')
                 .attr('aria-hidden', false);
+              root.select('.legend-svg')
+                .attr('aria-hidden', true);
             } else {
               root.select('.legend-data')
                 .attr('aria-hidden', false);
               root.select('.legend-withheld')
                 .attr('aria-hidden', true);
+              root.select('.legend-svg')
+                .attr('aria-hidden', false);
             }
 
             root.select('.legend-no-data')
@@ -127,6 +131,8 @@
               .attr('aria-hidden', true);
             root.select('.legend-no-data')
               .attr('aria-hidden', false);
+            root.select('.legend-svg')
+                .attr('aria-hidden', true);
             root.select('.details-container')
               .attr('aria-hidden', true)
               .select('button')
@@ -144,12 +150,7 @@
             : eiti.format.si;
 
           var settings = {
-            horizontal : {
-              width: 50,
-              height: 12,
-              padding: 6
-            },
-            narrowHorizontal: {
+            horizontal: {
               width: 70,
               height: 12,
               padding: 10
@@ -191,47 +192,15 @@
 
           marks.attr('fill', scale);
 
-
           this.scale = scale;
-
-          // start map legend
-          function uniq(value, index, self) {
-            return self.indexOf(value) === index;
-          }
-
-          function getUnique(data, steps, domain) {
-            var getSteps = d3.scale[type]()
-              .domain(domain)
-              .range(steps);
-
-            var values = [];
-            data.forEach(function(d) {
-              values.push(getSteps(d));
-            });
-
-            return values.filter(uniq);
-          }
-
-
-          var _steps = d3.range(0, 9)
-
-          // find which steps are represented in the map
-          var uniqueSteps = getUnique(marks.data(), _steps, domain);
-          var narrowHorizontal = uniqueSteps.length < 6;
 
           var orient = this.isWideView
             ? 'horizontal'
             : 'vertical';
 
-          if (narrowHorizontal && orient === 'horizontal') {
-            shapeWidth = settings.narrowHorizontal.width;
-            shapeHeight = settings.narrowHorizontal.height;
-            shapePadding = settings.narrowHorizontal.padding;
-          } else {
-            shapeWidth = settings[orient].width;
-            shapeHeight = settings[orient].height;
-            shapePadding = settings[orient].padding;
-          }
+          shapeWidth = settings[orient].width;
+          shapeHeight = settings[orient].height;
+          shapePadding = settings[orient].padding;
 
           var svgLegend = d3.select(this)
             .select('.legend-svg')
@@ -259,38 +228,6 @@
 
             legendScale.call(legend);
 
-            // start consolidate (translate) visible cells
-            var cells = svgLegend.selectAll('.cell');
-            var cellHeight = legend.shapeHeight() + legend.shapePadding();
-            var cellWidth = legend.shapeWidth() + legend.shapePadding();
-            var count = 0;
-
-            var that = this;
-            cells.each(function(cell, i) {
-              var present = uniqueSteps.indexOf(i) > -1;
-
-              if (!present) {
-                // hide cells swatches that aren't in the map
-                cells[0][i].setAttribute('aria-hidden', true);
-                count++;
-              } else  {
-                if (that.isWideView) {
-                  var translateWidth = (i * cellWidth) - (count * cellWidth);
-                  cells[0][i].setAttribute('transform',
-                    'translate(' + translateWidth + ', 0)');
-                  cells[0][i].setAttribute('aria-hidden', false);
-                } else {
-                  // trim spacing between swatches that are visible
-                  var translateHeight = (i * cellHeight) - (count * cellHeight);
-                  cells[0][i].setAttribute('transform',
-                    'translate(0,' + translateHeight + ')');
-                  cells[0][i].setAttribute('aria-hidden', false);
-                }
-
-              }
-            });
-            // end consolidation
-            // end map legend
           } else {
             console.warn('this <eiti-data-map> element does not have an associated svg legend.');
           }

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -174,11 +174,17 @@
 
           var marks = this.marks;
 
-          var stripWithheld = function(marks) {
+          // Accepts an array of marks
+          // Returns an array of marks without 'Withheld'
+          // or undefined values
+          var cleanseMarks = function(marks) {
             marks = marks.filter(function(mark) {
               return mark !== WITHHELD_FLAG && mark !== NO_DATA_FLAG;
             });
-            if (!marks[1]) {
+            // If there is only one mark in the array,
+            // then insert an additional value.
+            // Used because the cleansed marks are used to determine the domain
+            if (marks.length < 2) {
               marks.unshift(0);
             }
             return marks;
@@ -186,7 +192,7 @@
 
           var domain = this.hasAttribute('domain')
             ? JSON.parse(this.getAttribute('domain'))
-            : d3.extent(stripWithheld(marks.data()));
+            : d3.extent(cleanseMarks(marks.data()));
 
           if (domain[0] > 0) {
             domain[0] = 0;

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -4,6 +4,7 @@
 
   var eiti = require('./../eiti');
   var WITHHELD_FLAG = 'Withheld';
+  var NO_DATA_FLAG = undefined;
 
   exports.EITIDataMap = document.registerElement('eiti-data-map', {
     prototype: Object.create(
@@ -101,7 +102,6 @@
           var root = d3.select(this);
 
           if (hasData.indexOf(true) >= 0 || hasData.indexOf(WITHHELD_FLAG) >= 0) {
-
             if (hasData.indexOf(true) < 0) {
               root.select('.legend-data')
                 .attr('aria-hidden', true);
@@ -174,9 +174,19 @@
 
           var marks = this.marks;
 
+          var stripWithheld = function(marks) {
+            marks = marks.filter(function(mark) {
+              return mark !== WITHHELD_FLAG && mark !== NO_DATA_FLAG;
+            });
+            if (!marks[1]) {
+              marks.unshift(0);
+            }
+            return marks;
+          }
+
           var domain = this.hasAttribute('domain')
             ? JSON.parse(this.getAttribute('domain'))
-            : d3.extent(marks.data());
+            : d3.extent(stripWithheld(marks.data()));
 
           if (domain[0] > 0) {
             domain[0] = 0;

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -182,7 +182,7 @@
               marks.unshift(0);
             }
             return marks;
-          }
+          };
 
           var domain = this.hasAttribute('domain')
             ? JSON.parse(this.getAttribute('domain'))

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11603,7 +11603,7 @@
 	              marks.unshift(0);
 	            }
 	            return marks;
-	          }
+	          };
 
 	          var domain = this.hasAttribute('domain')
 	            ? JSON.parse(this.getAttribute('domain'))

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11528,11 +11528,15 @@
 	                .attr('aria-hidden', true);
 	              root.select('.legend-withheld')
 	                .attr('aria-hidden', false);
+	              root.select('.legend-svg')
+	                .attr('aria-hidden', true);
 	            } else {
 	              root.select('.legend-data')
 	                .attr('aria-hidden', false);
 	              root.select('.legend-withheld')
 	                .attr('aria-hidden', true);
+	              root.select('.legend-svg')
+	                .attr('aria-hidden', false);
 	            }
 
 	            root.select('.legend-no-data')
@@ -11548,6 +11552,8 @@
 	              .attr('aria-hidden', true);
 	            root.select('.legend-no-data')
 	              .attr('aria-hidden', false);
+	            root.select('.legend-svg')
+	                .attr('aria-hidden', true);
 	            root.select('.details-container')
 	              .attr('aria-hidden', true)
 	              .select('button')
@@ -11565,12 +11571,7 @@
 	            : eiti.format.si;
 
 	          var settings = {
-	            horizontal : {
-	              width: 50,
-	              height: 12,
-	              padding: 6
-	            },
-	            narrowHorizontal: {
+	            horizontal: {
 	              width: 70,
 	              height: 12,
 	              padding: 10
@@ -11612,47 +11613,15 @@
 
 	          marks.attr('fill', scale);
 
-
 	          this.scale = scale;
-
-	          // start map legend
-	          function uniq(value, index, self) {
-	            return self.indexOf(value) === index;
-	          }
-
-	          function getUnique(data, steps, domain) {
-	            var getSteps = d3.scale[type]()
-	              .domain(domain)
-	              .range(steps);
-
-	            var values = [];
-	            data.forEach(function(d) {
-	              values.push(getSteps(d));
-	            });
-
-	            return values.filter(uniq);
-	          }
-
-
-	          var _steps = d3.range(0, 9)
-
-	          // find which steps are represented in the map
-	          var uniqueSteps = getUnique(marks.data(), _steps, domain);
-	          var narrowHorizontal = uniqueSteps.length < 6;
 
 	          var orient = this.isWideView
 	            ? 'horizontal'
 	            : 'vertical';
 
-	          if (narrowHorizontal && orient === 'horizontal') {
-	            shapeWidth = settings.narrowHorizontal.width;
-	            shapeHeight = settings.narrowHorizontal.height;
-	            shapePadding = settings.narrowHorizontal.padding;
-	          } else {
-	            shapeWidth = settings[orient].width;
-	            shapeHeight = settings[orient].height;
-	            shapePadding = settings[orient].padding;
-	          }
+	          shapeWidth = settings[orient].width;
+	          shapeHeight = settings[orient].height;
+	          shapePadding = settings[orient].padding;
 
 	          var svgLegend = d3.select(this)
 	            .select('.legend-svg')
@@ -11680,38 +11649,6 @@
 
 	            legendScale.call(legend);
 
-	            // start consolidate (translate) visible cells
-	            var cells = svgLegend.selectAll('.cell');
-	            var cellHeight = legend.shapeHeight() + legend.shapePadding();
-	            var cellWidth = legend.shapeWidth() + legend.shapePadding();
-	            var count = 0;
-
-	            var that = this;
-	            cells.each(function(cell, i) {
-	              var present = uniqueSteps.indexOf(i) > -1;
-
-	              if (!present) {
-	                // hide cells swatches that aren't in the map
-	                cells[0][i].setAttribute('aria-hidden', true);
-	                count++;
-	              } else  {
-	                if (that.isWideView) {
-	                  var translateWidth = (i * cellWidth) - (count * cellWidth);
-	                  cells[0][i].setAttribute('transform',
-	                    'translate(' + translateWidth + ', 0)');
-	                  cells[0][i].setAttribute('aria-hidden', false);
-	                } else {
-	                  // trim spacing between swatches that are visible
-	                  var translateHeight = (i * cellHeight) - (count * cellHeight);
-	                  cells[0][i].setAttribute('transform',
-	                    'translate(0,' + translateHeight + ')');
-	                  cells[0][i].setAttribute('aria-hidden', false);
-	                }
-
-	              }
-	            });
-	            // end consolidation
-	            // end map legend
 	          } else {
 	            console.warn('this <eiti-data-map> element does not have an associated svg legend.');
 	          }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11595,11 +11595,17 @@
 
 	          var marks = this.marks;
 
-	          var stripWithheld = function(marks) {
+	          // Accepts an array of marks
+	          // Returns an array of marks without 'Withheld'
+	          // or undefined values
+	          var cleanseMarks = function(marks) {
 	            marks = marks.filter(function(mark) {
 	              return mark !== WITHHELD_FLAG && mark !== NO_DATA_FLAG;
 	            });
-	            if (!marks[1]) {
+	            // If there is only one mark in the array,
+	            // then insert an additional value.
+	            // Used because the cleansed marks are used to determine the domain
+	            if (marks.length < 2) {
 	              marks.unshift(0);
 	            }
 	            return marks;
@@ -11607,7 +11613,7 @@
 
 	          var domain = this.hasAttribute('domain')
 	            ? JSON.parse(this.getAttribute('domain'))
-	            : d3.extent(stripWithheld(marks.data()));
+	            : d3.extent(cleanseMarks(marks.data()));
 
 	          if (domain[0] > 0) {
 	            domain[0] = 0;

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11425,6 +11425,7 @@
 
 	  var eiti = __webpack_require__(15);
 	  var WITHHELD_FLAG = 'Withheld';
+	  var NO_DATA_FLAG = undefined;
 
 	  exports.EITIDataMap = document.registerElement('eiti-data-map', {
 	    prototype: Object.create(
@@ -11522,7 +11523,6 @@
 	          var root = d3.select(this);
 
 	          if (hasData.indexOf(true) >= 0 || hasData.indexOf(WITHHELD_FLAG) >= 0) {
-
 	            if (hasData.indexOf(true) < 0) {
 	              root.select('.legend-data')
 	                .attr('aria-hidden', true);
@@ -11595,9 +11595,19 @@
 
 	          var marks = this.marks;
 
+	          var stripWithheld = function(marks) {
+	            marks = marks.filter(function(mark) {
+	              return mark !== WITHHELD_FLAG && mark !== NO_DATA_FLAG;
+	            });
+	            if (!marks[1]) {
+	              marks.unshift(0);
+	            }
+	            return marks;
+	          }
+
 	          var domain = this.hasAttribute('domain')
 	            ? JSON.parse(this.getAttribute('domain'))
-	            : d3.extent(marks.data());
+	            : d3.extent(stripWithheld(marks.data()));
 
 	          if (domain[0] > 0) {
 	            domain[0] = 0;


### PR DESCRIPTION
Fixes issue(s) #1822 

### Previews

[:sunglasses: offshore alaska – NOW](https://federalist.18f.gov/preview/18F/doi-extractives-data/legend-work/offshore/alaska)

[😢  offshore alaska – before ](https://federalist.18f.gov/preview/18F/doi-extractives-data/dev/offshore/alaska)

[:sunglasses: NV – NOW](https://federalist.18f.gov/preview/18F/doi-extractives-data/legend-work/explore/NV)

[😢  before NV - before ](https://federalist.18f.gov/preview/18F/doi-extractives-data/dev/explore/NV)

### Changes proposed in this pull request:
- make color domain 5 instead of 9
- make legend show and hide depending on whether or not it has data
- fix bug that was breaking the legend when there were less than two counties and one of them was `Withheld`

/cc @shawnbot 