### PR TITLE
"Overview" consistency

### DIFF
--- a/_case-studies/default.md
+++ b/_case-studies/default.md
@@ -3,7 +3,7 @@ title: Overview | Case Studies
 layout: case-studies-landing
 permalink: /case-studies/
 nav_items:
-  - name: overview
+  - name: title
     title: Top
   - name: revenue-sustainability
     title: Revenue sustainability
@@ -17,9 +17,7 @@ resource: default
 selector: list
 ---
 
-## Overview
-
-While extractive industries made up 2.6% of the U.S. GDP in 2013, they play a much larger role in some local communities. For example, extractive industries make up more than a third of Wyoming’s GDP.[^1] At the county level, certain communities may be even more economically dependent on extractive industries.
+> While extractive industries made up 2.6% of the U.S. GDP in 2013, they play a much larger role in some local communities. For example, extractive industries make up more than a third of Wyoming’s GDP.[^1] At the county level, certain communities may be even more economically dependent on extractive industries.
 
 ## Revenue sustainability
 

--- a/_includes/case-studies/_selector.html
+++ b/_includes/case-studies/_selector.html
@@ -1,9 +1,8 @@
 <div class="case_studies_intro-select {{include.screen}}">
-  <label for="case_studies-selector">Choose a community page</label>
   <select id="case_studies-selector" onchange="window.location = '{{ site.baseurl }}/case-studies/' + this.value + '/'">
     <option
     {% if page.permalink == '/case-studies/' %}selected{% endif %}
-    value="#">Overview</option>
+    value="#">Choose a case study</option>
     <optgroup label="Coal">
       <option
         {% if page.permalink == '/case-studies/boone-logan-and-mingo/' %}selected{% endif %}

--- a/_layouts/case-studies-landing.html
+++ b/_layouts/case-studies-landing.html
@@ -17,9 +17,11 @@ layout: default
     <div class="container-right-4 ribbon-card-column ribbon-card state_pages-ribbon-card ribbon-card-no-margin">
       <figure class="ribbon-card-top ribbon-card-case_studies">
         <h2 class="ribbon-card-top-text-header">How do extractive industries impact communities like mine?</h2>
-        <p>This section includes twelve case studies that provide a snapshot of communities that have led the U.S. in producing oil, gas, coal, gold, iron, or copper over the last decade. These case studies shed light on the economic and fiscal effects of oil, gas, and mineral extraction on local communities.</p>
+        <p>This section includes twelve case studies that provide a snapshot of communities that have led the U.S. in producing oil, gas, coal, gold, iron, or copper over the last decade.</p>
+        <p>These case studies shed light on the economic and fiscal effects of oil, gas, and mineral extraction on local communities.</p>
       </figure>
       <figcaption class="ribbon-card-bottom state_pages-select">
+      <label for="case_studies-selector">Browse this section:</label>
         {% include case-studies/_selector.html %}
       </figcaption>
     </div>


### PR DESCRIPTION
Fixes issue(s) #1928

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/overview-top/)

this pull request makes our usage of "overview" more consistent by:

- changing the default in the drop-down on the case studies landing page
- removing the "overview" header on the case studies landing page, and making that first paragraph more consistent with other case study pages
- leaving the "overview" header on the state pages 😄 

/cc @ericronne @meiqimichelle 

