### PR TITLE
Tooltip follow up

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ selector: location
       </aside>
     </section> -->
 
-    <section class="eiti-tab-panel explore_home-main" id="production" role="tabpanel" aria-hidden="true">
+    <!-- <section class="eiti-tab-panel explore_home-main" id="production" role="tabpanel" aria-hidden="true">
       <div class="container-left-3">
         <p>For the first time, data on all production on federal lands is available publicly. See how much energy was produced nationally, or explore all resources extracted on federal lands.</p>
         <a href="{{ site.baseurl }}/explore/#production" class="button-primary explore_home-button">Explore data</a>
@@ -93,9 +93,9 @@ selector: location
           <div><a href="{{ site.baseurl }}/explore/#federal-production">Federal production data →</a></div>
         </aside>
       </div>
-    </section>
+    </section> -->
 
-    <section class="eiti-tab-panel explore_home-main" id="impact" role="tabpanel" aria-hidden="true">
+   <!--  <section class="eiti-tab-panel explore_home-main" id="impact" role="tabpanel" aria-hidden="true">
       <div class="container-left-3">
         <p>Extractive industries account for 2.6 percent of the national GDP, and contribute to exports and employment in many parts of the country.</p>
         <a href="{{ site.baseurl }}/explore/#economic-impact" class="button-primary explore_home-button">Explore data</a>
@@ -112,7 +112,7 @@ selector: location
           <div><a href="{{ site.baseurl }}/explore/#employment">Jobs data →</a></div>
         </aside>
       </div>
-    </section>
+    </section> -->
 
   </div>
 </section>

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -18,13 +18,13 @@
 
   var attached = function() {
     var self = d3.select(this);
-    var svg = d3.select('svg');
-    var svgParent = self;
+    var svg = self.select('svg');
     var titles = self.selectAll('title');
     var tiles = self.selectAll('use');
 
     var tooltip,
-      tooltipText;
+      tooltipText,
+      OFFSET = 2;
 
     var init = function(initialize) {
       tooltip = self.select('.eiti-tooltip');
@@ -53,7 +53,6 @@
     var update = function() {
       var event = event || d3.event || window.event;
       var elem = event.target || event.srcElement;
-
       var parentElement = d3.select(elem.parentElement);
       var title = parentElement.select('title');
 
@@ -72,20 +71,24 @@
           var tooltipWidth = depixelize(tooltip.style('width'));
           var svgWidth = depixelize(svg.style('width'));
 
-          if (svgWidth <= tooltipWidth + event.layerX) {
-            return pixelize(event.layerX - tooltipWidth);
+          var x = event.layerX + OFFSET;
+
+          if (svgWidth <= tooltipWidth + x) {
+            return pixelize(event.layerX - tooltipWidth - OFFSET);
           } else {
-            return pixelize(event.layerX);
+            return pixelize(x);
           }
         })
         .style('top', function() {
           var tooltipHeight = depixelize(tooltip.style('height'));
           var svgHeight = depixelize(svg.style('height'));
 
-          if (svgHeight <= tooltipHeight + event.layerY) {
-            return pixelize(event.layerY - tooltipHeight);
+          var y = event.layerY + OFFSET;
+
+          if (svgHeight <= tooltipHeight + y) {
+            return pixelize(event.layerY - tooltipHeight - OFFSET);
           } else {
-            return pixelize(event.layerY);
+            return pixelize(y);
           }
         });
     };
@@ -93,6 +96,7 @@
     var hide = function () {
       var event = event || window.event;
       var elem = event.target || event.srcElement;
+
       if (elem.nodeName === 'svg') {
         var tooltip = self.select('.eiti-tooltip');
         hideTooltip(tooltip);

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -49,7 +49,7 @@
 	  'use strict';
 
 	  __webpack_require__(7);
-	  __webpack_require__(41);
+	  __webpack_require__(8);
 
 	})(window);
 
@@ -196,7 +196,7 @@
 
 /***/ },
 
-/***/ 41:
+/***/ 8:
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -219,13 +219,13 @@
 
 	  var attached = function() {
 	    var self = d3.select(this);
-	    var svg = d3.select('svg');
-	    var svgParent = self;
+	    var svg = self.select('svg');
 	    var titles = self.selectAll('title');
 	    var tiles = self.selectAll('use');
 
 	    var tooltip,
-	      tooltipText;
+	      tooltipText,
+	      OFFSET = 2;
 
 	    var init = function(initialize) {
 	      tooltip = self.select('.eiti-tooltip');
@@ -254,7 +254,6 @@
 	    var update = function() {
 	      var event = event || d3.event || window.event;
 	      var elem = event.target || event.srcElement;
-
 	      var parentElement = d3.select(elem.parentElement);
 	      var title = parentElement.select('title');
 
@@ -273,20 +272,24 @@
 	          var tooltipWidth = depixelize(tooltip.style('width'));
 	          var svgWidth = depixelize(svg.style('width'));
 
-	          if (svgWidth <= tooltipWidth + event.layerX) {
-	            return pixelize(event.layerX - tooltipWidth);
+	          var x = event.layerX + OFFSET;
+
+	          if (svgWidth <= tooltipWidth + x) {
+	            return pixelize(event.layerX - tooltipWidth - OFFSET);
 	          } else {
-	            return pixelize(event.layerX);
+	            return pixelize(x);
 	          }
 	        })
 	        .style('top', function() {
 	          var tooltipHeight = depixelize(tooltip.style('height'));
 	          var svgHeight = depixelize(svg.style('height'));
 
-	          if (svgHeight <= tooltipHeight + event.layerY) {
-	            return pixelize(event.layerY - tooltipHeight);
+	          var y = event.layerY + OFFSET;
+
+	          if (svgHeight <= tooltipHeight + y) {
+	            return pixelize(event.layerY - tooltipHeight - OFFSET);
 	          } else {
-	            return pixelize(event.layerY);
+	            return pixelize(y);
 	          }
 	        });
 	    };
@@ -294,6 +297,7 @@
 	    var hide = function () {
 	      var event = event || window.event;
 	      var elem = event.target || event.srcElement;
+
 	      if (elem.nodeName === 'svg') {
 	        var tooltip = self.select('.eiti-tooltip');
 	        hideTooltip(tooltip);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -53,7 +53,7 @@
 	  __webpack_require__(38);
 	  __webpack_require__(39);
 	  __webpack_require__(40);
-	  __webpack_require__(41);
+	  __webpack_require__(8);
 
 	  __webpack_require__(7);
 
@@ -712,7 +712,138 @@
 
 
 /***/ },
-/* 8 */,
+/* 8 */
+/***/ function(module, exports) {
+
+	(function(exports) {
+
+	  var depixelize = function(value) {
+	    if (value.indexOf('px') > -1) {
+	      return +value.substr(0, value.length - 2);
+	    } else {
+	      return value;
+	    }
+	  };
+
+	  var pixelize = function(value) {
+	    return value + 'px';
+	  };
+
+	  var hideTooltip = function (tooltip) {
+	    tooltip.attr('aria-hidden', true);
+	  };
+
+	  var attached = function() {
+	    var self = d3.select(this);
+	    var svg = self.select('svg');
+	    var titles = self.selectAll('title');
+	    var tiles = self.selectAll('use');
+
+	    var tooltip,
+	      tooltipText,
+	      OFFSET = 2;
+
+	    var init = function(initialize) {
+	      tooltip = self.select('.eiti-tooltip');
+
+	      if (tooltip.empty()) {
+	        tooltip = self.append('div')
+	          .classed('eiti-tooltip', true);
+	      }
+
+	      tooltip
+	        .attr('aria-hidden', true);
+
+	      tooltipText = tooltip.select('p');
+
+	      if (tooltipText.empty()) {
+	        tooltipText = tooltip.append('p');
+	      }
+
+	      // clear <title> text
+	      // if no javascript runs, <title> will serve as the tooltip
+	      // otherwise, clear it so that it doesn't interfere with
+	      // this tooltip
+	      titles.text('');
+	    };
+
+	    var update = function() {
+	      var event = event || d3.event || window.event;
+	      var elem = event.target || event.srcElement;
+	      var parentElement = d3.select(elem.parentElement);
+	      var title = parentElement.select('title');
+
+	      init();
+
+	      tooltipText.text(function(){
+	        return title.attr('desc');
+	      });
+
+	      tooltip
+	        .attr('aria-hidden', false)
+	        .attr('aria-label', function(){
+	          return title.attr('alt');
+	        })
+	        .style('left', function() {
+	          var tooltipWidth = depixelize(tooltip.style('width'));
+	          var svgWidth = depixelize(svg.style('width'));
+
+	          var x = event.layerX + OFFSET;
+
+	          if (svgWidth <= tooltipWidth + x) {
+	            return pixelize(event.layerX - tooltipWidth - OFFSET);
+	          } else {
+	            return pixelize(x);
+	          }
+	        })
+	        .style('top', function() {
+	          var tooltipHeight = depixelize(tooltip.style('height'));
+	          var svgHeight = depixelize(svg.style('height'));
+
+	          var y = event.layerY + OFFSET;
+
+	          if (svgHeight <= tooltipHeight + y) {
+	            return pixelize(event.layerY - tooltipHeight - OFFSET);
+	          } else {
+	            return pixelize(y);
+	          }
+	        });
+	    };
+
+	    var hide = function () {
+	      var event = event || window.event;
+	      var elem = event.target || event.srcElement;
+
+	      if (elem.nodeName === 'svg') {
+	        var tooltip = self.select('.eiti-tooltip');
+	        hideTooltip(tooltip);
+	      }
+	    };
+
+	    init(this);
+
+	    tiles.on('mouseover', update);
+	    svg.on('mouseout', hide);
+	  };
+
+	  var detached = function() { };
+
+	  exports.EITITooltipWrapper = document.registerElement('eiti-tooltip-wrapper', {
+	    extends: 'div',
+	    prototype: Object.create(
+	      HTMLElement.prototype,
+	      {
+	        attachedCallback: {value: attached},
+	        detachdCallback: {value: detached}
+	      }
+	    )
+	  });
+
+	})(this);
+
+
+
+/***/ },
 /* 9 */
 /***/ function(module, exports, __webpack_require__) {
 
@@ -13491,134 +13622,6 @@
 	      }
 	    )
 	  })
-
-	})(this);
-
-
-
-/***/ },
-/* 41 */
-/***/ function(module, exports) {
-
-	(function(exports) {
-
-	  var depixelize = function(value) {
-	    if (value.indexOf('px') > -1) {
-	      return +value.substr(0, value.length - 2);
-	    } else {
-	      return value;
-	    }
-	  };
-
-	  var pixelize = function(value) {
-	    return value + 'px';
-	  };
-
-	  var hideTooltip = function (tooltip) {
-	    tooltip.attr('aria-hidden', true);
-	  };
-
-	  var attached = function() {
-	    var self = d3.select(this);
-	    var svg = d3.select('svg');
-	    var svgParent = self;
-	    var titles = self.selectAll('title');
-	    var tiles = self.selectAll('use');
-
-	    var tooltip,
-	      tooltipText;
-
-	    var init = function(initialize) {
-	      tooltip = self.select('.eiti-tooltip');
-
-	      if (tooltip.empty()) {
-	        tooltip = self.append('div')
-	          .classed('eiti-tooltip', true);
-	      }
-
-	      tooltip
-	        .attr('aria-hidden', true);
-
-	      tooltipText = tooltip.select('p');
-
-	      if (tooltipText.empty()) {
-	        tooltipText = tooltip.append('p');
-	      }
-
-	      // clear <title> text
-	      // if no javascript runs, <title> will serve as the tooltip
-	      // otherwise, clear it so that it doesn't interfere with
-	      // this tooltip
-	      titles.text('');
-	    };
-
-	    var update = function() {
-	      var event = event || d3.event || window.event;
-	      var elem = event.target || event.srcElement;
-
-	      var parentElement = d3.select(elem.parentElement);
-	      var title = parentElement.select('title');
-
-	      init();
-
-	      tooltipText.text(function(){
-	        return title.attr('desc');
-	      });
-
-	      tooltip
-	        .attr('aria-hidden', false)
-	        .attr('aria-label', function(){
-	          return title.attr('alt');
-	        })
-	        .style('left', function() {
-	          var tooltipWidth = depixelize(tooltip.style('width'));
-	          var svgWidth = depixelize(svg.style('width'));
-
-	          if (svgWidth <= tooltipWidth + event.layerX) {
-	            return pixelize(event.layerX - tooltipWidth);
-	          } else {
-	            return pixelize(event.layerX);
-	          }
-	        })
-	        .style('top', function() {
-	          var tooltipHeight = depixelize(tooltip.style('height'));
-	          var svgHeight = depixelize(svg.style('height'));
-
-	          if (svgHeight <= tooltipHeight + event.layerY) {
-	            return pixelize(event.layerY - tooltipHeight);
-	          } else {
-	            return pixelize(event.layerY);
-	          }
-	        });
-	    };
-
-	    var hide = function () {
-	      var event = event || window.event;
-	      var elem = event.target || event.srcElement;
-	      if (elem.nodeName === 'svg') {
-	        var tooltip = self.select('.eiti-tooltip');
-	        hideTooltip(tooltip);
-	      }
-	    };
-
-	    init(this);
-
-	    tiles.on('mouseover', update);
-	    svg.on('mouseout', hide);
-	  };
-
-	  var detached = function() { };
-
-	  exports.EITITooltipWrapper = document.registerElement('eiti-tooltip-wrapper', {
-	    extends: 'div',
-	    prototype: Object.create(
-	      HTMLElement.prototype,
-	      {
-	        attachedCallback: {value: attached},
-	        detachdCallback: {value: detached}
-	      }
-	    )
-	  });
 
 	})(this);
 


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/tooltip-followup/)

Changes proposed in this pull request:
- commented out additional tab tiles on homepage
- added a tooltip offset that limits the amount of flashing that people see when they rapidly change states
- fixes bug that was preventing the tooltip from hiding when exiting the svg

/cc @meiqimichelle 

