### PR TITLE
Sticky headers redux

### DIFF
--- a/_how-it-works/reconciliation.html
+++ b/_how-it-works/reconciliation.html
@@ -26,7 +26,7 @@ permalink: /how-it-works/reconciliation/
 
     <section class="container-right-8">
       <!-- TODO remove style hack -->
-      <div class="sticky sticky-top sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" style="display:none;">
+      <div class="sticky sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" style="display:none;">
 
         <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
 

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -5,7 +5,7 @@
 
 <section id="all-production" is="year-switcher-section" class="all-lands production">
 
-  <h3>Energy production nationwide</h3>
+  <h3 class="sticky">Energy production nationwide</h3>
 
   <div class="chart-selector-wrapper">
 
@@ -53,7 +53,7 @@
             <span class="eiti-bar-chart-x-value">{{ year }}</span>.
           </span>
           <span class="caption-no-data" aria-hidden="true">
-            There is no data about production of {{ product_name | downcase | suffix: units_suffix }} in 
+            There is no data about production of {{ product_name | downcase | suffix: units_suffix }} in
             <span class="eiti-bar-chart-x-value">{{ year }}</span>.
           </span>
         </figcaption>

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -8,7 +8,7 @@
 
   <section class="county-map-table" is="year-switcher-section">
 
-    <h3>Production on federal land nationwide</h3>
+    <h3 class="sticky">Production on federal land nationwide</h3>
 
     <div class="chart-selector-wrapper">
 
@@ -18,7 +18,7 @@
         ONRR collects detailed data about natural resources produced on federal lands and waters.
         <br>
         <a href="{{site.baseurl}}/downloads/federal-production/">
-          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation 
+          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
         </a>
       </p>
     </div>
@@ -75,8 +75,8 @@
               <span class="eiti-bar-chart-x-value">{{ year }}</span>.
             </span>
             <span class="caption-withheld" aria-hidden="true">
-              Data about {{ product_name | downcase | suffix:units_suffix }} production on federal land in 
-              <span class="eiti-bar-chart-x-value">{{ year }}</span> 
+              Data about {{ product_name | downcase | suffix:units_suffix }} production on federal land in
+              <span class="eiti-bar-chart-x-value">{{ year }}</span>
               is withheld.
             </span>
           </figcaption>

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -11,7 +11,7 @@
 
   <p>Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.</p>
 
-  <h3>Revenue from extraction on federal land</h3>
+  <h3 class="sticky">Revenue from extraction on federal land</h3>
 
   <section id="federal-revenue">
 

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -11,9 +11,9 @@
 
   <p>Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.</p>
 
-  <h3 class="sticky">Revenue from extraction on federal land</h3>
-
   <section id="federal-revenue">
+
+    <h3 class="sticky">Revenue from extraction on federal land</h3>
 
     <p>When companies extract natural resources on federal lands and waters, they pay royalties, rents, bonuses, and other fees, much like they would to any landowner. This non-tax revenue is collected and reported by the Office of Natural Resources Revenue (ONRR).</p>
 
@@ -105,17 +105,17 @@
 
       {% endfor %}
 
-    </section>
-    <!-- .chart-list -->
+    </section><!-- /.chart-list -->
 
-  </section>
-  <!-- #federal-revenue -->
+  </section><!-- /#federal-revenue -->
 
-   <h3 id="federal-tax-revenue">Federal tax revenue</h3>
+  <section>
+    <h3 id="federal-tax-revenue">Federal tax revenue</h3>
 
     <div>
       <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to romote other policy goals.</p>
       <p>Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
     </div>
+  </section>
 
 </section>

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -6,7 +6,7 @@
   
 <section id="all-production" is="year-switcher-section" class="all-lands production">
 
-  <h3>Energy production in the entire state of {{ state_name }}</h3>
+  <h3 class="sticky">Energy production in the entire state of {{ state_name }}</h3>
 
   <div class="chart-selector-wrapper">
 
@@ -16,10 +16,10 @@
 
     <p class="chart-description{% unless all_products %} no-selector{% endunless %}">
       The U.S. Energy Information Administration collects data about all energy-related natural resources produced on federal, state, and privately owned land. 
-        <br>
-        <a href="{{site.baseurl}}/downloads/#production-all">
-          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-        </a>
+      <br>
+      <a href="{{site.baseurl}}/downloads/#production-all">
+        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+      </a>
     </p>
   </div>
 

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -1,6 +1,6 @@
 <section id="federal-disbursements" class="disbursements">
 
-  <h3>Federal disbursements</h2>
+  <h3>Federal disbursements</h3>
 
   <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called “disbursement.”</p>
   <p>
@@ -11,35 +11,35 @@
 
   {% if disbursements %}
 
-    <p>
-      ONRR also disburses some revenue from natural resource extraction to state governments.
-      <strong>
-        In {{ year }}, ONRR disbursed
-          ${{ disbursements.All.All[year] | round | intcomma }}
-         to {{ state_name }}.
-      </strong>
-      <!-- Includes a table showing onshore/offshore only if there are offshore disbursements to show -->
-      {% if disbursements.All.Offshore[year] > 0 %}
-          This included revenues from both onshore and offshore extraction in or near {{ state_name }}:
-        </p>
-        <ul>
-          <li>${{ disbursements.All.Onshore[year] | round | intcomma }} was from onshore revenues</li>
-          <li>${{ disbursements.All.Offshore[year] | round | intcomma }} was from offshore revenues</li>
-        </ul>
-      {% else %}
-        </p>
-      {% endif %}
+  <p>
+    ONRR also disburses some revenue from natural resource extraction to state governments.
+    <strong>
+      In {{ year }}, ONRR disbursed
+        ${{ disbursements.All.All[year] | round | intcomma }}
+        to {{ state_name }}.
+    </strong>
+    <!-- Includes a table showing onshore/offshore only if there are offshore disbursements to show -->
+    {% if disbursements.All.Offshore[year] > 0 %}
+    This included revenues from both onshore and offshore extraction in or near {{ state_name }}:
+  </p>
+  <ul>
+    <li>${{ disbursements.All.Onshore[year] | round | intcomma }} was from onshore revenues</li>
+    <li>${{ disbursements.All.Offshore[year] | round | intcomma }} was from offshore revenues</li>
+  </ul>
+  {% else %}
+  </p>
+  {% endif %}
 
 
   {% else %}
   <!-- If no disbursements -->
-    <p><strong>
-      {{ state_name }} did not receive any disbursements from ONRR in {{ year }}. This is usually because there was no natural resource extraction on federal land in the state.
-    </strong></p>
+  <p><strong>
+    {{ state_name }} did not receive any disbursements from ONRR in {{ year }}. This is usually because there was no natural resource extraction on federal land in the state.
+  </strong></p>
   {% endif %}
 
   <p>
-    <a href="{{site.baseurl}}/downloads/disbursements/" class="data-downloads">
+    <a href="{{ site.baseurl }}/downloads/disbursements/" class="data-downloads">
       <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
     </a>
   </p>

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -8,29 +8,27 @@
 
   <section class="county-map-table" is="year-switcher-section">
 
-    <h3>Production on federal land in {{ state_name }}</h3>
+    <h3 class="sticky">Production on federal land in {{ state_name }}</h3>
 
     {% if federal_products_num == 0 %}
-      <p>
-        ONRR collects detailed data about natural resources produced on federal land. According to that data, there was no natural resource production on federal land in {{  state_name }} in {{ year }}.
-        <br>
-        <a href="{{site.baseurl}}/downloads/federal-production/" class="data-downloads">
-          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-        </a>
-      </p>
+    <p>
+      ONRR collects detailed data about natural resources produced on federal land. According to that data, there was no natural resource production on federal land in {{  state_name }} in {{ year }}.
+      <br>
+      <a href="{{ site.baseurl }}/downloads/federal-production/" class="data-downloads">
+        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+      </a>
+    </p>
     {% else %}
-      <div class="chart-selector-wrapper">
-
-        {% include year-selector.html year_range=year_range %}
-
-        <p class="chart-description">
-            ONRR collects detailed data about natural resources produced on federal land in {{ state_name }}.
-            <br>
-            <a href="{{site.baseurl}}/downloads/federal-production/">
-              <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-            </a>
-        </p>
-      </div>
+    <div class="chart-selector-wrapper">
+      {% include year-selector.html year_range=year_range %}
+      <p class="chart-description">
+          ONRR collects detailed data about natural resources produced on federal land in {{ state_name }}.
+          <br>
+          <a href="{{ site.baseurl }}/downloads/federal-production/">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+          </a>
+      </p>
+    </div>
     {% endif %}
 
     <div class="chart-list">

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -13,7 +13,7 @@
 
   <section id="federal-revenue">
 
-    <h3>Federal revenue</h3>
+    <h3{% if revenue_commodities %} class="sticky"{% endif %}>Federal revenue</h3>
 
     <p>
       Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.
@@ -22,9 +22,9 @@
         <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation 
       </a>
     </p>
-    
+
     <h4>Revenue from production on federal land by resource</h4>
-    
+
 {% if revenue_commodities %}
 
     <p>When companies extract natural resources on federal lands and waters, they pay royalties, rents, bonuses, and other fees, much like they would to any landowner. This non-tax revenue is collected and reported by the Office of Natural Resources Revenue (ONRR).</p>
@@ -115,7 +115,7 @@
   <!-- #federal-revenue -->
 
   <section id="state-local-revenue" class="state revenue">
-    <h3>State revenue</h3>
+    <h3{% if page.opt_in == true %} class="sticky"{% endif %}>State revenue</h3>
 
     {% if page.opt_in == true %}
       {% include location/opt-in/state-revenues.html location_id=state_id %}

--- a/_layouts/federal-revenue-by-company.html
+++ b/_layouts/federal-revenue-by-company.html
@@ -39,7 +39,7 @@ layout: default
 
     <div class="container-right-8">
 
-      <div class="sticky sticky-top sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" aria-expanded="false">
+      <div class="sticky sticky_nav sticky_nav-show_mobile filters-wrapper container" data-toggler="filters" aria-expanded="false">
         <button class="toggle-filters toggle-desktop" is="eiti-toggle" aria-controls="filters" data-expanded-text="Hide filters" data-collapsed-text="Show filters" data-toggler="filters">Show filters</button>
 
         <form id="filters" aria-hidden="true" class="filters">

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -129,12 +129,12 @@ nav_items:
         {% include location/section-disbursements.html %}
 
         <section id="state-disbursements" class="disbursements">
-          <h3>State disbursements</h3>
+          <h3{% if page.opt_in == true %} class="sticky"{% endif %}>State disbursements</h3>
 
           {% if page.opt_in == true %}
             {% include location/opt-in/state-disbursements.html location_id=state_id %}
           {% else %}
-            <p>We don’t have detailed data about how states or local governments distribute revenue from natural resource extraction.</p>
+          <p>We don’t have detailed data about how states or local governments distribute revenue from natural resource extraction.</p>
           {% endif %}
         </section>
 
@@ -144,11 +144,11 @@ nav_items:
       <section id="economic-impact">
         <h2>Economic impact</h2>
         {% if page.state_impact %}
-          {{ page.state_impact | markdownify }}
+        {{ page.state_impact | markdownify }}
 
-          <p>
-            In addition to generating economic activity, extractive industries can have <a href="#fiscal-costs-of-extractive-activity">fiscal costs</a> for state and local communities.
-          </p>
+        <p>
+          In addition to generating economic activity, extractive industries can have <a href="#fiscal-costs-of-extractive-activity">fiscal costs</a> for state and local communities.
+        </p>
         {% endif %}
 
         {% include location/section-gdp.html %}

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -23,8 +23,9 @@
     @include h3-bar;
   }
 
-  h3:not(.chart-title):not(.title-land-ownership):not(.state-page-nav-title) {
-    padding-top: 2rem;
+  h3:not(.chart-title):not(.title-land-ownership):not(.state-page-nav-title):not(.sticky),
+  .pre-sticky {
+    margin-top: 4rem;
   }
 
   ul + h3:not(.chart-title):not(.title-land-ownership),

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -5,7 +5,7 @@
   section + section,
   h2 + section:not(.state-pages-top),
   p + h4 {
-    margin-top: -0.75rem; //to compensate for margin from preceding selectors
+    margin-top: 0; // -0.75rem; //to compensate for margin from preceding selectors
   }
 
   h2:not(.ribbon-card-top-text-header) {
@@ -24,7 +24,7 @@
   }
 
   h3:not(.chart-title):not(.title-land-ownership):not(.state-page-nav-title) {
-    padding-top: 4rem;
+    padding-top: 2rem;
   }
 
   ul + h3:not(.chart-title):not(.title-land-ownership),
@@ -55,6 +55,10 @@
   h3 + [class*='panel-'] {
     margin-bottom: $standard-padding;
     margin-top: $standard-padding;
+
+    &.sticky {
+      margin-top: 0;
+    }
   }
 
   figure {

--- a/_sass/components/_sticky.scss
+++ b/_sass/components/_sticky.scss
@@ -1,11 +1,10 @@
 .sticky {
+  background: $white;
+  padding-top: $base-padding-lite;
   position: -webkit-sticky;
   position: sticky;
-  top: 50px;
-
-  &.sticky-top {
-    top: 0;
-  }
+  top: 0;
+  z-index: $z-roof;
 }
 
 .sticky::before,

--- a/explore/index.html
+++ b/explore/index.html
@@ -44,7 +44,7 @@ nav_items:
 {% assign oilgas = 'Oil & Gas (Non-Royalty)' %}
 {% assign commodity_names = site.data.commodity_names %}
 {% assign top_products = 10 %}
-{% assign steps=9 %}
+{% assign steps = 9 %}
 
 
 <main id="national" class="layout-state-pages national-page">
@@ -53,7 +53,7 @@ nav_items:
     <div class="container-page-wrapper landing-section_top ribbon ribbon-column">
       <div class="container-left-8 ribbon-hero ribbon-hero-column">
         <h1>Explore data</h1>
-        <figure is="data-map" color-scheme="Reds" steps="9">
+        <figure>
           {%
             include state-map.html
             href=':url'
@@ -145,6 +145,5 @@ nav_items:
   </section>
 
 </main>
-
 
 <script src="{{ site.baseurl }}/js/lib/state-pages.min.js"></script>

--- a/js/components/sticky.js
+++ b/js/components/sticky.js
@@ -1,15 +1,12 @@
 (function(exports) {
 
-  var Stickyfill = require('stickyfill');
-  var stickyfill = Stickyfill();
+  var stickyfill = require('stickyfill')();
 
-  var stickyElements = document.getElementsByClassName('sticky');
+  [].forEach.call(
+    document.querySelector('.sticky'),
+    stickyfill.add
+  );
 
-  for (var i = stickyElements.length - 1; i >= 0; i--) {
-      stickyfill.add(stickyElements[i]);
-  }
-  exports.Stickyfill = Stickyfill;
   exports.stickyfill = stickyfill;
 
-
-})(this);
+})(window);

--- a/js/components/sticky.js
+++ b/js/components/sticky.js
@@ -1,12 +1,13 @@
 (function(exports) {
+  'use strict';
 
-  var stickyfill = require('stickyfill')();
+  var sticky = require('stickyfill')();
 
   [].forEach.call(
-    document.querySelector('.sticky'),
-    stickyfill.add
+    document.querySelectorAll('.sticky'),
+    sticky.add
   );
 
-  exports.stickyfill = stickyfill;
+  exports.stickyfill = sticky;
 
 })(window);

--- a/js/components/sticky.js
+++ b/js/components/sticky.js
@@ -5,7 +5,11 @@
 
   [].forEach.call(
     document.querySelectorAll('.sticky'),
-    sticky.add
+    function(el) {
+      sticky.add(el);
+      el.parentNode.insertBefore(document.createElement('div'), el)
+        .setAttribute('class', 'pre-sticky');
+    }
   );
 
   exports.stickyfill = sticky;

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -69,7 +69,11 @@
 
 	  [].forEach.call(
 	    document.querySelectorAll('.sticky'),
-	    sticky.add
+	    function(el) {
+	      sticky.add(el);
+	      el.parentNode.insertBefore(document.createElement('div'), el)
+	        .setAttribute('class', 'pre-sticky');
+	    }
 	  );
 
 	  exports.stickyfill = sticky;

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -64,19 +64,16 @@
 
 	(function(exports) {
 
-	  var Stickyfill = __webpack_require__(4);
-	  var stickyfill = Stickyfill();
+	  var stickyfill = __webpack_require__(4)();
 
-	  var stickyElements = document.getElementsByClassName('sticky');
+	  [].forEach.call(
+	    document.querySelector('.sticky'),
+	    stickyfill.add
+	  );
 
-	  for (var i = stickyElements.length - 1; i >= 0; i--) {
-	      stickyfill.add(stickyElements[i]);
-	  }
-	  exports.Stickyfill = Stickyfill;
 	  exports.stickyfill = stickyfill;
 
-
-	})(this);
+	})(window);
 
 
 /***/ },

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -63,15 +63,16 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
+	  'use strict';
 
-	  var stickyfill = __webpack_require__(4)();
+	  var sticky = __webpack_require__(4)();
 
 	  [].forEach.call(
-	    document.querySelector('.sticky'),
-	    stickyfill.add
+	    document.querySelectorAll('.sticky'),
+	    sticky.add
 	  );
 
-	  exports.stickyfill = stickyfill;
+	  exports.stickyfill = sticky;
 
 	})(window);
 

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -66,15 +66,16 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
+	  'use strict';
 
-	  var stickyfill = __webpack_require__(4)();
+	  var sticky = __webpack_require__(4)();
 
 	  [].forEach.call(
-	    document.querySelector('.sticky'),
-	    stickyfill.add
+	    document.querySelectorAll('.sticky'),
+	    sticky.add
 	  );
 
-	  exports.stickyfill = stickyfill;
+	  exports.stickyfill = sticky;
 
 	})(window);
 

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -72,7 +72,11 @@
 
 	  [].forEach.call(
 	    document.querySelectorAll('.sticky'),
-	    sticky.add
+	    function(el) {
+	      sticky.add(el);
+	      el.parentNode.insertBefore(document.createElement('div'), el)
+	        .setAttribute('class', 'pre-sticky');
+	    }
 	  );
 
 	  exports.stickyfill = sticky;

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -67,19 +67,16 @@
 
 	(function(exports) {
 
-	  var Stickyfill = __webpack_require__(4);
-	  var stickyfill = Stickyfill();
+	  var stickyfill = __webpack_require__(4)();
 
-	  var stickyElements = document.getElementsByClassName('sticky');
+	  [].forEach.call(
+	    document.querySelector('.sticky'),
+	    stickyfill.add
+	  );
 
-	  for (var i = stickyElements.length - 1; i >= 0; i--) {
-	      stickyfill.add(stickyElements[i]);
-	  }
-	  exports.Stickyfill = Stickyfill;
 	  exports.stickyfill = stickyfill;
 
-
-	})(this);
+	})(window);
 
 
 /***/ },

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -78,19 +78,16 @@
 
 	(function(exports) {
 
-	  var Stickyfill = __webpack_require__(4);
-	  var stickyfill = Stickyfill();
+	  var stickyfill = __webpack_require__(4)();
 
-	  var stickyElements = document.getElementsByClassName('sticky');
+	  [].forEach.call(
+	    document.querySelector('.sticky'),
+	    stickyfill.add
+	  );
 
-	  for (var i = stickyElements.length - 1; i >= 0; i--) {
-	      stickyfill.add(stickyElements[i]);
-	  }
-	  exports.Stickyfill = Stickyfill;
 	  exports.stickyfill = stickyfill;
 
-
-	})(this);
+	})(window);
 
 
 /***/ },

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -59,11 +59,10 @@
 
 	  __webpack_require__(3);
 
-	  var OpenListNav = __webpack_require__(27);
-
 	  // exporting instance of OpenListNav because openListNav is
 	  // referenced in the markup:
 	  // _includes/hash_selector.html
+	  var OpenListNav = __webpack_require__(27);
 	  exports.openListNav = new OpenListNav();
 
 	})(window);
@@ -77,15 +76,16 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	(function(exports) {
+	  'use strict';
 
-	  var stickyfill = __webpack_require__(4)();
+	  var sticky = __webpack_require__(4)();
 
 	  [].forEach.call(
-	    document.querySelector('.sticky'),
-	    stickyfill.add
+	    document.querySelectorAll('.sticky'),
+	    sticky.add
 	  );
 
-	  exports.stickyfill = stickyfill;
+	  exports.stickyfill = sticky;
 
 	})(window);
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -82,7 +82,11 @@
 
 	  [].forEach.call(
 	    document.querySelectorAll('.sticky'),
-	    sticky.add
+	    function(el) {
+	      sticky.add(el);
+	      el.parentNode.insertBefore(document.createElement('div'), el)
+	        .setAttribute('class', 'pre-sticky');
+	    }
 	  );
 
 	  exports.stickyfill = sticky;

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -13,11 +13,10 @@
 
   require('../components/sticky.js');
 
-  var OpenListNav = require('../components/open-list-nav.js');
-
   // exporting instance of OpenListNav because openListNav is
   // referenced in the markup:
   // _includes/hash_selector.html
+  var OpenListNav = require('../components/open-list-nav.js');
   exports.openListNav = new OpenListNav();
 
 })(window);


### PR DESCRIPTION
Fixes #1852. Adds sticky subheadings to explore and state pages. Opt-in states conditionally get sticky headings where appropriate. Thanks for pairing, @ericronne!

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/sticky-headers-redux/explore/)

Changes proposed in this pull request:
- [x] Simplify stickyfill (`position: sticky` polyfill) logic
- [x] Make some `<h3>` subheads on the explore page sticky
- [ ] Test it on different screen sizes and browsers

/cc @ericronne @gemfarmer 
