### PR TITLE
Allow glossary links and other valid liquid in frontmatter

### DIFF
--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -113,7 +113,7 @@ nav_items:
 
         {% if page.state_land %}
           <h3 id="state-production">Production on state land in {{ state_name }}</h3>
-          {{ page.state_land | markdownify }}
+          {{ page.state_land | liquify | markdownify }}
         {% endif %}
         {% if page.state_land_production %}
           {{ page.state_land_production | markdownify }}

--- a/_plugins/liquify.rb
+++ b/_plugins/liquify.rb
@@ -1,0 +1,7 @@
+module LiquidFilter
+  def liquify(input)
+    Liquid::Template.parse(input).render(@context)
+  end
+end
+
+Liquid::Template.register_filter(LiquidFilter)

--- a/_states/WY.md
+++ b/_states/WY.md
@@ -20,7 +20,7 @@ state_production: |
 
     **Nonenergy minerals:** In 2011, Wyoming's nonenergy mineral production was valued at over $2.14 billion. Notably, Wyoming produces more trona (the chief source of [soda ash](http://minerals.usgs.gov/minerals/pubs/commodity/soda_ash/)) than any other state, and the largest deposit of trona in the world sits under Sweetwater County in Wyoming. For details about what other minerals are extracted, see the [USGS Minerals Yearbook for Wyoming](http://minerals.usgs.gov/minerals/pubs/state/wy.html).
 state_land: |
-    The state government of Wyoming administers 3.4 million surface acres of land (about 5.5% of the state) and 3.9 million mineral acres. For detailed information about land ownership in each county, see the [Wyoming Statewide Parcel Viewer](http://gis.wyo.gov/parcels/).
+    The state government of Wyoming administers 3.4 million surface acres of land (about 5.5% of the state) and 3.9 million {{ "mineral acres" | term_end }}. For detailed information about land ownership in each county, see the [Wyoming Statewide Parcel Viewer](http://gis.wyo.gov/parcels/).
 state_land_production: |
     In FY 2014, 29.3 million short tons of surface-mined coal and 2.4 million short tons of underground-mined coal were extracted on state lands in Wyoming.
 
@@ -40,8 +40,8 @@ state_tax_expenditures: |
 state_disbursements: |
     [State agencies](#state-agencies) distribute natural resource revenues according to the [Wyoming State Code](http://legisweb.state.wy.us/LSOWeb/wyStatutes.aspx), which is defined by the legislature.
 
-    Prior to FY 2002, individual severance taxes had distinct distribution formulas. In the 2000 and 2001 legislative sessions, the Wyoming Legislature revised statutes — a process they called “de-earmarking” — to simplify the distribution process. The Department of Revenue now collects severance tax revenues, aggregates them, and distributes that total amount according to statute. 
-    
+    Prior to FY 2002, individual severance taxes had distinct distribution formulas. In the 2000 and 2001 legislative sessions, the Wyoming Legislature revised statutes — a process they called “de-earmarking” — to simplify the distribution process. The Department of Revenue now collects severance tax revenues, aggregates them, and distributes that total amount according to statute.
+
     At the local level, county tax collectors collect all property taxes on production and distribute them within their own jurisdictions.
 state_saving_spending: |
     The state of Wyoming saves about 68% of severance tax revenue and 39% of federal mineral royalty revenues. These two revenue streams are Wyoming's two largest sources of revenue from natural resource extraction. Wyoming saves revenue by contributing to the Budget Reserve Account and the Permanent Wyoming Mineral Trust Fund. Interest from the Permanent Wyoming Mineral Trust Fund goes to the General Fund.
@@ -84,7 +84,7 @@ The [Wyoming Department of Environmental Quality](http://deq.wyoming.gov/) (DEQ)
 * The [Land Quality Division](http://deq.wyoming.gov/lqd/) regulates surface mining operations and surface operations for underground mines, works to ensure reclamation following mining, establishes reclamation bond amounts, and holds reclamation bonds on mine operations. It publishes an [annual report (PDF)](http://deq.wyoming.gov/media/uploads/admin/annual_report_2014.pdf) that includes bond amounts.
 * The [Abandoned Mine Land Division](http://deq.wyoming.gov/aml/) administers the federal AML program for coal and select hardrock reclamation projects.
 
-The [Wyoming State Geological Survey](http://www.wsgs.wyo.gov/) also provides geological information about natural resources. 
+The [Wyoming State Geological Survey](http://www.wsgs.wyo.gov/) also provides geological information about natural resources.
 
 ### State laws and regulations
 
@@ -128,10 +128,10 @@ See [state agencies](#state-agencies) for information about statewide water mana
 
 Population growth due to increased natural resource extraction can increase demands on the medical, fire, and police services of states, counties, and towns.
 
-Prior to 2001, the Sublette County Rural Health Care District had two all-volunteer Emergency Medical Services (EMS) units. By 2006, the district had hired 25 full-time emergency medical technicians. From 2001 to 2007, EMS runs increased 116% for the Pinedale facility and 94.47% for the Marbleton-Big Piney facility. To serve the Jonah gas field and the South Anticline, the district built a new EMS facility in 2007 at Sand Draw. Local industry paid for $900,000 of the cost of the facility, with the county paying $500,000. 
+Prior to 2001, the Sublette County Rural Health Care District had two all-volunteer Emergency Medical Services (EMS) units. By 2006, the district had hired 25 full-time emergency medical technicians. From 2001 to 2007, EMS runs increased 116% for the Pinedale facility and 94.47% for the Marbleton-Big Piney facility. To serve the Jonah gas field and the South Anticline, the district built a new EMS facility in 2007 at Sand Draw. Local industry paid for $900,000 of the cost of the facility, with the county paying $500,000.
 
 #### Reclamation
 
-Wyoming has been “certified” by the federal Abandoned Mine Land (AML) Reclamation program, meaning it has reclaimed its identified high-priority abandoned coal mine areas. It also means AML funds, which are sourced from fees paid by coal mine operators, can be used for a wider range of purposes beyond reclamation, including abandoned hardrock mine sites. The program currently estimates that Wyoming has $52 million in unreclaimed coal AML sites and $686,000 in unreclaimed non-coal AML sites (such as uranium mining sites). To learn more about recently completed projects and projects underway, search for Wyoming Annual Evaluation Reports in the [OSMRE Oversight Document Database](http://odocs.osmre.gov/). 
+Wyoming has been “certified” by the federal Abandoned Mine Land (AML) Reclamation program, meaning it has reclaimed its identified high-priority abandoned coal mine areas. It also means AML funds, which are sourced from fees paid by coal mine operators, can be used for a wider range of purposes beyond reclamation, including abandoned hardrock mine sites. The program currently estimates that Wyoming has $52 million in unreclaimed coal AML sites and $686,000 in unreclaimed non-coal AML sites (such as uranium mining sites). To learn more about recently completed projects and projects underway, search for Wyoming Annual Evaluation Reports in the [OSMRE Oversight Document Database](http://odocs.osmre.gov/).
 
 See [state agencies](#state-agencies) for additional statewide reclamation activities.


### PR DESCRIPTION
Fixes issue(s) #1966 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/liquid-in-frontmatter/explore/WY/#state-production)

I'm pretty excited about this one! Basically, this PR allows us to use any valid liquid, including custom filters that we have made inside jekyll front matter. 

To make sure that the frontmatter is being read as liquid and not as markdown or as a plain value, we can do the following [(like I did here for the Wyoming state_land attribute)](https://github.com/18F/doi-extractives-data/compare/liquid-in-frontmatter?expand=1#diff-6ec0cd03783b6e398866fa7e25cdef33R116):

```
state_land: |
    The state government of Wyoming administers 3.4 million 
    surface acres of land (about 5.5% of the state) and 
    3.9 million {{ "mineral acres" | term_end }}. For detailed 
    information about land ownership in each county, see 
    the [Wyoming Statewide Parcel Viewer](http://gis.wyo.gov/parcels/).

...


{{ page.state_land | liquify | markdownify }}
```

NOTE: make sure to `liquify` and _then_ `markdownify`. If it is done in reverse order, markdownify will void the values within the `{{}}` as invalid markdown!

![screen shot 2016-09-20 at 1 44 10 pm](https://cloud.githubusercontent.com/assets/4803473/18684027/57f429e0-7f38-11e6-91d0-6e86feb6e18b.png)


/cc @coreycaitlin @shawnbot @meiqimichelle 

