### PR TITLE
Map tooltips

### DIFF
--- a/_includes/maps/offshore-regions.html
+++ b/_includes/maps/offshore-regions.html
@@ -4,7 +4,8 @@
   <g class="state offshore-area feature" fill><!--- FIXME: nix fill attribute -->
     <title is="eiti-tooltip"
            desc="{{ region.title }}"
-           alt="{{ region.title }}"></title>
+           alt="{{ region.title }}"
+           href="{% if include.href %}{{ site.baseurl }}{{ include.href | format_url: region }}{% endif %}">{{ state.title }}</title>
     <use xlink:href="{{ _svg_path }}#{{ region.id }}"  aria-label="{{ region.title }}"></use>
   </g>
   {% if include.href %}</a>{% endif %}

--- a/_includes/maps/offshore-regions.html
+++ b/_includes/maps/offshore-regions.html
@@ -4,8 +4,7 @@
   <g class="state offshore-area feature" fill><!--- FIXME: nix fill attribute -->
     <title is="eiti-tooltip"
            desc="{{ region.title }}"
-           alt="{{ region.title }}"
-           href="{% if include.href %}{{ site.baseurl }}{{ include.href | format_url: region }}{% endif %}">{{ state.title }}</title>
+           alt="{{ region.title }}">{{ state.title }}</title>
     <use xlink:href="{{ _svg_path }}#{{ region.id }}"  aria-label="{{ region.title }}"></use>
   </g>
   {% if include.href %}</a>{% endif %}

--- a/_includes/maps/offshore-regions.html
+++ b/_includes/maps/offshore-regions.html
@@ -2,8 +2,7 @@
 {% for region in site.offshore_regions %}
   {% if include.href %}<a xlink:href="{{ site.baseurl }}{{ include.href | format_url: region }}">{% endif %}
   <g class="state offshore-area feature" fill><!--- FIXME: nix fill attribute -->
-    <title is="eiti-tooltip"
-           desc="{{ region.title }}"
+    <title desc="{{ region.title }}"
            alt="{{ region.title }}">{{ state.title }}</title>
     <use xlink:href="{{ _svg_path }}#{{ region.id }}"  aria-label="{{ region.title }}"></use>
   </g>

--- a/_includes/maps/offshore-regions.html
+++ b/_includes/maps/offshore-regions.html
@@ -2,8 +2,10 @@
 {% for region in site.offshore_regions %}
   {% if include.href %}<a xlink:href="{{ site.baseurl }}{{ include.href | format_url: region }}">{% endif %}
   <g class="state offshore-area feature" fill><!--- FIXME: nix fill attribute -->
-    <title>{{ region.title }}</title>
-    <use xlink:href="{{ _svg_path }}#{{ region.id }}"></use>
+    <title is="eiti-tooltip"
+           desc="{{ region.title }}"
+           alt="{{ region.title }}"></title>
+    <use xlink:href="{{ _svg_path }}#{{ region.id }}"  aria-label="{{ region.title }}"></use>
   </g>
   {% if include.href %}</a>{% endif %}
   <g class="states mesh">

--- a/_includes/maps/state-areas.html
+++ b/_includes/maps/state-areas.html
@@ -9,7 +9,8 @@
     data-value='{{ state_value | default: 0 | jsonify }}'{% endif %}>
     <title is="eiti-tooltip"
            desc="{{ state.title }}"
-           alt="{{ state.title }}"></title>
+           alt="{{ state.title }}"
+           href="{% if include.href %}{{ site.baseurl }}{{ include.href | format_url: state }}{% endif %}">{{ state.title }}</title>
     <use xlink:href="{{ _svg_path }}#state-{{ state.id }}" aria-label="{{ state.title }}"></use>
   </g>
 

--- a/_includes/maps/state-areas.html
+++ b/_includes/maps/state-areas.html
@@ -9,8 +9,7 @@
     data-value='{{ state_value | default: 0 | jsonify }}'{% endif %}>
     <title is="eiti-tooltip"
            desc="{{ state.title }}"
-           alt="{{ state.title }}"
-           href="{% if include.href %}{{ site.baseurl }}{{ include.href | format_url: state }}{% endif %}">{{ state.title }}</title>
+           alt="{{ state.title }}">{{ state.title }}</title>
     <use xlink:href="{{ _svg_path }}#state-{{ state.id }}" aria-label="{{ state.title }}"></use>
   </g>
 

--- a/_includes/maps/state-areas.html
+++ b/_includes/maps/state-areas.html
@@ -7,9 +7,12 @@
   <g class="state feature" {% if include.value %}
     {% assign state_value = include.states[state.id] | get: include.value %}
     data-value='{{ state_value | default: 0 | jsonify }}'{% endif %}>
-    <title>{{ state.title }}: {{ value }}</title>
-    <use xlink:href="{{ _svg_path }}#state-{{ state.id }}"></use>
+    <title is="eiti-tooltip"
+           desc="{{ state.title }}"
+           alt="{{ state.title }}"></title>
+    <use xlink:href="{{ _svg_path }}#state-{{ state.id }}" aria-label="{{ state.title }}"></use>
   </g>
+
 {% if include.href %}</a>{% endif %}
 {% endfor %}
 

--- a/_includes/maps/state-areas.html
+++ b/_includes/maps/state-areas.html
@@ -7,8 +7,7 @@
   <g class="state feature" {% if include.value %}
     {% assign state_value = include.states[state.id] | get: include.value %}
     data-value='{{ state_value | default: 0 | jsonify }}'{% endif %}>
-    <title is="eiti-tooltip"
-           desc="{{ state.title }}"
+    <title desc="{{ state.title }}"
            alt="{{ state.title }}">{{ state.title }}</title>
     <use xlink:href="{{ _svg_path }}#state-{{ state.id }}" aria-label="{{ state.title }}"></use>
   </g>

--- a/_includes/state-map.html
+++ b/_includes/state-map.html
@@ -30,7 +30,4 @@
       {% include case-studies/_points-of-interest.html %}
     {% endif %}
   </svg>
-  <div is="eiti-tooltip"
-       description="{{ state.title }}"
-       alt="{{ state.title }}"></div>
 </div>

--- a/_includes/state-map.html
+++ b/_includes/state-map.html
@@ -2,7 +2,7 @@
 {% assign states_svg = '/maps/states/all.svg' %}
 {% assign offshore_svg = '/maps/offshore/all.svg' %}
 
-<div class="state svg-container map-container wide"{% if _viewbox %} style="padding-bottom: {{ _viewbox | svg_viewbox_padding }}%;"{% endif %}>
+<div is="eiti-tooltip-wrapper" class="state svg-container map-container wide"{% if _viewbox %} style="padding-bottom: {{ _viewbox | svg_viewbox_padding }}%;"{% endif %}>
   <svg class="states map{% if include.case_studies %} case_studies {% endif %}{% if include.ownership %} ownership {% endif %}{% if include.no_outline %} no-outlines {% endif %}"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
 
     {% if include.offshore_regions != false %}

--- a/_includes/state-map.html
+++ b/_includes/state-map.html
@@ -29,5 +29,6 @@
     {% if include.case_studies %}
       {% include case-studies/_points-of-interest.html %}
     {% endif %}
+
   </svg>
 </div>

--- a/_includes/state-map.html
+++ b/_includes/state-map.html
@@ -29,6 +29,8 @@
     {% if include.case_studies %}
       {% include case-studies/_points-of-interest.html %}
     {% endif %}
-
   </svg>
+  <div is="eiti-tooltip"
+       description="{{ state.title }}"
+       alt="{{ state.title }}"></div>
 </div>

--- a/_sass/components/_all.scss
+++ b/_sass/components/_all.scss
@@ -21,3 +21,4 @@
 @import 'flowchart';
 @import 'tabs';
 @import 'sticky';
+@import 'tooltip';

--- a/_sass/components/_tooltip.scss
+++ b/_sass/components/_tooltip.scss
@@ -1,11 +1,11 @@
 .eiti-tooltip {
   background: $white;
   border: 2px solid $greenest-land;
+  max-width: 300px;
   padding: $base-padding-lite;
   padding-bottom: ($base-padding-lite / 2);
   padding-top: 0.23em; // to account for verticality of text
   position: absolute;
-  max-width: 300px;
   z-index: 9000;
 
   p {

--- a/_sass/components/_tooltip.scss
+++ b/_sass/components/_tooltip.scss
@@ -11,7 +11,7 @@
   p {
     @include heading('para-sm');
 
-    color: $green-land;
+    color: $greenest-land;
     font-weight: $weight-bold;
     margin: 0;
   }

--- a/_sass/components/_tooltip.scss
+++ b/_sass/components/_tooltip.scss
@@ -1,16 +1,18 @@
 .eiti-tooltip {
-	position: absolute;
-	z-index: 9000;
-	background: $white;
-	border: 2px solid $greenest-land;
-	padding: $base-padding-lite;
-	max-width: 300px;
+  position: absolute;
+  z-index: 9000;
+  background: $white;
+  border: 2px solid $greenest-land;
+  padding: $base-padding-lite;
+  padding-bottom: ($base-padding-lite / 2);
+  padding-top: 0.23em; // to account for verticality of text
+  max-width: 300px;
 
-	p {
-		@include heading('para-md');
+  p {
+    @include heading('para-sm');
 
-		font-weight: $weight-bold;
-		color: $green-land;
-		margin: 0;
-	}
+    font-weight: $weight-bold;
+    color: $green-land;
+    margin: 0;
+  }
 }

--- a/_sass/components/_tooltip.scss
+++ b/_sass/components/_tooltip.scss
@@ -1,18 +1,18 @@
 .eiti-tooltip {
-  position: absolute;
-  z-index: 9000;
   background: $white;
   border: 2px solid $greenest-land;
   padding: $base-padding-lite;
   padding-bottom: ($base-padding-lite / 2);
   padding-top: 0.23em; // to account for verticality of text
+  position: absolute;
   max-width: 300px;
+  z-index: 9000;
 
   p {
     @include heading('para-sm');
 
-    font-weight: $weight-bold;
     color: $green-land;
+    font-weight: $weight-bold;
     margin: 0;
   }
 }

--- a/_sass/components/_tooltip.scss
+++ b/_sass/components/_tooltip.scss
@@ -1,0 +1,16 @@
+.eiti-tooltip {
+	position: absolute;
+	z-index: 9000;
+	background: $white;
+	border: 2px solid $greenest-land;
+	padding: $base-padding-lite;
+	max-width: 300px;
+
+	p {
+		@include heading('para-md');
+
+		font-weight: $weight-bold;
+		color: $green-land;
+		margin: 0;
+	}
+}

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -27,12 +27,16 @@ svg.map {
 
   .feature.offshore-area use {
     fill: $greenest-land;
+
+    &:hover,
+    &:active,
+    &:focus {
+      fill: darken($greenest-land, 5%);
+    }
   }
 
   .feature:not([fill]) use {
     fill-opacity: 0;
-
-    @include transition('fill-opacity', 0.3s);
 
     &:hover,
     &:active,

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -31,6 +31,14 @@ svg.map {
 
   .feature:not([fill]) use {
     fill-opacity: 0;
+
+    @include transition('fill-opacity', 0.3s);
+
+    &:hover,
+    &:active,
+    &:focus {
+      fill-opacity: 0.3;
+    }
   }
 
   .feature[fill] use {

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -1,13 +1,5 @@
 (function(exports) {
 
-  var findParentSVG = function (childObj) {
-    var obj = childObj.parentNode;
-    while(obj.tagName !== 'svg') {
-      obj = obj.parentNode;
-    }
-    return obj;
-  };
-
   var depixelize = function(value) {
     if (value.indexOf('px') > -1) {
       return +value.substr(0, value.length - 2);
@@ -26,25 +18,24 @@
 
   var attached = function() {
     var self = d3.select(this);
-    var svg = d3.select(findParentSVG(this));
-    var svgParent = d3.select(findParentSVG(this).parentElement);
-    var parent = d3.select(this.parentElement).select('use');
+    var svg = d3.select('svg');
+    var svgParent = self;
+    var titles = self.selectAll('title');
+    var tiles = self.selectAll('use');
 
     var tooltip,
       tooltipText;
 
     var init = function(initialize) {
-      tooltip = svgParent.select('.eiti-tooltip');
+      tooltip = self.select('.eiti-tooltip');
 
       if (tooltip.empty()) {
-        svgParent.append('div')
+        tooltip = self.append('div')
           .classed('eiti-tooltip', true);
       }
 
-      tooltip.attr('aria-label', function(){
-          return self.attr('alt');
-        })
-        .attr('aria-hidden', false);
+      tooltip
+        .attr('aria-hidden', true);
 
       tooltipText = tooltip.select('p');
 
@@ -54,22 +45,29 @@
 
       // clear <title> text
       // if no javascript runs, <title> will serve as the tooltip
-      self.text('');
-
-      if (initialize) {
-        hideTooltip(tooltip);
-      }
+      // otherwise, clear it so that it doesn't interfere with
+      // this tooltip
+      titles.text('');
     };
 
     var update = function() {
+      var event = event || d3.event || window.event;
+      var elem = event.target || event.srcElement;
+
+      var parentElement = d3.select(elem.parentElement);
+      var title = parentElement.select('title');
 
       init();
 
       tooltipText.text(function(){
-        return self.attr('desc');
+        return title.attr('desc');
       });
 
       tooltip
+        .attr('aria-hidden', false)
+        .attr('aria-label', function(){
+          return title.attr('alt');
+        })
         .style('left', function() {
           var tooltipWidth = depixelize(tooltip.style('width'));
           var svgWidth = depixelize(svg.style('width'));
@@ -93,25 +91,26 @@
     };
 
     var hide = function () {
-      if (event.fromElement.nodeName === 'svg') {
-        var tooltip = svgParent.select('.eiti-tooltip');
+      var event = event || window.event;
+      var elem = event.target || event.srcElement;
+      if (elem.nodeName === 'svg') {
+        var tooltip = self.select('.eiti-tooltip');
         hideTooltip(tooltip);
       }
     };
 
     init(this);
 
-    parent.on('mouseover', update);
+    tiles.on('mouseover', update);
     svg.on('mouseout', hide);
   };
 
-  var detached = function() {
-  };
+  var detached = function() { };
 
-  exports.EITITooltip = document.registerElement('eiti-tooltip', {
-    extends: 'title',
+  exports.EITITooltipWrapper = document.registerElement('eiti-tooltip-wrapper', {
+    extends: 'div',
     prototype: Object.create(
-      SVGElement.prototype,
+      HTMLElement.prototype,
       {
         attachedCallback: {value: attached},
         detachdCallback: {value: detached}

--- a/js/components/eiti-tooltip.js
+++ b/js/components/eiti-tooltip.js
@@ -20,6 +20,10 @@
     return value + 'px';
   }
 
+  var hideTooltip = function (tooltip) {
+    tooltip.attr('aria-hidden', true);
+  }
+
   var attached = function() {
     var root = d3.select(this);
     var self = d3.select(this);
@@ -27,64 +31,66 @@
     var svgParent = d3.select(findParentSVG(this).parentElement);
     var parent = d3.select(this.parentElement).select('use');
 
+    var tooltip,
+      tooltipText;
 
-    var hideTooltip = function (tooltip) {
-      tooltip.attr('aria-hidden', true);
-    }
-
-    var update = function() {
-      var delay = 50;
-
-      var tooltip = svgParent.select('.eiti-tooltip');
+    var init = function(initialize) {
+      tooltip = svgParent.select('.eiti-tooltip');
 
       if (tooltip.empty()) {
         svgParent.append('div')
-        .classed('eiti-tooltip', true)
+          .classed('eiti-tooltip', true);
       }
 
       tooltip.attr('aria-label', function(){
           return self.attr('alt');
         })
-        .attr('aria-hidden', false)
-        .text('')
-        .transition()
-        .delay(delay);
+        .attr('aria-hidden', false);
 
-      var tooltipText = tooltip.select('p');
+      tooltipText = tooltip.select('p');
 
       if (tooltipText.empty()) {
-        tooltipText = tooltip.append('p')
+        tooltipText = tooltip.append('p');
       }
+
+      // clear <title> text
+      // if no javascript runs, <title> will serve as the tooltip
+      self.text('');
+
+      if (initialize) {
+        hideTooltip(tooltip);
+      }
+    }
+
+    var update = function() {
+
+      init();
 
       tooltipText.text(function(){
         return self.attr('desc');
       });
 
-      tooltip.style('left', function() {
-        var tooltipWidth = depixelize(tooltip.style('width'));
-        var svgWidth = depixelize(svg.style('width'));
+      tooltip
+        .style('left', function() {
+          var tooltipWidth = depixelize(tooltip.style('width'));
+          var svgWidth = depixelize(svg.style('width'));
 
-        if (svgWidth <= tooltipWidth + event.layerX) {
-          return pixelize(event.layerX - tooltipWidth);
-        } else {
-          return pixelize(event.layerX);
-        }
-      })
-      .style('top', function() {
-        var tooltipHeight = depixelize(tooltip.style('height'));
-        var svgHeight = depixelize(svg.style('height'));
+          if (svgWidth <= tooltipWidth + event.layerX) {
+            return pixelize(event.layerX - tooltipWidth);
+          } else {
+            return pixelize(event.layerX);
+          }
+        })
+        .style('top', function() {
+          var tooltipHeight = depixelize(tooltip.style('height'));
+          var svgHeight = depixelize(svg.style('height'));
 
-        if (svgHeight <= tooltipHeight + event.layerY) {
-          return pixelize(event.layerY - tooltipHeight);
-        } else {
-          return pixelize(event.layerY);
-        }
-      });
-
-      // hide automatically after 5 seconds
-      setTimeout(function() {
-        hideTooltip(tooltip);
-      }, 5000);
+          if (svgHeight <= tooltipHeight + event.layerY) {
+            return pixelize(event.layerY - tooltipHeight);
+          } else {
+            return pixelize(event.layerY);
+          }
+        });
     };
 
     var hide = function () {
@@ -93,6 +99,8 @@
         hideTooltip(tooltip);
       }
     }
+
+    init(this);
 
     parent.on('mouseover', update);
     svg.on('mouseout', hide);

--- a/js/components/eiti-tooltip.js
+++ b/js/components/eiti-tooltip.js
@@ -65,14 +65,26 @@
         var svgWidth = depixelize(svg.style('width'));
 
         if (svgWidth <= tooltipWidth + event.layerX) {
-          return pixelize(event.layerX - tooltipWidth)
+          return pixelize(event.layerX - tooltipWidth);
         } else {
           return pixelize(event.layerX);
         }
       })
       .style('top', function() {
-        return pixelize(event.layerY);
+        var tooltipHeight = depixelize(tooltip.style('height'));
+        var svgHeight = depixelize(svg.style('height'));
+
+        if (svgHeight <= tooltipHeight + event.layerY) {
+          return pixelize(event.layerY - tooltipHeight);
+        } else {
+          return pixelize(event.layerY);
+        }
       });
+
+      // hide automatically after 5 seconds
+      setTimeout(function() {
+        hideTooltip(tooltip);
+      }, 5000);
     };
 
     var hide = function () {

--- a/js/components/eiti-tooltip.js
+++ b/js/components/eiti-tooltip.js
@@ -8,6 +8,18 @@
     return obj;
   }
 
+  var depixelize = function(value) {
+    if (value.indexOf('px') > -1) {
+      return +value.substr(0, value.length - 2);
+    } else {
+      return value;
+    }
+  }
+
+  var pixelize = function(value) {
+    return value + 'px';
+  }
+
   var attached = function() {
     var root = d3.select(this);
     var self = d3.select(this);
@@ -15,13 +27,13 @@
     var svgParent = d3.select(findParentSVG(this).parentElement);
     var parent = d3.select(this.parentElement).select('use');
 
+
     var hideTooltip = function (tooltip) {
       tooltip.attr('aria-hidden', true);
     }
 
     var update = function() {
-      console.log(event)
-      var delay = 200;
+      var delay = 50;
 
       var tooltip = svgParent.select('.eiti-tooltip');
 
@@ -34,41 +46,44 @@
           return self.attr('alt');
         })
         .attr('aria-hidden', false)
+        .text('')
         .transition()
-        .delay(delay)
-        .style('left', function() {
-          return event.layerX + 'px';
-        })
-        .style('top', function() {
-          return event.layerY + 'px';
-        })
+        .delay(delay);
 
       var tooltipText = tooltip.select('p');
 
       if (tooltipText.empty()) {
-        tooltipText = tooltip
-          .append('p')
+        tooltipText = tooltip.append('p')
       }
 
       tooltipText.text(function(){
-        console.log(self)
         return self.attr('desc');
       });
 
-      // setTimeout(function() {
-      //   hideTooltip(tooltip);
-      // }, 5000);
-    }
+      tooltip.style('left', function() {
+        var tooltipWidth = depixelize(tooltip.style('width'));
+        var svgWidth = depixelize(svg.style('width'));
 
+        if (svgWidth <= tooltipWidth + event.layerX) {
+          return pixelize(event.layerX - tooltipWidth)
+        } else {
+          return pixelize(event.layerX);
+        }
+      })
+      .style('top', function() {
+        return pixelize(event.layerY);
+      });
+    };
 
     var hide = function () {
-      var tooltip = self.select('.tooltip');
-      hideTooltip(tooltip);
+      if (event.fromElement.nodeName === 'svg') {
+        var tooltip = svgParent.select('.eiti-tooltip');
+        hideTooltip(tooltip);
+      }
     }
 
     parent.on('mouseover', update);
-
-    // svg.on('mouseleave', hide);
+    svg.on('mouseout', hide);
   };
 
   var detached = function() {

--- a/js/components/eiti-tooltip.js
+++ b/js/components/eiti-tooltip.js
@@ -6,7 +6,7 @@
       obj = obj.parentNode;
     }
     return obj;
-  }
+  };
 
   var depixelize = function(value) {
     if (value.indexOf('px') > -1) {
@@ -14,20 +14,19 @@
     } else {
       return value;
     }
-  }
+  };
 
   var pixelize = function(value) {
     return value + 'px';
-  }
+  };
 
   var hideTooltip = function (tooltip) {
     tooltip.attr('aria-hidden', true);
-  }
+  };
 
   var attached = function() {
     var root = d3.select(this);
-    var self = d3.select(this);
-    var svg = d3.select(findParentSVG(this))
+    var svg = d3.select(findParentSVG(this));
     var svgParent = d3.select(findParentSVG(this).parentElement);
     var parent = d3.select(this.parentElement).select('use');
 
@@ -60,7 +59,7 @@
       if (initialize) {
         hideTooltip(tooltip);
       }
-    }
+    };
 
     var update = function() {
 
@@ -98,7 +97,7 @@
         var tooltip = svgParent.select('.eiti-tooltip');
         hideTooltip(tooltip);
       }
-    }
+    };
 
     init(this);
 
@@ -118,7 +117,7 @@
         detachdCallback: {value: detached}
       }
     )
-  })
+  });
 
 })(this);
 

--- a/js/components/eiti-tooltip.js
+++ b/js/components/eiti-tooltip.js
@@ -25,7 +25,7 @@
   };
 
   var attached = function() {
-    var root = d3.select(this);
+    var self = d3.select(this);
     var svg = d3.select(findParentSVG(this));
     var svgParent = d3.select(findParentSVG(this).parentElement);
     var parent = d3.select(this.parentElement).select('use');

--- a/js/components/eiti-tooltip.js
+++ b/js/components/eiti-tooltip.js
@@ -1,0 +1,89 @@
+(function(exports) {
+
+  var findParentSVG = function (childObj) {
+    var obj = childObj.parentNode;
+    while(obj.tagName !== 'svg') {
+      obj = obj.parentNode;
+    }
+    return obj;
+  }
+
+  var attached = function() {
+    var root = d3.select(this);
+    var self = d3.select(this);
+    var svg = d3.select(findParentSVG(this))
+    var svgParent = d3.select(findParentSVG(this).parentElement);
+    var parent = d3.select(this.parentElement).select('use');
+
+    var hideTooltip = function (tooltip) {
+      tooltip.attr('aria-hidden', true);
+    }
+
+    var update = function() {
+      console.log(event)
+      var delay = 200;
+
+      var tooltip = svgParent.select('.eiti-tooltip');
+
+      if (tooltip.empty()) {
+        svgParent.append('div')
+        .classed('eiti-tooltip', true)
+      }
+
+      tooltip.attr('aria-label', function(){
+          return self.attr('alt');
+        })
+        .attr('aria-hidden', false)
+        .transition()
+        .delay(delay)
+        .style('left', function() {
+          return event.layerX + 'px';
+        })
+        .style('top', function() {
+          return event.layerY + 'px';
+        })
+
+      var tooltipText = tooltip.select('p');
+
+      if (tooltipText.empty()) {
+        tooltipText = tooltip
+          .append('p')
+      }
+
+      tooltipText.text(function(){
+        console.log(self)
+        return self.attr('desc');
+      });
+
+      // setTimeout(function() {
+      //   hideTooltip(tooltip);
+      // }, 5000);
+    }
+
+
+    var hide = function () {
+      var tooltip = self.select('.tooltip');
+      hideTooltip(tooltip);
+    }
+
+    parent.on('mouseover', update);
+
+    // svg.on('mouseleave', hide);
+  };
+
+  var detached = function() {
+  };
+
+  exports.EITITooltip = document.registerElement('eiti-tooltip', {
+    extends: 'title',
+    prototype: Object.create(
+      SVGElement.prototype,
+      {
+        attachedCallback: {value: attached},
+        detachdCallback: {value: detached}
+      }
+    )
+  })
+
+})(this);
+

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -221,6 +221,10 @@
 	    return value + 'px';
 	  }
 
+	  var hideTooltip = function (tooltip) {
+	    tooltip.attr('aria-hidden', true);
+	  }
+
 	  var attached = function() {
 	    var root = d3.select(this);
 	    var self = d3.select(this);
@@ -228,64 +232,66 @@
 	    var svgParent = d3.select(findParentSVG(this).parentElement);
 	    var parent = d3.select(this.parentElement).select('use');
 
+	    var tooltip,
+	      tooltipText;
 
-	    var hideTooltip = function (tooltip) {
-	      tooltip.attr('aria-hidden', true);
-	    }
-
-	    var update = function() {
-	      var delay = 50;
-
-	      var tooltip = svgParent.select('.eiti-tooltip');
+	    var init = function(initialize) {
+	      tooltip = svgParent.select('.eiti-tooltip');
 
 	      if (tooltip.empty()) {
 	        svgParent.append('div')
-	        .classed('eiti-tooltip', true)
+	          .classed('eiti-tooltip', true);
 	      }
 
 	      tooltip.attr('aria-label', function(){
 	          return self.attr('alt');
 	        })
-	        .attr('aria-hidden', false)
-	        .text('')
-	        .transition()
-	        .delay(delay);
+	        .attr('aria-hidden', false);
 
-	      var tooltipText = tooltip.select('p');
+	      tooltipText = tooltip.select('p');
 
 	      if (tooltipText.empty()) {
-	        tooltipText = tooltip.append('p')
+	        tooltipText = tooltip.append('p');
 	      }
+
+	      // clear <title> text
+	      // if no javascript runs, <title> will serve as the tooltip
+	      self.text('');
+
+	      if (initialize) {
+	        hideTooltip(tooltip);
+	      }
+	    }
+
+	    var update = function() {
+
+	      init();
 
 	      tooltipText.text(function(){
 	        return self.attr('desc');
 	      });
 
-	      tooltip.style('left', function() {
-	        var tooltipWidth = depixelize(tooltip.style('width'));
-	        var svgWidth = depixelize(svg.style('width'));
+	      tooltip
+	        .style('left', function() {
+	          var tooltipWidth = depixelize(tooltip.style('width'));
+	          var svgWidth = depixelize(svg.style('width'));
 
-	        if (svgWidth <= tooltipWidth + event.layerX) {
-	          return pixelize(event.layerX - tooltipWidth);
-	        } else {
-	          return pixelize(event.layerX);
-	        }
-	      })
-	      .style('top', function() {
-	        var tooltipHeight = depixelize(tooltip.style('height'));
-	        var svgHeight = depixelize(svg.style('height'));
+	          if (svgWidth <= tooltipWidth + event.layerX) {
+	            return pixelize(event.layerX - tooltipWidth);
+	          } else {
+	            return pixelize(event.layerX);
+	          }
+	        })
+	        .style('top', function() {
+	          var tooltipHeight = depixelize(tooltip.style('height'));
+	          var svgHeight = depixelize(svg.style('height'));
 
-	        if (svgHeight <= tooltipHeight + event.layerY) {
-	          return pixelize(event.layerY - tooltipHeight);
-	        } else {
-	          return pixelize(event.layerY);
-	        }
-	      });
-
-	      // hide automatically after 5 seconds
-	      setTimeout(function() {
-	        hideTooltip(tooltip);
-	      }, 5000);
+	          if (svgHeight <= tooltipHeight + event.layerY) {
+	            return pixelize(event.layerY - tooltipHeight);
+	          } else {
+	            return pixelize(event.layerY);
+	          }
+	        });
 	    };
 
 	    var hide = function () {
@@ -294,6 +300,8 @@
 	        hideTooltip(tooltip);
 	      }
 	    }
+
+	    init(this);
 
 	    parent.on('mouseover', update);
 	    svg.on('mouseout', hide);

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -49,7 +49,7 @@
 	  'use strict';
 
 	  __webpack_require__(7);
-	  __webpack_require__(8);
+	  __webpack_require__(41);
 
 	})(window);
 
@@ -196,18 +196,10 @@
 
 /***/ },
 
-/***/ 8:
+/***/ 41:
 /***/ function(module, exports) {
 
 	(function(exports) {
-
-	  var findParentSVG = function (childObj) {
-	    var obj = childObj.parentNode;
-	    while(obj.tagName !== 'svg') {
-	      obj = obj.parentNode;
-	    }
-	    return obj;
-	  };
 
 	  var depixelize = function(value) {
 	    if (value.indexOf('px') > -1) {
@@ -227,25 +219,24 @@
 
 	  var attached = function() {
 	    var self = d3.select(this);
-	    var svg = d3.select(findParentSVG(this));
-	    var svgParent = d3.select(findParentSVG(this).parentElement);
-	    var parent = d3.select(this.parentElement).select('use');
+	    var svg = d3.select('svg');
+	    var svgParent = self;
+	    var titles = self.selectAll('title');
+	    var tiles = self.selectAll('use');
 
 	    var tooltip,
 	      tooltipText;
 
 	    var init = function(initialize) {
-	      tooltip = svgParent.select('.eiti-tooltip');
+	      tooltip = self.select('.eiti-tooltip');
 
 	      if (tooltip.empty()) {
-	        svgParent.append('div')
+	        tooltip = self.append('div')
 	          .classed('eiti-tooltip', true);
 	      }
 
-	      tooltip.attr('aria-label', function(){
-	          return self.attr('alt');
-	        })
-	        .attr('aria-hidden', false);
+	      tooltip
+	        .attr('aria-hidden', true);
 
 	      tooltipText = tooltip.select('p');
 
@@ -255,22 +246,29 @@
 
 	      // clear <title> text
 	      // if no javascript runs, <title> will serve as the tooltip
-	      self.text('');
-
-	      if (initialize) {
-	        hideTooltip(tooltip);
-	      }
+	      // otherwise, clear it so that it doesn't interfere with
+	      // this tooltip
+	      titles.text('');
 	    };
 
 	    var update = function() {
+	      var event = event || d3.event || window.event;
+	      var elem = event.target || event.srcElement;
+
+	      var parentElement = d3.select(elem.parentElement);
+	      var title = parentElement.select('title');
 
 	      init();
 
 	      tooltipText.text(function(){
-	        return self.attr('desc');
+	        return title.attr('desc');
 	      });
 
 	      tooltip
+	        .attr('aria-hidden', false)
+	        .attr('aria-label', function(){
+	          return title.attr('alt');
+	        })
 	        .style('left', function() {
 	          var tooltipWidth = depixelize(tooltip.style('width'));
 	          var svgWidth = depixelize(svg.style('width'));
@@ -294,25 +292,26 @@
 	    };
 
 	    var hide = function () {
-	      if (event.fromElement.nodeName === 'svg') {
-	        var tooltip = svgParent.select('.eiti-tooltip');
+	      var event = event || window.event;
+	      var elem = event.target || event.srcElement;
+	      if (elem.nodeName === 'svg') {
+	        var tooltip = self.select('.eiti-tooltip');
 	        hideTooltip(tooltip);
 	      }
 	    };
 
 	    init(this);
 
-	    parent.on('mouseover', update);
+	    tiles.on('mouseover', update);
 	    svg.on('mouseout', hide);
 	  };
 
-	  var detached = function() {
-	  };
+	  var detached = function() { };
 
-	  exports.EITITooltip = document.registerElement('eiti-tooltip', {
-	    extends: 'title',
+	  exports.EITITooltipWrapper = document.registerElement('eiti-tooltip-wrapper', {
+	    extends: 'div',
 	    prototype: Object.create(
-	      SVGElement.prototype,
+	      HTMLElement.prototype,
 	      {
 	        attachedCallback: {value: attached},
 	        detachdCallback: {value: detached}

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -226,7 +226,7 @@
 	  };
 
 	  var attached = function() {
-	    var root = d3.select(this);
+	    var self = d3.select(this);
 	    var svg = d3.select(findParentSVG(this));
 	    var svgParent = d3.select(findParentSVG(this).parentElement);
 	    var parent = d3.select(this.parentElement).select('use');

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -49,6 +49,7 @@
 	  'use strict';
 
 	  __webpack_require__(7);
+	  __webpack_require__(8);
 
 	})(window);
 
@@ -191,6 +192,102 @@
 	});
 
 	});
+
+
+/***/ },
+
+/***/ 8:
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  var findParentSVG = function (childObj) {
+	    var obj = childObj.parentNode;
+	    while(obj.tagName !== 'svg') {
+	      obj = obj.parentNode;
+	    }
+	    return obj;
+	  }
+
+	  var attached = function() {
+	    var root = d3.select(this);
+	    var self = d3.select(this);
+	    var svg = d3.select(findParentSVG(this))
+	    var svgParent = d3.select(findParentSVG(this).parentElement);
+	    var parent = d3.select(this.parentElement).select('use');
+
+	    var hideTooltip = function (tooltip) {
+	      tooltip.attr('aria-hidden', true);
+	    }
+
+	    var update = function() {
+	      console.log(event)
+	      var delay = 200;
+
+	      var tooltip = svgParent.select('.eiti-tooltip');
+
+	      if (tooltip.empty()) {
+	        svgParent.append('div')
+	        .classed('eiti-tooltip', true)
+	      }
+
+	      tooltip.attr('aria-label', function(){
+	          return self.attr('alt');
+	        })
+	        .attr('aria-hidden', false)
+	        .transition()
+	        .delay(delay)
+	        .style('left', function() {
+	          return event.layerX + 'px';
+	        })
+	        .style('top', function() {
+	          return event.layerY + 'px';
+	        })
+
+	      var tooltipText = tooltip.select('p');
+
+	      if (tooltipText.empty()) {
+	        tooltipText = tooltip
+	          .append('p')
+	      }
+
+	      tooltipText.text(function(){
+	        console.log(self)
+	        return self.attr('desc');
+	      });
+
+	      // setTimeout(function() {
+	      //   hideTooltip(tooltip);
+	      // }, 5000);
+	    }
+
+
+	    var hide = function () {
+	      var tooltip = self.select('.tooltip');
+	      hideTooltip(tooltip);
+	    }
+
+	    parent.on('mouseover', update);
+
+	    // svg.on('mouseleave', hide);
+	  };
+
+	  var detached = function() {
+	  };
+
+	  exports.EITITooltip = document.registerElement('eiti-tooltip', {
+	    extends: 'title',
+	    prototype: Object.create(
+	      SVGElement.prototype,
+	      {
+	        attachedCallback: {value: attached},
+	        detachdCallback: {value: detached}
+	      }
+	    )
+	  })
+
+	})(this);
+
 
 
 /***/ }

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -207,7 +207,7 @@
 	      obj = obj.parentNode;
 	    }
 	    return obj;
-	  }
+	  };
 
 	  var depixelize = function(value) {
 	    if (value.indexOf('px') > -1) {
@@ -215,20 +215,19 @@
 	    } else {
 	      return value;
 	    }
-	  }
+	  };
 
 	  var pixelize = function(value) {
 	    return value + 'px';
-	  }
+	  };
 
 	  var hideTooltip = function (tooltip) {
 	    tooltip.attr('aria-hidden', true);
-	  }
+	  };
 
 	  var attached = function() {
 	    var root = d3.select(this);
-	    var self = d3.select(this);
-	    var svg = d3.select(findParentSVG(this))
+	    var svg = d3.select(findParentSVG(this));
 	    var svgParent = d3.select(findParentSVG(this).parentElement);
 	    var parent = d3.select(this.parentElement).select('use');
 
@@ -261,7 +260,7 @@
 	      if (initialize) {
 	        hideTooltip(tooltip);
 	      }
-	    }
+	    };
 
 	    var update = function() {
 
@@ -299,7 +298,7 @@
 	        var tooltip = svgParent.select('.eiti-tooltip');
 	        hideTooltip(tooltip);
 	      }
-	    }
+	    };
 
 	    init(this);
 
@@ -319,7 +318,7 @@
 	        detachdCallback: {value: detached}
 	      }
 	    )
-	  })
+	  });
 
 	})(this);
 

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -266,14 +266,26 @@
 	        var svgWidth = depixelize(svg.style('width'));
 
 	        if (svgWidth <= tooltipWidth + event.layerX) {
-	          return pixelize(event.layerX - tooltipWidth)
+	          return pixelize(event.layerX - tooltipWidth);
 	        } else {
 	          return pixelize(event.layerX);
 	        }
 	      })
 	      .style('top', function() {
-	        return pixelize(event.layerY);
+	        var tooltipHeight = depixelize(tooltip.style('height'));
+	        var svgHeight = depixelize(svg.style('height'));
+
+	        if (svgHeight <= tooltipHeight + event.layerY) {
+	          return pixelize(event.layerY - tooltipHeight);
+	        } else {
+	          return pixelize(event.layerY);
+	        }
 	      });
+
+	      // hide automatically after 5 seconds
+	      setTimeout(function() {
+	        hideTooltip(tooltip);
+	      }, 5000);
 	    };
 
 	    var hide = function () {

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -209,6 +209,18 @@
 	    return obj;
 	  }
 
+	  var depixelize = function(value) {
+	    if (value.indexOf('px') > -1) {
+	      return +value.substr(0, value.length - 2);
+	    } else {
+	      return value;
+	    }
+	  }
+
+	  var pixelize = function(value) {
+	    return value + 'px';
+	  }
+
 	  var attached = function() {
 	    var root = d3.select(this);
 	    var self = d3.select(this);
@@ -216,13 +228,13 @@
 	    var svgParent = d3.select(findParentSVG(this).parentElement);
 	    var parent = d3.select(this.parentElement).select('use');
 
+
 	    var hideTooltip = function (tooltip) {
 	      tooltip.attr('aria-hidden', true);
 	    }
 
 	    var update = function() {
-	      console.log(event)
-	      var delay = 200;
+	      var delay = 50;
 
 	      var tooltip = svgParent.select('.eiti-tooltip');
 
@@ -235,41 +247,44 @@
 	          return self.attr('alt');
 	        })
 	        .attr('aria-hidden', false)
+	        .text('')
 	        .transition()
-	        .delay(delay)
-	        .style('left', function() {
-	          return event.layerX + 'px';
-	        })
-	        .style('top', function() {
-	          return event.layerY + 'px';
-	        })
+	        .delay(delay);
 
 	      var tooltipText = tooltip.select('p');
 
 	      if (tooltipText.empty()) {
-	        tooltipText = tooltip
-	          .append('p')
+	        tooltipText = tooltip.append('p')
 	      }
 
 	      tooltipText.text(function(){
-	        console.log(self)
 	        return self.attr('desc');
 	      });
 
-	      // setTimeout(function() {
-	      //   hideTooltip(tooltip);
-	      // }, 5000);
-	    }
+	      tooltip.style('left', function() {
+	        var tooltipWidth = depixelize(tooltip.style('width'));
+	        var svgWidth = depixelize(svg.style('width'));
 
+	        if (svgWidth <= tooltipWidth + event.layerX) {
+	          return pixelize(event.layerX - tooltipWidth)
+	        } else {
+	          return pixelize(event.layerX);
+	        }
+	      })
+	      .style('top', function() {
+	        return pixelize(event.layerY);
+	      });
+	    };
 
 	    var hide = function () {
-	      var tooltip = self.select('.tooltip');
-	      hideTooltip(tooltip);
+	      if (event.fromElement.nodeName === 'svg') {
+	        var tooltip = svgParent.select('.eiti-tooltip');
+	        hideTooltip(tooltip);
+	      }
 	    }
 
 	    parent.on('mouseover', update);
-
-	    // svg.on('mouseleave', hide);
+	    svg.on('mouseout', hide);
 	  };
 
 	  var detached = function() {

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -50,44 +50,44 @@
 	  'use strict';
 
 	  // 3rd party dependencies
-	  var d3 = __webpack_require__(8);
+	  var d3 = __webpack_require__(9);
 	  exports.d3 = d3;
 
 	  // Custom map projection
-	  d3.geo.albersCustom = __webpack_require__(9);
+	  d3.geo.albersCustom = __webpack_require__(10);
 
 	  // common 3rd-party dependencies
-	  exports.queue = __webpack_require__(10);
-	  exports.topojson = __webpack_require__(11);
-	  exports.colorbrewer = __webpack_require__(12);
-	  exports.$ = exports.jQuery = __webpack_require__(14);
+	  exports.queue = __webpack_require__(11);
+	  exports.topojson = __webpack_require__(12);
+	  exports.colorbrewer = __webpack_require__(13);
+	  exports.$ = exports.jQuery = __webpack_require__(15);
 
 	  // EITI site-wide common code
-	  exports.eiti = __webpack_require__(15);
+	  exports.eiti = __webpack_require__(16);
 
 	  // custom elements polyfill
-	  __webpack_require__(16);
+	  __webpack_require__(17);
 
-	  exports.EITIMap = __webpack_require__(17);
-	  exports.EITISlider = __webpack_require__(19);
-	  exports.EITIToggle = __webpack_require__(20);
+	  exports.EITIMap = __webpack_require__(18);
+	  exports.EITISlider = __webpack_require__(20);
+	  exports.EITIToggle = __webpack_require__(21);
 
 	  // FIXME: does this export anything?
-	  __webpack_require__(21);
+	  __webpack_require__(22);
 
 	  // XXX List.js's node module isn't CommonJS compatible, so we have to use a
 	  // built version.
-	  exports.List = __webpack_require__(22);
+	  exports.List = __webpack_require__(23);
 
-	  exports.Glossary = __webpack_require__(23);
-	  exports.Accordion = __webpack_require__(24);
+	  exports.Glossary = __webpack_require__(24);
+	  exports.Accordion = __webpack_require__(25);
 
 	  $(function () {
 	    var glossary = new exports.Glossary(),
 	      accordion = new exports.Accordion();
 	  });
 
-	  var svg4everybody = __webpack_require__(25);
+	  var svg4everybody = __webpack_require__(26);
 	  svg4everybody();
 
 	})(window);
@@ -101,7 +101,8 @@
 /* 5 */,
 /* 6 */,
 /* 7 */,
-/* 8 */
+/* 8 */,
+/* 9 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
@@ -9660,12 +9661,12 @@
 	}();
 
 /***/ },
-/* 9 */
+/* 10 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
 
-	  var d3 = exports.d3 || __webpack_require__(8);
+	  var d3 = exports.d3 || __webpack_require__(9);
 
 	  var E = 1e-6;
 
@@ -9845,7 +9846,7 @@
 
 
 /***/ },
-/* 10 */
+/* 11 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function (global, factory) {
@@ -9966,7 +9967,7 @@
 	}));
 
 /***/ },
-/* 11 */
+/* 12 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
@@ -10506,14 +10507,14 @@
 
 
 /***/ },
-/* 12 */
+/* 13 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = __webpack_require__(13);
+	module.exports = __webpack_require__(14);
 
 
 /***/ },
-/* 13 */
+/* 14 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;// This product includes color specifications and designs developed by Cynthia Brewer (http://colorbrewer.org/).
@@ -10834,7 +10835,7 @@
 
 
 /***/ },
-/* 14 */
+/* 15 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
@@ -21848,14 +21849,14 @@
 
 
 /***/ },
-/* 15 */
+/* 16 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
 	  'use strict';
 
-	  var d3 = __webpack_require__(8);
-	  var queue = __webpack_require__(10);
+	  var d3 = __webpack_require__(9);
+	  var queue = __webpack_require__(11);
 
 	  /*
 	   * @namespace eiti
@@ -22565,21 +22566,21 @@
 
 
 /***/ },
-/* 16 */
+/* 17 */
 /***/ function(module, exports) {
 
 	/*! (C) WebReflection Mit Style License */
 	(function(e,t,n,r){"use strict";function rt(e,t){for(var n=0,r=e.length;n<r;n++)vt(e[n],t)}function it(e){for(var t=0,n=e.length,r;t<n;t++)r=e[t],nt(r,b[ot(r)])}function st(e){return function(t){j(t)&&(vt(t,e),rt(t.querySelectorAll(w),e))}}function ot(e){var t=e.getAttribute("is"),n=e.nodeName.toUpperCase(),r=S.call(y,t?v+t.toUpperCase():d+n);return t&&-1<r&&!ut(n,t)?-1:r}function ut(e,t){return-1<w.indexOf(e+'[is="'+t+'"]')}function at(e){var t=e.currentTarget,n=e.attrChange,r=e.attrName,i=e.target;Q&&(!i||i===t)&&t.attributeChangedCallback&&r!=="style"&&e.prevValue!==e.newValue&&t.attributeChangedCallback(r,n===e[a]?null:e.prevValue,n===e[l]?null:e.newValue)}function ft(e){var t=st(e);return function(e){X.push(t,e.target)}}function lt(e){K&&(K=!1,e.currentTarget.removeEventListener(h,lt)),rt((e.target||t).querySelectorAll(w),e.detail===o?o:s),B&&pt()}function ct(e,t){var n=this;q.call(n,e,t),G.call(n,{target:n})}function ht(e,t){D(e,t),et?et.observe(e,z):(J&&(e.setAttribute=ct,e[i]=Z(e),e.addEventListener(p,G)),e.addEventListener(c,at)),e.createdCallback&&Q&&(e.created=!0,e.createdCallback(),e.created=!1)}function pt(){for(var e,t=0,n=F.length;t<n;t++)e=F[t],E.contains(e)||(n--,F.splice(t--,1),vt(e,o))}function dt(e){throw new Error("A "+e+" type is already registered")}function vt(e,t){var n,r=ot(e);-1<r&&(tt(e,b[r]),r=0,t===s&&!e[s]?(e[o]=!1,e[s]=!0,r=1,B&&S.call(F,e)<0&&F.push(e)):t===o&&!e[o]&&(e[s]=!1,e[o]=!0,r=1),r&&(n=e[t+"Callback"])&&n.call(e))}if(r in t)return;var i="__"+r+(Math.random()*1e5>>0),s="attached",o="detached",u="extends",a="ADDITION",f="MODIFICATION",l="REMOVAL",c="DOMAttrModified",h="DOMContentLoaded",p="DOMSubtreeModified",d="<",v="=",m=/^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+$/,g=["ANNOTATION-XML","COLOR-PROFILE","FONT-FACE","FONT-FACE-SRC","FONT-FACE-URI","FONT-FACE-FORMAT","FONT-FACE-NAME","MISSING-GLYPH"],y=[],b=[],w="",E=t.documentElement,S=y.indexOf||function(e){for(var t=this.length;t--&&this[t]!==e;);return t},x=n.prototype,T=x.hasOwnProperty,N=x.isPrototypeOf,C=n.defineProperty,k=n.getOwnPropertyDescriptor,L=n.getOwnPropertyNames,A=n.getPrototypeOf,O=n.setPrototypeOf,M=!!n.__proto__,_=n.create||function mt(e){return e?(mt.prototype=e,new mt):this},D=O||(M?function(e,t){return e.__proto__=t,e}:L&&k?function(){function e(e,t){for(var n,r=L(t),i=0,s=r.length;i<s;i++)n=r[i],T.call(e,n)||C(e,n,k(t,n))}return function(t,n){do e(t,n);while((n=A(n))&&!N.call(n,t));return t}}():function(e,t){for(var n in t)e[n]=t[n];return e}),P=e.MutationObserver||e.WebKitMutationObserver,H=(e.HTMLElement||e.Element||e.Node).prototype,B=!N.call(H,E),j=B?function(e){return e.nodeType===1}:function(e){return N.call(H,e)},F=B&&[],I=H.cloneNode,q=H.setAttribute,R=H.removeAttribute,U=t.createElement,z=P&&{attributes:!0,characterData:!0,attributeOldValue:!0},W=P||function(e){J=!1,E.removeEventListener(c,W)},X,V=e.requestAnimationFrame||e.webkitRequestAnimationFrame||e.mozRequestAnimationFrame||e.msRequestAnimationFrame||function(e){setTimeout(e,10)},$=!1,J=!0,K=!0,Q=!0,G,Y,Z,et,tt,nt;O||M?(tt=function(e,t){N.call(t,e)||ht(e,t)},nt=ht):(tt=function(e,t){e[i]||(e[i]=n(!0),ht(e,t))},nt=tt),B?(J=!1,function(){var e=k(H,"addEventListener"),t=e.value,n=function(e){var t=new CustomEvent(c,{bubbles:!0});t.attrName=e,t.prevValue=this.getAttribute(e),t.newValue=null,t[l]=t.attrChange=2,R.call(this,e),this.dispatchEvent(t)},r=function(e,t){var n=this.hasAttribute(e),r=n&&this.getAttribute(e),i=new CustomEvent(c,{bubbles:!0});q.call(this,e,t),i.attrName=e,i.prevValue=n?r:null,i.newValue=t,n?i[f]=i.attrChange=1:i[a]=i.attrChange=0,this.dispatchEvent(i)},s=function(e){var t=e.currentTarget,n=t[i],r=e.propertyName,s;n.hasOwnProperty(r)&&(n=n[r],s=new CustomEvent(c,{bubbles:!0}),s.attrName=n.name,s.prevValue=n.value||null,s.newValue=n.value=t[r]||null,s.prevValue==null?s[a]=s.attrChange=0:s[f]=s.attrChange=1,t.dispatchEvent(s))};e.value=function(e,o,u){e===c&&this.attributeChangedCallback&&this.setAttribute!==r&&(this[i]={className:{name:"class",value:this.className}},this.setAttribute=r,this.removeAttribute=n,t.call(this,"propertychange",s)),t.call(this,e,o,u)},C(H,"addEventListener",e)}()):P||(E.addEventListener(c,W),E.setAttribute(i,1),E.removeAttribute(i),J&&(G=function(e){var t=this,n,r,s;if(t===e.target){n=t[i],t[i]=r=Z(t);for(s in r){if(!(s in n))return Y(0,t,s,n[s],r[s],a);if(r[s]!==n[s])return Y(1,t,s,n[s],r[s],f)}for(s in n)if(!(s in r))return Y(2,t,s,n[s],r[s],l)}},Y=function(e,t,n,r,i,s){var o={attrChange:e,currentTarget:t,attrName:n,prevValue:r,newValue:i};o[s]=e,at(o)},Z=function(e){for(var t,n,r={},i=e.attributes,s=0,o=i.length;s<o;s++)t=i[s],n=t.name,n!=="setAttribute"&&(r[n]=t.value);return r})),t[r]=function(n,r){c=n.toUpperCase(),$||($=!0,P?(et=function(e,t){function n(e,t){for(var n=0,r=e.length;n<r;t(e[n++]));}return new P(function(r){for(var i,s,o,u=0,a=r.length;u<a;u++)i=r[u],i.type==="childList"?(n(i.addedNodes,e),n(i.removedNodes,t)):(s=i.target,Q&&s.attributeChangedCallback&&i.attributeName!=="style"&&(o=s.getAttribute(i.attributeName),o!==i.oldValue&&s.attributeChangedCallback(i.attributeName,i.oldValue,o)))})}(st(s),st(o)),et.observe(t,{childList:!0,subtree:!0})):(X=[],V(function E(){while(X.length)X.shift().call(null,X.shift());V(E)}),t.addEventListener("DOMNodeInserted",ft(s)),t.addEventListener("DOMNodeRemoved",ft(o))),t.addEventListener(h,lt),t.addEventListener("readystatechange",lt),t.createElement=function(e,n){var r=U.apply(t,arguments),i=""+e,s=S.call(y,(n?v:d)+(n||i).toUpperCase()),o=-1<s;return n&&(r.setAttribute("is",n=n.toLowerCase()),o&&(o=ut(i.toUpperCase(),n))),Q=!t.createElement.innerHTMLHelper,o&&nt(r,b[s]),r},H.cloneNode=function(e){var t=I.call(this,!!e),n=ot(t);return-1<n&&nt(t,b[n]),e&&it(t.querySelectorAll(w)),t}),-2<S.call(y,v+c)+S.call(y,d+c)&&dt(n);if(!m.test(c)||-1<S.call(g,c))throw new Error("The type "+n+" is invalid");var i=function(){return f?t.createElement(l,c):t.createElement(l)},a=r||x,f=T.call(a,u),l=f?r[u].toUpperCase():c,c,p;return f&&-1<S.call(y,d+l)&&dt(l),p=y.push((f?v:d)+c)-1,w=w.concat(w.length?",":"",f?l+'[is="'+n.toLowerCase()+'"]':l),i.prototype=b[p]=T.call(a,"prototype")?a.prototype:_(H),rt(t.querySelectorAll(w),s),i}})(window,document,Object,"registerElement");
 
 /***/ },
-/* 17 */
+/* 18 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// globals d3, topojson, eiti
 	(function(exports) {
 	  'use strict';
 
-	  var CustomEvent = __webpack_require__(18);
+	  var CustomEvent = __webpack_require__(19);
 
 	  exports.EITIMap = document.registerElement('eiti-map', {
 	    // 'extends': 'svg',
@@ -23076,7 +23077,7 @@
 
 
 /***/ },
-/* 18 */
+/* 19 */
 /***/ function(module, exports) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {
@@ -23131,13 +23132,13 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 19 */
+/* 20 */
 /***/ function(module, exports, __webpack_require__) {
 
 	// globals d3
 	(function(exports) {
 
-	  var CustomEvent = __webpack_require__(18);
+	  var CustomEvent = __webpack_require__(19);
 
 	  exports.EITISlider = registerElement('eiti-slider', {
 	    createdCallback: function() {
@@ -23396,7 +23397,7 @@
 
 
 /***/ },
-/* 20 */
+/* 21 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -23538,7 +23539,7 @@
 
 
 /***/ },
-/* 21 */
+/* 22 */
 /***/ function(module, exports) {
 
 	$( document ).ready(function() {
@@ -23633,7 +23634,7 @@
 
 
 /***/ },
-/* 22 */
+/* 23 */
 /***/ function(module, exports, __webpack_require__) {
 
 	;(function(){
@@ -25113,7 +25114,7 @@
 
 
 /***/ },
-/* 23 */
+/* 24 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -25317,7 +25318,7 @@
 
 
 /***/ },
-/* 24 */
+/* 25 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -25478,7 +25479,7 @@
 
 
 /***/ },
-/* 25 */
+/* 26 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!function(root, factory) {
@@ -25487,7 +25488,7 @@
 	        return root.svg4everybody = factory();
 	    }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : "object" == typeof exports ? module.exports = factory() : root.svg4everybody = factory();
 	}(this, function() {
-	    /*! svg4everybody v2.1.0 | github.com/jonathantneal/svg4everybody */
+	    /*! svg4everybody v2.0.3 | github.com/jonathantneal/svg4everybody */
 	    function embed(node, target) {
 	        // if the target exists
 	        if (target) {

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -50,7 +50,7 @@
 
 	  __webpack_require__(3);
 
-	  var OpenListNav = __webpack_require__(26);
+	  var OpenListNav = __webpack_require__(27);
 
 	  // exporting instance of OpenListNav because openListNav is
 	  // referenced in the markup:
@@ -564,7 +564,7 @@
 
 /***/ },
 
-/***/ 26:
+/***/ 27:
 /***/ function(module, exports) {
 
 	(function(exports) {

--- a/js/lib/reconciliation.min.js
+++ b/js/lib/reconciliation.min.js
@@ -49,7 +49,7 @@
 	  'use strict';
 
 	  __webpack_require__(1);
-	  __webpack_require__(27);
+	  __webpack_require__(28);
 	})(window);
 
 
@@ -501,7 +501,7 @@
 
 /***/ },
 
-/***/ 27:
+/***/ 28:
 /***/ function(module, exports) {
 
 	// globals d3, eiti, EITIBar

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -742,7 +742,7 @@
 	  };
 
 	  var attached = function() {
-	    var root = d3.select(this);
+	    var self = d3.select(this);
 	    var svg = d3.select(findParentSVG(this));
 	    var svgParent = d3.select(findParentSVG(this).parentElement);
 	    var parent = d3.select(this.parentElement).select('use');

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -47,18 +47,19 @@
 	(function(exports) {
 	  'use strict';
 
-	  __webpack_require__(28);
 	  __webpack_require__(29);
-	  __webpack_require__(36);
+	  __webpack_require__(30);
 	  __webpack_require__(37);
 	  __webpack_require__(38);
 	  __webpack_require__(39);
+	  __webpack_require__(40);
+	  __webpack_require__(8);
 
 	  __webpack_require__(7);
 
 	  __webpack_require__(3);
 
-	  var OpenListNav = __webpack_require__(26);
+	  var OpenListNav = __webpack_require__(27);
 
 	  // exporting instance of OpenListNav because openListNav is
 	  // referenced in the markup:
@@ -712,6 +713,101 @@
 
 /***/ },
 /* 8 */
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  var findParentSVG = function (childObj) {
+	    var obj = childObj.parentNode;
+	    while(obj.tagName !== 'svg') {
+	      obj = obj.parentNode;
+	    }
+	    return obj;
+	  }
+
+	  var attached = function() {
+	    var root = d3.select(this);
+	    var self = d3.select(this);
+	    var svg = d3.select(findParentSVG(this))
+	    var svgParent = d3.select(findParentSVG(this).parentElement);
+	    var parent = d3.select(this.parentElement).select('use');
+
+	    var hideTooltip = function (tooltip) {
+	      tooltip.attr('aria-hidden', true);
+	    }
+
+	    var update = function() {
+	      console.log(event)
+	      var delay = 200;
+
+	      var tooltip = svgParent.select('.eiti-tooltip');
+
+	      if (tooltip.empty()) {
+	        svgParent.append('div')
+	        .classed('eiti-tooltip', true)
+	      }
+
+	      tooltip.attr('aria-label', function(){
+	          return self.attr('alt');
+	        })
+	        .attr('aria-hidden', false)
+	        .transition()
+	        .delay(delay)
+	        .style('left', function() {
+	          return event.layerX + 'px';
+	        })
+	        .style('top', function() {
+	          return event.layerY + 'px';
+	        })
+
+	      var tooltipText = tooltip.select('p');
+
+	      if (tooltipText.empty()) {
+	        tooltipText = tooltip
+	          .append('p')
+	      }
+
+	      tooltipText.text(function(){
+	        console.log(self)
+	        return self.attr('desc');
+	      });
+
+	      // setTimeout(function() {
+	      //   hideTooltip(tooltip);
+	      // }, 5000);
+	    }
+
+
+	    var hide = function () {
+	      var tooltip = self.select('.tooltip');
+	      hideTooltip(tooltip);
+	    }
+
+	    parent.on('mouseover', update);
+
+	    // svg.on('mouseleave', hide);
+	  };
+
+	  var detached = function() {
+	  };
+
+	  exports.EITITooltip = document.registerElement('eiti-tooltip', {
+	    extends: 'title',
+	    prototype: Object.create(
+	      SVGElement.prototype,
+	      {
+	        attachedCallback: {value: attached},
+	        detachdCallback: {value: detached}
+	      }
+	    )
+	  })
+
+	})(this);
+
+
+
+/***/ },
+/* 9 */
 /***/ function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;!function() {
@@ -10270,8 +10366,8 @@
 	}();
 
 /***/ },
-/* 9 */,
-/* 10 */
+/* 10 */,
+/* 11 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function (global, factory) {
@@ -10392,18 +10488,18 @@
 	}));
 
 /***/ },
-/* 11 */,
 /* 12 */,
 /* 13 */,
 /* 14 */,
-/* 15 */
+/* 15 */,
+/* 16 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
 	  'use strict';
 
-	  var d3 = __webpack_require__(8);
-	  var queue = __webpack_require__(10);
+	  var d3 = __webpack_require__(9);
+	  var queue = __webpack_require__(11);
 
 	  /*
 	   * @namespace eiti
@@ -11113,7 +11209,6 @@
 
 
 /***/ },
-/* 16 */,
 /* 17 */,
 /* 18 */,
 /* 19 */,
@@ -11123,7 +11218,8 @@
 /* 23 */,
 /* 24 */,
 /* 25 */,
-/* 26 */
+/* 26 */,
+/* 27 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -11333,8 +11429,8 @@
 
 
 /***/ },
-/* 27 */,
-/* 28 */
+/* 28 */,
+/* 29 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -11416,14 +11512,14 @@
 
 
 /***/ },
-/* 29 */
+/* 30 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
 
-	  __webpack_require__(30);
+	  __webpack_require__(31);
 
-	  var eiti = __webpack_require__(15);
+	  var eiti = __webpack_require__(16);
 	  var WITHHELD_FLAG = 'Withheld';
 	  var NO_DATA_FLAG = undefined;
 
@@ -11728,32 +11824,32 @@
 
 
 /***/ },
-/* 30 */
-/***/ function(module, exports, __webpack_require__) {
-
-	var d3 = __webpack_require__(8);
-
-	d3.legend = __webpack_require__(31);
-
-	module.exports = d3;
-
-
-/***/ },
 /* 31 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = {
-	  color: __webpack_require__(32),
-	  size: __webpack_require__(34),
-	  symbol: __webpack_require__(35)
-	};
+	var d3 = __webpack_require__(9);
+
+	d3.legend = __webpack_require__(32);
+
+	module.exports = d3;
 
 
 /***/ },
 /* 32 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var helper = __webpack_require__(33);
+	module.exports = {
+	  color: __webpack_require__(33),
+	  size: __webpack_require__(35),
+	  symbol: __webpack_require__(36)
+	};
+
+
+/***/ },
+/* 33 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var helper = __webpack_require__(34);
 
 	module.exports = function(){
 
@@ -11962,7 +12058,7 @@
 
 
 /***/ },
-/* 33 */
+/* 34 */
 /***/ function(module, exports) {
 
 	module.exports = {
@@ -12131,10 +12227,10 @@
 
 
 /***/ },
-/* 34 */
+/* 35 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var helper = __webpack_require__(33);
+	var helper = __webpack_require__(34);
 
 	module.exports =  function(){
 
@@ -12336,10 +12432,10 @@
 
 
 /***/ },
-/* 35 */
+/* 36 */
 /***/ function(module, exports, __webpack_require__) {
 
-	var helper = __webpack_require__(33);
+	var helper = __webpack_require__(34);
 
 	module.exports = function(){
 
@@ -12500,7 +12596,7 @@
 
 
 /***/ },
-/* 36 */
+/* 37 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -12897,12 +12993,12 @@
 
 
 /***/ },
-/* 37 */
+/* 38 */
 /***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
 
-	  var eiti = __webpack_require__(15);
+	  var eiti = __webpack_require__(16);
 	  // symbols for "private" variables
 	  var DATA = '__es_data__';
 	  var X = '__es_x__';
@@ -13288,7 +13384,7 @@
 
 
 /***/ },
-/* 38 */
+/* 39 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -13344,7 +13440,7 @@
 
 
 /***/ },
-/* 39 */
+/* 40 */
 /***/ function(module, exports) {
 
 	(function(exports) {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -53,7 +53,7 @@
 	  __webpack_require__(38);
 	  __webpack_require__(39);
 	  __webpack_require__(40);
-	  __webpack_require__(8);
+	  __webpack_require__(41);
 
 	  __webpack_require__(7);
 
@@ -712,135 +712,7 @@
 
 
 /***/ },
-/* 8 */
-/***/ function(module, exports) {
-
-	(function(exports) {
-
-	  var findParentSVG = function (childObj) {
-	    var obj = childObj.parentNode;
-	    while(obj.tagName !== 'svg') {
-	      obj = obj.parentNode;
-	    }
-	    return obj;
-	  };
-
-	  var depixelize = function(value) {
-	    if (value.indexOf('px') > -1) {
-	      return +value.substr(0, value.length - 2);
-	    } else {
-	      return value;
-	    }
-	  };
-
-	  var pixelize = function(value) {
-	    return value + 'px';
-	  };
-
-	  var hideTooltip = function (tooltip) {
-	    tooltip.attr('aria-hidden', true);
-	  };
-
-	  var attached = function() {
-	    var self = d3.select(this);
-	    var svg = d3.select(findParentSVG(this));
-	    var svgParent = d3.select(findParentSVG(this).parentElement);
-	    var parent = d3.select(this.parentElement).select('use');
-
-	    var tooltip,
-	      tooltipText;
-
-	    var init = function(initialize) {
-	      tooltip = svgParent.select('.eiti-tooltip');
-
-	      if (tooltip.empty()) {
-	        svgParent.append('div')
-	          .classed('eiti-tooltip', true);
-	      }
-
-	      tooltip.attr('aria-label', function(){
-	          return self.attr('alt');
-	        })
-	        .attr('aria-hidden', false);
-
-	      tooltipText = tooltip.select('p');
-
-	      if (tooltipText.empty()) {
-	        tooltipText = tooltip.append('p');
-	      }
-
-	      // clear <title> text
-	      // if no javascript runs, <title> will serve as the tooltip
-	      self.text('');
-
-	      if (initialize) {
-	        hideTooltip(tooltip);
-	      }
-	    };
-
-	    var update = function() {
-
-	      init();
-
-	      tooltipText.text(function(){
-	        return self.attr('desc');
-	      });
-
-	      tooltip
-	        .style('left', function() {
-	          var tooltipWidth = depixelize(tooltip.style('width'));
-	          var svgWidth = depixelize(svg.style('width'));
-
-	          if (svgWidth <= tooltipWidth + event.layerX) {
-	            return pixelize(event.layerX - tooltipWidth);
-	          } else {
-	            return pixelize(event.layerX);
-	          }
-	        })
-	        .style('top', function() {
-	          var tooltipHeight = depixelize(tooltip.style('height'));
-	          var svgHeight = depixelize(svg.style('height'));
-
-	          if (svgHeight <= tooltipHeight + event.layerY) {
-	            return pixelize(event.layerY - tooltipHeight);
-	          } else {
-	            return pixelize(event.layerY);
-	          }
-	        });
-	    };
-
-	    var hide = function () {
-	      if (event.fromElement.nodeName === 'svg') {
-	        var tooltip = svgParent.select('.eiti-tooltip');
-	        hideTooltip(tooltip);
-	      }
-	    };
-
-	    init(this);
-
-	    parent.on('mouseover', update);
-	    svg.on('mouseout', hide);
-	  };
-
-	  var detached = function() {
-	  };
-
-	  exports.EITITooltip = document.registerElement('eiti-tooltip', {
-	    extends: 'title',
-	    prototype: Object.create(
-	      SVGElement.prototype,
-	      {
-	        attachedCallback: {value: attached},
-	        detachdCallback: {value: detached}
-	      }
-	    )
-	  });
-
-	})(this);
-
-
-
-/***/ },
+/* 8 */,
 /* 9 */
 /***/ function(module, exports, __webpack_require__) {
 
@@ -13615,6 +13487,134 @@
 	      }
 	    )
 	  })
+
+	})(this);
+
+
+
+/***/ },
+/* 41 */
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  var depixelize = function(value) {
+	    if (value.indexOf('px') > -1) {
+	      return +value.substr(0, value.length - 2);
+	    } else {
+	      return value;
+	    }
+	  };
+
+	  var pixelize = function(value) {
+	    return value + 'px';
+	  };
+
+	  var hideTooltip = function (tooltip) {
+	    tooltip.attr('aria-hidden', true);
+	  };
+
+	  var attached = function() {
+	    var self = d3.select(this);
+	    var svg = d3.select('svg');
+	    var svgParent = self;
+	    var titles = self.selectAll('title');
+	    var tiles = self.selectAll('use');
+
+	    var tooltip,
+	      tooltipText;
+
+	    var init = function(initialize) {
+	      tooltip = self.select('.eiti-tooltip');
+
+	      if (tooltip.empty()) {
+	        tooltip = self.append('div')
+	          .classed('eiti-tooltip', true);
+	      }
+
+	      tooltip
+	        .attr('aria-hidden', true);
+
+	      tooltipText = tooltip.select('p');
+
+	      if (tooltipText.empty()) {
+	        tooltipText = tooltip.append('p');
+	      }
+
+	      // clear <title> text
+	      // if no javascript runs, <title> will serve as the tooltip
+	      // otherwise, clear it so that it doesn't interfere with
+	      // this tooltip
+	      titles.text('');
+	    };
+
+	    var update = function() {
+	      var event = event || d3.event || window.event;
+	      var elem = event.target || event.srcElement;
+
+	      var parentElement = d3.select(elem.parentElement);
+	      var title = parentElement.select('title');
+
+	      init();
+
+	      tooltipText.text(function(){
+	        return title.attr('desc');
+	      });
+
+	      tooltip
+	        .attr('aria-hidden', false)
+	        .attr('aria-label', function(){
+	          return title.attr('alt');
+	        })
+	        .style('left', function() {
+	          var tooltipWidth = depixelize(tooltip.style('width'));
+	          var svgWidth = depixelize(svg.style('width'));
+
+	          if (svgWidth <= tooltipWidth + event.layerX) {
+	            return pixelize(event.layerX - tooltipWidth);
+	          } else {
+	            return pixelize(event.layerX);
+	          }
+	        })
+	        .style('top', function() {
+	          var tooltipHeight = depixelize(tooltip.style('height'));
+	          var svgHeight = depixelize(svg.style('height'));
+
+	          if (svgHeight <= tooltipHeight + event.layerY) {
+	            return pixelize(event.layerY - tooltipHeight);
+	          } else {
+	            return pixelize(event.layerY);
+	          }
+	        });
+	    };
+
+	    var hide = function () {
+	      var event = event || window.event;
+	      var elem = event.target || event.srcElement;
+	      if (elem.nodeName === 'svg') {
+	        var tooltip = self.select('.eiti-tooltip');
+	        hideTooltip(tooltip);
+	      }
+	    };
+
+	    init(this);
+
+	    tiles.on('mouseover', update);
+	    svg.on('mouseout', hide);
+	  };
+
+	  var detached = function() { };
+
+	  exports.EITITooltipWrapper = document.registerElement('eiti-tooltip-wrapper', {
+	    extends: 'div',
+	    prototype: Object.create(
+	      HTMLElement.prototype,
+	      {
+	        attachedCallback: {value: attached},
+	        detachdCallback: {value: detached}
+	      }
+	    )
+	  });
 
 	})(this);
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -725,6 +725,18 @@
 	    return obj;
 	  }
 
+	  var depixelize = function(value) {
+	    if (value.indexOf('px') > -1) {
+	      return +value.substr(0, value.length - 2);
+	    } else {
+	      return value;
+	    }
+	  }
+
+	  var pixelize = function(value) {
+	    return value + 'px';
+	  }
+
 	  var attached = function() {
 	    var root = d3.select(this);
 	    var self = d3.select(this);
@@ -732,13 +744,13 @@
 	    var svgParent = d3.select(findParentSVG(this).parentElement);
 	    var parent = d3.select(this.parentElement).select('use');
 
+
 	    var hideTooltip = function (tooltip) {
 	      tooltip.attr('aria-hidden', true);
 	    }
 
 	    var update = function() {
-	      console.log(event)
-	      var delay = 200;
+	      var delay = 50;
 
 	      var tooltip = svgParent.select('.eiti-tooltip');
 
@@ -751,41 +763,44 @@
 	          return self.attr('alt');
 	        })
 	        .attr('aria-hidden', false)
+	        .text('')
 	        .transition()
-	        .delay(delay)
-	        .style('left', function() {
-	          return event.layerX + 'px';
-	        })
-	        .style('top', function() {
-	          return event.layerY + 'px';
-	        })
+	        .delay(delay);
 
 	      var tooltipText = tooltip.select('p');
 
 	      if (tooltipText.empty()) {
-	        tooltipText = tooltip
-	          .append('p')
+	        tooltipText = tooltip.append('p')
 	      }
 
 	      tooltipText.text(function(){
-	        console.log(self)
 	        return self.attr('desc');
 	      });
 
-	      // setTimeout(function() {
-	      //   hideTooltip(tooltip);
-	      // }, 5000);
-	    }
+	      tooltip.style('left', function() {
+	        var tooltipWidth = depixelize(tooltip.style('width'));
+	        var svgWidth = depixelize(svg.style('width'));
 
+	        if (svgWidth <= tooltipWidth + event.layerX) {
+	          return pixelize(event.layerX - tooltipWidth)
+	        } else {
+	          return pixelize(event.layerX);
+	        }
+	      })
+	      .style('top', function() {
+	        return pixelize(event.layerY);
+	      });
+	    };
 
 	    var hide = function () {
-	      var tooltip = self.select('.tooltip');
-	      hideTooltip(tooltip);
+	      if (event.fromElement.nodeName === 'svg') {
+	        var tooltip = svgParent.select('.eiti-tooltip');
+	        hideTooltip(tooltip);
+	      }
 	    }
 
 	    parent.on('mouseover', update);
-
-	    // svg.on('mouseleave', hide);
+	    svg.on('mouseout', hide);
 	  };
 
 	  var detached = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -737,6 +737,10 @@
 	    return value + 'px';
 	  }
 
+	  var hideTooltip = function (tooltip) {
+	    tooltip.attr('aria-hidden', true);
+	  }
+
 	  var attached = function() {
 	    var root = d3.select(this);
 	    var self = d3.select(this);
@@ -744,64 +748,66 @@
 	    var svgParent = d3.select(findParentSVG(this).parentElement);
 	    var parent = d3.select(this.parentElement).select('use');
 
+	    var tooltip,
+	      tooltipText;
 
-	    var hideTooltip = function (tooltip) {
-	      tooltip.attr('aria-hidden', true);
-	    }
-
-	    var update = function() {
-	      var delay = 50;
-
-	      var tooltip = svgParent.select('.eiti-tooltip');
+	    var init = function(initialize) {
+	      tooltip = svgParent.select('.eiti-tooltip');
 
 	      if (tooltip.empty()) {
 	        svgParent.append('div')
-	        .classed('eiti-tooltip', true)
+	          .classed('eiti-tooltip', true);
 	      }
 
 	      tooltip.attr('aria-label', function(){
 	          return self.attr('alt');
 	        })
-	        .attr('aria-hidden', false)
-	        .text('')
-	        .transition()
-	        .delay(delay);
+	        .attr('aria-hidden', false);
 
-	      var tooltipText = tooltip.select('p');
+	      tooltipText = tooltip.select('p');
 
 	      if (tooltipText.empty()) {
-	        tooltipText = tooltip.append('p')
+	        tooltipText = tooltip.append('p');
 	      }
+
+	      // clear <title> text
+	      // if no javascript runs, <title> will serve as the tooltip
+	      self.text('');
+
+	      if (initialize) {
+	        hideTooltip(tooltip);
+	      }
+	    }
+
+	    var update = function() {
+
+	      init();
 
 	      tooltipText.text(function(){
 	        return self.attr('desc');
 	      });
 
-	      tooltip.style('left', function() {
-	        var tooltipWidth = depixelize(tooltip.style('width'));
-	        var svgWidth = depixelize(svg.style('width'));
+	      tooltip
+	        .style('left', function() {
+	          var tooltipWidth = depixelize(tooltip.style('width'));
+	          var svgWidth = depixelize(svg.style('width'));
 
-	        if (svgWidth <= tooltipWidth + event.layerX) {
-	          return pixelize(event.layerX - tooltipWidth);
-	        } else {
-	          return pixelize(event.layerX);
-	        }
-	      })
-	      .style('top', function() {
-	        var tooltipHeight = depixelize(tooltip.style('height'));
-	        var svgHeight = depixelize(svg.style('height'));
+	          if (svgWidth <= tooltipWidth + event.layerX) {
+	            return pixelize(event.layerX - tooltipWidth);
+	          } else {
+	            return pixelize(event.layerX);
+	          }
+	        })
+	        .style('top', function() {
+	          var tooltipHeight = depixelize(tooltip.style('height'));
+	          var svgHeight = depixelize(svg.style('height'));
 
-	        if (svgHeight <= tooltipHeight + event.layerY) {
-	          return pixelize(event.layerY - tooltipHeight);
-	        } else {
-	          return pixelize(event.layerY);
-	        }
-	      });
-
-	      // hide automatically after 5 seconds
-	      setTimeout(function() {
-	        hideTooltip(tooltip);
-	      }, 5000);
+	          if (svgHeight <= tooltipHeight + event.layerY) {
+	            return pixelize(event.layerY - tooltipHeight);
+	          } else {
+	            return pixelize(event.layerY);
+	          }
+	        });
 	    };
 
 	    var hide = function () {
@@ -810,6 +816,8 @@
 	        hideTooltip(tooltip);
 	      }
 	    }
+
+	    init(this);
 
 	    parent.on('mouseover', update);
 	    svg.on('mouseout', hide);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -782,14 +782,26 @@
 	        var svgWidth = depixelize(svg.style('width'));
 
 	        if (svgWidth <= tooltipWidth + event.layerX) {
-	          return pixelize(event.layerX - tooltipWidth)
+	          return pixelize(event.layerX - tooltipWidth);
 	        } else {
 	          return pixelize(event.layerX);
 	        }
 	      })
 	      .style('top', function() {
-	        return pixelize(event.layerY);
+	        var tooltipHeight = depixelize(tooltip.style('height'));
+	        var svgHeight = depixelize(svg.style('height'));
+
+	        if (svgHeight <= tooltipHeight + event.layerY) {
+	          return pixelize(event.layerY - tooltipHeight);
+	        } else {
+	          return pixelize(event.layerY);
+	        }
 	      });
+
+	      // hide automatically after 5 seconds
+	      setTimeout(function() {
+	        hideTooltip(tooltip);
+	      }, 5000);
 	    };
 
 	    var hide = function () {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -723,7 +723,7 @@
 	      obj = obj.parentNode;
 	    }
 	    return obj;
-	  }
+	  };
 
 	  var depixelize = function(value) {
 	    if (value.indexOf('px') > -1) {
@@ -731,20 +731,19 @@
 	    } else {
 	      return value;
 	    }
-	  }
+	  };
 
 	  var pixelize = function(value) {
 	    return value + 'px';
-	  }
+	  };
 
 	  var hideTooltip = function (tooltip) {
 	    tooltip.attr('aria-hidden', true);
-	  }
+	  };
 
 	  var attached = function() {
 	    var root = d3.select(this);
-	    var self = d3.select(this);
-	    var svg = d3.select(findParentSVG(this))
+	    var svg = d3.select(findParentSVG(this));
 	    var svgParent = d3.select(findParentSVG(this).parentElement);
 	    var parent = d3.select(this.parentElement).select('use');
 
@@ -777,7 +776,7 @@
 	      if (initialize) {
 	        hideTooltip(tooltip);
 	      }
-	    }
+	    };
 
 	    var update = function() {
 
@@ -815,7 +814,7 @@
 	        var tooltip = svgParent.select('.eiti-tooltip');
 	        hideTooltip(tooltip);
 	      }
-	    }
+	    };
 
 	    init(this);
 
@@ -835,7 +834,7 @@
 	        detachdCallback: {value: detached}
 	      }
 	    )
-	  })
+	  });
 
 	})(this);
 

--- a/js/src/homepage.js
+++ b/js/src/homepage.js
@@ -2,6 +2,7 @@
   'use strict';
 
   require('./../components/aria-tabs.js');
+  require('./../components/eiti-tooltip.js');
 
 })(window);
 

--- a/js/src/homepage.js
+++ b/js/src/homepage.js
@@ -2,7 +2,7 @@
   'use strict';
 
   require('./../components/aria-tabs.js');
-  require('./../components/eiti-tooltip.js');
+  require('./../components/eiti-tooltip-wrapper.js');
 
 })(window);
 

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -7,7 +7,7 @@
   require('./../components/eiti-bar-chart.js');
   require('./../components/year-switcher-section.js');
   require('./../components/eiti-data-map-table.js');
-  require('./../components/eiti-tooltip.js');
+  require('./../components/eiti-tooltip-wrapper.js');
 
   require('./../components/aria-tabs.js');
 

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -7,6 +7,7 @@
   require('./../components/eiti-bar-chart.js');
   require('./../components/year-switcher-section.js');
   require('./../components/eiti-data-map-table.js');
+  require('./../components/eiti-tooltip.js');
 
   require('./../components/aria-tabs.js');
 


### PR DESCRIPTION
Fixes issue(s) #1520 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/map-tooltips/explore/)

Changes proposed in this pull request:
- adds an `eiti-tooltip` component to be used in conjunction with the `<title>` element

`eiti-tooltip` can be used like so: `<title is="eiti-tooltip">` and supports `desc` and `alt` attributes.

`desc`: text to be displayed
`alt`: applied to the `aria-label` attribute on the tooltip

Enhancement possibility: make tooltips clickable. Add `href` attribute support

/cc @shawnbot  @ericronne 
