### PR TITLE
Raise the roof

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -15,6 +15,7 @@ $base-font-size: 1rem;
 $base-font-multiplier: 1;
 $base-line-height: 1.375rem;
 
+$z-roof: 10000;
 $z-roof: 9000;
 $z-mid: 500;
 $z-negative: -1;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -15,7 +15,7 @@ $base-font-size: 1rem;
 $base-font-multiplier: 1;
 $base-line-height: 1.375rem;
 
-$z-roof: 10000;
+$z-sky: 10000;
 $z-roof: 9000;
 $z-mid: 500;
 $z-negative: -1;

--- a/_sass/components/_glossary.scss
+++ b/_sass/components/_glossary.scss
@@ -10,6 +10,7 @@ $term-width-max: 220px;
 
 #glossary {
   width: 100%;
+  z-index: $z-sky;
 
   @include respond-to(tiny-up) {
     width: $drawer-width;


### PR DESCRIPTION
Fixes issue #1999 . Adds a z-index value higher than what we had before so it can live on the glossary so the glossary is always on top of everything else.

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/raise-the-roof.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/raise-the-roof)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/raise-the-roof/)

/cc @shawnbot 
