### PR TITLE
Sliver o' 'zona

### DIFF
--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -33,10 +33,22 @@
     {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ include.state }}.svg{% endcapture %}
     {% capture offshore_svg %}{{ site.baseurl }}/maps/offshore/all.svg{% endcapture %}
     <g class="states features">
+      {% if page.neighbors %}
+        {% for neighbor in page.neighbors %}
+      <use xlink:href="{{ states_svg }}#state-{{ neighbor }}"></use>
+        {% endfor %}
+      {% else %}
       <use xlink:href="{{ states_svg }}#states"></use>
+      {% endif %}
     </g>
     <g class="states mesh">
+      {% if page.neighbors %}
+        {% for neighbor in page.neighbors %}
+      <use xlink:href="{{ states_svg }}#state-{{ neighbor }}"></use>
+        {% endfor %}
+      {% else %}
       <use xlink:href="{{ states_svg }}#states-mesh"></use>
+      {% endif %}
     </g>
 
     <g class="regions features">
@@ -86,7 +98,7 @@
         aria-controls="{{ include.toggle }}">
         <i class="icon icon-plus-sm"></i>
         {% if include.toggle_text %}
-          {{ include.toggle_text}}
+          {{ include.toggle_text }}
         {% else %}Show table{% endif %}
       </button>
     </h4>
@@ -99,7 +111,7 @@
       {{ include.caption }}
     </figcaption>
     <figcaption class="legend-no-data" aria-hidden="true">
-      There is no data for {{ region_name }} in <span data-year="{{ year }}" >{{ year}}</span>.
+      There is no data for {{ region_name }} in <span data-year="{{ year }}" >{{ year }}</span>.
       Select a new year to populate the map.
     </figcaption>
     <figcaption class="legend-withheld" aria-hidden="true">
@@ -115,7 +127,7 @@
         aria-controls="{{ include.toggle }}">
         <i class="icon icon-plus-sm"></i>
         {% if include.toggle_text %}
-          {{ include.toggle_text}}
+          {{ include.toggle_text }}
         {% else %}Show table{% endif %}
       </button>
     </h4>

--- a/_offshore_regions/alaska.md
+++ b/_offshore_regions/alaska.md
@@ -2,4 +2,10 @@
 id: alaska
 title: Alaska
 permalink: /offshore/alaska/
+
+# this triggers whitelisting of nearby states to render in county maps,
+# which solves the problem of Hawaii showing up on maps of Texas
+neighbors:
+- AK
+
 ---


### PR DESCRIPTION
Fixes issue(s) #1893 

There was _previously_ a sliver of Arizona that showed up on the offshore Alaska page.

[:sunglasses: Offshore Alaska before](https://federalist.18f.gov/preview/18F/doi-extractives-data/dev/offshore/alaska)

[:sunglasses: Offshore Alaska after](https://federalist.18f.gov/preview/18F/doi-extractives-data/whitelist-alaska/offshore/alaska)

Changes proposed in this pull request:
- updates offshore Alaska "county" template to support the `neighbors` attribute
- whitelists `AK` for alaska.md page file.

/cc @shawnbot @meiqimichelle 

