### PR TITLE
Add tooltips to other maps

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -26,7 +26,7 @@
   {% assign _width = 65.88078 | to_f %}
 {% endif %}
 
-<div class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
+<div  is="eiti-tooltip-wrapper" class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}

--- a/_includes/maps/offshore-regions.html
+++ b/_includes/maps/offshore-regions.html
@@ -2,8 +2,7 @@
 {% for region in site.offshore_regions %}
   {% if include.href %}<a xlink:href="{{ site.baseurl }}{{ include.href | format_url: region }}">{% endif %}
   <g class="state offshore-area feature" fill><!--- FIXME: nix fill attribute -->
-    <title desc="{{ region.title }}"
-           alt="{{ region.title }}">{{ state.title }}</title>
+    <title>{{ state.title }}</title>
     <use xlink:href="{{ _svg_path }}#{{ region.id }}"  aria-label="{{ region.title }}"></use>
   </g>
   {% if include.href %}</a>{% endif %}

--- a/_includes/maps/offshore-regions.html
+++ b/_includes/maps/offshore-regions.html
@@ -2,7 +2,7 @@
 {% for region in site.offshore_regions %}
   {% if include.href %}<a xlink:href="{{ site.baseurl }}{{ include.href | format_url: region }}">{% endif %}
   <g class="state offshore-area feature" fill><!--- FIXME: nix fill attribute -->
-    <title>{{ state.title }}</title>
+    <title>{{ region.title }}</title>
     <use xlink:href="{{ _svg_path }}#{{ region.id }}"  aria-label="{{ region.title }}"></use>
   </g>
   {% if include.href %}</a>{% endif %}

--- a/_includes/maps/state-areas.html
+++ b/_includes/maps/state-areas.html
@@ -7,8 +7,7 @@
   <g class="state feature" {% if include.value %}
     {% assign state_value = include.states[state.id] | get: include.value %}
     data-value='{{ state_value | default: 0 | jsonify }}'{% endif %}>
-    <title desc="{{ state.title }}"
-           alt="{{ state.title }}">{{ state.title }}</title>
+    <title>{{ state.title }}</title>
     <use xlink:href="{{ _svg_path }}#state-{{ state.id }}" aria-label="{{ state.title }}"></use>
   </g>
 

--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -26,7 +26,7 @@
   {% assign _width = 65.88078 | to_f %}
 {% endif %}
 
-<div class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
+<div is="eiti-tooltip-wrapper" class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -53,7 +53,16 @@
       // if no javascript runs, <title> will serve as the tooltip
       // otherwise, clear it so that it doesn't interfere with
       // this tooltip
-      titles.text('');
+      titles
+        .attr('desc', function(d){
+          var self = d3.select(this);
+          return self.attr('desc') || self.text();
+        })
+        .attr('alt', function(d){
+          var self = d3.select(this);
+          return self.attr('alt') || self.text();
+        })
+        .text('');
     };
 
     var update = function() {

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -49,10 +49,8 @@
         tooltipText = tooltip.append('p');
       }
 
-      // clear <title> text
-      // if no javascript runs, <title> will serve as the tooltip
-      // otherwise, clear it so that it doesn't interfere with
-      // this tooltip
+      // if <title> tags do not have 'desc' or 'alt' attributes
+      // use text instead
       titles
         .attr('desc', function(d){
           var self = d3.select(this);
@@ -62,6 +60,10 @@
           var self = d3.select(this);
           return self.attr('alt') || self.text();
         })
+        // clear <title> text
+        // if no javascript runs, <title> will serve as the tooltip
+        // otherwise, clear it so that it doesn't interfere with
+        // this tooltip
         .text('');
     };
 
@@ -77,7 +79,9 @@
         return title.attr('desc');
       });
 
-      tooltip
+      // before rendering the tooltip, ensure that there is text
+      if (tooltipText.text()) {
+        tooltip
         .call(show)
         .attr('aria-label', function() {
           return title.attr('alt');
@@ -106,6 +110,8 @@
             return pixelize(y);
           }
         });
+      }
+
     };
 
     var mouseout = function() {

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -52,11 +52,11 @@
       // if <title> tags do not have 'desc' or 'alt' attributes
       // use text instead
       titles
-        .attr('desc', function(d){
+        .attr('desc', function(){
           var self = d3.select(this);
           return self.attr('desc') || self.text();
         })
-        .attr('alt', function(d){
+        .attr('alt', function(){
           var self = d3.select(this);
           return self.attr('alt') || self.text();
         })

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -75,41 +75,43 @@
 
       init();
 
-      tooltipText.text(function() {
-        return title.attr('desc');
-      });
-
-      // before rendering the tooltip, ensure that there is text
-      if (tooltipText.text()) {
-        tooltip
-        .call(show)
-        .attr('aria-label', function() {
-          return title.attr('alt');
-        })
-        .style('left', function() {
-          var tooltipWidth = depixelize(tooltip.style('width'));
-          var svgWidth = depixelize(svg.style('width'));
-
-          var x = event.layerX + OFFSET_POSITION;
-
-          if (svgWidth <= tooltipWidth + x) {
-            return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
-          } else {
-            return pixelize(x);
-          }
-        })
-        .style('top', function() {
-          var tooltipHeight = depixelize(tooltip.style('height'));
-          var svgHeight = depixelize(svg.style('height'));
-
-          var y = event.layerY + OFFSET_POSITION;
-
-          if (svgHeight <= tooltipHeight + y) {
-            return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
-          } else {
-            return pixelize(y);
-          }
+      if (!title.empty()) {
+        tooltipText.text(function() {
+          return title.attr('desc');
         });
+
+        // before rendering the tooltip, ensure that there is text
+        if (tooltipText.text()) {
+          tooltip
+          .call(show)
+          .attr('aria-label', function() {
+            return title.attr('alt');
+          })
+          .style('left', function() {
+            var tooltipWidth = depixelize(tooltip.style('width'));
+            var svgWidth = depixelize(svg.style('width'));
+
+            var x = event.layerX + OFFSET_POSITION;
+
+            if (svgWidth <= tooltipWidth + x) {
+              return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
+            } else {
+              return pixelize(x);
+            }
+          })
+          .style('top', function() {
+            var tooltipHeight = depixelize(tooltip.style('height'));
+            var svgHeight = depixelize(svg.style('height'));
+
+            var y = event.layerY + OFFSET_POSITION;
+
+            if (svgHeight <= tooltipHeight + y) {
+              return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
+            } else {
+              return pixelize(y);
+            }
+          });
+        }
       }
 
     };

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -254,7 +254,16 @@
 	      // if no javascript runs, <title> will serve as the tooltip
 	      // otherwise, clear it so that it doesn't interfere with
 	      // this tooltip
-	      titles.text('');
+	      titles
+	        .attr('desc', function(d){
+	          var self = d3.select(this);
+	          return self.attr('desc') || self.text();
+	        })
+	        .attr('alt', function(d){
+	          var self = d3.select(this);
+	          return self.attr('alt') || self.text();
+	        })
+	        .text('');
 	    };
 
 	    var update = function() {

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -253,11 +253,11 @@
 	      // if <title> tags do not have 'desc' or 'alt' attributes
 	      // use text instead
 	      titles
-	        .attr('desc', function(d){
+	        .attr('desc', function(){
 	          var self = d3.select(this);
 	          return self.attr('desc') || self.text();
 	        })
-	        .attr('alt', function(d){
+	        .attr('alt', function(){
 	          var self = d3.select(this);
 	          return self.attr('alt') || self.text();
 	        })

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -276,41 +276,43 @@
 
 	      init();
 
-	      tooltipText.text(function() {
-	        return title.attr('desc');
-	      });
-
-	      // before rendering the tooltip, ensure that there is text
-	      if (tooltipText.text()) {
-	        tooltip
-	        .call(show)
-	        .attr('aria-label', function() {
-	          return title.attr('alt');
-	        })
-	        .style('left', function() {
-	          var tooltipWidth = depixelize(tooltip.style('width'));
-	          var svgWidth = depixelize(svg.style('width'));
-
-	          var x = event.layerX + OFFSET_POSITION;
-
-	          if (svgWidth <= tooltipWidth + x) {
-	            return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
-	          } else {
-	            return pixelize(x);
-	          }
-	        })
-	        .style('top', function() {
-	          var tooltipHeight = depixelize(tooltip.style('height'));
-	          var svgHeight = depixelize(svg.style('height'));
-
-	          var y = event.layerY + OFFSET_POSITION;
-
-	          if (svgHeight <= tooltipHeight + y) {
-	            return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
-	          } else {
-	            return pixelize(y);
-	          }
+	      if (!title.empty()) {
+	        tooltipText.text(function() {
+	          return title.attr('desc');
 	        });
+
+	        // before rendering the tooltip, ensure that there is text
+	        if (tooltipText.text()) {
+	          tooltip
+	          .call(show)
+	          .attr('aria-label', function() {
+	            return title.attr('alt');
+	          })
+	          .style('left', function() {
+	            var tooltipWidth = depixelize(tooltip.style('width'));
+	            var svgWidth = depixelize(svg.style('width'));
+
+	            var x = event.layerX + OFFSET_POSITION;
+
+	            if (svgWidth <= tooltipWidth + x) {
+	              return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
+	            } else {
+	              return pixelize(x);
+	            }
+	          })
+	          .style('top', function() {
+	            var tooltipHeight = depixelize(tooltip.style('height'));
+	            var svgHeight = depixelize(svg.style('height'));
+
+	            var y = event.layerY + OFFSET_POSITION;
+
+	            if (svgHeight <= tooltipHeight + y) {
+	              return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
+	            } else {
+	              return pixelize(y);
+	            }
+	          });
+	        }
 	      }
 
 	    };

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -250,10 +250,8 @@
 	        tooltipText = tooltip.append('p');
 	      }
 
-	      // clear <title> text
-	      // if no javascript runs, <title> will serve as the tooltip
-	      // otherwise, clear it so that it doesn't interfere with
-	      // this tooltip
+	      // if <title> tags do not have 'desc' or 'alt' attributes
+	      // use text instead
 	      titles
 	        .attr('desc', function(d){
 	          var self = d3.select(this);
@@ -263,6 +261,10 @@
 	          var self = d3.select(this);
 	          return self.attr('alt') || self.text();
 	        })
+	        // clear <title> text
+	        // if no javascript runs, <title> will serve as the tooltip
+	        // otherwise, clear it so that it doesn't interfere with
+	        // this tooltip
 	        .text('');
 	    };
 
@@ -278,7 +280,9 @@
 	        return title.attr('desc');
 	      });
 
-	      tooltip
+	      // before rendering the tooltip, ensure that there is text
+	      if (tooltipText.text()) {
+	        tooltip
 	        .call(show)
 	        .attr('aria-label', function() {
 	          return title.attr('alt');
@@ -307,6 +311,8 @@
 	            return pixelize(y);
 	          }
 	        });
+	      }
+
 	    };
 
 	    var mouseout = function() {

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -25488,7 +25488,7 @@
 	        return root.svg4everybody = factory();
 	    }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : "object" == typeof exports ? module.exports = factory() : root.svg4everybody = factory();
 	}(this, function() {
-	    /*! svg4everybody v2.1.0 | github.com/jonathantneal/svg4everybody */
+	    /*! svg4everybody v2.0.3 | github.com/jonathantneal/svg4everybody */
 	    function embed(node, target) {
 	        // if the target exists
 	        if (target) {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -767,10 +767,8 @@
 	        tooltipText = tooltip.append('p');
 	      }
 
-	      // clear <title> text
-	      // if no javascript runs, <title> will serve as the tooltip
-	      // otherwise, clear it so that it doesn't interfere with
-	      // this tooltip
+	      // if <title> tags do not have 'desc' or 'alt' attributes
+	      // use text instead
 	      titles
 	        .attr('desc', function(d){
 	          var self = d3.select(this);
@@ -780,6 +778,10 @@
 	          var self = d3.select(this);
 	          return self.attr('alt') || self.text();
 	        })
+	        // clear <title> text
+	        // if no javascript runs, <title> will serve as the tooltip
+	        // otherwise, clear it so that it doesn't interfere with
+	        // this tooltip
 	        .text('');
 	    };
 
@@ -795,7 +797,9 @@
 	        return title.attr('desc');
 	      });
 
-	      tooltip
+	      // before rendering the tooltip, ensure that there is text
+	      if (tooltipText.text()) {
+	        tooltip
 	        .call(show)
 	        .attr('aria-label', function() {
 	          return title.attr('alt');
@@ -824,6 +828,8 @@
 	            return pixelize(y);
 	          }
 	        });
+	      }
+
 	    };
 
 	    var mouseout = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -793,41 +793,43 @@
 
 	      init();
 
-	      tooltipText.text(function() {
-	        return title.attr('desc');
-	      });
-
-	      // before rendering the tooltip, ensure that there is text
-	      if (tooltipText.text()) {
-	        tooltip
-	        .call(show)
-	        .attr('aria-label', function() {
-	          return title.attr('alt');
-	        })
-	        .style('left', function() {
-	          var tooltipWidth = depixelize(tooltip.style('width'));
-	          var svgWidth = depixelize(svg.style('width'));
-
-	          var x = event.layerX + OFFSET_POSITION;
-
-	          if (svgWidth <= tooltipWidth + x) {
-	            return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
-	          } else {
-	            return pixelize(x);
-	          }
-	        })
-	        .style('top', function() {
-	          var tooltipHeight = depixelize(tooltip.style('height'));
-	          var svgHeight = depixelize(svg.style('height'));
-
-	          var y = event.layerY + OFFSET_POSITION;
-
-	          if (svgHeight <= tooltipHeight + y) {
-	            return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
-	          } else {
-	            return pixelize(y);
-	          }
+	      if (!title.empty()) {
+	        tooltipText.text(function() {
+	          return title.attr('desc');
 	        });
+
+	        // before rendering the tooltip, ensure that there is text
+	        if (tooltipText.text()) {
+	          tooltip
+	          .call(show)
+	          .attr('aria-label', function() {
+	            return title.attr('alt');
+	          })
+	          .style('left', function() {
+	            var tooltipWidth = depixelize(tooltip.style('width'));
+	            var svgWidth = depixelize(svg.style('width'));
+
+	            var x = event.layerX + OFFSET_POSITION;
+
+	            if (svgWidth <= tooltipWidth + x) {
+	              return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
+	            } else {
+	              return pixelize(x);
+	            }
+	          })
+	          .style('top', function() {
+	            var tooltipHeight = depixelize(tooltip.style('height'));
+	            var svgHeight = depixelize(svg.style('height'));
+
+	            var y = event.layerY + OFFSET_POSITION;
+
+	            if (svgHeight <= tooltipHeight + y) {
+	              return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
+	            } else {
+	              return pixelize(y);
+	            }
+	          });
+	        }
 	      }
 
 	    };

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -771,7 +771,16 @@
 	      // if no javascript runs, <title> will serve as the tooltip
 	      // otherwise, clear it so that it doesn't interfere with
 	      // this tooltip
-	      titles.text('');
+	      titles
+	        .attr('desc', function(d){
+	          var self = d3.select(this);
+	          return self.attr('desc') || self.text();
+	        })
+	        .attr('alt', function(d){
+	          var self = d3.select(this);
+	          return self.attr('alt') || self.text();
+	        })
+	        .text('');
 	    };
 
 	    var update = function() {
@@ -13072,12 +13081,12 @@
 	  var barHeight = bottom - top;
 
 	  var extentPercent = 0.05; // 5%
-	  var extentMargin = barHeight * extentPercent;
-	  var extentLessTop = top;
+	  extentMargin = barHeight * extentPercent;
 	  top = top + extentMargin;
 	  var extentTop = top - extentMargin;
 
-	  var fullHeight = height + textMargin + extentMargin + tickPadding - (2 * baseMargin);
+	  var fullHeight = height + textMargin + extentMargin
+	    + tickPadding - (2 * baseMargin);
 	  var extentlessHeight = fullHeight - extentMargin;
 
 	  var attached = function() {
@@ -13128,8 +13137,6 @@
 	        .key(function(d) { return d.x; })
 	        .rollup(function(d) { return d[0]; })
 	        .entries(data);
-
-
 	    } else {
 	      values = Object.keys(data).reduce(function(map, key) {
 	        map[key] = {x: +key, y: data[key]};
@@ -13212,10 +13219,10 @@
 	        var baseHeight = isUndefined || isZero || isWithheld
 	          ? 0
 	          : 2;
-
-	        return d.height = height(d.y) > baseHeight
+	        d.height = height(d.y) > baseHeight
 	          ? height(d.y)
 	          : baseHeight;
+	        return d.height;
 	      })
 	      .attr('y', function(d) {
 	        return barHeight - d.height;
@@ -13290,7 +13297,7 @@
 	        .call(axis);
 
 	    function isInSet (year, vals) {
-	      var vals = vals || values;
+	      vals = vals || values;
 	      if (vals[year] !== undefined) {
 	        return vals[year].y !== null;
 	      } else {
@@ -13316,7 +13323,7 @@
 	      text = [text, units].join(' ');
 	    }
 	    return text;
-	  }
+	  };
 
 	  var hideCaption = function(selection, data, noData, withheld) {
 	    selection.select('.caption-data')
@@ -13325,7 +13332,7 @@
 	      .attr('aria-hidden', noData);
 	    selection.select('.caption-withheld')
 	    .attr('aria-hidden', withheld);
-	  }
+	  };
 
 	  var updateSelected = function(selection, x, hover) {
 	    var index;
@@ -13437,7 +13444,7 @@
 /* 39 */
 /***/ function(module, exports, __webpack_require__) {
 
-	(function(exports) {
+	(function() {
 
 	  var assign = __webpack_require__(40);
 	  var d3 = __webpack_require__(9);
@@ -13511,14 +13518,14 @@
 	        attachedCallback: function() {
 	          update.call(this);
 	        },
-	        attributeChangedCallback: function(attr) {
+	        attributeChangedCallback: function() {
 	          update.call(this);
 	        }
 	      }
 	    )
 	  });
 
-	})(window);
+	})();
 
 
 /***/ },
@@ -13614,7 +13621,7 @@
 /* 41 */
 /***/ function(module, exports) {
 
-	(function(exports) {
+	(function() {
 
 	  var attached = function() {
 	    var root = d3.select(this);
@@ -13625,7 +13632,7 @@
 
 	    var mapTables = root.selectAll('.eiti-data-map-table');
 
-	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
+	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]');
 
 	    var yearValues = root.selectAll('year-value');
 
@@ -13655,18 +13662,18 @@
 	  var detached = function() {
 	  };
 
-	  exports.EITIYearSwitcherSection = document.registerElement('year-switcher-section', {
+	  document.registerElement('year-switcher-section', {
 	    'extends': 'section',
 	    prototype: Object.create(
 	      HTMLElement.prototype,
 	      {
 	        attachedCallback: {value: attached},
-	        detachdCallback: {value: detached}
+	        detachedCallback: {value: detached}
 	      }
 	    )
-	  })
+	  });
 
-	})(this);
+	})();
 
 
 /***/ },

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -770,11 +770,11 @@
 	      // if <title> tags do not have 'desc' or 'alt' attributes
 	      // use text instead
 	      titles
-	        .attr('desc', function(d){
+	        .attr('desc', function(){
 	          var self = d3.select(this);
 	          return self.attr('desc') || self.text();
 	        })
-	        .attr('alt', function(d){
+	        .attr('alt', function(){
 	          var self = d3.select(this);
 	          return self.attr('alt') || self.text();
 	        })


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/tooltips-other-maps/explore/CO/#federal-production)

Changes proposed in this pull request:
- Adds tooltips to county and offshore area maps
- updates tooltip logic to simplify templating. No longer need `<title desc="Alaska">Alaska</title>`, but simply `<title>Alaska</title>`

/cc @meiqimichelle @ericronne 
