### PR TITLE
Fixes case study meta page title

### DIFF
--- a/_case-studies/default.md
+++ b/_case-studies/default.md
@@ -1,5 +1,5 @@
 ---
-title: Overview | Case Studies
+title: Case Studies
 layout: case-studies-landing
 permalink: /case-studies/
 nav_items:


### PR DESCRIPTION
Fixes issue(s) #1979 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/overview-eradication.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/overview-eradication)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/overview-eradication/)

Changes proposed in this pull request:

- Removes the one remaining instance of the word "Overview" on the case study landing page, which was in the YAML front matter

- This might be the tiniest PR of all time, sorry.