### PR TITLE
Fix county table map bugs

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -40,40 +40,47 @@
     <g class="counties features">
       <use xlink:href="{{ state_svg }}#counties"></use>
     </g>
-    <g class="counties mesh">
-      <use xlink:href="{{ state_svg }}#counties-mesh"></use>
-    </g>
 
-    {% if include.counties %}
-      {% assign keys = include.value %}
-      {% for county in include.counties %}
-        {% assign fips = county[0] | pad_left: 5, '0' %}
-        {% if include.href %}<a xlink:href="{{ include.href | format_url: fips }}">{% endif %}
-        {% assign value = county[1] | get: keys %}
+    <g>
+      {% if include.counties %}
+        {% assign keys = include.value %}
+        {% for county in include.counties %}
+          {% assign fips = county[0] | pad_left: 5, '0' %}
+          {% if include.href %}<a xlink:href="{{ include.href | format_url: fips }}">{% endif %}
+          {% assign value = county[1] | get: keys %}
 
-        {% assign year_values = null %}
-        {% if include.years %}
-          {% assign year_values = county[1] | get: include.years %}
-          {% if include.years_property %}
-            {% assign year_values = year_values | map_hash: include.years_property %}
+          {% assign year_values = null %}
+          {% if include.years %}
+            {% assign year_values = county[1] | get: include.years %}
+            {% if include.years_property %}
+              {% assign year_values = year_values | map_hash: include.years_property %}
+            {% endif %}
           {% endif %}
-        {% endif %}
 
-        {% if year_values %}
-          <g class="county feature"
-            data-fips="{{ fips }}"
-            data-value='{{ value | jsonify }}'
-            data-year-values='{{ year_values | jsonify }}'>
-            <title>{{ county[1].name }}</title>
-            <use xlink:href="{{ state_svg }}#county-{{ fips }}"></use>
-          </g>
-        {% endif %}
-        {% if include.href %}</a>{% endif %}
-      {% endfor %}
-    {% endif %}
+          {% if year_values %}
+            <g class="county feature"
+              data-fips="{{ fips }}"
+              data-value='{{ value | jsonify }}'
+              data-year-values='{{ year_values | jsonify }}'>
+              <title>{{ county[1].name }}</title>
+              <use xlink:href="{{ state_svg }}#county-{{ fips }}"></use>
+            </g>
+          {% endif %}
+          {% if include.href %}</a>{% endif %}
+        {% endfor %}
+      {% endif %}
+
+      <g class="counties mesh">
+        <use xlink:href="{{ state_svg }}#counties-mesh"></use>
+      </g>
+    </g>
 
     <g class="state feature overlay">
       <use xlink:href="{{ states_svg }}#state-{{ include.state }}"></use>
+    </g>
+
+    <g class="counties-overlay">
+
     </g>
   </svg>
 

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -78,10 +78,6 @@
     <g class="state feature overlay">
       <use xlink:href="{{ states_svg }}#state-{{ include.state }}"></use>
     </g>
-
-    <g class="counties-overlay">
-
-    </g>
   </svg>
 
   {% if include.toggle %}

--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -47,10 +47,6 @@
       <use xlink:href="{{ offshore_svg }}#{{ region_id }}"></use>
     </g>
 
-    <g class="regions mesh">
-      <use xlink:href="{{ offshore_svg }}#{{ region_id }}-mesh"></use>
-    </g>
-
     {% if include.areas %}
       {% assign keys = include.value %}
       {% for area in include.areas %}
@@ -78,6 +74,10 @@
         {% if include.href %}</a>{% endif %}
       {% endfor %}
     {% endif %}
+
+    <g class="regions mesh">
+      <use xlink:href="{{ offshore_svg }}#{{ region_id }}-mesh"></use>
+    </g>
   </svg>
 
   {% if include.toggle %}

--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -47,36 +47,38 @@
       <use xlink:href="{{ offshore_svg }}#{{ region_id }}"></use>
     </g>
 
-    {% if include.areas %}
-      {% assign keys = include.value %}
-      {% for area in include.areas %}
-        {% assign area_id = area[0] %}
-        {% if include.href %}<a xlink:href="{{ include.href | format_url: area_id }}">{% endif %}
-        {% assign value = area[1] | get: keys %}
+    <g>
+      {% if include.areas %}
+        {% assign keys = include.value %}
+        {% for area in include.areas %}
+          {% assign area_id = area[0] %}
+          {% if include.href %}<a xlink:href="{{ include.href | format_url: area_id }}">{% endif %}
+          {% assign value = area[1] | get: keys %}
 
-        {% assign year_values = null %}
-        {% if include.years %}
-          {% assign year_values = area[1] | get: include.years %}
-          {% if include.years_property %}
-            {% assign year_values = year_values | map_hash: include.years_property %}
+          {% assign year_values = null %}
+          {% if include.years %}
+            {% assign year_values = area[1] | get: include.years %}
+            {% if include.years_property %}
+              {% assign year_values = year_values | map_hash: include.years_property %}
+            {% endif %}
           {% endif %}
-        {% endif %}
 
-        {% if year_values %}
-          <g class="county feature"
-            data-fips="{{ area_id }}"
-            data-value='{{ value | jsonify }}'
-            data-year-values='{{ year_values | jsonify }}'>
-            <title>{{ area[1].name }}</title>
-            <use xlink:href="{{ offshore_svg }}#{{ area_id }}"></use>
-          </g>
-        {% endif %}
-        {% if include.href %}</a>{% endif %}
-      {% endfor %}
-    {% endif %}
+          {% if year_values %}
+            <g class="county feature"
+              data-fips="{{ area_id }}"
+              data-value='{{ value | jsonify }}'
+              data-year-values='{{ year_values | jsonify }}'>
+              <title>{{ area[1].name }}</title>
+              <use xlink:href="{{ offshore_svg }}#{{ area_id }}"></use>
+            </g>
+          {% endif %}
+          {% if include.href %}</a>{% endif %}
+        {% endfor %}
+      {% endif %}
 
-    <g class="regions mesh">
-      <use xlink:href="{{ offshore_svg }}#{{ region_id }}-mesh"></use>
+      <g class="regions mesh">
+        <use xlink:href="{{ offshore_svg }}#{{ region_id }}-mesh"></use>
+      </g>
     </g>
   </svg>
 

--- a/_sass/blocks/_county-bar-table.scss
+++ b/_sass/blocks/_county-bar-table.scss
@@ -21,7 +21,8 @@
 
   tbody > tr:hover,
   tbody > tr:focus,
-  tbody > tr.selected {
+  tbody > tr.selected,
+  tbody > tr.mouseover {
     background-color: $gray-pale;
 
     .swatch {

--- a/_sass/blocks/_county-bar-table.scss
+++ b/_sass/blocks/_county-bar-table.scss
@@ -28,10 +28,6 @@
     .swatch {
       border: 1px solid $neutral-gray;
     }
-
-    .bar .bar {
-      background-color: $green-dark-chart-mid;
-    }
   }
 
   tbody > tr.selected {

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -11,36 +11,6 @@
     background: $white;
   }
 
-  // tbody > tr:hover,
-  // tbody > tr:focus,
-  // tbody > tr.selected {
-  //   background-color: $gray-pale;
-
-  //   .swatch {
-  //     border: 1px solid $neutral-gray;
-  //   }
-
-  //   .bar .bar {
-  //     background-color: $green-dark-chart-mid;
-  //   }
-  // }
-
-  // tbody > tr.selected {
-  //   font-weight: $weight-book;
-
-  //   td[data-sentence] {
-  //     font-weight: $weight-light;
-  //   }
-
-  //   &[data-year-values] {
-  //     border-bottom: 0;
-  //   }
-
-  //   .bar .bar {
-  //     background-color: $green-dark;
-  //   }
-  // }
-
   .bar {
     background: $light-gray;
   }

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -175,6 +175,8 @@
 
   var show = function(fips) {
     var rows = d3.select(this).selectAll('tbody > tr');
+    rows
+      .classed('mouseover', false);
 
     rows.select('[data-sentence]')
       .attr('aria-hidden', true);
@@ -194,7 +196,7 @@
     rows
       .classed('mouseover', false);
 
-    if (event !== 'mouseleave') {
+    if (event !== 'mouseout') {
       rows
       .classed('mouseover', false)
       .filter(function(row) {

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -175,18 +175,34 @@
 
   var show = function(fips) {
     var rows = d3.select(this).selectAll('tbody > tr');
-    rows.classed('selected', false);
 
-    rows.selectAll('[data-sentence]').attr('aria-hidden', true);
+    rows.select('[data-sentence]')
+      .attr('aria-hidden', true);
 
-    // show matching row
-    rows.filter(function(row) {
-      return this.getAttribute('data-fips') === fips;
-    })
-    .classed('selected', true)
-    .select('[data-sentence]')
-    .attr('aria-hidden', false);
+    rows
+      .classed('selected', false)
+      .filter(function(row) {
+        return this.getAttribute('data-fips') === fips;
+      })
+      .classed('selected', true)
+      .select('[data-sentence]')
+        .attr('aria-hidden', false);
+  }
 
+  var highlight = function(fips, event) {
+    var rows = d3.select(this).selectAll('tbody > tr');
+    rows
+      .classed('mouseover', false);
+
+    if (event !== 'mouseleave') {
+      rows
+      .classed('mouseover', false)
+      .filter(function(row) {
+        return this.getAttribute('data-fips') === fips;
+      })
+      .classed('mouseover', true)
+        .attr('aria-hidden', false);
+    }
   }
 
   var update = function() {
@@ -353,6 +369,8 @@
         setYear: {value: setYear},
 
         show: {value: show},
+
+        highlight: {value: highlight},
 
         orient: {
           get: function() {

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -183,13 +183,13 @@
 
     rows
       .classed('selected', false)
-      .filter(function(row) {
+      .filter(function() {
         return this.getAttribute('data-fips') === fips;
       })
       .classed('selected', true)
       .select('[data-sentence]')
         .attr('aria-hidden', false);
-  }
+  };
 
   var highlight = function(fips, event) {
     var rows = d3.select(this).selectAll('tbody > tr');
@@ -199,7 +199,7 @@
     if (event !== 'mouseout') {
       rows
       .classed('mouseover', false)
-      .filter(function(row) {
+      .filter(function() {
         return this.getAttribute('data-fips') === fips;
       })
       .classed('mouseover', true)

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -4,11 +4,27 @@
     var root = d3.select(this);
     var self = d3.select(this);
 
+    var moveToFront = function() {
+      return this.each(function(){
+        var child = this.parentNode.appendChild(this);
+      });
+    };
+
+    var moveToBack = function() {
+      return this.each(function() {
+        var firstChild = this.parentNode.firstChild;
+        if (firstChild) {
+          this.parentNode.insertBefore(this, firstChild);
+        }
+      });
+    };
+
+
     var select = root.selectAll('select.chart-selector');
     var maps = root.selectAll('eiti-data-map');
     var mapToggles = maps.selectAll('button[is="aria-toggle"]');
     var mapTables = root.selectAll('.eiti-data-map-table');
-    var counties = maps.selectAll('.county.feature')
+    var counties = maps.selectAll('.county.feature');
 
     var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
 
@@ -18,21 +34,27 @@
       event = event || 'selected';
       counties.classed('mouseover', false);
       counties.classed(event, false);
+      var unselectedCounties = counties.filter(function(){
+        return !d3.select(this).classed('selected');
+      })
+      unselectedCounties.call(moveToBack);
 
       counties.each(function(d, i){
         var county = d3.select(this);
         if (+county.attr('data-fips') === +fips) {
           county.classed(event, true);
+
+          county.call(moveToFront);
         }
       });
     };
 
-    var toggleTable = function(d, i) {
+    var toggleTable = function(context) {
+      var context = context || this;
+      var countyName = context.querySelector('title').textContent;
+      var countyFIPS = context.getAttribute('data-fips');
 
-      var countyName = this.querySelector('title').textContent;
-      var countyFIPS = this.getAttribute('data-fips');
-
-      highlightCounty(countyFIPS);
+      highlightCounty(countyFIPS, 'selected');
 
       mapToggles.each(function(){
         this.expand();
@@ -43,31 +65,54 @@
       })
     };
 
+    var mouseTable = function(context, event) {
+      var context = context || this;
+      var countyName = context.querySelector('title').textContent;
+      var countyFIPS = context.getAttribute('data-fips');
+
+      highlightCounty(countyFIPS, event);
+
+
+      chartTables.each(function(){
+        this.highlight(countyFIPS, event);
+      })
+    };
+
     var toggleMap = function() {
       var fips = this.getAttribute('data-fips');
-
       highlightCounty(fips);
 
       chartTables.each(function(){
-        this.show(fips);
+        this.show(fips, 'selected');
       });
     };
 
-    var mouseoverMap = function () {
+    var mouseMap = function (event) {
       var fips = this.getAttribute('data-fips');
-      highlightCounty(fips, 'mouseover');
-    };
-
-    var mouseleaveMap = function () {
-      var fips = this.getAttribute('data-fips');
-      highlightCounty(fips, 'mouseleave');
+      highlightCounty(fips, event);
     };
 
     chartRows.on('click.countyTable', toggleMap);
-    chartRows.on('mouseover.countyTable', mouseoverMap);
-    chartRows.on('mouseleave.countyTable', mouseleaveMap);
+    chartRows.on('mouseover.countyTable', mouseMap, 'mouseover');
+    chartRows.on('mouseout.countyTable', mouseMap, 'mouseleave');
 
-    counties.on('click.county', toggleTable);
+
+    counties
+      .on('click.county', function(){
+        toggleTable(this);
+      })
+      .on('mouseenter.county', function(){
+        var that = this;
+        setTimeout(function(){
+          eiti.util.throttle(mouseTable(that, 'mouseover'), 200);
+        }, 10);
+      })
+      .on('mouseleave.county', function(){
+        var that = this;
+        setTimeout(function(){
+          mouseTable(that, 'mouseleave');
+        }, 20);
+      });
   };
 
   var detached = function() {

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -6,7 +6,7 @@
 
     var moveToFront = function() {
       return this.each(function(){
-        var child = this.parentNode.appendChild(this);
+        this.parentNode.appendChild(this);
       });
     };
 
@@ -42,7 +42,7 @@
       counties.each(function(d, i){
         var county = d3.select(this);
         var numbers = typeof(county.attr('data-fips')) === 'number' ||
-          typeof(fips) === 'number'
+          typeof(fips) === 'number';
         var areEqual = numbers
           ? +county.attr('data-fips') === +fips
           : county.attr('data-fips') === fips;
@@ -56,7 +56,6 @@
 
     var toggleTable = function(context) {
       var context = context || this;
-      var countyName = context.querySelector('title').textContent;
       var countyFIPS = context.getAttribute('data-fips');
 
       highlightCounty(countyFIPS, 'selected');
@@ -67,19 +66,18 @@
 
       chartTables.each(function(){
         this.show(countyFIPS, 'selected');
-      })
+      });
     };
 
     var mouseTable = function(context, event) {
-      var context = context || this;
-      var countyName = context.querySelector('title').textContent;
+      context = context || this;
       var countyFIPS = context.getAttribute('data-fips');
 
       highlightCounty(countyFIPS, event);
 
       chartTables.each(function(){
         this.highlight(countyFIPS, event);
-      })
+      });
     };
 
     var toggleMap = function() {

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -36,7 +36,7 @@
       counties.classed(event, false);
       var unselectedCounties = counties.filter(function(){
         return !d3.select(this).classed('selected');
-      })
+      });
       unselectedCounties.call(moveToBack);
 
       counties.each(function(d, i){

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -55,7 +55,7 @@
     };
 
     var toggleTable = function(context) {
-      var context = context || this;
+      context = context || this;
       var countyFIPS = context.getAttribute('data-fips');
 
       highlightCounty(countyFIPS, 'selected');

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -41,9 +41,14 @@
 
       counties.each(function(d, i){
         var county = d3.select(this);
-        if (+county.attr('data-fips') === +fips) {
-          county.classed(event, true);
+        var numbers = typeof(county.attr('data-fips')) === 'number' ||
+          typeof(fips) === 'number'
+        var areEqual = numbers
+          ? +county.attr('data-fips') === +fips
+          : county.attr('data-fips') === fips;
 
+        if (areEqual) {
+          county.classed(event, true);
           county.call(moveToFront);
         }
       });
@@ -61,7 +66,7 @@
       });
 
       chartTables.each(function(){
-        this.show(countyFIPS);
+        this.show(countyFIPS, 'selected');
       })
     };
 
@@ -72,7 +77,6 @@
 
       highlightCounty(countyFIPS, event);
 
-
       chartTables.each(function(){
         this.highlight(countyFIPS, event);
       })
@@ -80,21 +84,27 @@
 
     var toggleMap = function() {
       var fips = this.getAttribute('data-fips');
-      highlightCounty(fips);
+      highlightCounty(fips, 'selected');
 
       chartTables.each(function(){
         this.show(fips, 'selected');
       });
     };
 
-    var mouseMap = function (event) {
+    var mouseMap = function () {
+      event = event.type;
       var fips = this.getAttribute('data-fips');
+
       highlightCounty(fips, event);
+
+      chartTables.each(function(){
+        this.highlight(fips, event);
+      });
     };
 
     chartRows.on('click.countyTable', toggleMap);
-    chartRows.on('mouseover.countyTable', mouseMap, 'mouseover');
-    chartRows.on('mouseout.countyTable', mouseMap, 'mouseleave');
+    chartRows.on('mouseover.countyTable', mouseMap);
+    chartRows.on('mouseout.countyTable', mouseMap);
 
 
     counties
@@ -110,7 +120,7 @@
       .on('mouseleave.county', function(){
         var that = this;
         setTimeout(function(){
-          mouseTable(that, 'mouseleave');
+          mouseTable(that, 'mouseout');
         }, 20);
       });
   };

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13372,7 +13372,7 @@
 	    };
 
 	    var toggleTable = function(context) {
-	      var context = context || this;
+	      context = context || this;
 	      var countyFIPS = context.getAttribute('data-fips');
 
 	      highlightCounty(countyFIPS, 'selected');

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12648,6 +12648,8 @@
 
 	  var show = function(fips) {
 	    var rows = d3.select(this).selectAll('tbody > tr');
+	    rows
+	      .classed('mouseover', false);
 
 	    rows.select('[data-sentence]')
 	      .attr('aria-hidden', true);
@@ -12667,7 +12669,7 @@
 	    rows
 	      .classed('mouseover', false);
 
-	    if (event !== 'mouseleave') {
+	    if (event !== 'mouseout') {
 	      rows
 	      .classed('mouseover', false)
 	      .filter(function(row) {
@@ -13356,9 +13358,14 @@
 
 	      counties.each(function(d, i){
 	        var county = d3.select(this);
-	        if (+county.attr('data-fips') === +fips) {
-	          county.classed(event, true);
+	        var numbers = typeof(county.attr('data-fips')) === 'number' ||
+	          typeof(fips) === 'number'
+	        var areEqual = numbers
+	          ? +county.attr('data-fips') === +fips
+	          : county.attr('data-fips') === fips;
 
+	        if (areEqual) {
+	          county.classed(event, true);
 	          county.call(moveToFront);
 	        }
 	      });
@@ -13376,7 +13383,7 @@
 	      });
 
 	      chartTables.each(function(){
-	        this.show(countyFIPS);
+	        this.show(countyFIPS, 'selected');
 	      })
 	    };
 
@@ -13387,7 +13394,6 @@
 
 	      highlightCounty(countyFIPS, event);
 
-
 	      chartTables.each(function(){
 	        this.highlight(countyFIPS, event);
 	      })
@@ -13395,21 +13401,27 @@
 
 	    var toggleMap = function() {
 	      var fips = this.getAttribute('data-fips');
-	      highlightCounty(fips);
+	      highlightCounty(fips, 'selected');
 
 	      chartTables.each(function(){
 	        this.show(fips, 'selected');
 	      });
 	    };
 
-	    var mouseMap = function (event) {
+	    var mouseMap = function () {
+	      event = event.type;
 	      var fips = this.getAttribute('data-fips');
+
 	      highlightCounty(fips, event);
+
+	      chartTables.each(function(){
+	        this.highlight(fips, event);
+	      });
 	    };
 
 	    chartRows.on('click.countyTable', toggleMap);
-	    chartRows.on('mouseover.countyTable', mouseMap, 'mouseover');
-	    chartRows.on('mouseout.countyTable', mouseMap, 'mouseleave');
+	    chartRows.on('mouseover.countyTable', mouseMap);
+	    chartRows.on('mouseout.countyTable', mouseMap);
 
 
 	    counties
@@ -13425,7 +13437,7 @@
 	      .on('mouseleave.county', function(){
 	        var that = this;
 	        setTimeout(function(){
-	          mouseTable(that, 'mouseleave');
+	          mouseTable(that, 'mouseout');
 	        }, 20);
 	      });
 	  };

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12656,13 +12656,13 @@
 
 	    rows
 	      .classed('selected', false)
-	      .filter(function(row) {
+	      .filter(function() {
 	        return this.getAttribute('data-fips') === fips;
 	      })
 	      .classed('selected', true)
 	      .select('[data-sentence]')
 	        .attr('aria-hidden', false);
-	  }
+	  };
 
 	  var highlight = function(fips, event) {
 	    var rows = d3.select(this).selectAll('tbody > tr');
@@ -12672,7 +12672,7 @@
 	    if (event !== 'mouseout') {
 	      rows
 	      .classed('mouseover', false)
-	      .filter(function(row) {
+	      .filter(function() {
 	        return this.getAttribute('data-fips') === fips;
 	      })
 	      .classed('mouseover', true)
@@ -13323,7 +13323,7 @@
 
 	    var moveToFront = function() {
 	      return this.each(function(){
-	        var child = this.parentNode.appendChild(this);
+	        this.parentNode.appendChild(this);
 	      });
 	    };
 
@@ -13359,7 +13359,7 @@
 	      counties.each(function(d, i){
 	        var county = d3.select(this);
 	        var numbers = typeof(county.attr('data-fips')) === 'number' ||
-	          typeof(fips) === 'number'
+	          typeof(fips) === 'number';
 	        var areEqual = numbers
 	          ? +county.attr('data-fips') === +fips
 	          : county.attr('data-fips') === fips;
@@ -13373,7 +13373,6 @@
 
 	    var toggleTable = function(context) {
 	      var context = context || this;
-	      var countyName = context.querySelector('title').textContent;
 	      var countyFIPS = context.getAttribute('data-fips');
 
 	      highlightCounty(countyFIPS, 'selected');
@@ -13384,19 +13383,18 @@
 
 	      chartTables.each(function(){
 	        this.show(countyFIPS, 'selected');
-	      })
+	      });
 	    };
 
 	    var mouseTable = function(context, event) {
-	      var context = context || this;
-	      var countyName = context.querySelector('title').textContent;
+	      context = context || this;
 	      var countyFIPS = context.getAttribute('data-fips');
 
 	      highlightCounty(countyFIPS, event);
 
 	      chartTables.each(function(){
 	        this.highlight(countyFIPS, event);
-	      })
+	      });
 	    };
 
 	    var toggleMap = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12648,18 +12648,34 @@
 
 	  var show = function(fips) {
 	    var rows = d3.select(this).selectAll('tbody > tr');
-	    rows.classed('selected', false);
 
-	    rows.selectAll('[data-sentence]').attr('aria-hidden', true);
+	    rows.select('[data-sentence]')
+	      .attr('aria-hidden', true);
 
-	    // show matching row
-	    rows.filter(function(row) {
-	      return this.getAttribute('data-fips') === fips;
-	    })
-	    .classed('selected', true)
-	    .select('[data-sentence]')
-	    .attr('aria-hidden', false);
+	    rows
+	      .classed('selected', false)
+	      .filter(function(row) {
+	        return this.getAttribute('data-fips') === fips;
+	      })
+	      .classed('selected', true)
+	      .select('[data-sentence]')
+	        .attr('aria-hidden', false);
+	  }
 
+	  var highlight = function(fips, event) {
+	    var rows = d3.select(this).selectAll('tbody > tr');
+	    rows
+	      .classed('mouseover', false);
+
+	    if (event !== 'mouseleave') {
+	      rows
+	      .classed('mouseover', false)
+	      .filter(function(row) {
+	        return this.getAttribute('data-fips') === fips;
+	      })
+	      .classed('mouseover', true)
+	        .attr('aria-hidden', false);
+	    }
 	  }
 
 	  var update = function() {
@@ -12826,6 +12842,8 @@
 	        setYear: {value: setYear},
 
 	        show: {value: show},
+
+	        highlight: {value: highlight},
 
 	        orient: {
 	          get: function() {
@@ -13301,11 +13319,27 @@
 	    var root = d3.select(this);
 	    var self = d3.select(this);
 
+	    var moveToFront = function() {
+	      return this.each(function(){
+	        var child = this.parentNode.appendChild(this);
+	      });
+	    };
+
+	    var moveToBack = function() {
+	      return this.each(function() {
+	        var firstChild = this.parentNode.firstChild;
+	        if (firstChild) {
+	          this.parentNode.insertBefore(this, firstChild);
+	        }
+	      });
+	    };
+
+
 	    var select = root.selectAll('select.chart-selector');
 	    var maps = root.selectAll('eiti-data-map');
 	    var mapToggles = maps.selectAll('button[is="aria-toggle"]');
 	    var mapTables = root.selectAll('.eiti-data-map-table');
-	    var counties = maps.selectAll('.county.feature')
+	    var counties = maps.selectAll('.county.feature');
 
 	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
 
@@ -13315,21 +13349,27 @@
 	      event = event || 'selected';
 	      counties.classed('mouseover', false);
 	      counties.classed(event, false);
+	      var unselectedCounties = counties.filter(function(){
+	        return !d3.select(this).classed('selected');
+	      })
+	      unselectedCounties.call(moveToBack);
 
 	      counties.each(function(d, i){
 	        var county = d3.select(this);
 	        if (+county.attr('data-fips') === +fips) {
 	          county.classed(event, true);
+
+	          county.call(moveToFront);
 	        }
 	      });
 	    };
 
-	    var toggleTable = function(d, i) {
+	    var toggleTable = function(context) {
+	      var context = context || this;
+	      var countyName = context.querySelector('title').textContent;
+	      var countyFIPS = context.getAttribute('data-fips');
 
-	      var countyName = this.querySelector('title').textContent;
-	      var countyFIPS = this.getAttribute('data-fips');
-
-	      highlightCounty(countyFIPS);
+	      highlightCounty(countyFIPS, 'selected');
 
 	      mapToggles.each(function(){
 	        this.expand();
@@ -13340,31 +13380,54 @@
 	      })
 	    };
 
+	    var mouseTable = function(context, event) {
+	      var context = context || this;
+	      var countyName = context.querySelector('title').textContent;
+	      var countyFIPS = context.getAttribute('data-fips');
+
+	      highlightCounty(countyFIPS, event);
+
+
+	      chartTables.each(function(){
+	        this.highlight(countyFIPS, event);
+	      })
+	    };
+
 	    var toggleMap = function() {
 	      var fips = this.getAttribute('data-fips');
-
 	      highlightCounty(fips);
 
 	      chartTables.each(function(){
-	        this.show(fips);
+	        this.show(fips, 'selected');
 	      });
 	    };
 
-	    var mouseoverMap = function () {
+	    var mouseMap = function (event) {
 	      var fips = this.getAttribute('data-fips');
-	      highlightCounty(fips, 'mouseover');
-	    };
-
-	    var mouseleaveMap = function () {
-	      var fips = this.getAttribute('data-fips');
-	      highlightCounty(fips, 'mouseleave');
+	      highlightCounty(fips, event);
 	    };
 
 	    chartRows.on('click.countyTable', toggleMap);
-	    chartRows.on('mouseover.countyTable', mouseoverMap);
-	    chartRows.on('mouseleave.countyTable', mouseleaveMap);
+	    chartRows.on('mouseover.countyTable', mouseMap, 'mouseover');
+	    chartRows.on('mouseout.countyTable', mouseMap, 'mouseleave');
 
-	    counties.on('click.county', toggleTable);
+
+	    counties
+	      .on('click.county', function(){
+	        toggleTable(this);
+	      })
+	      .on('mouseenter.county', function(){
+	        var that = this;
+	        setTimeout(function(){
+	          eiti.util.throttle(mouseTable(that, 'mouseover'), 200);
+	        }, 10);
+	      })
+	      .on('mouseleave.county', function(){
+	        var that = this;
+	        setTimeout(function(){
+	          mouseTable(that, 'mouseleave');
+	        }, 20);
+	      });
 	  };
 
 	  var detached = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13353,7 +13353,7 @@
 	      counties.classed(event, false);
 	      var unselectedCounties = counties.filter(function(){
 	        return !d3.select(this).classed('selected');
-	      })
+	      });
 	      unselectedCounties.call(moveToBack);
 
 	      counties.each(function(d, i){


### PR DESCRIPTION
[:sunglasses: PREVIEW MT](https://federalist.18f.gov/preview/18F/doi-extractives-data/map-colors/explore/MT)

[:sunglasses: PREVIEW gulf](https://federalist.18f.gov/preview/18F/doi-extractives-data/map-colors/offshore/gulf)

Changes proposed in this pull request:
- added the same template logic to the offshore area map template
- updated fips filtering so that the selection code supports non-numeric fips, such as `WGM`
- simplifies logic for select and hover states so that selection works both directions (map --> table, table --> map). Specifically, this involves adding new API method to `bar-chart-table.js` so that hover events and click events would register via distinct pathways.

Remaining issues: 
- Mouseout events on the county maps sometimes don't register. This means that occasionally, the light green highlight on the map and the highlighted table row remain when a user's cursor leaves the map. Unfortunately, this only happens _some_ of the time, making it especially annoying.

/cc @ericronne @shawnbot 
