### PR TITLE
Federal Production Data Sentinels

### DIFF
--- a/test/data/federal-production.js
+++ b/test/data/federal-production.js
@@ -35,7 +35,6 @@ describe('federal production (ONRR) sentinels', function() {
       );
     };
 
-    // [pending] until discrepency in Oil values is solved
     it('check sentinel values', function(done) {
 
       var sentinels = [

--- a/test/data/federal-production.js
+++ b/test/data/federal-production.js
@@ -94,8 +94,7 @@ describe('federal production (ONRR) sentinels', function() {
       );
     };
 
-    // [pending] until discrepency in Oil values is solved
-    xit('check sentinel values', function(done) {
+    it('check sentinel values', function(done) {
 
       var sentinels = [
         {

--- a/test/data/federal-production.js
+++ b/test/data/federal-production.js
@@ -29,7 +29,9 @@ describe('federal production (ONRR) sentinels', function() {
       var difference = expected - actual
       assert.ok(
         Math.abs(difference) < 10,
-        'expected ' + expected + ', got: ' + actual + ' for: ' + [product, year].join(' | ')
+        'expected ' + expected +
+        ', got: ' + actual +
+        ' for: ' + [product, year].join(' | ')
       );
     };
 

--- a/test/data/federal-production.js
+++ b/test/data/federal-production.js
@@ -10,7 +10,7 @@ var _ = require('lodash');
 
 var OUT_PATH = path.join(__dirname, '../../_data');
 
-describe('federal production (ONRR)', function() {
+describe('federal production (ONRR) sentinels', function() {
 
   describe('national values', function() {
 
@@ -149,8 +149,7 @@ describe('federal production (ONRR)', function() {
       );
     };
 
-    // // [pending] until issue with Oil is worked out
-    xit('check sentinels', function(done) {
+    it('check sentinels', function(done) {
 
       var sentinels = [
         {
@@ -159,7 +158,7 @@ describe('federal production (ONRR)', function() {
           fips: '02185',
           product: 'Oil (bbl)',
           year: 2014,
-          value: 894025
+          value: 7693
         },
         {
           state: 'MS',

--- a/test/data/federal-production.js
+++ b/test/data/federal-production.js
@@ -26,7 +26,7 @@ describe('federal production (ONRR) sentinels', function() {
       var expected = Math.round(value);
       var actual = products[product].volume[year];
 
-      var difference = expected - actual
+      var difference = expected - actual;
       assert.ok(
         Math.abs(difference) < 10,
         'expected ' + expected +

--- a/test/data/federal-production.js
+++ b/test/data/federal-production.js
@@ -25,14 +25,16 @@ describe('federal production (ONRR) sentinels', function() {
     var assertSentinelMatch = function (product, year, value) {
       var expected = Math.round(value);
       var actual = products[product].volume[year];
-      assert.equal(
-        expected, actual,
-        'expected ' + value + ' for: ' + [product, year].join(' | ')
+
+      var difference = expected - actual
+      assert.ok(
+        Math.abs(difference) < 10,
+        'expected ' + expected + ', got: ' + actual + ' for: ' + [product, year].join(' | ')
       );
     };
 
     // [pending] until discrepency in Oil values is solved
-    xit('check sentinel values', function(done) {
+    it('check sentinel values', function(done) {
 
       var sentinels = [
         {


### PR DESCRIPTION
Fixes issue(s) #1994 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/data-fed-production.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/data-fed-production)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/data-fed-production/)

Changes proposed in this pull request:
- addresses `pending` data checks in federal-production.js

NOTE: it looks like the issue here was less the data tests, and more the sentinel values we received.

Specifically, we need to talk to Chris about
- [this value difference here](https://github.com/18F/doi-extractives-data/compare/dev...data-fed-production#diff-37dc4303b7491a4d4d9955117ebde1e7L162): this is the value for the Alaska state level rollup up for Oil, not a county-level check
- The values that we are checking for the national Oil rollups.
  - sentinel value Chris provided for Oil | 2013: 623103687.09
  - value in our data                                           : 623103681  ( difference of 6)
  - sentinel value Chris provided for Oil | 2015: 755158058.14
  - value in our data                                           : 755158065  ( difference of 7)
  - Because all of our production data in [data/federal-production/federal-production.tsv](https://github.com/18F/doi-extractives-data/blob/dev/data/federal-production/federal-production.tsv) is rounded, I think we are summing different values, and that this difference is very likely rounding error. We could be fine with it as is, or get a more up to date tsv file.

/cc @meiqimichelle 
