### PR TITLE
Economic impact percents change w/year

### DIFF
--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -76,9 +76,8 @@
             </eiti-bar-chart>
             <figcaption id="exports-figures-{{ commodity_slug }}">
               <span class="caption-data">
-                <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">
-                  ${{ exports[year].dollars | intcomma }}
-                </span>
+                <span class="eiti-bar-chart-y-value"
+                  data-format="{{ _format }}">${{ exports[year].dollars | intcomma }}</span>
                 worth of {{ commodity[0] | downcase }}
                 was exported from {{ state_name }}
                 in <span class="eiti-bar-chart-x-value">{{ year }}</span>.

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -52,14 +52,16 @@
           <span class="caption-data">
             In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
             extractive industries accounted for
-            <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">${{ gdp[year].dollars | intcomma }}</span>, or
-            {{ gdp[year].percent | percent }}%
+            <span class="eiti-bar-chart-y-value"
+              data-format="{{ _format }}">${{ gdp[year].dollars | intcomma }}</span>, or
+            <year-value year="{{ year }}" data-year-values='{{ gdp | map_hash: "percent" | jsonify }}'
+              empty="--">{{ gdp[year].percent | percent }}</year-value>%
             of {{ state_name }}’s GDP.
           </span>
           <span class="caption-no-data" aria-hidden="true">
-              There is no data for {{ state_name }} in
-              <span class="eiti-bar-chart-x-value">{{ year }}</span>
-            </span>
+            There is no data for {{ state_name }} in
+            <span class="eiti-bar-chart-x-value">{{ year }}</span>
+          </span>
         </figcaption>
       </figure><!-- /.chart -->
 

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -60,12 +60,12 @@
             <span class="caption-data">
               In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
               there were
-              <span class="eiti-bar-chart-y-value" data-format=",">
-                {{ jobs[year].jobs | intcomma }}
-              </span>
+              <span class="eiti-bar-chart-y-value"
+                data-format=",">{{ jobs[year].jobs | intcomma }}</span>
               jobs in the extractive industries in
               {{ state_name }}, and they accounted for 
-              {{ jobs_percent | percent }}% 
+              <year-value year="{{ year }}" data-year-values='{{ jobs | map_hash: "percent" | jsonify }}'
+                empty="--">{{ jobs_percent | percent }}</year-value>%
               of statewide employment.
             </span>
             <span class="caption-no-data" aria-hidden="true">

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -29,12 +29,12 @@
   var barHeight = bottom - top;
 
   var extentPercent = 0.05; // 5%
-  var extentMargin = barHeight * extentPercent;
-  var extentLessTop = top;
+  extentMargin = barHeight * extentPercent;
   top = top + extentMargin;
   var extentTop = top - extentMargin;
 
-  var fullHeight = height + textMargin + extentMargin + tickPadding - (2 * baseMargin);
+  var fullHeight = height + textMargin + extentMargin
+    + tickPadding - (2 * baseMargin);
   var extentlessHeight = fullHeight - extentMargin;
 
   var attached = function() {
@@ -85,8 +85,6 @@
         .key(function(d) { return d.x; })
         .rollup(function(d) { return d[0]; })
         .entries(data);
-
-
     } else {
       values = Object.keys(data).reduce(function(map, key) {
         map[key] = {x: +key, y: data[key]};
@@ -169,10 +167,10 @@
         var baseHeight = isUndefined || isZero || isWithheld
           ? 0
           : 2;
-
-        return d.height = height(d.y) > baseHeight
+        d.height = height(d.y) > baseHeight
           ? height(d.y)
           : baseHeight;
+        return d.height;
       })
       .attr('y', function(d) {
         return barHeight - d.height;
@@ -213,11 +211,11 @@
 
     // conditional used as proxy for having an extent line
     if (this.hasAttribute('data-units') && +ymax > 0) {
-    var extentLine = svg.append('g')
-        .attr('class', 'extent-line')
+      var extentLine = svg.append('g')
+        .attr('class', 'extent-line');
 
-      var dataUnits = this.getAttribute('data-units'),
-      dataFormat = this.getAttribute('data-format') || '';
+      var dataUnits = this.getAttribute('data-units');
+      var dataFormat = this.getAttribute('data-format') || '';
 
       if (dataUnits.indexOf('$') > -1) {
         dataFormat = eiti.format.transform(
@@ -247,7 +245,7 @@
         .call(axis);
 
     function isInSet (year, vals) {
-      var vals = vals || values;
+      vals = vals || values;
       if (vals[year] !== undefined) {
         return vals[year].y !== null;
       } else {
@@ -273,7 +271,7 @@
       text = [text, units].join(' ');
     }
     return text;
-  }
+  };
 
   var hideCaption = function(selection, data, noData, withheld) {
     selection.select('.caption-data')
@@ -282,7 +280,7 @@
       .attr('aria-hidden', noData);
     selection.select('.caption-withheld')
     .attr('aria-hidden', withheld);
-  }
+  };
 
   var updateSelected = function(selection, x, hover) {
     var index;
@@ -310,9 +308,14 @@
 
     var id = selection.attr('aria-controls');
     if (id) {
-      var output = d3.select('#' + id)
+      var output = d3.select('#' + id);
+
       output.selectAll('.eiti-bar-chart-x-value')
         .text(value.x);
+
+      output.selectAll('year-value')
+        .attr('year', value.x);
+
       var y = output.selectAll('.eiti-bar-chart-y-value');
       var format = d3.format(y.attr('data-format') || ',');
       var units = y.attr('data-units');
@@ -324,7 +327,7 @@
           hideCaption(output, true, false, true);
         } else {
           hideCaption(output, false, true, true);
-          y.text(formatUnits(format(value.y),units));
+          y.text(formatUnits(format(value.y), units));
         }
       }
 

--- a/js/components/year-switcher-section.js
+++ b/js/components/year-switcher-section.js
@@ -1,4 +1,4 @@
-(function(exports) {
+(function() {
 
   var attached = function() {
     var root = d3.select(this);
@@ -9,7 +9,9 @@
 
     var mapTables = root.selectAll('.eiti-data-map-table');
 
-    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
+    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]');
+
+    var yearValues = root.selectAll('year-value');
 
     var update = function(year) {
       charts.property('x', year);
@@ -17,10 +19,11 @@
         this.setYear(year);
       });
       select.property('value', year);
-      chartTables.each(function(){
+      chartTables.each(function() {
         this.setYear(year);
         this.update();
-      })
+      });
+      yearValues.attr('year', year);
     };
 
     select.on('change.year', function() {
@@ -36,15 +39,15 @@
   var detached = function() {
   };
 
-  exports.EITIYearSwitcherSection = document.registerElement('year-switcher-section', {
+  document.registerElement('year-switcher-section', {
     'extends': 'section',
     prototype: Object.create(
       HTMLElement.prototype,
       {
         attachedCallback: {value: attached},
-        detachdCallback: {value: detached}
+        detachedCallback: {value: detached}
       }
     )
-  })
+  });
 
-})(this);
+})();

--- a/js/components/year-value.js
+++ b/js/components/year-value.js
@@ -1,0 +1,82 @@
+(function() {
+
+  var assign = require('object-assign');
+  var d3 = require('d3');
+  var identity = function(d) { return d; };
+
+  var attributeReflector = function(attr, options) {
+    var read = options.read || identity;
+    var write = options.write || identity;
+    var defaultValue = d3.functor(options.defaultValue);
+    var change = options.update;
+    return {
+      get: function() {
+        return this.hasAttribute(attr)
+          ? read.call(this, this.getAttribute(attr), attr)
+          : defaultValue.call(this, attr);
+      },
+      set: function(value) {
+        if (value !== this[attr]) {
+          this.setAttribute(attr, write.call(this, value, attr));
+          if (typeof change === 'function') {
+            change.call(this);
+          }
+        }
+      }
+    };
+  };
+
+  var update = function() {
+    var year = this.year;
+    if (isNaN(year)) {
+      return;
+    }
+    var values = JSON.parse(
+      this.getAttribute('data-year-values') || '{}'
+    );
+    var value = values[this.year];
+    var format = this.format;
+    if (value === null || value === undefined) {
+      this.textContent = this.empty;
+    } else {
+      this.textContent = format
+        ? d3.format(format)(value)
+        : String(value);
+    }
+  };
+
+  document.registerElement('year-value', {
+    observedAttributes: ['year', 'format', 'empty'],
+    prototype: assign(
+      Object.create(
+        HTMLElement.prototype,
+        // descriptors go here
+        {
+          year: attributeReflector('year', {
+            read: Number,
+            write: String,
+            change: update
+          }),
+
+          format: attributeReflector('format', {
+          }),
+
+          empty: attributeReflector('empty', {
+            defaultValue: ''
+          })
+        }
+      ),
+      // methods go here
+      {
+        update: update,
+        attachedCallback: function() {
+          update.call(this);
+        },
+        attributeChangedCallback: function() {
+          update.call(this);
+        }
+      }
+    )
+  });
+
+})();

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -52,7 +52,8 @@
 	  __webpack_require__(37);
 	  __webpack_require__(38);
 	  __webpack_require__(39);
-	  __webpack_require__(40);
+	  __webpack_require__(41);
+	  __webpack_require__(42);
 	  __webpack_require__(8);
 
 	  __webpack_require__(7);
@@ -13255,11 +13256,11 @@
 
 	    // conditional used as proxy for having an extent line
 	    if (this.hasAttribute('data-units') && +ymax > 0) {
-	    var extentLine = svg.append('g')
-	        .attr('class', 'extent-line')
+	      var extentLine = svg.append('g')
+	        .attr('class', 'extent-line');
 
-	      var dataUnits = this.getAttribute('data-units'),
-	      dataFormat = this.getAttribute('data-format') || '';
+	      var dataUnits = this.getAttribute('data-units');
+	      var dataFormat = this.getAttribute('data-format') || '';
 
 	      if (dataUnits.indexOf('$') > -1) {
 	        dataFormat = eiti.format.transform(
@@ -13352,9 +13353,14 @@
 
 	    var id = selection.attr('aria-controls');
 	    if (id) {
-	      var output = d3.select('#' + id)
+	      var output = d3.select('#' + id);
+
 	      output.selectAll('.eiti-bar-chart-x-value')
 	        .text(value.x);
+
+	      output.selectAll('year-value')
+	        .attr('year', value.x);
+
 	      var y = output.selectAll('.eiti-bar-chart-y-value');
 	      var format = d3.format(y.attr('data-format') || ',');
 	      var units = y.attr('data-units');
@@ -13366,7 +13372,7 @@
 	          hideCaption(output, true, false, true);
 	        } else {
 	          hideCaption(output, false, true, true);
-	          y.text(formatUnits(format(value.y),units));
+	          y.text(formatUnits(format(value.y), units));
 	        }
 	      }
 
@@ -13429,6 +13435,183 @@
 
 /***/ },
 /* 39 */
+/***/ function(module, exports, __webpack_require__) {
+
+	(function(exports) {
+
+	  var assign = __webpack_require__(40);
+	  var d3 = __webpack_require__(9);
+	  var identity = function(d) { return d; };
+
+	  var attributeReflector = function(attr, options) {
+	    var read = options.read || identity;
+	    var write = options.write || identity;
+	    var defaultValue = d3.functor(options.defaultValue);
+	    var change = options.update;
+	    return {
+	      get: function() {
+	        return this.hasAttribute(attr)
+	          ? read.call(this, this.getAttribute(attr), attr)
+	          : defaultValue.call(this, attr);
+	      },
+	      set: function(value) {
+	        if (value !== this[attr]) {
+	          this.setAttribute(attr, write.call(this, value, attr));
+	          if (typeof change === 'function') {
+	            change.call(this);
+	          }
+	        }
+	      }
+	    };
+	  };
+
+	  var update = function() {
+	    var year = this.year;
+	    if (isNaN(year)) {
+	      return;
+	    }
+	    var values = JSON.parse(
+	      this.getAttribute('data-year-values') || '{}'
+	    );
+	    var value = values[this.year];
+	    var format = this.format;
+	    if (value === null || value === undefined) {
+	      this.textContent = this.empty;
+	    } else {
+	      this.textContent = format
+	        ? d3.format(format)(value)
+	        : String(value);
+	    }
+	  };
+
+	  document.registerElement('year-value', {
+	    observedAttributes: ['year', 'format', 'empty'],
+	    prototype: assign(
+	      Object.create(
+	        HTMLElement.prototype,
+	        // descriptors go here
+	        {
+	          year: attributeReflector('year', {
+	            read: Number,
+	            write: String,
+	            change: update
+	          }),
+
+	          format: attributeReflector('format', {
+	          }),
+
+	          empty: attributeReflector('empty', {
+	            defaultValue: ''
+	          })
+	        }
+	      ),
+	      // methods go here
+	      {
+	        update: update,
+	        attachedCallback: function() {
+	          update.call(this);
+	        },
+	        attributeChangedCallback: function(attr) {
+	          update.call(this);
+	        }
+	      }
+	    )
+	  });
+
+	})(window);
+
+
+/***/ },
+/* 40 */
+/***/ function(module, exports) {
+
+	'use strict';
+	/* eslint-disable no-unused-vars */
+	var hasOwnProperty = Object.prototype.hasOwnProperty;
+	var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+	function toObject(val) {
+		if (val === null || val === undefined) {
+			throw new TypeError('Object.assign cannot be called with null or undefined');
+		}
+
+		return Object(val);
+	}
+
+	function shouldUseNative() {
+		try {
+			if (!Object.assign) {
+				return false;
+			}
+
+			// Detect buggy property enumeration order in older V8 versions.
+
+			// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+			var test1 = new String('abc');  // eslint-disable-line
+			test1[5] = 'de';
+			if (Object.getOwnPropertyNames(test1)[0] === '5') {
+				return false;
+			}
+
+			// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+			var test2 = {};
+			for (var i = 0; i < 10; i++) {
+				test2['_' + String.fromCharCode(i)] = i;
+			}
+			var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+				return test2[n];
+			});
+			if (order2.join('') !== '0123456789') {
+				return false;
+			}
+
+			// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+			var test3 = {};
+			'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+				test3[letter] = letter;
+			});
+			if (Object.keys(Object.assign({}, test3)).join('') !==
+					'abcdefghijklmnopqrst') {
+				return false;
+			}
+
+			return true;
+		} catch (e) {
+			// We don't expect any of the above to throw, but better to be safe.
+			return false;
+		}
+	}
+
+	module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+		var from;
+		var to = toObject(target);
+		var symbols;
+
+		for (var s = 1; s < arguments.length; s++) {
+			from = Object(arguments[s]);
+
+			for (var key in from) {
+				if (hasOwnProperty.call(from, key)) {
+					to[key] = from[key];
+				}
+			}
+
+			if (Object.getOwnPropertySymbols) {
+				symbols = Object.getOwnPropertySymbols(from);
+				for (var i = 0; i < symbols.length; i++) {
+					if (propIsEnumerable.call(from, symbols[i])) {
+						to[symbols[i]] = from[symbols[i]];
+					}
+				}
+			}
+		}
+
+		return to;
+	};
+
+
+/***/ },
+/* 41 */
 /***/ function(module, exports) {
 
 	(function(exports) {
@@ -13444,16 +13627,19 @@
 
 	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
 
+	    var yearValues = root.selectAll('year-value');
+
 	    var update = function(year) {
 	      charts.property('x', year);
 	      maps.each(function() {
 	        this.setYear(year);
 	      });
 	      select.property('value', year);
-	      chartTables.each(function(){
+	      chartTables.each(function() {
 	        this.setYear(year);
 	        this.update();
-	      })
+	      });
+	      yearValues.attr('year', year);
 	    };
 
 	    select.on('change.year', function() {
@@ -13484,7 +13670,7 @@
 
 
 /***/ },
-/* 40 */
+/* 42 */
 /***/ function(module, exports) {
 
 	(function(exports) {

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -5,6 +5,7 @@
   require('../components/eiti-data-map.js');
   require('../components/bar-chart-table.js');
   require('../components/eiti-bar-chart.js');
+  require('../components/year-value.js');
   require('../components/year-switcher-section.js');
   require('../components/eiti-data-map-table.js');
   require('../components/eiti-tooltip-wrapper.js');


### PR DESCRIPTION
Fixes #1953.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/econ-impact-percents/explore/WY/#gdp)

Changes proposed in this pull request:
- Add `<year-value>` component, which responds to changes of the `year` attribute and updates with values in the `data-year-values` JSON-encoded attribute.
- Incorporate `<year-value>` elements as % displays for state GDP and wage/salary jobs.
- Fix up some linting errors.

/cc relevant people
