### PR TITLE
Map polish follow up

### DIFF
--- a/_includes/location_selector.html
+++ b/_includes/location_selector.html
@@ -1,6 +1,13 @@
 <select
   id="location-selector"
   onchange="window.location = '{{ site.baseurl }}' + this.value">
+
+  {% if include.default %}
+    <option value="" disabled selected>{{ include.default }}</option>
+  {% endif %}
+  {% if include.nationwide %}
+    <option value="{{ include.nationwide_url }}">{{ include.nationwide_title }}</option>
+  {% endif %}
   <optgroup label="States">
     {% for state in site.states %}
     <option value="{{ state.url }}">{{ state.title }}</option>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -84,14 +84,14 @@ nav_items:
       /
     </div>
     <h1 id="title">{{ state_name }}</h1>
-    
+
     <div class="container-left-9">
-      
+
       <section id="overview">
         <h2 class="state-page-overview">Overview</h2>
-        
+
         {% include location/section-overview.html %}
-        
+
       </section>
 
       <section id="production">

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -2,7 +2,7 @@
 //
 // Styleguide blocks.explore-home
 .explore_home-heading {
-  font-weight: $weight-book;
+  font-weight: $weight-bold;
   line-height: 1.3;
   margin-bottom: $base-padding-lite;
   padding-right: $base-padding-lite;
@@ -37,7 +37,7 @@
     padding-top: $base-padding;
 
     label {
-      font-size: 0.8rem;
+      @include heading('para-sm');
     }
 
     select {

--- a/_sass/blocks/_home-explore.scss
+++ b/_sass/blocks/_home-explore.scss
@@ -36,10 +36,6 @@
   .state_pages-select {
     padding-top: $base-padding;
 
-    label {
-      @include heading('para-sm');
-    }
-
     select {
       width: 85%;
     }

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -8,7 +8,7 @@
     margin-top: -0.75rem; //to compensate for margin from preceding selectors
   }
 
-  h2:not(.ribbon-card-top-text-header) {
+  h2:not(.ribbon-card-top-text-header):not(.heading-top-of-page) {
     @include h2-bar;
     padding-top: 6rem;
 

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -8,7 +8,7 @@
     margin-top: -0.75rem; //to compensate for margin from preceding selectors
   }
 
-  h2:not(.ribbon-card-top-text-header):not(.heading-top-of-page) {
+  h2:not(.ribbon-card-top-text-header) {
     @include h2-bar;
     padding-top: 6rem;
 
@@ -112,5 +112,11 @@
   .state-pages-ownership {
     float: right;
     margin-left: 20px;
+  }
+}
+
+.national-page {
+  .slab-delta {
+    margin-bottom: 6rem;
   }
 }

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -82,7 +82,3 @@
     visibility: hidden;
   }
 }
-
-.national-page .state-page-nav-title {
-  margin: 8.6em 0 0;
-}

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -55,6 +55,7 @@ data-map {
 .legend-ownership-svg {
   .cells {
     display: flex;
+    justify-content: center;
     list-style-type: none;
     margin: 0;
     padding: 0;

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -29,6 +29,13 @@
   }
 }
 
+
+.national-page {
+  .container-page-wrapper {
+    padding-top: 6rem;
+  }
+}
+
 .container-page-wrapper {
   @extend .container;
   margin-left: $base-padding;

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -29,12 +29,11 @@
   }
 }
 
-
-.national-page {
-  .container-page-wrapper {
-    padding-top: 6rem;
-  }
-}
+// .national-page {
+//   .container-page-wrapper {
+//     padding-top: 6rem;
+//   }
+// }
 
 .container-page-wrapper {
   @extend .container;

--- a/explore/index.html
+++ b/explore/index.html
@@ -91,7 +91,7 @@ nav_items:
 
       <section id="production">
 
-        <h2>Production</h2>
+        <h2 class="heading-top-of-page">Production</h2>
 
         <p>The U.S. produces more <a href="#all-production-natural-gas-mcf">natural gas</a> and <a href="#all-production-oil-bbl">oil</a> than any other country, ranks second in the world for production of <a href="#all-production-coal-short-tons">coal</a> and renewable energy, and ranks third in the world for gold production. Learn more about <a href="{{ site.baseurl }}/how-it-works/production/">natural resource production in the U.S.</a></p>
 

--- a/explore/index.html
+++ b/explore/index.html
@@ -91,7 +91,7 @@ nav_items:
 
       <section id="production">
 
-        <h2 class="heading-top-of-page">Production</h2>
+        <h2 class="state-page-overview">Production</h2>
 
         <p>The U.S. produces more <a href="#all-production-natural-gas-mcf">natural gas</a> and <a href="#all-production-oil-bbl">oil</a> than any other country, ranks second in the world for production of <a href="#all-production-coal-short-tons">coal</a> and renewable energy, and ranks third in the world for gold production. Learn more about <a href="{{ site.baseurl }}/how-it-works/production/">natural resource production in the U.S.</a></p>
 

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ selector: location
         Explore production, revenue, and economic impact data for each state, as well as additional contextual information and data about three states that chose to participate in deeper USEITI reporting: <a href="{{ site.baseurl }}/explore/AK/">Alaska</a>, <a href="{{ site.baseurl }}/explore/MT/">Montana</a>, and <a href="{{ site.baseurl }}/explore/WY/">Wyoming</a>.
       </p>
       <figcaption class="state_pages-select">
-        <label for="location-selector">Choose one to a location to explore USEITI data:</label>
+        <label for="location-selector">Choose a location to explore USEITI data:</label>
         {% include selector.html
            nationwide = true
            nationwide_url = '/explore/'

--- a/index.html
+++ b/index.html
@@ -28,12 +28,12 @@ selector: location
         Explore production, revenue, and economic impact data for each state, as well as additional contextual information and data about three states that chose to participate in deeper USEITI reporting: <a href="{{ site.baseurl }}/explore/AK/">Alaska</a>, <a href="{{ site.baseurl }}/explore/MT/">Montana</a>, and <a href="{{ site.baseurl }}/explore/WY/">Wyoming</a>.
       </p>
       <figcaption class="state_pages-select">
-        <label for="location-selector">Explore data</label>
+        <label for="location-selector">Choose one to a location to explore USEITI data:</label>
         {% include selector.html
            nationwide = true
            nationwide_url = '/explore/'
            nationwide_title = 'Nationwide data'
-           default = 'Choose one (COREY???)'
+           default = 'State or offshore region'
         %}
       </figcaption>
     </div>

--- a/index.html
+++ b/index.html
@@ -28,12 +28,12 @@ selector: location
         Explore production, revenue, and economic impact data for each state, as well as additional contextual information and data about three states that chose to participate in deeper USEITI reporting: <a href="{{ site.baseurl }}/explore/AK/">Alaska</a>, <a href="{{ site.baseurl }}/explore/MT/">Montana</a>, and <a href="{{ site.baseurl }}/explore/WY/">Wyoming</a>.
       </p>
       <figcaption class="state_pages-select">
-        <label for="location-selector">Choose a location to explore data:</label>
+        <label for="location-selector">Explore data:</label>
         {% include selector.html
            nationwide = true
            nationwide_url = '/explore/'
            nationwide_title = 'Nationwide data'
-           default = 'State or offshore region'
+           default = 'Choose location'
         %}
       </figcaption>
     </div>

--- a/index.html
+++ b/index.html
@@ -23,14 +23,18 @@ selector: location
 <section class="slab-alpha container-padded explore_home-map">
   <div class="container-page-wrapper">
     <div class="container-left-4 explore_home-map-intro">
-      <p class="h5 explore_home-subhead">Explore data</p>
       <h2 class="h3 explore_home-heading">Learn about natural resource extraction in each state</h2>
       <p>
         Explore production, revenue, and economic impact data for each state, as well as additional contextual information and data about three states that chose to participate in deeper USEITI reporting: <a href="{{ site.baseurl }}/explore/AK/">Alaska</a>, <a href="{{ site.baseurl }}/explore/MT/">Montana</a>, and <a href="{{ site.baseurl }}/explore/WY/">Wyoming</a>.
       </p>
       <figcaption class="state_pages-select">
-        <label for="location-selector">Choose a state or offshore region</label>
-        {% include selector.html %}
+        <label for="location-selector">Explore data</label>
+        {% include selector.html
+           nationwide = true
+           nationwide_url = '/explore/'
+           nationwide_title = 'Nationwide data'
+           default = 'Choose one (COREY???)'
+        %}
       </figcaption>
     </div>
     <div class="container-right-8">

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ selector: location
         Explore production, revenue, and economic impact data for each state, as well as additional contextual information and data about three states that chose to participate in deeper USEITI reporting: <a href="{{ site.baseurl }}/explore/AK/">Alaska</a>, <a href="{{ site.baseurl }}/explore/MT/">Montana</a>, and <a href="{{ site.baseurl }}/explore/WY/">Wyoming</a>.
       </p>
       <figcaption class="state_pages-select">
-        <label for="location-selector">Choose a location to explore USEITI data:</label>
+        <label for="location-selector">Choose a location to explore data:</label>
         {% include selector.html
            nationwide = true
            nationwide_url = '/explore/'


### PR DESCRIPTION
Fixes issue(s) #1938, other assorted issues

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/homepage-map-polish-followup/)

Changes proposed in this pull request:
- center-aligned map legend on explore and homepage
- Updated the selector to include 'Nationwide data' as an option, default option
- addressed #1938

/cc @ericronne @coreycaitlin 

