### PR TITLE
Homepage map legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ selector: location
         %}
       </figure>
       <aside class="wide">
-        {% include maps/federal_land_ownership_legend.html %}
+        {% include maps/federal_land_ownership_legend.html land=true %}
       </aside>
     </div>
   </div>


### PR DESCRIPTION
Fixes issue(s) #2020 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/homepage-land/)

Changes proposed in this pull request:
- adds 'land' to homepage map legend items

/cc @ericronne 

