### PR TITLE
Scraps o' Hawaii

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -32,10 +32,22 @@
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
     {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ include.state }}.svg{% endcapture %}
     <g class="states features">
+      {% if page.neighbors %}
+        {% for neighbor in page.neighbors %}
+      <use xlink:href="{{ states_svg }}#state-{{ neighbor }}"></use>
+        {% endfor %}
+      {% else %}
       <use xlink:href="{{ states_svg }}#states"></use>
+      {% endif %}
     </g>
     <g class="states mesh">
+      {% if page.neighbors %}
+        {% for neighbor in page.neighbors %}
+      <use xlink:href="{{ states_svg }}#state-{{ neighbor }}"></use>
+        {% endfor %}
+      {% else %}
       <use xlink:href="{{ states_svg }}#states-mesh"></use>
+      {% endif %}
     </g>
     <g class="counties features">
       <use xlink:href="{{ state_svg }}#counties"></use>
@@ -83,7 +95,7 @@
         aria-controls="{{ include.toggle }}">
         <i class="icon icon-plus-sm"></i>
         {% if include.toggle_text %}
-          {{ include.toggle_text}}
+          {{ include.toggle_text }}
         {% else %}Show table{% endif %}
       </button>
     </h4>
@@ -96,11 +108,11 @@
       {{ include.caption }}
     </figcaption>
     <figcaption class="legend-no-data" aria-hidden="true">
-      There is no data for {{ state_name }} in <span data-year="{{ year }}" >{{ year}}</span>.
+      There is no data for {{ state_name }} in <span data-year="{{ year }}" >{{ year }}</span>.
       Select a new year to populate the map.
     </figcaption>
     <figcaption class="legend-withheld" aria-hidden="true">
-      County-level data for <span data-year="{{ year }}" >{{ year}}</span> is withheld.
+      County-level data for <span data-year="{{ year }}" >{{ year }}</span> is withheld.
     </figcaption>
   {% endif %}
 
@@ -112,7 +124,7 @@
         aria-controls="{{ include.toggle }}">
         <i class="icon icon-plus-sm"></i>
         {% if include.toggle_text %}
-          {{ include.toggle_text}}
+          {{ include.toggle_text }}
         {% else %}Show table{% endif %}
       </button>
     </h4>

--- a/_states/TX.md
+++ b/_states/TX.md
@@ -3,6 +3,17 @@ id: TX
 title: Texas
 FIPS: '48'
 
+# this triggers whitelisting of nearby states to render in county maps,
+# which solves the problem of Hawaii showing up on maps of Texas
+neighbors:
+- AR
+- CO
+- KS
+- LA
+- MO
+- NM
+- OK
+
 priority: true
 
 offshore_area: |


### PR DESCRIPTION
Fixes #1646.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/scraps-o-hawaii/explore/TX/#federal-production)

Changes proposed in this pull request:
- Adds support for a `page.neighbors` list of whitelisted states to show in county maps for a given state.
- Sets the `neighbors` list for Texas so that Hawaii is no longer displayed in Texas county maps.

/cc @gemfarmer @coreycaitlin 
