### PR TITLE
Fixes broken fed rev by company link; also visual bug squishes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -89,7 +89,7 @@ collections:
     permalink: /explore/:path/
   federal-revenue-by-company:
     output: true
-    permalink: /explore/federal-revenue-by-company/:path/
+    permalink: /how-it-works/federal-revenue-by-company/:path/
   how-it-works:
     output: true
     permalink: /how-it-works/:path/

--- a/_how-it-works/default.md
+++ b/_how-it-works/default.md
@@ -101,9 +101,9 @@ permalink: /how-it-works/
       
       <div class="container landing-section">
         <div>
-          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/federal-revenue-by-company/">Federal revenue by company</a></h4>
+          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/federal-revenue-by-company/2015/">Federal revenue by company</a></h4>
           <p>See federal non-tax revenues from natural resource extraction on federal land in 2015 by commodity, revenue type, and company.</p>
-          <p><a href="{{site.baseurl}}/how-it-works/#/">See revenue by company</a></p>
+          <p><a href="{{site.baseurl}}/how-it-works/2015/">See revenue by company</a></p>
         </div>
         <div>
           <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/corporate-income-tax/">Corporate income tax</a></h4>

--- a/_layouts/federal-revenue-by-company.html
+++ b/_layouts/federal-revenue-by-company.html
@@ -1,5 +1,8 @@
 ---
+title: Federal Revenue by Company | How it Works
 layout: default
+permalink: /how-it-works/federal-revenue-by-company/2015/
+title_display: Federal Revenue by Company
 ---
 
 <section id="companies" data-year="{{ page.year }}" class="explore-subpage container container-margin">

--- a/_sass/blocks/_landing.scss
+++ b/_sass/blocks/_landing.scss
@@ -46,7 +46,7 @@
 .landing-section > div {
   @include span-columns(12);
 
-  @include respond-to(medium-up) {
+  @include respond-to(huge-up) {
     @include span-columns(6);
     @include omega(2n);
   }
@@ -85,7 +85,7 @@
 
   p {
     float: left;
-    width: 59%;
+    width: 57%;
   }
 }
 
@@ -97,7 +97,7 @@
 
 .landing-coal {
   svg {
-    margin-right: 10px;
+    margin-right: 0;
     margin-top: 30px;
   }
 }


### PR DESCRIPTION
Fixes #1970. 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/many-teensy-squishes/)

- Fixes broken federal rev by company links on how it works page.
- Adjusts media queries on how it works page for diving graphic images so that they don't break at medium screen sizes. #1970

/cc @ericronne 

