### PR TITLE
Clean up package.json; v2.1.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ description: >
 url: https://useiti.doi.gov
 
 # app version number
-version: v1.3.4
+version: v2.1.0
 
 beckley_api_key: LXJh2PKSC6zxY0YNuBRYgIj2JxSPcDwSPCZuHBG1
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "doi-extractives-data",
-  "version": "1.1.0",
-  "description": "",
-  "main": "index.js",
-  "directories": {
-    "test": "test"
+  "private": true,
+  "homepage": "https://useiti.doi.gov/",
+  "author": "18F",
+  "license": "CC0-1.0",
+  "repository": "github:18F/doi-extractives-data",
+  "bugs": {
+    "url": "https://github.com/18F/doi-extractives-data/issues"
   },
   "engines": {
     "node": ">=5.12"
@@ -69,15 +70,5 @@
     "lint-js": "jshint -c .jshintrc --exclude-path .jshintignore js || echo '(there were JavaScript linting errors)'",
     "lint-ruby": "bundle exec rubocop -c .rubocop.yml _plugins/eiti_*.rb",
     "lint-scss": "bundle exec scss-lint -c .scss-lint.yml || echo '(there were SCSS linting errors)'"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/18F/doi-extractives-data.git"
-  },
-  "author": "18F",
-  "license": "CC0-1.0",
-  "bugs": {
-    "url": "https://github.com/18F/doi-extractives-data/issues"
-  },
-  "homepage": "https://github.com/18F/doi-extractives-data"
+  }
 }


### PR DESCRIPTION
Fixes #2007.

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/clean-package.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/clean-package)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/clean-package/)

Changes proposed in this pull request:
- Clean up and reorganize `package.json` (with useful metadata at the top, and `private: true`)
- Update the Jekyll config with `version: 2.1.0`

/cc @gemfarmer 
