### PR TITLE
[WIP] List withheld/no data products

### DIFF
--- a/_data/state_federal_production.yml
+++ b/_data/state_federal_production.yml
@@ -97,11 +97,11 @@ AL:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Coal (tons):
       name: Coal
       units: tons
@@ -109,27 +109,27 @@ AL:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: 1760930
           percent: 0.42
@@ -137,15 +137,15 @@ AL:
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Gas (mcf):
       name: Gas
       units: mcf
@@ -339,19 +339,19 @@ AR:
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: 4701
           percent: 100
@@ -365,39 +365,39 @@ AZ:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
 CA:
   products:
     Gas (mcf):
@@ -691,43 +691,43 @@ CA:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Soda Ash (tons):
       name: Soda Ash
       units: tons
@@ -735,43 +735,43 @@ CA:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Sodium Bi-Carbonate (tons):
       name: Sodium Bi-Carbonate
       units: tons
@@ -779,43 +779,43 @@ CA:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
 CO:
   products:
     Coal (tons):
@@ -957,11 +957,11 @@ CO:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: 102512
           percent: 66.77
@@ -969,31 +969,31 @@ CO:
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
 FL:
   products:
     Oil (bbl):
@@ -1011,23 +1011,23 @@ FL:
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
 ID:
   products:
     Phosphate Raw Ore (tons):
@@ -1263,39 +1263,39 @@ KY:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Gas (mcf):
       name: Gas
       units: mcf
@@ -1939,11 +1939,11 @@ ND:
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: 338405
           percent: 0.07
@@ -2163,43 +2163,43 @@ NM:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Gas (mcf):
       name: Gas
       units: mcf
@@ -2471,39 +2471,39 @@ NM:
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Salt (tons):
       name: Salt
       units: tons
@@ -2511,11 +2511,11 @@ NM:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: 314483
           percent: 49.58
@@ -2733,7 +2733,7 @@ NV:
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
 NY:
   products:
     Gas (mcf):
@@ -2789,7 +2789,7 @@ OH:
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Gas (mcf):
       name: Gas
       units: mcf
@@ -3279,35 +3279,35 @@ UT:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: 33520
           percent: 100
@@ -3491,7 +3491,7 @@ UT:
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: 35927
           percent: 100
@@ -3499,11 +3499,11 @@ UT:
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: 16078
           percent: 100
@@ -3559,43 +3559,43 @@ UT:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Salt (tons):
       name: Salt
       units: tons
@@ -3603,43 +3603,43 @@ UT:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
 VA:
   products:
     Gas (mcf):
@@ -3695,11 +3695,11 @@ WA:
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
 WV:
   products:
     Gas (mcf):
@@ -3947,43 +3947,43 @@ WY:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2011':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2012':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2013':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2014':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2015':
           volume: null
           percent: null
-          rank: 1
+          rank: null
     Soda Ash (tons):
       name: Soda Ash
       units: tons
@@ -4035,19 +4035,19 @@ WY:
         '2006':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2007':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2008':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2009':
           volume: null
           percent: null
-          rank: 1
+          rank: null
         '2010':
           volume: 46904
           percent: 25.95

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -91,20 +91,16 @@
       </section>
     {% endfor %}
 
-    {% if withheld_products.size > 0 %}
-      <section id="national-federal-production-withheld" class="product chart-item">
-        <h4 class="chart-title">
-          <span>No data reported</span>
-        </h4>
-        <ul>
-          {% for product in withheld_products %}
-          <li>{{ product }}</li>
-          {% endfor %}
-        </ul>
-      </section>
-    {% endif %}
-
     </div><!-- /.chart-list -->
+
+    {% if withheld_products.size > 0 %}
+    <section id="national-federal-production-withheld" class="product chart-item">
+      <h3>Withheld production data</h3>
+      <p>Data was {{ 'withheld' | term }} for
+        {% for product in withheld_products %}{% if forloop.last %} and {% endif %}
+        <span>{{ product }}</span>{% unless forloop.last %},{% endunless %}{% endfor %}.</p>
+    </section>
+    {% endif %}
 
   </section>
 

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -94,9 +94,9 @@
     </div><!-- /.chart-list -->
 
     {% if withheld_products.size > 0 %}
-    <section id="national-federal-production-withheld" class="product chart-item">
+    <section id="national-federal-production-withheld">
       <h3>Data withheld (<span class="eiti-bar-chart-x-value">{{ year }}</span>)</h3>
-      <ul>
+      <ul id="federal-production-withheld-products" class="expandable">
         {% assign all_years = year_list | to_s %}
         {% for product in withheld_products %}
           {% assign product_years = '' | split: '' %}
@@ -109,6 +109,12 @@
         </li>
         {% endfor %}
       </ul>
+      <button is="aria-toggle" aria-expanded="false"
+        aria-toggles="aria-expanded"
+        aria-controls="federal-production-withheld-products">
+        <span class="hide-expanded">Show all</span>
+        <span class="show-expanded">Hide some</span>
+      </button>
     </section>
     {% endif %}
 

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -28,6 +28,7 @@
     {% assign withheld_products = '' | split: '' %}
 
     {% for product in federal_products %}
+      {% assign product_name = product[1].name | default: product[0] %}
 
       {% assign all_withheld = true %}
       {% for product_year in product[1].volume %}
@@ -36,7 +37,6 @@
           {% break %}
         {% endif %}
       {% endfor %}
-      {% assign product_name = product[1].name | default: product[0] %}
       {% if all_withheld %}
         <!-- all withheld: {{ product[0] }} -->
         {% assign withheld_products = withheld_products | push: product %}
@@ -93,9 +93,15 @@
 
     </div><!-- /.chart-list -->
 
-    {% if withheld_products.size > 0 %}
     <section id="national-federal-production-withheld">
-      <h3>Data withheld (<span class="eiti-bar-chart-x-value">{{ year }}</span>)</h3>
+      <!-- withheld products: {{ withheld_products | jsonify }} -->
+    {% if withheld_products.size > 0 %}
+      <h3>Data withheld</h3>
+      <p>
+        Production volume was {{ 'withheld' | term }} for the
+        following products in
+        <span class="eiti-bar-chart-x-value">{{ year }}</span>:
+      </p>
       <ul id="federal-production-withheld-products" class="expandable">
         {% assign all_years = year_list | to_s %}
         {% for product in withheld_products %}
@@ -103,8 +109,8 @@
           {% for _year in product[1].volume %}
             {% assign product_years = product_years | push: _year[0] %}
           {% endfor %}
-          <li data-years-visible="{{ product_years | join: ',' }}"
-            {% unless product_years contains year %}aria-hidden="true"{% endunless %}>
+        <li data-years-visible="{{ product_years | join: ',' }}"
+          {% unless product_years contains year %}aria-hidden="true"{% endunless %}>
           {{ product[1].name | default: product[0] }}
         </li>
         {% endfor %}
@@ -115,8 +121,8 @@
         <span class="hide-expanded">Show all</span>
         <span class="show-expanded">Close</span>
       </button>
-    </section>
     {% endif %}
+    </section>
 
   </section>
 

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -95,9 +95,9 @@
 
     {% if withheld_products.size > 0 %}
     <section id="national-federal-production-withheld" class="product chart-item">
-      <h3>Withheld production data</h3>
+      <h4>Other products (withheld)</h3>
       {% assign all_years = year_list | to_s %}
-      <p>Data was {{ 'withheld' | term }} for
+      <p>Data about some products is {{ 'withheld' | term }} to protect trade secrets. Data about the following products was withheld:
         {% for product in withheld_products %}{% if forloop.last %} and {% endif %}
           {% assign product_years = '' | split: '' %}
           {% for _year in product[1].volume %}

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -39,7 +39,7 @@
       {% assign product_name = product[1].name | default: product[0] %}
       {% if all_withheld %}
         <!-- all withheld: {{ product[0] }} -->
-        {% assign withheld_products = withheld_products | push: product_name %}
+        {% assign withheld_products = withheld_products | push: product %}
         {% continue %}
       {% endif %}
 
@@ -96,9 +96,15 @@
     {% if withheld_products.size > 0 %}
     <section id="national-federal-production-withheld" class="product chart-item">
       <h3>Withheld production data</h3>
+      {% assign all_years = year_list | to_s %}
       <p>Data was {{ 'withheld' | term }} for
         {% for product in withheld_products %}{% if forloop.last %} and {% endif %}
-        <span>{{ product }}</span>{% unless forloop.last %},{% endunless %}{% endfor %}.</p>
+          {% assign product_years = '' | split: '' %}
+          {% for _year in product[1].volume %}
+            {% assign product_years = product_years | push: _year[0] %}
+          {% endfor %}
+        <span>{{ product[0].name | default: product[0] }}
+          <tt>[{% for y in all_years %}{% if product_years contains y %}?{% else %}-{% endif %}{% endfor %}]</tt></span>{% unless forloop.last %},{% endunless %}{% endfor %}.</p>
     </section>
     {% endif %}
 

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -105,7 +105,7 @@
           {% endfor %}
           <li data-years-visible="{{ product_years | join: ',' }}"
             {% unless product_years contains year %}aria-hidden="true"{% endunless %}>
-          {{ product[0].name | default: product[0] }}
+          {{ product[1].name | default: product[0] }}
         </li>
         {% endfor %}
       </ul>
@@ -113,7 +113,7 @@
         aria-toggles="aria-expanded"
         aria-controls="federal-production-withheld-products">
         <span class="hide-expanded">Show all</span>
-        <span class="show-expanded">Hide some</span>
+        <span class="show-expanded">Close</span>
       </button>
     </section>
     {% endif %}

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -116,7 +116,7 @@
       <button is="aria-toggle" aria-expanded="false"
         aria-toggles="aria-expanded"
         aria-controls="federal-production-withheld-products">
-        <span class="hide-expanded">Show all</span>
+        <span class="hide-expanded">Show all {{ withheld_products.size }} product{{ withheld_products.size | plural }}</span>
         <span class="show-expanded">Close</span>
       </button>
     {% endif %}

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -63,13 +63,13 @@
 
         <figure class="chart">
           <eiti-bar-chart
-            aria-controls="national-federal-production-figures-{{ product_slug }}"
+            aria-controls="national-federal-production-figures-{{ product_slug }} national-federal-production-withheld"
             data='{{ production_values | jsonify }}'
             x-range="{{ year_range }}"
             x-value="{{ year }}"
             data-units="{{ long_units }}">
           </eiti-bar-chart>
-          <figcaption id="national-federal-production-figures-{{ product_slug }}">
+          <figcaption id="national-federal-production-figures-{{ product_slug }}" class="control-hover">
             <span class="caption-data">
               <span class="eiti-bar-chart-y-value" data-format=",">{{ volume | default: 0 | intcomma }}</span>
                 {{ long_units | term }} of {{ product_name | downcase | suffix:units_suffix }} were
@@ -95,20 +95,20 @@
 
     {% if withheld_products.size > 0 %}
     <section id="national-federal-production-withheld" class="product chart-item">
-      <h4>Other products (withheld)</h3>
-      {% assign all_years = year_list | to_s %}
-      <p>Data about some products is {{ 'withheld' | term }} to protect trade secrets. Data about the following products was withheld:
-        {% for product in withheld_products %}{% if forloop.last %} and {% endif %}
+      <h3>Data withheld (<span class="eiti-bar-chart-x-value">{{ year }}</span>)</h3>
+      <ul>
+        {% assign all_years = year_list | to_s %}
+        {% for product in withheld_products %}
           {% assign product_years = '' | split: '' %}
           {% for _year in product[1].volume %}
             {% assign product_years = product_years | push: _year[0] %}
           {% endfor %}
-        <span>{{ product[0].name | default: product[0] }}
-          <tt>[{% for y in all_years %}{% if product_years contains y %}?{% else %}-{% endif %}{% endfor %}]</tt></span>{% unless forloop.last %},{% endunless %}{% endfor %}.
-      </p>
-      <p>Above, the <tt>[-----?????]</tt> pictograms represent when
-        each product was withheld (<tt>?</tt>) or had no data (<tt>-</tt>)
-        in each year from {{ year_list | first }}-{{ year_list | last }}.</p>
+          <li data-years-visible="{{ product_years | join: ',' }}"
+            {% unless product_years contains year %}aria-hidden="true"{% endunless %}>
+          {{ product[0].name | default: product[0] }}
+        </li>
+        {% endfor %}
+      </ul>
     </section>
     {% endif %}
 

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -94,13 +94,11 @@
     </div><!-- /.chart-list -->
 
     <section id="national-federal-production-withheld">
-      <!-- withheld products: {{ withheld_products | jsonify }} -->
     {% if withheld_products.size > 0 %}
       <h3>Data withheld</h3>
       <p>
         Production volume was {{ 'withheld' | term }} for the
-        following products in
-        <span class="eiti-bar-chart-x-value">{{ year }}</span>:
+        following products:
       </p>
       <ul id="federal-production-withheld-products" class="expandable">
         {% assign all_years = year_list | to_s %}
@@ -109,9 +107,9 @@
           {% for _year in product[1].volume %}
             {% assign product_years = product_years | push: _year[0] %}
           {% endfor %}
-        <li data-years-visible="{{ product_years | join: ',' }}"
-          {% unless product_years contains year %}aria-hidden="true"{% endunless %}>
+        <li>
           {{ product[1].name | default: product[0] }}
+          ({{ product_years | year_range }})
         </li>
         {% endfor %}
       </ul>

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -25,6 +25,8 @@
 
     <div class="chart-list">
 
+    {% assign withheld_products = '' | split: '' %}
+
     {% for product in federal_products %}
 
       {% assign all_withheld = true %}
@@ -34,10 +36,14 @@
           {% break %}
         {% endif %}
       {% endfor %}
-      {% if all_withheld %}<!-- all withheld: {{ product[0] }} -->{% continue %}{% endif %}
+      {% assign product_name = product[1].name | default: product[0] %}
+      {% if all_withheld %}
+        <!-- all withheld: {{ product[0] }} -->
+        {% assign withheld_products = withheld_products | push: product_name %}
+        {% continue %}
+      {% endif %}
 
       {% assign product_slug = product[0] | slugify %}
-      {% assign product_name = product[1].name | default: product[0] %}
       {% assign production_values = product[1].volume %}
       {% assign volume = production_values[year] %}
       {% assign units = product[1].units | downcase %}
@@ -84,6 +90,19 @@
 
       </section>
     {% endfor %}
+
+    {% if withheld_products.size > 0 %}
+      <section id="national-federal-production-withheld" class="product chart-item">
+        <h4 class="chart-title">
+          <span>No data reported</span>
+        </h4>
+        <ul>
+          {% for product in withheld_products %}
+          <li>{{ product }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
 
     </div><!-- /.chart-list -->
 

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -104,7 +104,11 @@
             {% assign product_years = product_years | push: _year[0] %}
           {% endfor %}
         <span>{{ product[0].name | default: product[0] }}
-          <tt>[{% for y in all_years %}{% if product_years contains y %}?{% else %}-{% endif %}{% endfor %}]</tt></span>{% unless forloop.last %},{% endunless %}{% endfor %}.</p>
+          <tt>[{% for y in all_years %}{% if product_years contains y %}?{% else %}-{% endif %}{% endfor %}]</tt></span>{% unless forloop.last %},{% endunless %}{% endfor %}.
+      </p>
+      <p>Above, the <tt>[-----?????]</tt> pictograms represent when
+        each product was withheld (<tt>?</tt>) or had no data (<tt>-</tt>)
+        in each year from {{ year_list | first }}-{{ year_list | last }}.</p>
     </section>
     {% endif %}
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -33,9 +33,25 @@
 
     <div class="chart-list">
 
+    {% assign withheld_products = '' | split: '' %}
+
     {% for product in federal_products %}
-      {% assign product_slug = product[0] | slugify %}
       {% assign product_name = product[1].name | default: product[0] %}
+
+      {% assign all_withheld = true %}
+      {% for product_year in product[1].volume %}
+        {% if year_range contains product_year[0] and product_year[1].volume != nil %}
+          {% assign all_withheld = false %}
+          {% break %}
+        {% endif %}
+      {% endfor %}
+      {% if all_withheld %}
+        <!-- all withheld: {{ product[0] }} -->
+        {% assign withheld_products = withheld_products | push: product %}
+        {% continue %}
+      {% endif %}
+
+      {% assign product_slug = product[0] | slugify %}
       {% assign production_values = product[1].volume %}
       {% assign volume = production_values[year].volume %}
       {% assign units = product[1].units | downcase | default: 'units' %}
@@ -59,7 +75,7 @@
 
             <figure class="chart">
               <eiti-bar-chart
-                aria-controls="federal-production-figures-{{ product_slug }}"
+                aria-controls="federal-production-figures-{{ product_slug }} federal-production-withheld"
                 data='{{ production_values | map_hash: "volume" | jsonify }}'
                 x-range="{{ year_range }}"
                 x-value="{{ year }}"
@@ -145,6 +161,31 @@
     {% endfor %}
 
     </div><!-- /.chart-list -->
+
+    <section id="federal-production-withheld">
+      <!-- withheld products: {{ withheld_products | jsonify }} -->
+    {% if withheld_products.size > 0 %}
+      <h3>Data withheld</h3>
+      <p>
+        Production volume was {{ 'withheld' | term }} for the
+        following product(s) in
+        <span class="eiti-bar-chart-x-value">{{ year }}</span>:
+      </p>
+      <ul>
+        {% assign all_years = year_list | to_s %}
+        {% for product in withheld_products %}
+          {% assign product_years = '' | split: '' %}
+          {% for _year in product[1].volume %}
+            {% assign product_years = product_years | push: _year[0] %}
+          {% endfor %}
+        <li data-years-visible="{{ product_years | join: ',' }}"
+          {% unless product_years contains year %}aria-hidden="true"{% endunless %}>
+          {{ product[1].name | default: product[0] }}
+        </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    </section>
 
   </section>
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -167,9 +167,8 @@
     {% if withheld_products.size > 0 %}
       <h3>Data withheld</h3>
       <p>
-        Production volume was {{ 'withheld' | term }} for the
-        following product(s) in
-        <span class="eiti-bar-chart-x-value">{{ year }}</span>:
+        Production volume in {{ state_name }} was
+        {{ 'withheld' | term }} for the following product(s):
       </p>
       <ul>
         {% assign all_years = year_list | to_s %}
@@ -178,9 +177,9 @@
           {% for _year in product[1].volume %}
             {% assign product_years = product_years | push: _year[0] %}
           {% endfor %}
-        <li data-years-visible="{{ product_years | join: ',' }}"
-          {% unless product_years contains year %}aria-hidden="true"{% endunless %}>
+        <li>
           {{ product[1].name | default: product[0] }}
+          ({{ product_years | year_range }})
         </li>
         {% endfor %}
       </ul>

--- a/_plugins/eiti_format.rb
+++ b/_plugins/eiti_format.rb
@@ -60,6 +60,24 @@ module EITI
     def suffix(text, suffix = '')
       suffix.empty? ? text : "#{text} #{suffix}"
     end
+
+    def year_range(years)
+      years = years.map{ |y| y.to_i }
+      def abbr(y)
+        "’#{y.to_s.slice(-2, 2)}"
+      end
+      if years.size == 1
+        abbr(years.first)
+      elsif years.last == (years.first + years.size - 1)
+        [years.first, years.last]
+          .map{ |y| abbr(y) }
+          .join('&ndash;')
+      else
+        years
+          .map{ |y| abbr(y) }
+          .join(', ')
+      end
+    end
   end
 end
 

--- a/_plugins/eiti_format.rb
+++ b/_plugins/eiti_format.rb
@@ -61,20 +61,21 @@ module EITI
       suffix.empty? ? text : "#{text} #{suffix}"
     end
 
+    def abbr_year(year)
+      "’#{year.to_s.slice(-2, 2)}"
+    end
+
     def year_range(years)
-      years = years.map{ |y| y.to_i }
-      def abbr(y)
-        "’#{y.to_s.slice(-2, 2)}"
-      end
+      years = years.map(&:to_i)
       if years.size == 1
-        abbr(years.first)
+        abbr_year(years.first)
       elsif years.last == (years.first + years.size - 1)
         [years.first, years.last]
-          .map{ |y| abbr(y) }
+          .map{ |y| abbr_year(y) }
           .join('&ndash;')
       else
         years
-          .map{ |y| abbr(y) }
+          .map{ |y| abbr_year(y) }
           .join(', ')
       end
     end

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -125,3 +125,13 @@
     margin-bottom: 6rem;
   }
 }
+
+.expandable {
+  position: relative;
+
+  &[aria-expanded=false] {
+    // XXX magic number
+    max-height: 7.5em;
+    overflow-y: hidden;
+  }
+}

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -131,7 +131,19 @@
 
   &[aria-expanded=false] {
     // XXX magic number
-    max-height: 7.5em;
+    max-height: 7.2em;
     overflow-y: hidden;
+
+    // add a little white shadow when it's collapsed
+    &::after {
+      bottom: -50px;
+      box-shadow: 0 -10px 25px $white;
+      content: '';
+      display: table;
+      height: 50px;
+      left: 0;
+      position: absolute;
+      width: 100%;
+    }
   }
 }

--- a/_sass/components/_aria-toggle.scss
+++ b/_sass/components/_aria-toggle.scss
@@ -1,4 +1,10 @@
 [is=aria-toggle] {
+
+  &[aria-expanded=false] .show-expanded,
+  &[aria-expanded=true] .hide-expanded {
+    display: none;
+  }
+
   &.not-button-like {
     @include appearance(none);
 

--- a/_sass/elements/_elements.scss
+++ b/_sass/elements/_elements.scss
@@ -56,3 +56,11 @@ figure {
 .hidden {
   display: none;
 }
+
+pre,
+tt {
+  color: $blue;
+  font-family: Monaco, monospace;
+  font-size: 12px;
+  white-space: pre;
+}

--- a/js/components/aria-toggle.js
+++ b/js/components/aria-toggle.js
@@ -10,20 +10,20 @@
     }
     var target = document.getElementById(button.getAttribute(CONTROLS));
     button.setAttribute(EXPANDED, expanded);
-    target.setAttribute(HIDDEN, !expanded);
+    var attr = button.getAttribute('aria-toggles') || HIDDEN;
+    target.setAttribute(
+      attr,
+      (attr === HIDDEN) ? !expanded : expanded
+    );
     return expanded;
   };
 
   var collapse = function(button) {
-    var target = document.getElementById(button.getAttribute(CONTROLS));
-    button.setAttribute(EXPANDED, false);
-    target.setAttribute(HIDDEN, true);
+    return toggle(button, false);
   }
 
   var expand = function(button) {
-    var target = document.getElementById(button.getAttribute(CONTROLS));
-    button.setAttribute(EXPANDED, true);
-    target.setAttribute(HIDDEN, false);
+    return toggle(button, true);
   }
 
   var click = function(event) {
@@ -61,12 +61,8 @@
 
         attributeChangedCallback: {value: function(attr, old, value) {
           switch (attr) {
-            case 'aria-expanded':
-              if (value === 'false') {
-                collapse(this);
-              } else if (value === 'true') {
-                expand(this);
-              }
+            case EXPANDED:
+              return toggle(this, value === 'true');
           }
         }}
       }

--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -295,7 +295,7 @@
           console.warn('no cell @', i);
           return;
         } else if (cell.parentNode.hasAttribute('data-value')) {
-          console.warn('cell is child', i);
+          // console.warn('cell is child', i);
         }
 
         var cellAlwaysEmpty = cell.getAttribute('data-year-values') === 'null';

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -341,17 +341,6 @@
         }
       }
 
-      if (!hover) {
-        var year = String(value.x);
-        output.selectAll('[data-years-visible]')
-          .datum(function(d) {
-            return d || this.getAttribute('data-years-visible').split(',');
-          })
-          .attr('aria-hidden', function(years) {
-            return years.indexOf(year) === -1;
-          });
-      }
-
     }
   };
 

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -308,7 +308,17 @@
 
     var id = selection.attr('aria-controls');
     if (id) {
-      var output = d3.select('#' + id);
+      // further qualify controlled elements with the "control-hover"
+      // class if `hover` is true. This excludes the "no data" list so
+      // that we don't thrash the layout too hard when hovering over
+      // bars.
+      var qualifier = hover ? '.control-hover' : '';
+
+      var selector = id.split(' ').map(function(id) {
+        return '#' + id + qualifier;
+      }).join(', ');
+
+      var output = d3.selectAll(selector);
 
       output.selectAll('.eiti-bar-chart-x-value')
         .text(value.x);
@@ -329,6 +339,17 @@
           hideCaption(output, false, true, true);
           y.text(formatUnits(format(value.y), units));
         }
+      }
+
+      if (!hover) {
+        var year = String(value.x);
+        output.selectAll('[data-years-visible]')
+          .datum(function(d) {
+            return d || this.getAttribute('data-years-visible').split(',');
+          })
+          .attr('aria-hidden', function(years) {
+            return years.indexOf(year) === -1;
+          });
       }
 
     }

--- a/js/components/year-switcher-section.js
+++ b/js/components/year-switcher-section.js
@@ -15,6 +15,9 @@
     var yearValues = root.selectAll('year-value');
 
     var update = function(year) {
+      root.selectAll('.eiti-bar-chart-x-value')
+        .text(year);
+
       charts.property('x', year);
       maps.each(function() {
         this.setYear(year);

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -25488,7 +25488,7 @@
 	        return root.svg4everybody = factory();
 	    }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__)) : "object" == typeof exports ? module.exports = factory() : root.svg4everybody = factory();
 	}(this, function() {
-	    /*! svg4everybody v2.0.3 | github.com/jonathantneal/svg4everybody */
+	    /*! svg4everybody v2.1.0 | github.com/jonathantneal/svg4everybody */
 	    function embed(node, target) {
 	        // if the target exists
 	        if (target) {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11508,20 +11508,20 @@
 	    }
 	    var target = document.getElementById(button.getAttribute(CONTROLS));
 	    button.setAttribute(EXPANDED, expanded);
-	    target.setAttribute(HIDDEN, !expanded);
+	    var attr = button.getAttribute('aria-toggles') || HIDDEN;
+	    target.setAttribute(
+	      attr,
+	      (attr === HIDDEN) ? !expanded : expanded
+	    );
 	    return expanded;
 	  };
 
 	  var collapse = function(button) {
-	    var target = document.getElementById(button.getAttribute(CONTROLS));
-	    button.setAttribute(EXPANDED, false);
-	    target.setAttribute(HIDDEN, true);
+	    return toggle(button, false);
 	  }
 
 	  var expand = function(button) {
-	    var target = document.getElementById(button.getAttribute(CONTROLS));
-	    button.setAttribute(EXPANDED, true);
-	    target.setAttribute(HIDDEN, false);
+	    return toggle(button, true);
 	  }
 
 	  var click = function(event) {
@@ -11559,12 +11559,8 @@
 
 	        attributeChangedCallback: {value: function(attr, old, value) {
 	          switch (attr) {
-	            case 'aria-expanded':
-	              if (value === 'false') {
-	                collapse(this);
-	              } else if (value === 'true') {
-	                expand(this);
-	              }
+	            case EXPANDED:
+	              return toggle(this, value === 'true');
 	          }
 	        }}
 	      }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12957,7 +12957,7 @@
 	          console.warn('no cell @', i);
 	          return;
 	        } else if (cell.parentNode.hasAttribute('data-value')) {
-	          console.warn('cell is child', i);
+	          // console.warn('cell is child', i);
 	        }
 
 	        var cellAlwaysEmpty = cell.getAttribute('data-year-values') === 'null';

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13679,6 +13679,9 @@
 	    var yearValues = root.selectAll('year-value');
 
 	    var update = function(year) {
+	      root.selectAll('.eiti-bar-chart-x-value')
+	        .text(year);
+
 	      charts.property('x', year);
 	      maps.each(function() {
 	        this.setYear(year);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13413,17 +13413,6 @@
 	        }
 	      }
 
-	      if (!hover) {
-	        var year = String(value.x);
-	        output.selectAll('[data-years-visible]')
-	          .datum(function(d) {
-	            return d || this.getAttribute('data-years-visible').split(',');
-	          })
-	          .attr('aria-hidden', function(years) {
-	            return years.indexOf(year) === -1;
-	          });
-	      }
-
 	    }
 	  };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13384,7 +13384,17 @@
 
 	    var id = selection.attr('aria-controls');
 	    if (id) {
-	      var output = d3.select('#' + id);
+	      // further qualify controlled elements with the "control-hover"
+	      // class if `hover` is true. This excludes the "no data" list so
+	      // that we don't thrash the layout too hard when hovering over
+	      // bars.
+	      var qualifier = hover ? '.control-hover' : '';
+
+	      var selector = id.split(' ').map(function(id) {
+	        return '#' + id + qualifier;
+	      }).join(', ');
+
+	      var output = d3.selectAll(selector);
 
 	      output.selectAll('.eiti-bar-chart-x-value')
 	        .text(value.x);
@@ -13405,6 +13415,17 @@
 	          hideCaption(output, false, true, true);
 	          y.text(formatUnits(format(value.y), units));
 	        }
+	      }
+
+	      if (!hover) {
+	        var year = String(value.x);
+	        output.selectAll('[data-years-visible]')
+	          .datum(function(d) {
+	            return d || this.getAttribute('data-years-visible').split(',');
+	          })
+	          .attr('aria-hidden', function(years) {
+	            return years.indexOf(year) === -1;
+	          });
 	      }
 
 	    }


### PR DESCRIPTION
### 🚧 ⚠️  Work in progress ⚠️ 🚧 

Fixes #1851.

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/list-no-data/explore/#national-federal-production-withheld)

Changes proposed in this pull request:
- Add a paragraph (not a list, as described in #1851) at the bottom of the federal production section that lists all products with no numeric production volume (withheld _or_ no data for every year in 2006-2015)
- Add back basic CSS for `<tt>` and `<pre>` elements (not used anywhere else on the site)
- **Temporarily** add a little pictogram alongside each to explain whether it has no data or withheld production for each year in the 2006-2015 range

![image](https://cloud.githubusercontent.com/assets/113896/18652904/f17fd77a-7e8a-11e6-9e48-6d2496d9f654.png)

### TODO
- [x] Figure out what to say/display here
- [x] Remove the pictograms and some of the template logic needed to display them

/cc @coreycaitlin @meiqimichelle @ericronne 
