### PR TITLE
Homepage map polish

### DIFF
--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -4,7 +4,7 @@
 .explore_home-heading {
   font-weight: $weight-book;
   line-height: 1.3;
-  margin-bottom: $base-padding;
+  margin-bottom: $base-padding-lite;
   padding-right: $base-padding-lite;
 }
 
@@ -22,6 +22,32 @@
     margin-top: 0;
     padding-top: 0;
   }
+}
+
+.explore_home-map {
+  aside {
+    margin-left: $base-padding-large;
+  }
+
+  figure {
+    margin-top: -$base-padding;
+  }
+
+  .state_pages-select {
+    padding-top: $base-padding;
+
+    label {
+      font-size: 0.8rem;
+    }
+
+    select {
+      width: 85%;
+    }
+  }
+}
+
+.explore_home-map-intro {
+  padding-right: $base-padding-large;
 }
 
 .explore_home-tabs {

--- a/index.html
+++ b/index.html
@@ -42,6 +42,9 @@ selector: location
           no_outline=true
         %}
       </figure>
+      <aside class="wide">
+        {% include maps/federal_land_ownership_legend.html %}
+      </aside>
     </div>
   </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@ selector: location
   </div>
 </section>
 
-<section class="slab-alpha container-padded">
+<section class="slab-alpha container-padded explore_home-map">
   <div class="container-page-wrapper">
-    <div class="container-left-4">
+    <div class="container-left-4 explore_home-map-intro">
       <p class="h5 explore_home-subhead">Explore data</p>
       <h2 class="h3 explore_home-heading">Learn about natural resource extraction in each state</h2>
       <p>
@@ -46,77 +46,6 @@ selector: location
         {% include maps/federal_land_ownership_legend.html %}
       </aside>
     </div>
-  </div>
-</section>
-
-<!-- <section class="slab-alpha container-padded">
-  <div class="container-page-wrapper tab-interface">
-
-    <p class="h5 explore_home-subhead">Explore data</p>
-    <h2 class="h3 explore_home-heading explore_home-explore_heading">Learn about extractive industries throughout the country</h2>
-
-    <ul class="eiti-tabs explore_home-tabs" role="tablist">
-      <li role="presentation"><a href="#revenue" tabindex="0" role="tab" aria-controls="revenue" aria-selected="true" class="link-charlie">Revenue</a></li>
-      <li role="presentation"><a href="#production" tabindex="-1" role="tab" aria-controls="production" class="link-charlie">Production</a></li>
-      <li role="presentation"><a href="#impact" tabindex="-1" role="tab" aria-controls="impact" class="link-charlie"><span class="explore_home-tab_mobile">Impact</span><span class="explore_home-tab_desktop">Economic Impact</span></a></li>
-    </ul>
-
-    <section class="eiti-tab-panel explore_home-main" id="revenue" role="tabpanel">
-      <div class="container-left-3">
-        <p>Revenue data shows where federal revenue from extractive industries is coming from, who pays it, and where it goes.</p>
-        <a href="{{ site.baseurl }}/explore/#revenue" class="button-primary explore_home-button">Explore data</a>
-      </div>
-      <div  class="container-left-6">
-        <a href="{{ site.baseurl }}/explore/#revenue" class="explore_home-img">
-          <img src="{{ site.baseurl }}/img/explore-home-revenue.png" alt="Map showing revenues from extractive resources on federal lands">
-        </a>
-      </div>
-      <div class="container-left-3">
-        <p class="explore_home-fact">In 2013, the federal government collected over <strong>$12 billion</strong> from those extracting resources on federal lands and waters.</p>
-        <aside class="explore_home-links">
-          <div><a href="{{ site.baseurl }}/explore/#revenue">Federal revenue from all lands →</a></div>
-        </div>
-      </aside>
-    </section> -->
-
-    <!-- <section class="eiti-tab-panel explore_home-main" id="production" role="tabpanel" aria-hidden="true">
-      <div class="container-left-3">
-        <p>For the first time, data on all production on federal lands is available publicly. See how much energy was produced nationally, or explore all resources extracted on federal lands.</p>
-        <a href="{{ site.baseurl }}/explore/#production" class="button-primary explore_home-button">Explore data</a>
-      </div>
-      <div  class="container-left-6">
-        <a href="{{ site.baseurl }}/explore/#federal-production" class="explore_home-img">
-          <h4>Production from federal vs. non-federal lands and waters</h4>
-          <img src="{{ site.baseurl }}/img/explore-home-production.png" alt="Chart showing percentage of production occuring on federal versus non-federal lands and waters">
-        </a>
-      </div>
-      <div class="container-left-3">
-        <p class="explore_home-fact">Natural resources located on federal lands belong to all U.S. citizens. Explore how much of 55 specific products is produced on federal lands and waters.</p>
-        <aside class="explore_home-links">
-          <div><a href="{{ site.baseurl }}/explore/#federal-production">Federal production data →</a></div>
-        </aside>
-      </div>
-    </section> -->
-
-   <!--  <section class="eiti-tab-panel explore_home-main" id="impact" role="tabpanel" aria-hidden="true">
-      <div class="container-left-3">
-        <p>Extractive industries account for 2.6 percent of the national GDP, and contribute to exports and employment in many parts of the country.</p>
-        <a href="{{ site.baseurl }}/explore/#economic-impact" class="button-primary explore_home-button">Explore data</a>
-      </div>
-      <div  class="container-left-6">
-        <a href="{{ site.baseurl }}/explore/#empoyment" class="explore_home-img">
-          <h4>Employment in extractive industries vs. all other industries</h4>
-          <img src="{{ site.baseurl }}/img/explore-home-impact.png" alt="Chart showing employment in extractive industries vs. all other industries">
-        </a>
-      </div>
-      <div class="container-left-3">
-        <p class="explore_home-fact">Over <strong>800,000 people</strong> worked in the extractive industries in 2013. Texas and Oklahoma stand out as the states with the most jobs in these industries.</p>
-        <aside class="explore_home-links">
-          <div><a href="{{ site.baseurl }}/explore/#employment">Jobs data →</a></div>
-        </aside>
-      </div>
-    </section> -->
-
   </div>
 </section>
 


### PR DESCRIPTION
For #1742.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/homepage-map-polish/)

Adjusts padding and sizes on the homepage map to get ever-closer to mock. Looks like:

![screenshot 2016-09-14 18 03 44](https://cloud.githubusercontent.com/assets/4827522/18535025/9c12d3a2-7aa5-11e6-8e8b-f7f29df60c82.png)

/cc @ericronne 
