### PR TITLE
[WIP] Makes top of state pages look scrollable. We hope.

### DIFF
--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -1,6 +1,10 @@
-<section id="overview">
+<section class="state-pages-top">
 
   <section class="container">
+    
+    <div class="state-pages-ownership">
+      {% include location/section-ownership.html %}
+    </div>
 
     <!-- Includes the GDP percentage, then outputs employment percentage if it's over 2%.-->
     <p>

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -8,9 +8,6 @@
   {% assign __viewbox = site.data.viewboxes_cropped[state_id] %}
 
   <aside class="map-container" style="width: 100%;">
-    <aside class="wide">
-      {% include maps/federal_land_ownership_legend.html %}
-    </aside>
     <figure>
       <div class="svg-container county map-container wide"{% if __viewbox %}
         style="padding-bottom: {{ __viewbox | svg_viewbox_padding: _width }}%;"{% endif %}>
@@ -38,7 +35,10 @@
       </div>
 
     </figure>
-
+    
+    <aside class="wide" style="clear:both;">
+      {% include maps/federal_land_ownership_legend.html %}
+    </aside>
 
   </aside>
 </section>

--- a/_layouts/offshore-region.html
+++ b/_layouts/offshore-region.html
@@ -32,28 +32,23 @@ nav_items:
 
     <h1 id="title">{{ region_title }}</h1>
 
-    <div class="container-half">
+    <div class="container-left-9">
+      
       <section id="overview">
-        <section class="container">
+        <h2 class="state-page-overview">Overview</h2>
           <p>
             Unlike land (which can be owned by states, local governments, corporations, or private individuals), the waters and submerged lands of the {{ "Outer Continental Shelf" | term }} are entirely administered by the federal government. This means that all <a href="{{ site.baseurl }}/how-it-works/offshore-oil-gas/">offshore drilling</a> and <a href="{{ site.baseurl }}/how-it-works/offshore-renewables/">renewable energy generation</a> takes place in federal waters.
           </p>
-        </section>
       </section>
-    </div>
-  </section>
 
-  <section class="container">
-    <div class="container-left-9">
-
-    <section id="production">
+      <section id="production">
         <h2>Production</h2>
 
         {% include
           location/offshore-region-federal-production.html
           region_name=region_name
         %}
-    </section>
+      </section>
 
       {% include location/offshore-region-revenue.html %}
 

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -2,7 +2,7 @@
 layout: default
 nav_items:
   - name: overview
-    title: Overview
+    title: Top
   - name: production
     title: Production
     subnav_items:
@@ -82,19 +82,15 @@ nav_items:
       /
     </div>
     <h1 id="title">{{ state_name }}</h1>
-
-    <div class="container-half">
-
-
-      {% include location/section-overview.html %}
-    </div>
-    <div class="container-right-5 container-shift-1">
-      {% include location/section-ownership.html %}
-    </div>
-  </section>
-
-  <section class="container">
+    
     <div class="container-left-9">
+      
+      <section id="overview">
+        <h2 class="state-page-overview">Overview</h2>
+        
+        {% include location/section-overview.html %}
+        
+      </section>
 
       <section id="production">
         <h2>Production</h2>

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -3,7 +3,7 @@
 
   p + section,
   section + section,
-  h2 + section,
+  h2 + section:not(.state-pages-top),
   p + h4 {
     margin-top: -0.75rem; //to compensate for margin from preceding selectors
   }
@@ -11,6 +11,10 @@
   h2:not(.ribbon-card-top-text-header) {
     @include h2-bar;
     padding-top: 6rem;
+
+    &.state-page-overview {
+      padding-top: 0;
+    }
   }
 
   h3:not(.chart-title):not(.state-page-nav-title),
@@ -35,8 +39,9 @@
   }
 
   .title-land-ownership:not(.chart-title):not(.state-page-nav-title) {
-    border-bottom: 1px solid $neutral-gray;
-    margin-bottom: $base-padding-lite * 2;
+    border-bottom: none;
+    font-size: 1rem;
+    margin-bottom: 0;
   }
 
   hr {
@@ -102,5 +107,10 @@
     &:active {
       text-decoration: underline;
     }
+  }
+  
+  .state-pages-ownership {
+    float: right;
+    margin-left: 20px;
   }
 }

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -108,7 +108,7 @@
       text-decoration: underline;
     }
   }
-  
+
   .state-pages-ownership {
     float: right;
     margin-left: 20px;

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -5,7 +5,7 @@
   border-bottom: 1px solid $mid-gray;
   display: flex;
   justify-content: flex-start;
-  margin: 4rem 0 0 0;
+  margin: 0;
   position: relative;
 
   svg.map {

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -83,6 +83,6 @@
   }
 }
 
-#national .state-page-nav-title {
-  margin: 8.6em 0 0 0;
+.national-page .state-page-nav-title {
+  margin: 8.6em 0 0;
 }

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -82,3 +82,7 @@
     visibility: hidden;
   }
 }
+
+#national .state-page-nav-title {
+  margin: 8.6em 0 0 0;
+}

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -34,6 +34,12 @@ data-map {
         @include omega();
       }
     }
+    
+    .map-container {
+      background-color: $gray-lighter;
+      border-top: 10px solid $gray-lighter;
+      margin-bottom: 10px;
+    }
 
     .legend-container {
       @include span-columns(4);
@@ -150,11 +156,6 @@ eiti-data-map {
   height: 215px;
   padding: 0;
   width: 200px;
-
-  // .swatch {
-  //   stroke: $neutral-gray;
-  //   stroke-width: 1;
-  // }
 
   .cell text {
     @include font-size(3 / 4);

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -34,7 +34,7 @@ data-map {
         @include omega();
       }
     }
-    
+
     .map-container {
       background-color: $gray-lighter;
       border-top: 10px solid $gray-lighter;

--- a/explore/index.html
+++ b/explore/index.html
@@ -61,6 +61,9 @@ nav_items:
             no_outline=true
           %}
         </figure>
+        <aside class="wide">
+          {% include maps/federal_land_ownership_legend.html %}
+        </aside>
       </div>
       <div class="container-right-4 ribbon-card-column ribbon-card state_pages-ribbon-card">
         <figure class="ribbon-card-top">

--- a/explore/index.html
+++ b/explore/index.html
@@ -47,7 +47,7 @@ nav_items:
 {% assign steps=9 %}
 
 
-<main id="national" class="layout-state-pages">
+<main id="national" class="layout-state-pages national-page">
 
   <section  id="title" class="slab-delta">
     <div class="container-page-wrapper landing-section_top ribbon ribbon-column">

--- a/explore/index.html
+++ b/explore/index.html
@@ -7,7 +7,7 @@ national_page: true
 selector: location
 nav_items:
   - name: title
-    title: Overview
+    title: Top
   - name: production
     title: Production
     subnav_items:
@@ -49,10 +49,10 @@ nav_items:
 
 <main id="national" class="layout-state-pages">
 
-  <section class="slab-delta">
+  <section  id="title" class="slab-delta">
     <div class="container-page-wrapper landing-section_top ribbon ribbon-column">
       <div class="container-left-8 ribbon-hero ribbon-hero-column">
-        <h1 id="title">Explore data</h1>
+        <h1>Explore data</h1>
         <figure is="data-map" color-scheme="Reds" steps="9">
           {%
             include state-map.html


### PR DESCRIPTION
For #1612

Also fixes #1868 by double-checking that all nav items say the same thing for the first entry (top) and that they all anchor link somewhere reasonable.

Also also adds legend to explore home.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/will-they-scroll/explore)

<img width="1030" alt="screenshot 2016-09-13 21 26 56" src="https://cloud.githubusercontent.com/assets/4827522/18500043/f8615ba4-79f8-11e6-9b2f-8de26626158d.png">

@gemfarmer is there a way to make the padding under the states smaller (now that there's a background color, this is more obvious)

/cc @ericronne 

