### PR TITLE
Year default consistency

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -29,8 +29,6 @@
 
 <div class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
-  <!-- county-map year: {{ year }} -->
-  <!-- county-map include.year: {{ include.year }} -->
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
     {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ include.state }}.svg{% endcapture %}
@@ -63,8 +61,6 @@
           {% assign fips = county[0] | pad_left: 5, '0' %}
           {% if include.href %}<a xlink:href="{{ include.href | format_url: fips }}">{% endif %}
           {% assign value = county[1] | get: keys %}
-          <!-- county: {{ county }} -->
-          <!-- value: {{ value }} -->
           {% assign year_values = null %}
           {% if include.years %}
             {% assign year_values = county[1] | get: include.years %}

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -4,6 +4,7 @@
 {% assign caption = include.caption %}
 {% assign toggle = include.toggle %}
 {% assign units = include.units %}
+{% assign year = include.year | default: year | default: '2015' %}
 
 {% if _inherit_width %}
   {% assign __width = '' %}
@@ -28,6 +29,8 @@
 
 <div class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
+  <!-- county-map year: {{ year }} -->
+  <!-- county-map include.year: {{ include.year }} -->
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
     {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ include.state }}.svg{% endcapture %}
@@ -60,7 +63,8 @@
           {% assign fips = county[0] | pad_left: 5, '0' %}
           {% if include.href %}<a xlink:href="{{ include.href | format_url: fips }}">{% endif %}
           {% assign value = county[1] | get: keys %}
-
+          <!-- county: {{ county }} -->
+          <!-- value: {{ value }} -->
           {% assign year_values = null %}
           {% if include.years %}
             {% assign year_values = county[1] | get: include.years %}

--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -9,7 +9,8 @@
 
 <table is='bar-chart-table'
        data-percent-max='100'
-       class='county-table'>
+       class='county-table'
+       year='{{ include.year }}'>
   <thead>
     <tr>
       <th>{{ locality_name }}</th>

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -1,7 +1,7 @@
 {% assign caption = include.caption %}
 {% assign locality_name = include.locality_name | default: locality_name %}
 
-<table is='bar-chart-table' data-percent-max='100' class='county-table'>
+<table is='bar-chart-table' data-percent-max='100' class='county-table' year='{{ include.year }}'>
   <thead>
     <tr>
       <th>{{ locality_name }}</th>

--- a/_includes/location/display-jobs-county.html
+++ b/_includes/location/display-jobs-county.html
@@ -1,6 +1,6 @@
 {% assign caption = include.caption %}
 
-<table is='bar-chart-table' data-percent-max='100' class="county-table">
+<table is='bar-chart-table' data-percent-max='100' class="county-table" year='{{ include.year }}'>
   <thead>
     <tr>
       <th>{{ locality_name }}</th>

--- a/_includes/location/offshore-area-federal-production-table.html
+++ b/_includes/location/offshore-area-federal-production-table.html
@@ -10,7 +10,8 @@
 
 <table is='bar-chart-table'
        data-percent-max='100'
-       class='county-table'>
+       class='county-table'
+       year='{{ include.year }}'>
   <thead>
     <tr>
       <th>{{ locality_name }}</th>

--- a/_includes/location/offshore-federal-revenue-area.html
+++ b/_includes/location/offshore-federal-revenue-area.html
@@ -65,6 +65,7 @@
             inherit_width=true
             caption=caption
             toggle=toggle
+            year=year
           %}
         </eiti-data-map>
 

--- a/_includes/location/offshore-region-federal-production.html
+++ b/_includes/location/offshore-region-federal-production.html
@@ -115,6 +115,7 @@
                   inherit_width=true
                   caption=caption
                   toggle=toggle
+                  year=year
                 %}
 
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -116,6 +116,7 @@
                   inherit_width=true
                   caption=caption
                   toggle=toggle
+                  year=year
                 %}
 
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -96,8 +96,12 @@
 
             {% capture toggle %}federal-production-{{ product_slug }}-counties{% endcapture %}
             <figure is="eiti-data-map-table">
+
               {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
               {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
+              <!-- year: {{ year }} -->
+              <!-- value_key: {{ value_key }} -->
+              <!-- years_key: {{ years_key }} -->
               {% assign _width ='inherit' %}
 
               {% capture caption %}{{ locality_name }} production of {{ product_name | downcase | suffix:units_suffix }} in <span data-year="{{ year }}">{{ year }}</span>{% if units %} <span class="legend-units">({{ short_units | default:units }})</span>{% endif %}{% endcapture %}

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -99,9 +99,6 @@
 
               {% capture value_key %}products.{{ product[0] }}.volume.{{ year }}{% endcapture %}
               {% capture years_key %}products.{{ product[0] }}.volume{% endcapture %}
-              <!-- year: {{ year }} -->
-              <!-- value_key: {{ value_key }} -->
-              <!-- years_key: {{ years_key }} -->
               {% assign _width ='inherit' %}
 
               {% capture caption %}{{ locality_name }} production of {{ product_name | downcase | suffix:units_suffix }} in <span data-year="{{ year }}">{{ year }}</span>{% if units %} <span class="legend-units">({{ short_units | default:units }})</span>{% endif %}{% endcapture %}

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -30,7 +30,7 @@
 
       <div class="chart-description{% unless jobs %} no-selector{% endunless %}">
         <p>
-          Wage and salary data, from the Bureau of Labor Statistics, describes the number of people employed in natural resource extraction that receive wages or salaries from companies. 
+          Wage and salary data, from the Bureau of Labor Statistics, describes the number of people employed in natural resource extraction that receive wages or salaries from companies.
           <br>
           <a href="{{site.baseurl}}/downloads/#jobs">
             <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
@@ -63,7 +63,7 @@
               <span class="eiti-bar-chart-y-value"
                 data-format=",">{{ jobs[year].jobs | intcomma }}</span>
               jobs in the extractive industries in
-              {{ state_name }}, and they accounted for 
+              {{ state_name }}, and they accounted for
               <year-value year="{{ year }}" data-year-values='{{ jobs | map_hash: "percent" | jsonify }}'
                 empty="--">{{ jobs_percent | percent }}</year-value>%
               of statewide employment.
@@ -104,6 +104,7 @@
               inherit_width=true
               caption=caption
               toggle=toggle
+              year=year
             %}
           </eiti-data-map>
           <div class="eiti-data-map-table" id="{{ toggle }}" aria-hidden="true">
@@ -153,7 +154,7 @@
           Self-employment data, from the Bureau of Economic Analysis, describes people who work in natural resource extraction, but don’t receive wages or salaries because they own their own companies.
           <br>
           <a href="{{site.baseurl}}/downloads/#jobs">
-            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation 
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
           </a>
         </p>
       </div>

--- a/_includes/location/state-federal-revenue-county.html
+++ b/_includes/location/state-federal-revenue-county.html
@@ -24,7 +24,7 @@
         </eiti-bar-chart>
         <figcaption id="federal-revenue-county-figures-All">
           <span class="caption-data">
-            Companies paid 
+            Companies paid
             <span class="eiti-bar-chart-y-value" data-format="$,">${{ current_revenue | intcomma }}</span>
             to produce natural resources on federal land in {{ state_name }} in <span class="eiti-bar-chart-x-value">{{ year }}</span>.
           </span>
@@ -62,6 +62,7 @@
             inherit_width=true
             caption=caption
             toggle=toggle
+            year=year
           %}
         </eiti-data-map>
 

--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -4,6 +4,7 @@
 {% assign caption = include.caption %}
 {% assign toggle = include.toggle %}
 {% assign units = include.units %}
+{% assign year = include.year | default: year | default: '2015' %}
 
 {% if _inherit_width %}
   {% assign __width = '' %}

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -1,5 +1,9 @@
 (function(exports) {
 
+  var WITHHELD_FLAG = 'Withheld';
+  var NO_DATA_FLAG = undefined;
+  var DEFAULT_YEAR = '2015';
+
   var initialize = function() {
     this._cells = [].slice.call(this.querySelectorAll('tr > [data-value]'));
     this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
@@ -7,12 +11,11 @@
     this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
     this.isCountyTable = d3.select(this).classed('county-table');
 
-    this.setYear();
+    console.log(this)
+    var year = this.getAttribute('year') || DEFAULT_YEAR;
+    this.setYear(year);
     this.update();
   };
-
-  var WITHHELD_FLAG = 'Withheld';
-  var NO_DATA_FLAG = undefined;
 
   var setYear = function(year) {
     var root = d3.select(this);
@@ -67,8 +70,8 @@
           return format(value);
         }
       }
-
-      var year = year || '2013';
+      console.log('year---', year)
+      var year = year || '2015';
       var bars = root.selectAll('[data-value]');
       var texts = root.selectAll('[data-value-text]');
       var sentences = root.selectAll('[data-sentence]');

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -11,7 +11,6 @@
     this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
     this.isCountyTable = d3.select(this).classed('county-table');
 
-    console.log(this)
     var year = this.getAttribute('year') || DEFAULT_YEAR;
     this.setYear(year);
     this.update();
@@ -70,7 +69,7 @@
           return format(value);
         }
       }
-      console.log('year---', year)
+
       var year = year || '2015';
       var bars = root.selectAll('[data-value]');
       var texts = root.selectAll('[data-value-text]');

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -99,7 +99,6 @@
               return true;
             }
           });
-          console.log(this.marks.data())
 
           var root = d3.select(this);
           var truthy = hasData.indexOf(true) > -1;

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -28,7 +28,7 @@
           } else {
             this.isWideView = true;
           }
-          this.update();
+          this.update('init');
         }},
 
         setYear: {value: function(year) {
@@ -85,7 +85,7 @@
           }
         }},
 
-        update: {value: function() {
+        update: {value: function(init) {
           var hasData = [];
           this.marks.data().every(function(d){
             if (d === WITHHELD_FLAG) {
@@ -99,6 +99,7 @@
               return true;
             }
           });
+          console.log(this.marks.data())
 
           var root = d3.select(this);
           var truthy = hasData.indexOf(true) > -1;
@@ -297,7 +298,9 @@
 
           svgContainer.style('padding-bottom', percentage);
           // end trim
-
+          if (init) {
+            this.setYear('2015')
+          }
         }}
       }
     )

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -298,7 +298,7 @@
           svgContainer.style('padding-bottom', percentage);
           // end trim
           if (init) {
-            this.setYear('2015')
+            this.setYear('2015');
           }
         }}
       }

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -25488,7 +25488,7 @@
 	        return root.svg4everybody = factory();
 	    }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : "object" == typeof exports ? module.exports = factory() : root.svg4everybody = factory();
 	}(this, function() {
-	    /*! svg4everybody v2.1.0 | github.com/jonathantneal/svg4everybody */
+	    /*! svg4everybody v2.0.3 | github.com/jonathantneal/svg4everybody */
 	    function embed(node, target) {
 	        // if the target exists
 	        if (target) {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11590,7 +11590,7 @@
 	          } else {
 	            this.isWideView = true;
 	          }
-	          this.update();
+	          this.update('init');
 	        }},
 
 	        setYear: {value: function(year) {
@@ -11647,7 +11647,7 @@
 	          }
 	        }},
 
-	        update: {value: function() {
+	        update: {value: function(init) {
 	          var hasData = [];
 	          this.marks.data().every(function(d){
 	            if (d === WITHHELD_FLAG) {
@@ -11661,6 +11661,7 @@
 	              return true;
 	            }
 	          });
+	          console.log(this.marks.data())
 
 	          var root = d3.select(this);
 	          var truthy = hasData.indexOf(true) > -1;
@@ -11859,7 +11860,9 @@
 
 	          svgContainer.style('padding-bottom', percentage);
 	          // end trim
-
+	          if (init) {
+	            this.setYear('2015')
+	          }
 	        }}
 	      }
 	    )

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12659,7 +12659,6 @@
 	    this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
 	    this.isCountyTable = d3.select(this).classed('county-table');
 
-	    console.log(this)
 	    var year = this.getAttribute('year') || DEFAULT_YEAR;
 	    this.setYear(year);
 	    this.update();
@@ -12718,7 +12717,7 @@
 	          return format(value);
 	        }
 	      }
-	      console.log('year---', year)
+
 	      var year = year || '2015';
 	      var bars = root.selectAll('[data-value]');
 	      var texts = root.selectAll('[data-value-text]');

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12646,6 +12646,10 @@
 
 	(function(exports) {
 
+	  var WITHHELD_FLAG = 'Withheld';
+	  var NO_DATA_FLAG = undefined;
+	  var DEFAULT_YEAR = '2015';
+
 	  var initialize = function() {
 	    this._cells = [].slice.call(this.querySelectorAll('tr > [data-value]'));
 	    this.nested_cells = [].slice.call(this.querySelectorAll('tr > [data-value] > [data-value]'));
@@ -12653,12 +12657,11 @@
 	    this.eitiDataMap = this.parentNode.parentNode.querySelector('eiti-data-map');
 	    this.isCountyTable = d3.select(this).classed('county-table');
 
-	    this.setYear();
+	    console.log(this)
+	    var year = this.getAttribute('year') || DEFAULT_YEAR;
+	    this.setYear(year);
 	    this.update();
 	  };
-
-	  var WITHHELD_FLAG = 'Withheld';
-	  var NO_DATA_FLAG = undefined;
 
 	  var setYear = function(year) {
 	    var root = d3.select(this);
@@ -12713,8 +12716,8 @@
 	          return format(value);
 	        }
 	      }
-
-	      var year = year || '2013';
+	      console.log('year---', year)
+	      var year = year || '2015';
 	      var bars = root.selectAll('[data-value]');
 	      var texts = root.selectAll('[data-value-text]');
 	      var sentences = root.selectAll('[data-sentence]');
@@ -13072,12 +13075,12 @@
 	  var barHeight = bottom - top;
 
 	  var extentPercent = 0.05; // 5%
-	  var extentMargin = barHeight * extentPercent;
-	  var extentLessTop = top;
+	  extentMargin = barHeight * extentPercent;
 	  top = top + extentMargin;
 	  var extentTop = top - extentMargin;
 
-	  var fullHeight = height + textMargin + extentMargin + tickPadding - (2 * baseMargin);
+	  var fullHeight = height + textMargin + extentMargin
+	    + tickPadding - (2 * baseMargin);
 	  var extentlessHeight = fullHeight - extentMargin;
 
 	  var attached = function() {
@@ -13128,8 +13131,6 @@
 	        .key(function(d) { return d.x; })
 	        .rollup(function(d) { return d[0]; })
 	        .entries(data);
-
-
 	    } else {
 	      values = Object.keys(data).reduce(function(map, key) {
 	        map[key] = {x: +key, y: data[key]};
@@ -13212,10 +13213,10 @@
 	        var baseHeight = isUndefined || isZero || isWithheld
 	          ? 0
 	          : 2;
-
-	        return d.height = height(d.y) > baseHeight
+	        d.height = height(d.y) > baseHeight
 	          ? height(d.y)
 	          : baseHeight;
+	        return d.height;
 	      })
 	      .attr('y', function(d) {
 	        return barHeight - d.height;
@@ -13290,7 +13291,7 @@
 	        .call(axis);
 
 	    function isInSet (year, vals) {
-	      var vals = vals || values;
+	      vals = vals || values;
 	      if (vals[year] !== undefined) {
 	        return vals[year].y !== null;
 	      } else {
@@ -13316,7 +13317,7 @@
 	      text = [text, units].join(' ');
 	    }
 	    return text;
-	  }
+	  };
 
 	  var hideCaption = function(selection, data, noData, withheld) {
 	    selection.select('.caption-data')
@@ -13325,7 +13326,7 @@
 	      .attr('aria-hidden', noData);
 	    selection.select('.caption-withheld')
 	    .attr('aria-hidden', withheld);
-	  }
+	  };
 
 	  var updateSelected = function(selection, x, hover) {
 	    var index;
@@ -13437,7 +13438,7 @@
 /* 39 */
 /***/ function(module, exports, __webpack_require__) {
 
-	(function(exports) {
+	(function() {
 
 	  var assign = __webpack_require__(40);
 	  var d3 = __webpack_require__(9);
@@ -13511,14 +13512,14 @@
 	        attachedCallback: function() {
 	          update.call(this);
 	        },
-	        attributeChangedCallback: function(attr) {
+	        attributeChangedCallback: function() {
 	          update.call(this);
 	        }
 	      }
 	    )
 	  });
 
-	})(window);
+	})();
 
 
 /***/ },
@@ -13614,7 +13615,7 @@
 /* 41 */
 /***/ function(module, exports) {
 
-	(function(exports) {
+	(function() {
 
 	  var attached = function() {
 	    var root = d3.select(this);
@@ -13625,7 +13626,7 @@
 
 	    var mapTables = root.selectAll('.eiti-data-map-table');
 
-	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]')
+	    var chartTables = mapTables.selectAll('table[is="bar-chart-table"]');
 
 	    var yearValues = root.selectAll('year-value');
 
@@ -13655,18 +13656,18 @@
 	  var detached = function() {
 	  };
 
-	  exports.EITIYearSwitcherSection = document.registerElement('year-switcher-section', {
+	  document.registerElement('year-switcher-section', {
 	    'extends': 'section',
 	    prototype: Object.create(
 	      HTMLElement.prototype,
 	      {
 	        attachedCallback: {value: attached},
-	        detachdCallback: {value: detached}
+	        detachedCallback: {value: detached}
 	      }
 	    )
-	  })
+	  });
 
-	})(this);
+	})();
 
 
 /***/ },

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11661,7 +11661,6 @@
 	              return true;
 	            }
 	          });
-	          console.log(this.marks.data())
 
 	          var root = d3.select(this);
 	          var truthy = hasData.indexOf(true) > -1;


### PR DESCRIPTION
Fixes issue(s) #1925 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/year-consistency.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/year-consistency)

[:sunglasses: PREVIEW AZ 🌵](https://federalist.18f.gov/preview/18F/doi-extractives-data/year-consistency/AZ/#federal-production)

[:sunglasses: PREVIEW CO 🗻](https://federalist.18f.gov/preview/18F/doi-extractives-data/year-consistency/AZ/#federal-production)

Changes proposed in this pull request:
- makes it so that years in the county (and offshore area) maps and charts default to the same year as the corresponding bar chart

/cc @meiqimichelle 
