### PR TITLE
Fix black maps in IE11

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -38,6 +38,9 @@
 // Import Fonts
 @import 'fonts';
 
+// include FontAwesome Sass variables, etc.
+@import 'lib/font-awesome/font-awesome';
+
 // Components
 //
 // Site components

--- a/_sass/blocks/state-pages/_iconic-nav.scss
+++ b/_sass/blocks/state-pages/_iconic-nav.scss
@@ -9,12 +9,14 @@
   position: relative;
 
   svg.map {
-    .state.feature use,
-    .offshore-area.feature use {
+    @include svg-use(
+      '.state.feature',
+      '.offshore-area.feature'
+    ) {
       fill-opacity: 1;
     }
 
-    .states.features use {
+    @include svg-use('.states.features') {
       @include transition(all, 0.2s);
 
       fill: $gray;
@@ -22,7 +24,7 @@
       stroke: $gray;
     }
 
-    .offshore.features use {
+    @include svg-use('.offshore.features') {
       @include transition(all, 0.2s);
 
       fill: $gray-light;
@@ -44,18 +46,24 @@
         visibility: visible;
       }
 
-      svg.map .states.features use,
-      svg.map .state.feature use {
-        fill: $black-light;
-        fill-opacity: 1;
-        stroke: $black-light;
-      }
+      svg.map {
+        @include svg-use(
+          '.states.features',
+          '.state.feature'
+        ) {
+          fill: $black-light;
+          fill-opacity: 1;
+          stroke: $black-light;
+        }
 
-      svg.map .offshore.features use,
-      svg.map .offshore-area.feature use {
-        fill: $gray-darker;
-        fill-opacity: 1;
-        stroke: $gray-darker;
+        @include svg-use(
+          '.offshore.features',
+          '.offshore-area.feature'
+        ) {
+          fill: $gray-darker;
+          fill-opacity: 1;
+          stroke: $gray-darker;
+        }
       }
     }
 

--- a/_sass/components/_map.scss
+++ b/_sass/components/_map.scss
@@ -1,3 +1,4 @@
+// scss-lint:disable QualifyingElement, SelectorDepth, DeclarationOrder, DuplicateProperty
 
 // Map TODO
 //============================================
@@ -77,7 +78,7 @@
     display: inline-block;
     height: 55px;
     margin-left: 10px;
-    padding: 33px 0 10px 0;
+    padding: 33px 0 10px;
     text-align: center;
     width: 55px;
 

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -1,4 +1,4 @@
-// scss-lint:disable QualifyingElement, SelectorDepth
+// scss-lint:disable QualifyingElement, SelectorDepth, DeclarationOrder
 svg.map {
   background: none;
   box-sizing: border-box;
@@ -142,7 +142,7 @@ svg.ownership {
 }
 
 svg.case_studies {
-    @include svg-use(
+  @include svg-use(
     '.feature.offshore-area',
     '.feature.state'
   ) {

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -7,19 +7,21 @@ svg.map {
   padding: 1em;
   width: 100%;
 
-  .mesh use {
+  @include svg-use('.mesh') {
     fill: none;
     pointer-events: none;
     stroke: $neutral-gray;
     stroke-width: 0.5;
   }
 
-  .states.features use,
-  .regions.features use {
+  @include svg-use(
+    '.states.features',
+    '.regions.features'
+  ) {
     fill: $light-gray;
   }
 
-  .feature.offshore-area use {
+  @include svg-use('.feature.offshore-area') {
     fill: $greenest-land;
 
     &:hover,
@@ -29,7 +31,7 @@ svg.map {
     }
   }
 
-  .feature:not([fill]) use {
+  @include svg-use('.feature:not([fill])') {
     fill-opacity: 0;
 
     &:hover,
@@ -39,24 +41,26 @@ svg.map {
     }
   }
 
-  .feature[fill] use {
+  @include svg-use('.feature[fill]') {
     fill-opacity: 1;
   }
 
-  .counties.features use {
+  @include svg-use('.counties.features') {
     fill: $white;
   }
 
-  .states.mesh use,
-  .regions.mesh use {
+  @include svg-use(
+    '.states.mesh',
+    '.regions.mesh'
+  ) {
     stroke: $another-gray;
   }
 
-  .counties.mesh use {
+  @include svg-use('.counties.mesh') {
     stroke-width: 1;
   }
 
-  .feature.overlay use {
+  @include svg-use('.feature.overlay') {
     fill: none;
     pointer-events: none;
     stroke: $dark-gray;
@@ -96,13 +100,13 @@ svg.map {
       opacity: $opacity-federal;
     }
 
-    .counties.features use {
+    @include svg-use('.counties.features') {
       fill: $green-land;
     }
   }
 
   &.states.ownership {
-    .states.features use {
+    @include svg-use('.states.features') {
       fill: $green-land;
     }
   }
@@ -110,7 +114,7 @@ svg.map {
 
 svg.ownership {
   &.no-outlines {
-    .states.mesh use {
+    @include svg-use('.states.mesh') {
       stroke: $pale-blue;
       stroke-width: 1.5px;
     }
@@ -118,11 +122,11 @@ svg.ownership {
     &.state-page {
       padding-top: 0;
 
-      .states.features use {
+      @include svg-use('.states.features') {
         fill: transparent;
       }
 
-      .states.mesh use {
+      @include svg-use('.states.mesh') {
         stroke: transparent;
       }
     }
@@ -130,8 +134,10 @@ svg.ownership {
 }
 
 svg.case_studies {
-  .feature.offshore-area use,
-  .feature.state use {
+    @include svg-use(
+    '.feature.offshore-area',
+    '.feature.state'
+  ) {
     fill: $gray;
 
     &:active,
@@ -142,19 +148,19 @@ svg.case_studies {
   }
 
   &.no-outlines {
-    .states.mesh use {
+    @include svg-use('.states.mesh') {
       stroke: $pale-blue;
       stroke-width: 1.5px;
     }
 
-    .states.features use {
+    @include svg-use('.states.features') {
       fill: $gray;
     }
   }
 }
 
 svg.icon {
-  .feature.offshore-area use {
+  @include svg-use('.feature.offshore-area') {
     fill: inherit;
   }
 }

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -7,12 +7,6 @@ svg.map {
   padding: 1em;
   width: 100%;
 
-  use {
-    fill: inherit;
-    stroke: inherit;
-    stroke-width: inherit;
-  }
-
   .mesh use {
     fill: none;
     pointer-events: none;

--- a/_sass/elements/_svg.scss
+++ b/_sass/elements/_svg.scss
@@ -20,3 +20,10 @@
     top: 0;
   }
 }
+
+svg use {
+  all: inherit;
+  fill: inherit;
+  stroke: inherit;
+  stroke-width: inherit;
+}

--- a/_sass/mixins/_all.scss
+++ b/_sass/mixins/_all.scss
@@ -1,4 +1,5 @@
 @import 'type-mixins';
 @import 'rotate';
 @import 'padded-in-mobile';
+@import 'svg-use';
 @import 'tabs';

--- a/_sass/mixins/_svg-use.scss
+++ b/_sass/mixins/_svg-use.scss
@@ -1,0 +1,9 @@
+// duplicates a selector
+@mixin svg-use($selectors...) {
+  @each $selector in $selectors {
+    #{$selector} use,
+    #{$selector} path {
+      @content;
+    }
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -11,9 +11,3 @@
 
 // include site specific base styles
 @import 'base';
-
-// include fonts (and @import font-face declarations from /css/fonts)
-@import 'fonts';
-
-// include FontAwesome Sass variables, etc.
-@import 'lib/font-awesome/font-awesome';

--- a/css/print.scss
+++ b/css/print.scss
@@ -12,11 +12,5 @@
 // include site specific base styles
 @import 'base';
 
-// include fonts (and @import font-face declarations from /css/fonts)
-@import 'fonts';
-
-// include FontAwesome Sass variables, etc.
-@import 'lib/font-awesome/font-awesome';
-
 // include print stylesheet overrides
 @import 'print';


### PR DESCRIPTION
Fixes #1991.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-ie11/explore/)

Some screenshots from IE11 (on VirtualBox):

* [Explore](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-ie11/explore/)
  ![image](https://cloud.githubusercontent.com/assets/113896/18646956/b9bafc10-7e68-11e6-99f7-b8407d052af1.png)

* [North Dakota](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-ie11/explore/ND/)
  ![image](https://cloud.githubusercontent.com/assets/113896/18646924/8fe378f4-7e68-11e6-9902-3b49c283a815.png)

* [Colorado](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-ie11/explore/CO/)
  ![image](https://cloud.githubusercontent.com/assets/113896/18647127/61357a92-7e69-11e6-81d0-63a10665e399.png)


Changes proposed in this pull request:
- Create `svg-use(selector1, selector2)` SCSS mixin
- Replace all `use` qualified selectors with `@include svg-use('selector', ...)`
- Clean up duplicate font-related imports in top-level SCSS files (these were causing the output CSS to include the font stuff twice)

/cc @gemfarmer the most crucial thing to note here is that those CSS selectors need to be quoted as arguments to `svg-use()`, otherwise (if they begin with, say, a `.`) they will cause parse errors.
