### PR TITLE
Case studies tooltips

### DIFF
--- a/_data/case_studies_points.yml
+++ b/_data/case_studies_points.yml
@@ -1,3 +1,6 @@
+# attributes dictate the content of the case studies tooltips
+# order DOES matter. Objects at the end of the array
+# will render on top of objects at the beginning
 locations:
   north_slope:
     name: North Slope Borough
@@ -42,8 +45,8 @@ locations:
   tarrant_johnson:
     name: Tarrant and Johnson Counties
     lines:
-      - Tarrant
-      - and Johnson Counties
+      - Tarrant and
+      - Johnson Counties
     state: Texas
     permalink: /case-studies/tarrant-and-johnson/
     commodity: gas
@@ -80,8 +83,8 @@ locations:
   humboldt_lander:
     name: Humboldt and Lander Counties
     lines:
-      - Humboldt
-      - and Lander Counties
+      - Humboldt and
+      - Lander Counties
     state: Nevada
     permalink: /case-studies/humboldt-and-lander/
     commodity: gold
@@ -91,8 +94,9 @@ locations:
   boone_logan_mingo:
     name: Boone, Logan, and Mingo Counties
     lines:
-      - Boone, Logan
-      - and Mingo Counties
+      - Boone, Logan and
+      - Mingo Counties
+    wide: true
     state: West Virginia
     permalink: /case-studies/boone-logan-and-mingo/
     commodity: coal

--- a/_data/case_studies_points.yml
+++ b/_data/case_studies_points.yml
@@ -1,38 +1,60 @@
-coal:
-  boone_logan_mingo:
-    name: Boone, Logan, and Mingo Counties
-    state: West Virginia
-    permalink: /case-studies/boone-logan-and-mingo/
+locations:
+  north_slope:
+    name: North Slope Borough
+    permalink: /case-studies/north-slope/
+    state: Alaska
+    commodity: oil
     circle:
-      'x': 740
-      'y': 280
-  campbell:
-    name: Campbell County
-    state: Wyoming
-    permalink: /case-studies/campbell/
+      'x': 185
+      'y': 465
+  pima:
+    name: Pima County
+    state: Arizona
+    permalink: /case-studies/pima/
+    commodity: copper
     circle:
-      'x': 375
-      'y': 185
-gold:
-  elko_eureka:
-    name: Elko and Eureka Counties
-    state: Nevada
-    permalink: /case-studies/elko-and-eureka/
+      'x': 260
+      'y': 405
+  kern:
+    name: Kern County
+    state: California
+    commodity: oil
+    permalink: /case-studies/kern/
     circle:
-      'x': 250
-      'y': 235
-  humboldt_lander:
-    name: Humboldt and Lander Counties
-    state: Nevada
-    permalink: /case-studies/humboldt-and-lander/
+      'x': 170
+      'y': 310
+  greenlee:
+    name: Greenlee County
+    state: Arizona
+    permalink: /case-studies/greenlee/
+    commodity: copper
     circle:
-      'x': 190
-      'y': 205
-iron:
+      'x': 300
+      'y': 365
+  desoto:
+    name: DeSoto Parish
+    state: Louisiana
+    permalink: /case-studies/desoto/
+    commodity: gas
+    circle:
+      'x': 550
+      'y': 435
+  tarrant_johnson:
+    name: Tarrant and Johnson Counties
+    lines:
+      - Tarrant
+      - and Johnson Counties
+    state: Texas
+    permalink: /case-studies/tarrant-and-johnson/
+    commodity: gas
+    circle:
+      'x': 490
+      'y': 415
   marquette:
     name: Marquette County
     state: Michigan
     permalink: /case-studies/marquette/
+    commodity: iron
     circle:
       'x': 610
       'y': 170
@@ -40,51 +62,48 @@ iron:
     name: St. Louis County
     state: Minnesota
     permalink: /case-studies/st-louis/
+    commodity: iron
     circle:
       'x': 550
       'y': 140
-gas:
-  desoto:
-    name: DeSoto Parish
-    state: Louisiana
-    permalink: /case-studies/desoto/
+  elko_eureka:
+    name: Elko and Eureka Counties
+    lines:
+      - Elko and
+      - Eureka Counties
+    state: Nevada
+    permalink: /case-studies/elko-and-eureka/
+    commodity: gold
     circle:
-      'x': 550
-      'y': 435
-  tarrant_johnson:
-    name: Tarrant and Johnson Counties
-    state: Texas
-    permalink: /case-studies/tarrant-and-johnson/
+      'x': 250
+      'y': 235
+  humboldt_lander:
+    name: Humboldt and Lander Counties
+    lines:
+      - Humboldt
+      - and Lander Counties
+    state: Nevada
+    permalink: /case-studies/humboldt-and-lander/
+    commodity: gold
     circle:
-      'x': 490
-      'y': 415
-oil:
-  kern:
-    name: Kern County
-    state: California
-    permalink: /case-studies/kern/
+      'x': 190
+      'y': 205
+  boone_logan_mingo:
+    name: Boone, Logan, and Mingo Counties
+    lines:
+      - Boone, Logan
+      - and Mingo Counties
+    state: West Virginia
+    permalink: /case-studies/boone-logan-and-mingo/
+    commodity: coal
     circle:
-      'x': 170
-      'y': 310
-  north_slope:
-    name: North Slope Borough
-    permalink: /case-studies/north-slope/
-    state: Alaska
+      'x': 740
+      'y': 280
+  campbell:
+    name: Campbell County
+    state: Wyoming
+    permalink: /case-studies/campbell/
+    commodity: coal
     circle:
-      'x': 185
-      'y': 465
-copper:
-  pima:
-    name: Pima County
-    state: Arizona
-    permalink: /case-studies/pima/
-    circle:
-      'x': 260
-      'y': 405
-  greenlee:
-    name: Greenlee County
-    state: Arizona
-    permalink: /case-studies/greenlee/
-    circle:
-      'x': 300
-      'y': 365
+      'x': 375
+      'y': 185

--- a/_includes/case-studies/_points-of-interest.html
+++ b/_includes/case-studies/_points-of-interest.html
@@ -1,40 +1,54 @@
 {% assign case_studies_points = site.data.case_studies_points %}
 {% assign circle_radius = 21 %}
-{% assign caption_height = 85 %}
+{% assign caption_height = 87 %}
 {% assign caption_width = 205 %}
 {% assign commodities = 'oil,copper,gas,iron,gold,coal' | split:',' %}
 {% assign black_light = '#323c42' %}
 
 <g class="case-studies-points">
-  {% for commodity in commodities %}
-    {% for point in case_studies_points[commodity] %}
-      {% assign point_id = point[0] %}
-      {% assign point_name = point[1].name %}
-      {% assign point_state = point[1].state %}
-      {% assign point_permalink = point[1].permalink %}
-      {% assign coords = point[1].circle %}
-      {% assign x_offset = coords.x | minus: circle_radius %}
-      {% assign y_offset = coords.y | minus: circle_radius %}
+  {% for location in case_studies_points.locations %}
 
-      {% capture caption %}
-        {{ commodity | capitalize }} in {{ point_state }}
-      {% endcapture %}
+    {% assign location_id = location[0] %}
+    {% assign location_name = location[1].name %}
+    {% assign location_lines = location[1].lines %}
+    {% assign location_state = location[1].state %}
+    {% assign location_commodity = location[1].commodity %}
+    {% assign location_permalink = location[1].permalink %}
+    {% assign coords = location[1].circle %}
+    {% assign x_offset = coords.x | minus: circle_radius %}
+    {% assign y_offset = coords.y | minus: circle_radius %}
 
-      <g class="case-studies-circle-group">
-        <g class="case-studies-caption {{ point_id }}">
-          <a xlink:href="{{ point_permalink | prepend:site.baseurl }}">
-            {% if point_id == 'boone_logan_mingo' %}
-              <rect x="{{ x_offset }}" y="{{ y_offset }}" width="{{ caption_width | times:1.05 }}" height="{{ caption_height  | times:1.05 }}"></rect>
-            {% else %}
-              <rect x="{{ x_offset }}" y="{{ y_offset }}" width="{{ caption_width }}" height="{{ caption_height }}"></rect>
-            {% endif %}
-            <text x="{{ x_offset }}" y="{{ y_offset }}">{{ caption }}</text>
-          </a>
-          <text class="case-studies-description" x="{{ x_offset }}" y="{{ y_offset | plus:20 }}">{{ point_name }}</text>
-        </g>
-        <circle cx="{{ coords.x }}" cy="{{ coords.y }}" r="{{ circle_radius }}" fill="#fff" stroke="{{ black_light }}" stroke-width="2px"></circle>
-        {% include svg/circle-icon-{{ commodity }}.svg x=x_offset y=y_offset caption=caption %}
+    {% capture caption %}
+      {{ location_commodity | capitalize }} in {{ location_state }}
+    {% endcapture %}
+
+    <g class="case-studies-circle-group">
+      <g class="case-studies-caption {% if location_lines %}long{% endif %}">
+        <a xlink:href="{{ location_permalink | prepend:site.baseurl }}">
+          {% if location_id == 'boone_logan_mingo' %}
+            <rect x="{{ x_offset }}" y="{{ y_offset }}" width="{{ caption_width | times:1.25 }}" height="{{ caption_height  | times:1.25 }}"></rect>
+          {% else %}
+            <rect x="{{ x_offset }}" y="{{ y_offset }}" width="{{ caption_width }}" height="{{ caption_height }}"></rect>
+          {% endif %}
+          <text x="{{ x_offset }}" y="{{ y_offset }}">{{ caption }}</text>
+        </a>
+        {% if location_lines %}
+          {% assign line_height = y_offset | plus: 22 %}
+          {% for line in location_lines %}
+            <text class="case-studies-description" x="{{ x_offset }}" y="{{ line_height }}">
+              {{ line }}
+            </text>
+            {% assign line_height = line_height | plus: 18 %}
+          {% endfor %}
+        {% else %}
+          <text class="case-studies-description" x="{{ x_offset }}" y="{{ y_offset | plus:20 }}">
+            {{ location_name }}
+          </text>
+        {% endif %}
+
       </g>
-    {% endfor %}
+      <circle cx="{{ coords.x }}" cy="{{ coords.y }}" r="{{ circle_radius }}" fill="#fff" stroke="{{ black_light }}" stroke-width="2px"></circle>
+      {% include svg/circle-icon-{{ location_commodity }}.svg x=x_offset y=y_offset caption=caption %}
+    </g>
   {% endfor %}
 </g>

--- a/_includes/case-studies/_points-of-interest.html
+++ b/_includes/case-studies/_points-of-interest.html
@@ -17,23 +17,24 @@
     {% assign coords = location[1].circle %}
     {% assign x_offset = coords.x | minus: circle_radius %}
     {% assign y_offset = coords.y | minus: circle_radius %}
+    {% assign y_text_block = y_offset | plus: 5 %}
 
     {% capture caption %}
       {{ location_commodity | capitalize }} in {{ location_state }}
     {% endcapture %}
 
     <g class="case-studies-circle-group">
-      <g class="case-studies-caption {% if location_lines %}long{% endif %}">
+      <g class="case-studies-caption {% if location[1].wide %} wide{% endif %}{% if location_lines %} long{% endif %}">
         <a xlink:href="{{ location_permalink | prepend:site.baseurl }}">
           {% if location_id == 'boone_logan_mingo' %}
             <rect x="{{ x_offset }}" y="{{ y_offset }}" width="{{ caption_width | times:1.25 }}" height="{{ caption_height  | times:1.25 }}"></rect>
           {% else %}
             <rect x="{{ x_offset }}" y="{{ y_offset }}" width="{{ caption_width }}" height="{{ caption_height }}"></rect>
           {% endif %}
-          <text x="{{ x_offset }}" y="{{ y_offset }}">{{ caption }}</text>
+          <text x="{{ x_offset }}" y="{{ y_text_block }}">{{ caption }}</text>
         </a>
         {% if location_lines %}
-          {% assign line_height = y_offset | plus: 22 %}
+          {% assign line_height = y_text_block | plus: 22 %}
           {% for line in location_lines %}
             <text class="case-studies-description" x="{{ x_offset }}" y="{{ line_height }}">
               {{ line }}
@@ -41,7 +42,7 @@
             {% assign line_height = line_height | plus: 18 %}
           {% endfor %}
         {% else %}
-          <text class="case-studies-description" x="{{ x_offset }}" y="{{ y_offset | plus:20 }}">
+          <text class="case-studies-description" x="{{ x_offset }}" y="{{ y_text_block | plus:20 }}">
             {{ location_name }}
           </text>
         {% endif %}

--- a/_sass/blocks/case-studies/_map-homepage.scss
+++ b/_sass/blocks/case-studies/_map-homepage.scss
@@ -19,20 +19,26 @@
 
   $circle-radius: 21px;
   $stroke-width: 2px;
-  $caption-width: 205px;
+  $caption-width: 180px;
   $caption-height: 87px;
   $caption-offset-x: -($caption-width / 2) + $circle-radius;
   $caption-offset-y: $circle-radius;
+
+  $wide-caption-width: 205px;
+  $wide-caption-offset-x: -($wide-caption-width / 2) + $circle-radius;
 
 
   .case-studies-caption {
     visibility: hidden;
 
-    &.long {
-      $multiplier: 1.25;
-      rect {
-        height: $caption-height * $multiplier;
-      }
+    $multiplier: 1.25;
+    &.long rect {
+      height: $caption-height * $multiplier;
+    }
+
+    &.wide rect {
+      width: $wide-caption-width;
+      transform: translate(#{$wide-caption-offset-x}, #{$caption-offset-y});
     }
   }
 
@@ -62,6 +68,8 @@
 
   a text {
     @include font-size(1.1);
+
+    font-weight: $weight-bold;
   }
 }
 

--- a/_sass/blocks/case-studies/_map-homepage.scss
+++ b/_sass/blocks/case-studies/_map-homepage.scss
@@ -28,14 +28,10 @@
   .case-studies-caption {
     visibility: hidden;
 
-    &.boone_logan_mingo {
-      $multiplier: 1.05;
-      $large-caption-offset-x: $caption-offset-x * $multiplier;
-
+    &.long {
+      $multiplier: 1.25;
       rect {
         height: $caption-height * $multiplier;
-        transform: translate(#{$large-caption-offset-x}, #{$caption-offset-y});
-        width: $caption-width * $multiplier;
       }
     }
   }
@@ -58,6 +54,10 @@
     fill: $black-light;
     text-anchor: middle;
     transform: translate(#{$circle-radius}, 61px);
+
+    tspan {
+      text-anchor: middle;
+    }
   }
 
   a text {

--- a/_sass/blocks/case-studies/_map-homepage.scss
+++ b/_sass/blocks/case-studies/_map-homepage.scss
@@ -32,6 +32,7 @@
     visibility: hidden;
 
     $multiplier: 1.25;
+
     &.long rect {
       height: $caption-height * $multiplier;
     }

--- a/_sass/blocks/case-studies/_map-homepage.scss
+++ b/_sass/blocks/case-studies/_map-homepage.scss
@@ -20,7 +20,7 @@
   $circle-radius: 21px;
   $stroke-width: 2px;
   $caption-width: 205px;
-  $caption-height: 75px;
+  $caption-height: 87px;
   $caption-offset-x: -($caption-width / 2) + $circle-radius;
   $caption-offset-y: $circle-radius;
 
@@ -57,7 +57,7 @@
     cursor: pointer;
     fill: $black-light;
     text-anchor: middle;
-    transform: translate(#{$circle-radius}, 55px);
+    transform: translate(#{$circle-radius}, 61px);
   }
 
   a text {

--- a/_sass/blocks/case-studies/_map-homepage.scss
+++ b/_sass/blocks/case-studies/_map-homepage.scss
@@ -37,8 +37,8 @@
     }
 
     &.wide rect {
-      width: $wide-caption-width;
       transform: translate(#{$wide-caption-offset-x}, #{$caption-offset-y});
+      width: $wide-caption-width;
     }
   }
 

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -139,6 +139,12 @@ svg.case_studies {
   .feature.offshore-area use,
   .feature.state use {
     fill: $gray;
+
+    &:active,
+    &:hover,
+    &:focus {
+      fill: $gray;
+    }
   }
 
   &.no-outlines {


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/tooltip-followup/case-studies/)

Changes proposed in this pull request:
- fixes issue with case studies offshore areas highlighting
- adjusts spacing in case studies tooltips
- adjusts templates to allow for multiple text lines in the svg tooltips

/cc @meiqimichelle @ericronne 
