### PR TITLE
Fix exports "no data" years

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -126,7 +126,8 @@ defaults:
       path: ''
       type: offshore_areas
     values:
-      layout: offshore-area
+      # 'offshore-area' no longer exists; irrelevant w/ouptut: false
+      layout: default
 
 shruggie:
   - d8394cf27efbf8ae2f96ee12788eb257f4358a42

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -1,6 +1,4 @@
 {% assign export_commodities = site.data.state_exports[state_id].commodities %}
-{% assign exports_total = exports.All[include.year].dollars %}
-{% assign exports_commodities_num = exports | size %}
 
 {% assign restore_year = year %}
 {% assign year_range = site.data.years.exports %}
@@ -9,9 +7,11 @@
 {% else %}
   {% assign year_range = site.data.years.default %}
 {% endif %}
+
+{% assign exports_total = export_commodities.All[year].dollars %}
+
 {% assign year_list = year_range | to_list %}
 {% assign year_range = year_range | jsonify %}
-
 {% assign empty_years = '' | split: '' %}
 
 <section id="exports" is="year-switcher-section" class="economic exports">
@@ -21,30 +21,31 @@
   <div class="chart-list">
 
     <div class="chart-selector-wrapper">
-      {% if export_commodities.size > 1 %}
-        {% for y in year_list %}
-          {% assign s_y = y | to_s %}
-          {% for _commodity in export_commodities %}
-            {% unless _commodity[1][s_y].size %}
-              {% if _commodity[0] != "Total" and _commodity[0] != "All" %}
-                {% assign empty_years = empty_years | push:s_y %}
-              {% endif %}
-            {% endunless %}
-          {% endfor %}
+      {% if export_commodities %}
+        {% for _year in year_list %}
+          {% assign _year_string = _year | to_s %}
+          {% unless export_commodities.All[_year_string].dollars > 0 %}
+            {% assign empty_years = empty_years | push: _year_string %}
+          {% endunless %}
         {% endfor %}
-        {% assign empty_years = empty_years | join:',' %}
-
         {% include year-selector.html year_range=year_range empty_years=empty_years %}
+      {% endif %}
+
+      {% if empty_years.size == year_range.size %}
+        {% assign has_exports = true %}
+      {% else %}
+        {% assign has_exports = false %}
       {% endif %}
 
       <p class="chart-description{% if export_commodities.size > 1 %}{% else %} no-selector{% endif %}">
         The U.S. Census Bureau collects information about the top 25 exports in each state.
 
-        {% if export_commodities.size > 1 %}
+        {% if exports_total > 0 %}
           In {{ year }}, one or more natural resources
           ranked among the top 25 exports from {{ state_name }}.
         {% else %}
-          In {{ year }}, extractive industries products did not rank among the top 25 exports from {{ state_name }}.
+          In {{ year }}, extractive industries products did not rank
+          among the top 25 exports from {{ state_name }}.
         {% endif %}
         <br>
         <a href="{{site.baseurl}}/downloads/#exports">

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -1,24 +1,20 @@
 {% assign gdp = site.data.state_gdp[state_id] %}
 {% assign year_range = site.data.years.gdp | default: site.data.years.default | jsonify %}
+{% assign empty_years = '' | split: '' %}
 
 <section id="gdp" is="year-switcher-section" class="economic gdp">
 
   <h3>Gross Domestic Product (GDP)</h3>
 
   <div class="chart-selector-wrapper">
-
     {% if gdp %}
-      {% assign empty_years = '' | split:'' %}
       {% for y in year_list %}
         {% assign s_y = y | to_s %}
-        {% unless gdp[s_y].size %}
+        {% unless gdp[s_y].dollars > 0 %}
           {% assign empty_years = empty_years | push:s_y %}
         {% endunless %}
       {% endfor %}
-
-      {% assign empty_years = empty_years | join:',' %}
       {% include year-selector.html year_range=year_range empty_years=empty_years %}
-
     {% endif %}
     <p class="chart-description{% unless gdp %} no-selector{% endunless %}">
       Data about each state's gross domestic product (GDP) comes from the U.S. Bureau of Economic Analysis.
@@ -27,49 +23,49 @@
         <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
       </a>
     </p>
-  </div><!-- .chart-selector-wrapper -->
+  </div><!-- /.chart-selector-wrapper -->
 
   {% if gdp %}
-    <div class="chart-list">
+  <div class="chart-list">
 
-      {% assign _metrics = 'dollars' | split: ' ' %}
-      {% for _metric in _metrics %}
-        {% assign _format = ',' %}
-        {% if _metric == 'dollars' %}
-          {% assign _format = '$,' %}
-        {% elsif _metric == 'percent' %}
-          {% assign _format = '%' %}
-        {% endif %}
+    {% assign _metrics = 'dollars' | split: ' ' %}
+    {% for _metric in _metrics %}
+      {% assign _format = ',' %}
+      {% if _metric == 'dollars' %}
+        {% assign _format = '$,' %}
+      {% elsif _metric == 'percent' %}
+        {% assign _format = '%' %}
+      {% endif %}
 
-      <section class="chart-item">
-        <h3 class="chart-title"><span>GDP ({{ _metric }})</span></h3>
+    <section class="chart-item">
+      <h3 class="chart-title"><span>GDP ({{ _metric }})</span></h3>
 
-        <figure class="chart chart-{{ _metric }}">
-          <eiti-bar-chart
-            aria-controls="gdp-figures-{{ _metric }}"
-            data='{{ gdp | map_hash: _metric | jsonify }}'
-            x-range="{{ year_range }}"
-            x-value="{{ year }}"
-            data-units="{{ _metric }}">
-          </eiti-bar-chart>
-          <figcaption id="gdp-figures-{{ _metric }}">
-            <span class="caption-data">
-              In <span class="eiti-bar-chart-x-value">{{ year }}</span>, 
-              extractive industries accounted for
-              <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">${{ gdp[year].dollars | intcomma }}</span>, or 
-              {{ gdp[year].percent | percent }}% 
-              of {{ state_name }}&rsquo;s GDP.
+      <figure class="chart chart-{{ _metric }}">
+        <eiti-bar-chart
+          aria-controls="gdp-figures-{{ _metric }}"
+          data='{{ gdp | map_hash: _metric | jsonify }}'
+          x-range="{{ year_range }}"
+          x-value="{{ year }}"
+          data-units="{{ _metric }}">
+        </eiti-bar-chart>
+        <figcaption id="gdp-figures-{{ _metric }}">
+          <span class="caption-data">
+            In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
+            extractive industries accounted for
+            <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">${{ gdp[year].dollars | intcomma }}</span>, or
+            {{ gdp[year].percent | percent }}%
+            of {{ state_name }}&rsquo;s GDP.
+          </span>
+          <span class="caption-no-data" aria-hidden="true">
+              There is no data for {{ state_name }} in
+              <span class="eiti-bar-chart-x-value">{{ year }}</span>
             </span>
-            <span class="caption-no-data" aria-hidden="true">
-                There is no data for {{ state_name }} in
-                <span class="eiti-bar-chart-x-value">{{ year }}</span>
-              </span>
-          </figcaption>
-        </figure>
+        </figcaption>
+      </figure><!-- /.chart -->
 
-      </section><!-- /.chart-item -->
-      {% endfor %}
+    </section><!-- /.chart-item -->
+    {% endfor %}
 
-    </div><!-- /.chart-list -->
+  </div><!-- /.chart-list -->
   {% endif %}
 </section>

--- a/_plugins/eiti_format.rb
+++ b/_plugins/eiti_format.rb
@@ -32,14 +32,14 @@ module EITI
     # >> EITI::Format.percent(0.5, 0, '?')
     # => '?'
     def percent(num, precision = 1, small = '&lt;1')
-      if num.nil?
-        # FIXME: what should we represent null % as?
-        return '--'
+      if num.is_a? String
+        num = num.to_f
       end
-
-      num = num.to_f
+      if num.nil?
+        # XXX: what should we represent null % as?
+        return '--'
       # zero is zero
-      if num.zero?
+      elsif num.zero?
         return '0'
       # if it's less than 1, return the "small" representation
       elsif num < 1.0


### PR DESCRIPTION
Fixes #1883.

### :sunglasses: Preview
[before](https://federalist.18f.gov/preview/18F/doi-extractives-data/dev/explore/ME/#exports) vs. [after](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-exports-nodata/explore/ME/#exports)

![image](https://cloud.githubusercontent.com/assets/113896/18562056/19252534-7b37-11e6-8a82-c8f99d6cf6b3.png)

Changes proposed in this pull request:
- Fix up empty year and no data detection logic in the state exports template
- Tighten up empty year detection logic in the state GDP template
- Fix a bug in the `percent` template filter that would coerce `nil` to `0.0`
- Unrelated: set `layout: default` on the offshore-areas collection to suppress Jekyll build warnings about the removed `offshore-area` layout

/cc @gemfarmer @coreycaitlin @meiqimichelle 