### PR TITLE
Fix path to company revenue data

### DIFF
--- a/js/lib/company-revenue.min.js
+++ b/js/lib/company-revenue.min.js
@@ -503,7 +503,7 @@
 
 	// globals d3, eiti, EITIBar
 	(function() {
-	  // 'use strict';
+	  'use strict';
 
 	  var root = d3.select('#companies');
 	  var filterToggle = root.select('button.toggle-filters');
@@ -557,7 +557,7 @@
 	  if (!year) {
 	    throw new Error('No year found in', root.node());
 	  }
-	  var dataUrl = eiti.data.path + 'company/revenue/' + year + '.tsv';
+	  var dataUrl = eiti.data.path + 'company-revenue/output/' + year + '.tsv';
 
 	  var model = eiti.explore.model(dataUrl)
 	    .transform(removeRevenueTypePrefix)

--- a/js/pages/company-revenue.js
+++ b/js/pages/company-revenue.js
@@ -1,6 +1,6 @@
 // globals d3, eiti, EITIBar
 (function() {
-  // 'use strict';
+  'use strict';
 
   var root = d3.select('#companies');
   var filterToggle = root.select('button.toggle-filters');
@@ -54,7 +54,7 @@
   if (!year) {
     throw new Error('No year found in', root.node());
   }
-  var dataUrl = eiti.data.path + 'company/revenue/' + year + '.tsv';
+  var dataUrl = eiti.data.path + 'company-revenue/output/' + year + '.tsv';
 
   var model = eiti.explore.model(dataUrl)
     .transform(removeRevenueTypePrefix)


### PR DESCRIPTION
This is a hot fix for broken paths in the company revenue JS, which I broke when I reorganized the files in 14bea69556f96d8af5ac5df7df6f03ba6ae59fb0. 😬 

I'm going to merge this now and keep working on #1830 in this branch.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/static-company-revenue/explore/federal-revenue-by-company/2015/)

You can see it broken [here](https://federalist.18f.gov/preview/18F/doi-extractives-data/dev/explore/federal-revenue-by-company/2015/).

Changes proposed in this pull request:
- Fix the path to the company revenue TSVs in the page JS.
- Generate a new browser build.

/cc @gemfarmer 