### PR TITLE
Wide legend redesign

### DIFF
--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -256,27 +256,27 @@
           if (orient == 'horizontal') {
             var cumulative = 0;
 
-            var cells = svgLegend.select('.legendCells')
-            .selectAll('.cell')
-              .datum(function(){
-                return d3.select(this)
-                  .select('.label')
-                  .node()
-                  .getComputedTextLength()
-              })
-              .attr('transform',function(textWidth){
-                var shift = cumulative;
-                var s = settings.horizontal;
-                var margin = s.width + s.padding + s.margin;
-                cumulative += textWidth + margin;
-                return 'translate(' + shift + ', 0)';
-              })
-              .select('text')
-                 .attr('transform',function(d){
+            svgLegend.select('.legendCells')
+              .selectAll('.cell')
+                .datum(function(){
+                  return d3.select(this)
+                    .select('.label')
+                    .node()
+                    .getComputedTextLength();
+                })
+                .attr('transform',function(textWidth){
+                  var shift = cumulative;
                   var s = settings.horizontal;
-                  var padding = s.padding + s.width;
-                  return 'translate(' + padding + ', 10)';
-                });
+                  var margin = s.width + s.padding + s.margin;
+                  cumulative += textWidth + margin;
+                  return 'translate(' + shift + ', 0)';
+                })
+                .select('text')
+                   .attr('transform',function(){
+                    var s = settings.horizontal;
+                    var padding = s.padding + s.width;
+                    return 'translate(' + padding + ', 10)';
+                  });
           }
           // end horizontal legend shift
 

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -250,7 +250,9 @@
             console.warn('this <eiti-data-map> element does not have an associated svg legend.');
           }
 
-
+          // If the legend is 'horizontal',
+          // then shift the text and label from
+          // its default settings
           if (orient == 'horizontal') {
             var cumulative = 0;
 
@@ -262,7 +264,7 @@
                   .node()
                   .getComputedTextLength()
               })
-              .attr('transform',function(textWidth, i){
+              .attr('transform',function(textWidth){
                 var shift = cumulative;
                 var s = settings.horizontal;
                 var margin = s.width + s.padding + s.margin;
@@ -270,12 +272,13 @@
                 return 'translate(' + shift + ', 0)';
               })
               .select('text')
-                 .attr('transform',function(d, i){
+                 .attr('transform',function(d){
                   var s = settings.horizontal;
                   var padding = s.padding + s.width;
                   return 'translate(' + padding + ', 10)';
                 });
           }
+          // end horizontal legend shift
 
           // start trim height on map container
           var svgContainer = d3.select(this)

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -151,15 +151,17 @@
 
           var settings = {
             horizontal: {
-              width: 70,
+              width: 12,
               height: 12,
-              padding: 10
+              padding: 4,
+              margin: 10
             },
             vertical: {
               width: 15,
               height: 15,
               padding: 6
-            }
+            },
+
           },
           shapeWidth,
           shapeHeight,
@@ -246,6 +248,33 @@
 
           } else {
             console.warn('this <eiti-data-map> element does not have an associated svg legend.');
+          }
+
+
+          if (orient == 'horizontal') {
+            var cumulative = 0;
+
+            var cells = svgLegend.select('.legendCells')
+            .selectAll('.cell')
+              .datum(function(){
+                return d3.select(this)
+                  .select('.label')
+                  .node()
+                  .getComputedTextLength()
+              })
+              .attr('transform',function(textWidth, i){
+                var shift = cumulative;
+                var s = settings.horizontal;
+                var margin = s.width + s.padding + s.margin;
+                cumulative += textWidth + margin;
+                return 'translate(' + shift + ', 0)';
+              })
+              .select('text')
+                 .attr('transform',function(d, i){
+                  var s = settings.horizontal;
+                  var padding = s.padding + s.width;
+                  return 'translate(' + padding + ', 10)';
+                });
           }
 
           // start trim height on map container

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11572,15 +11572,17 @@
 
 	          var settings = {
 	            horizontal: {
-	              width: 70,
+	              width: 12,
 	              height: 12,
-	              padding: 10
+	              padding: 4,
+	              margin: 10
 	            },
 	            vertical: {
 	              width: 15,
 	              height: 15,
 	              padding: 6
-	            }
+	            },
+
 	          },
 	          shapeWidth,
 	          shapeHeight,
@@ -11667,6 +11669,33 @@
 
 	          } else {
 	            console.warn('this <eiti-data-map> element does not have an associated svg legend.');
+	          }
+
+
+	          if (orient == 'horizontal') {
+	            var cumulative = 0;
+
+	            var cells = svgLegend.select('.legendCells')
+	            .selectAll('.cell')
+	              .datum(function(){
+	                return d3.select(this)
+	                  .select('.label')
+	                  .node()
+	                  .getComputedTextLength()
+	              })
+	              .attr('transform',function(textWidth, i){
+	                var shift = cumulative;
+	                var s = settings.horizontal;
+	                var margin = s.width + s.padding + s.margin;
+	                cumulative += textWidth + margin;
+	                return 'translate(' + shift + ', 0)';
+	              })
+	              .select('text')
+	                 .attr('transform',function(d, i){
+	                  var s = settings.horizontal;
+	                  var padding = s.padding + s.width;
+	                  return 'translate(' + padding + ', 10)';
+	                });
 	          }
 
 	          // start trim height on map container

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11671,7 +11671,9 @@
 	            console.warn('this <eiti-data-map> element does not have an associated svg legend.');
 	          }
 
-
+	          // If the legend is 'horizontal',
+	          // then shift the text and label from
+	          // its default settings
 	          if (orient == 'horizontal') {
 	            var cumulative = 0;
 
@@ -11683,7 +11685,7 @@
 	                  .node()
 	                  .getComputedTextLength()
 	              })
-	              .attr('transform',function(textWidth, i){
+	              .attr('transform',function(textWidth){
 	                var shift = cumulative;
 	                var s = settings.horizontal;
 	                var margin = s.width + s.padding + s.margin;
@@ -11691,12 +11693,13 @@
 	                return 'translate(' + shift + ', 0)';
 	              })
 	              .select('text')
-	                 .attr('transform',function(d, i){
+	                 .attr('transform',function(d){
 	                  var s = settings.horizontal;
 	                  var padding = s.padding + s.width;
 	                  return 'translate(' + padding + ', 10)';
 	                });
 	          }
+	          // end horizontal legend shift
 
 	          // start trim height on map container
 	          var svgContainer = d3.select(this)

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11677,27 +11677,27 @@
 	          if (orient == 'horizontal') {
 	            var cumulative = 0;
 
-	            var cells = svgLegend.select('.legendCells')
-	            .selectAll('.cell')
-	              .datum(function(){
-	                return d3.select(this)
-	                  .select('.label')
-	                  .node()
-	                  .getComputedTextLength()
-	              })
-	              .attr('transform',function(textWidth){
-	                var shift = cumulative;
-	                var s = settings.horizontal;
-	                var margin = s.width + s.padding + s.margin;
-	                cumulative += textWidth + margin;
-	                return 'translate(' + shift + ', 0)';
-	              })
-	              .select('text')
-	                 .attr('transform',function(d){
+	            svgLegend.select('.legendCells')
+	              .selectAll('.cell')
+	                .datum(function(){
+	                  return d3.select(this)
+	                    .select('.label')
+	                    .node()
+	                    .getComputedTextLength();
+	                })
+	                .attr('transform',function(textWidth){
+	                  var shift = cumulative;
 	                  var s = settings.horizontal;
-	                  var padding = s.padding + s.width;
-	                  return 'translate(' + padding + ', 10)';
-	                });
+	                  var margin = s.width + s.padding + s.margin;
+	                  cumulative += textWidth + margin;
+	                  return 'translate(' + shift + ', 0)';
+	                })
+	                .select('text')
+	                   .attr('transform',function(){
+	                    var s = settings.horizontal;
+	                    var padding = s.padding + s.width;
+	                    return 'translate(' + padding + ', 10)';
+	                  });
 	          }
 	          // end horizontal legend shift
 


### PR DESCRIPTION
Fixes issue(s) # .

[:sunglasses: MT PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/squishy-squishy-bug-bang/explore/MT)

Changes proposed in this pull request:
- Work from a live coding session with @ericronne that restyles the map legend when states are in "wide" view

/cc @ericronne 

