### PR TITLE
State, offshore area tooltip style

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -27,7 +27,10 @@
   {% assign _width = 65.88078 | to_f %}
 {% endif %}
 
-<div is="eiti-tooltip-wrapper" tooltip-style="subtle" class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
+<div is="eiti-tooltip-wrapper"
+     tooltip-style="subtle"
+     tooltip-offset="10"
+     class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -27,7 +27,7 @@
   {% assign _width = 65.88078 | to_f %}
 {% endif %}
 
-<div  is="eiti-tooltip-wrapper" class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
+<div is="eiti-tooltip-wrapper" tooltip-style="subtle" class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -29,7 +29,7 @@
 
 <div is="eiti-tooltip-wrapper"
      tooltip-style="subtle"
-     tooltip-offset="10"
+     cursor-offset="10"
      class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>

--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -27,7 +27,10 @@
   {% assign _width = 65.88078 | to_f %}
 {% endif %}
 
-<div is="eiti-tooltip-wrapper" tooltip-style="subtle" class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
+<div is="eiti-tooltip-wrapper"
+     tooltip-style="subtle"
+     tooltip-offset="10"
+     class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}

--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -29,7 +29,7 @@
 
 <div is="eiti-tooltip-wrapper"
      tooltip-style="subtle"
-     tooltip-offset="10"
+     cursor-offset="10"
      class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>

--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -27,7 +27,7 @@
   {% assign _width = 65.88078 | to_f %}
 {% endif %}
 
-<div is="eiti-tooltip-wrapper" class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
+<div is="eiti-tooltip-wrapper" tooltip-style="subtle" class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
   style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -133,6 +133,7 @@ eiti-data-map {
     &.selected use,
     &.mouseover use {
       stroke-width: 3px;
+      stroke-linejoin: round;
     }
 
     &.mouseover use {

--- a/_sass/components/_tooltip.scss
+++ b/_sass/components/_tooltip.scss
@@ -15,8 +15,8 @@
     opacity: 0.95;
 
     p {
-       color: $base-font-color;
-       font-weight: $weight-light;
+      color: $base-font-color;
+      font-weight: $weight-light;
     }
   }
 

--- a/_sass/components/_tooltip.scss
+++ b/_sass/components/_tooltip.scss
@@ -10,6 +10,16 @@
   position: absolute;
   z-index: 9000;
 
+  &.subtle {
+    border: 1px solid $gray-light;
+    opacity: 0.95;
+
+    p {
+       color: $base-font-color;
+       font-weight: $weight-light;
+    }
+  }
+
   p {
     @include heading('para-sm');
 

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -32,8 +32,11 @@ svg.map {
   }
 
   @include svg-use('.feature:not([fill])') {
-    cursor: default;
     fill-opacity: 0;
+  }
+
+  @include svg-use('.county.feature:not([fill])') {
+    cursor: default;
   }
 
   @include svg-use(

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -2,7 +2,7 @@
 (function(exports) {
   'use strict';
 
-  var OFFSET_POSITION = 2;
+  var CURSOR_OFFSET = 2;
 
   var depixelize = function(value) {
     if (value.match(/px$/)) {
@@ -30,8 +30,8 @@
     var titles = self.selectAll('title');
     var tiles = self.selectAll('use');
     var tooltipStyle = self.attr('tooltip-style');
-    OFFSET_POSITION = Number(self.attr('tooltip-offset'))
-      || OFFSET_POSITION;
+    CURSOR_OFFSET = Number(self.attr('cursor-offset'))
+      || CURSOR_OFFSET;
 
     var tooltip;
     var tooltipText;
@@ -98,10 +98,10 @@
             var tooltipWidth = depixelize(tooltip.style('width'));
             var svgWidth = depixelize(svg.style('width'));
 
-            var x = event.layerX + OFFSET_POSITION;
+            var x = event.layerX + CURSOR_OFFSET;
 
             if (svgWidth <= tooltipWidth + x) {
-              return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
+              return pixelize(event.layerX - tooltipWidth - CURSOR_OFFSET);
             } else {
               return pixelize(x);
             }
@@ -110,10 +110,10 @@
             var tooltipHeight = depixelize(tooltip.style('height'));
             var svgHeight = depixelize(svg.style('height'));
 
-            var y = event.layerY + OFFSET_POSITION;
+            var y = event.layerY + CURSOR_OFFSET;
 
             if (svgHeight <= tooltipHeight + y) {
-              return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
+              return pixelize(event.layerY - tooltipHeight - CURSOR_OFFSET);
             } else {
               return pixelize(y);
             }

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -29,6 +29,7 @@
     var svg = self.select('svg');
     var titles = self.selectAll('title');
     var tiles = self.selectAll('use');
+    var tooltipStyle = self.attr('tooltip-style');
 
     var tooltip;
     var tooltipText;
@@ -39,6 +40,10 @@
       if (tooltip.empty()) {
         tooltip = self.append('div')
           .classed('eiti-tooltip', true);
+      }
+
+      if (tooltipStyle) {
+        tooltip.classed(tooltipStyle, true);
       }
 
       tooltip.call(hide);

--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -30,6 +30,8 @@
     var titles = self.selectAll('title');
     var tiles = self.selectAll('use');
     var tooltipStyle = self.attr('tooltip-style');
+    OFFSET_POSITION = Number(self.attr('tooltip-offset'))
+      || OFFSET_POSITION;
 
     var tooltip;
     var tooltipText;

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -203,7 +203,7 @@
 	(function(exports) {
 	  'use strict';
 
-	  var OFFSET_POSITION = 2;
+	  var CURSOR_OFFSET = 2;
 
 	  var depixelize = function(value) {
 	    if (value.match(/px$/)) {
@@ -231,8 +231,8 @@
 	    var titles = self.selectAll('title');
 	    var tiles = self.selectAll('use');
 	    var tooltipStyle = self.attr('tooltip-style');
-	    OFFSET_POSITION = Number(self.attr('tooltip-offset'))
-	      || OFFSET_POSITION;
+	    CURSOR_OFFSET = Number(self.attr('cursor-offset'))
+	      || CURSOR_OFFSET;
 
 	    var tooltip;
 	    var tooltipText;
@@ -299,10 +299,10 @@
 	            var tooltipWidth = depixelize(tooltip.style('width'));
 	            var svgWidth = depixelize(svg.style('width'));
 
-	            var x = event.layerX + OFFSET_POSITION;
+	            var x = event.layerX + CURSOR_OFFSET;
 
 	            if (svgWidth <= tooltipWidth + x) {
-	              return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
+	              return pixelize(event.layerX - tooltipWidth - CURSOR_OFFSET);
 	            } else {
 	              return pixelize(x);
 	            }
@@ -311,10 +311,10 @@
 	            var tooltipHeight = depixelize(tooltip.style('height'));
 	            var svgHeight = depixelize(svg.style('height'));
 
-	            var y = event.layerY + OFFSET_POSITION;
+	            var y = event.layerY + CURSOR_OFFSET;
 
 	            if (svgHeight <= tooltipHeight + y) {
-	              return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
+	              return pixelize(event.layerY - tooltipHeight - CURSOR_OFFSET);
 	            } else {
 	              return pixelize(y);
 	            }

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -231,6 +231,8 @@
 	    var titles = self.selectAll('title');
 	    var tiles = self.selectAll('use');
 	    var tooltipStyle = self.attr('tooltip-style');
+	    OFFSET_POSITION = Number(self.attr('tooltip-offset'))
+	      || OFFSET_POSITION;
 
 	    var tooltip;
 	    var tooltipText;

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -230,6 +230,7 @@
 	    var svg = self.select('svg');
 	    var titles = self.selectAll('title');
 	    var tiles = self.selectAll('use');
+	    var tooltipStyle = self.attr('tooltip-style');
 
 	    var tooltip;
 	    var tooltipText;
@@ -240,6 +241,10 @@
 	      if (tooltip.empty()) {
 	        tooltip = self.append('div')
 	          .classed('eiti-tooltip', true);
+	      }
+
+	      if (tooltipStyle) {
+	        tooltip.classed(tooltipStyle, true);
 	      }
 
 	      tooltip.call(hide);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -748,6 +748,7 @@
 	    var svg = self.select('svg');
 	    var titles = self.selectAll('title');
 	    var tiles = self.selectAll('use');
+	    var tooltipStyle = self.attr('tooltip-style');
 
 	    var tooltip;
 	    var tooltipText;
@@ -758,6 +759,10 @@
 	      if (tooltip.empty()) {
 	        tooltip = self.append('div')
 	          .classed('eiti-tooltip', true);
+	      }
+
+	      if (tooltipStyle) {
+	        tooltip.classed(tooltipStyle, true);
 	      }
 
 	      tooltip.call(hide);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -721,7 +721,7 @@
 	(function(exports) {
 	  'use strict';
 
-	  var OFFSET_POSITION = 2;
+	  var CURSOR_OFFSET = 2;
 
 	  var depixelize = function(value) {
 	    if (value.match(/px$/)) {
@@ -749,8 +749,8 @@
 	    var titles = self.selectAll('title');
 	    var tiles = self.selectAll('use');
 	    var tooltipStyle = self.attr('tooltip-style');
-	    OFFSET_POSITION = Number(self.attr('tooltip-offset'))
-	      || OFFSET_POSITION;
+	    CURSOR_OFFSET = Number(self.attr('cursor-offset'))
+	      || CURSOR_OFFSET;
 
 	    var tooltip;
 	    var tooltipText;
@@ -817,10 +817,10 @@
 	            var tooltipWidth = depixelize(tooltip.style('width'));
 	            var svgWidth = depixelize(svg.style('width'));
 
-	            var x = event.layerX + OFFSET_POSITION;
+	            var x = event.layerX + CURSOR_OFFSET;
 
 	            if (svgWidth <= tooltipWidth + x) {
-	              return pixelize(event.layerX - tooltipWidth - OFFSET_POSITION);
+	              return pixelize(event.layerX - tooltipWidth - CURSOR_OFFSET);
 	            } else {
 	              return pixelize(x);
 	            }
@@ -829,10 +829,10 @@
 	            var tooltipHeight = depixelize(tooltip.style('height'));
 	            var svgHeight = depixelize(svg.style('height'));
 
-	            var y = event.layerY + OFFSET_POSITION;
+	            var y = event.layerY + CURSOR_OFFSET;
 
 	            if (svgHeight <= tooltipHeight + y) {
-	              return pixelize(event.layerY - tooltipHeight - OFFSET_POSITION);
+	              return pixelize(event.layerY - tooltipHeight - CURSOR_OFFSET);
 	            } else {
 	              return pixelize(y);
 	            }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -749,6 +749,8 @@
 	    var titles = self.selectAll('title');
 	    var tiles = self.selectAll('use');
 	    var tooltipStyle = self.attr('tooltip-style');
+	    OFFSET_POSITION = Number(self.attr('tooltip-offset'))
+	      || OFFSET_POSITION;
 
 	    var tooltip;
 	    var tooltipText;


### PR DESCRIPTION
Fixes issue(s) #1992

[:sunglasses: PREVIEW county](https://federalist.18f.gov/preview/18F/doi-extractives-data/formatted-tips/explore/UT/#federal-production)

[:sunglasses: PREVIEW offshore-area](https://federalist.18f.gov/preview/18F/doi-extractives-data/formatted-tips/explore/offshore-gulf/#federal-production)

[:sunglasses: PREVIEW state map (unchanged)](https://federalist.18f.gov/preview/18F/doi-extractives-data/formatted-tips/explore/)

Changes proposed in this pull request:
- adds a 'subtle' tooltip style class that is used on the county and offshore area maps in accordance with @ericronne's proposed style.

/cc @ericronne 

