### PR TITLE
Fix tooltip interaction

### DIFF
--- a/_sass/components/_tooltip.scss
+++ b/_sass/components/_tooltip.scss
@@ -2,9 +2,11 @@
   background: $white;
   border: 2px solid $greenest-land;
   max-width: 300px;
+  opacity: 0.9;
   padding: $base-padding-lite;
   padding-bottom: ($base-padding-lite / 2);
   padding-top: 0.23em; // to account for verticality of text
+  pointer-events: none;
   position: absolute;
   z-index: 9000;
 

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -1,8 +1,12 @@
+/* jshint node: true, browser: true */
 (function(exports) {
+  'use strict';
+
+  var OFFSET_POSITION = 2;
 
   var depixelize = function(value) {
-    if (value.indexOf('px') > -1) {
-      return +value.substr(0, value.length - 2);
+    if (value.match(/px$/)) {
+      return Number(value.substr(0, value.length - 2));
     } else {
       return value;
     }
@@ -12,8 +16,12 @@
     return value + 'px';
   };
 
-  var hideTooltip = function (tooltip) {
-    tooltip.attr('aria-hidden', true);
+  var show = function() {
+    this.attr('aria-hidden', false);
+  };
+
+  var hide = function() {
+    this.attr('aria-hidden', true);
   };
 
   var attached = function() {
@@ -22,11 +30,10 @@
     var titles = self.selectAll('title');
     var tiles = self.selectAll('use');
 
-    var tooltip,
-      tooltipText,
-      OFFSET = 2;
+    var tooltip;
+    var tooltipText;
 
-    var init = function(initialize) {
+    var init = function() {
       tooltip = self.select('.eiti-tooltip');
 
       if (tooltip.empty()) {
@@ -34,8 +41,7 @@
           .classed('eiti-tooltip', true);
       }
 
-      tooltip
-        .attr('aria-hidden', true);
+      tooltip.call(hide);
 
       tooltipText = tooltip.select('p');
 
@@ -58,23 +64,23 @@
 
       init();
 
-      tooltipText.text(function(){
+      tooltipText.text(function() {
         return title.attr('desc');
       });
 
       tooltip
-        .attr('aria-hidden', false)
-        .attr('aria-label', function(){
+        .call(show)
+        .attr('aria-label', function() {
           return title.attr('alt');
         })
         .style('left', function() {
           var tooltipWidth = depixelize(tooltip.style('width'));
           var svgWidth = depixelize(svg.style('width'));
 
-          var x = event.layerX + OFFSET;
+          var x = event.layerX + OFFSET_POSITION;
 
           if (svgWidth <= tooltipWidth + x) {
-            return pixelize(event.layerX - tooltipWidth - OFFSET);
+            return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
           } else {
             return pixelize(x);
           }
@@ -83,44 +89,45 @@
           var tooltipHeight = depixelize(tooltip.style('height'));
           var svgHeight = depixelize(svg.style('height'));
 
-          var y = event.layerY + OFFSET;
+          var y = event.layerY + OFFSET_POSITION;
 
           if (svgHeight <= tooltipHeight + y) {
-            return pixelize(event.layerY - tooltipHeight - OFFSET);
+            return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
           } else {
             return pixelize(y);
           }
         });
     };
 
-    var hide = function () {
+    var mouseout = function() {
       var event = event || d3.event || window.event;
       var elem = event.target || event.srcElement;
-
-      if (elem.nodeName === 'svg') {
-        var tooltip = self.select('.eiti-tooltip');
-        hideTooltip(tooltip);
+      if (elem.nodeName.toLowerCase() === 'svg') {
+        self.select('.eiti-tooltip')
+          .call(hide);
       }
     };
 
     init(this);
 
     tiles.on('mouseover', update);
-    svg.on('mouseout', hide);
+    svg.on('mouseout', mouseout);
   };
 
   var detached = function() { };
 
-  exports.EITITooltipWrapper = document.registerElement('eiti-tooltip-wrapper', {
-    extends: 'div',
-    prototype: Object.create(
-      HTMLElement.prototype,
-      {
-        attachedCallback: {value: attached},
-        detachdCallback: {value: detached}
-      }
-    )
-  });
+  exports.EITITooltipWrapper = document.registerElement(
+    'eiti-tooltip-wrapper',
+    {
+      extends: 'div',
+      prototype: Object.create(
+        HTMLElement.prototype,
+        {
+          attachedCallback: {value: attached},
+          detachdCallback: {value: detached}
+        }
+      )
+    }
+  );
 
 })(this);
-

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -199,11 +199,15 @@
 /***/ 8:
 /***/ function(module, exports) {
 
+	/* jshint node: true, browser: true */
 	(function(exports) {
+	  'use strict';
+
+	  var OFFSET_POSITION = 2;
 
 	  var depixelize = function(value) {
-	    if (value.indexOf('px') > -1) {
-	      return +value.substr(0, value.length - 2);
+	    if (value.match(/px$/)) {
+	      return Number(value.substr(0, value.length - 2));
 	    } else {
 	      return value;
 	    }
@@ -213,8 +217,12 @@
 	    return value + 'px';
 	  };
 
-	  var hideTooltip = function (tooltip) {
-	    tooltip.attr('aria-hidden', true);
+	  var show = function() {
+	    this.attr('aria-hidden', false);
+	  };
+
+	  var hide = function() {
+	    this.attr('aria-hidden', true);
 	  };
 
 	  var attached = function() {
@@ -223,11 +231,10 @@
 	    var titles = self.selectAll('title');
 	    var tiles = self.selectAll('use');
 
-	    var tooltip,
-	      tooltipText,
-	      OFFSET = 2;
+	    var tooltip;
+	    var tooltipText;
 
-	    var init = function(initialize) {
+	    var init = function() {
 	      tooltip = self.select('.eiti-tooltip');
 
 	      if (tooltip.empty()) {
@@ -235,8 +242,7 @@
 	          .classed('eiti-tooltip', true);
 	      }
 
-	      tooltip
-	        .attr('aria-hidden', true);
+	      tooltip.call(hide);
 
 	      tooltipText = tooltip.select('p');
 
@@ -259,23 +265,23 @@
 
 	      init();
 
-	      tooltipText.text(function(){
+	      tooltipText.text(function() {
 	        return title.attr('desc');
 	      });
 
 	      tooltip
-	        .attr('aria-hidden', false)
-	        .attr('aria-label', function(){
+	        .call(show)
+	        .attr('aria-label', function() {
 	          return title.attr('alt');
 	        })
 	        .style('left', function() {
 	          var tooltipWidth = depixelize(tooltip.style('width'));
 	          var svgWidth = depixelize(svg.style('width'));
 
-	          var x = event.layerX + OFFSET;
+	          var x = event.layerX + OFFSET_POSITION;
 
 	          if (svgWidth <= tooltipWidth + x) {
-	            return pixelize(event.layerX - tooltipWidth - OFFSET);
+	            return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
 	          } else {
 	            return pixelize(x);
 	          }
@@ -284,35 +290,34 @@
 	          var tooltipHeight = depixelize(tooltip.style('height'));
 	          var svgHeight = depixelize(svg.style('height'));
 
-	          var y = event.layerY + OFFSET;
+	          var y = event.layerY + OFFSET_POSITION;
 
 	          if (svgHeight <= tooltipHeight + y) {
-	            return pixelize(event.layerY - tooltipHeight - OFFSET);
+	            return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
 	          } else {
 	            return pixelize(y);
 	          }
 	        });
 	    };
 
-	    var hide = function () {
+	    var mouseout = function() {
 	      var event = event || d3.event || window.event;
 	      var elem = event.target || event.srcElement;
-
-	      if (elem.nodeName === 'svg') {
-	        var tooltip = self.select('.eiti-tooltip');
-	        hideTooltip(tooltip);
+	      if (elem.nodeName.toLowerCase() === 'svg') {
+	        self.select('.eiti-tooltip')
+	          .call(hide);
 	      }
 	    };
 
 	    init(this);
 
 	    tiles.on('mouseover', update);
-	    svg.on('mouseout', hide);
+	    svg.on('mouseout', mouseout);
 	  };
 
 	  var detached = function() { };
 
-	  exports.EITITooltipWrapper = document.registerElement('eiti-tooltip-wrapper', {
+	  module.exports = document.registerElement('eiti-tooltip-wrapper', {
 	    extends: 'div',
 	    prototype: Object.create(
 	      HTMLElement.prototype,
@@ -324,7 +329,6 @@
 	  });
 
 	})(this);
-
 
 
 /***/ }

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -317,16 +317,19 @@
 
 	  var detached = function() { };
 
-	  module.exports = document.registerElement('eiti-tooltip-wrapper', {
-	    extends: 'div',
-	    prototype: Object.create(
-	      HTMLElement.prototype,
-	      {
-	        attachedCallback: {value: attached},
-	        detachdCallback: {value: detached}
-	      }
-	    )
-	  });
+	  exports.EITITooltipWrapper = document.registerElement(
+	    'eiti-tooltip-wrapper',
+	    {
+	      extends: 'div',
+	      prototype: Object.create(
+	        HTMLElement.prototype,
+	        {
+	          attachedCallback: {value: attached},
+	          detachdCallback: {value: detached}
+	        }
+	      )
+	    }
+	  );
 
 	})(this);
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -715,11 +715,15 @@
 /* 8 */
 /***/ function(module, exports) {
 
+	/* jshint node: true, browser: true */
 	(function(exports) {
+	  'use strict';
+
+	  var OFFSET_POSITION = 2;
 
 	  var depixelize = function(value) {
-	    if (value.indexOf('px') > -1) {
-	      return +value.substr(0, value.length - 2);
+	    if (value.match(/px$/)) {
+	      return Number(value.substr(0, value.length - 2));
 	    } else {
 	      return value;
 	    }
@@ -729,8 +733,12 @@
 	    return value + 'px';
 	  };
 
-	  var hideTooltip = function (tooltip) {
-	    tooltip.attr('aria-hidden', true);
+	  var show = function() {
+	    this.attr('aria-hidden', false);
+	  };
+
+	  var hide = function() {
+	    this.attr('aria-hidden', true);
 	  };
 
 	  var attached = function() {
@@ -739,11 +747,10 @@
 	    var titles = self.selectAll('title');
 	    var tiles = self.selectAll('use');
 
-	    var tooltip,
-	      tooltipText,
-	      OFFSET = 2;
+	    var tooltip;
+	    var tooltipText;
 
-	    var init = function(initialize) {
+	    var init = function() {
 	      tooltip = self.select('.eiti-tooltip');
 
 	      if (tooltip.empty()) {
@@ -751,8 +758,7 @@
 	          .classed('eiti-tooltip', true);
 	      }
 
-	      tooltip
-	        .attr('aria-hidden', true);
+	      tooltip.call(hide);
 
 	      tooltipText = tooltip.select('p');
 
@@ -775,23 +781,23 @@
 
 	      init();
 
-	      tooltipText.text(function(){
+	      tooltipText.text(function() {
 	        return title.attr('desc');
 	      });
 
 	      tooltip
-	        .attr('aria-hidden', false)
-	        .attr('aria-label', function(){
+	        .call(show)
+	        .attr('aria-label', function() {
 	          return title.attr('alt');
 	        })
 	        .style('left', function() {
 	          var tooltipWidth = depixelize(tooltip.style('width'));
 	          var svgWidth = depixelize(svg.style('width'));
 
-	          var x = event.layerX + OFFSET;
+	          var x = event.layerX + OFFSET_POSITION;
 
 	          if (svgWidth <= tooltipWidth + x) {
-	            return pixelize(event.layerX - tooltipWidth - OFFSET);
+	            return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
 	          } else {
 	            return pixelize(x);
 	          }
@@ -800,35 +806,34 @@
 	          var tooltipHeight = depixelize(tooltip.style('height'));
 	          var svgHeight = depixelize(svg.style('height'));
 
-	          var y = event.layerY + OFFSET;
+	          var y = event.layerY + OFFSET_POSITION;
 
 	          if (svgHeight <= tooltipHeight + y) {
-	            return pixelize(event.layerY - tooltipHeight - OFFSET);
+	            return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
 	          } else {
 	            return pixelize(y);
 	          }
 	        });
 	    };
 
-	    var hide = function () {
+	    var mouseout = function() {
 	      var event = event || d3.event || window.event;
 	      var elem = event.target || event.srcElement;
-
-	      if (elem.nodeName === 'svg') {
-	        var tooltip = self.select('.eiti-tooltip');
-	        hideTooltip(tooltip);
+	      if (elem.nodeName.toLowerCase() === 'svg') {
+	        self.select('.eiti-tooltip')
+	          .call(hide);
 	      }
 	    };
 
 	    init(this);
 
 	    tiles.on('mouseover', update);
-	    svg.on('mouseout', hide);
+	    svg.on('mouseout', mouseout);
 	  };
 
 	  var detached = function() { };
 
-	  exports.EITITooltipWrapper = document.registerElement('eiti-tooltip-wrapper', {
+	  module.exports = document.registerElement('eiti-tooltip-wrapper', {
 	    extends: 'div',
 	    prototype: Object.create(
 	      HTMLElement.prototype,
@@ -840,7 +845,6 @@
 	  });
 
 	})(this);
-
 
 
 /***/ },

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -833,16 +833,19 @@
 
 	  var detached = function() { };
 
-	  module.exports = document.registerElement('eiti-tooltip-wrapper', {
-	    extends: 'div',
-	    prototype: Object.create(
-	      HTMLElement.prototype,
-	      {
-	        attachedCallback: {value: attached},
-	        detachdCallback: {value: detached}
-	      }
-	    )
-	  });
+	  exports.EITITooltipWrapper = document.registerElement(
+	    'eiti-tooltip-wrapper',
+	    {
+	      extends: 'div',
+	      prototype: Object.create(
+	        HTMLElement.prototype,
+	        {
+	          attachedCallback: {value: attached},
+	          detachdCallback: {value: detached}
+	        }
+	      )
+	    }
+	  );
 
 	})(this);
 


### PR DESCRIPTION
Fixes #1952.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-tooltip/explore/)

Changes proposed in this pull request:
- Add `pointer-events: none` to the tooltip element to prevent them from interrupting mouse interactions
- Tidy up the JS a bit

/cc @gemfarmer 
