### PR TITLE
Fix chart hover

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ description: >
 url: https://useiti.doi.gov
 
 # app version number
-version: v2.1.0
+version: v2.1.1
 
 beckley_api_key: LXJh2PKSC6zxY0YNuBRYgIj2JxSPcDwSPCZuHBG1
 

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -70,7 +70,7 @@
             x-value="{{ year }}"
             data-units="{{ long_units }}">
           </eiti-bar-chart>
-          <figcaption id="national-federal-production-figures-{{ product_slug }}" class="control-hover">
+          <figcaption id="national-federal-production-figures-{{ product_slug }}">
             <span class="caption-data">
               <span class="eiti-bar-chart-y-value" data-format=",">{{ volume | default: 0 | intcomma }}</span>
                 {{ long_units | term: term_units }} of {{ product_name | downcase | suffix:units_suffix }} were

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -312,7 +312,7 @@
       // class if `hover` is true. This excludes the "no data" list so
       // that we don't thrash the layout too hard when hovering over
       // bars.
-      var qualifier = hover ? '.control-hover' : '';
+      var qualifier = '';
 
       var selector = id.split(' ').map(function(id) {
         return '#' + id + qualifier;

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13397,7 +13397,7 @@
 	      // class if `hover` is true. This excludes the "no data" list so
 	      // that we don't thrash the layout too hard when hovering over
 	      // bars.
-	      var qualifier = hover ? '.control-hover' : '';
+	      var qualifier = '';
 
 	      var selector = id.split(' ').map(function(id) {
 	        return '#' + id + qualifier;


### PR DESCRIPTION
Fixes un-filed issue with charts not updating on hover.

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/fix-chart-hover.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/fix-chart-hover)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/fix-chart-hover/)

Changes proposed in this pull request:
- Remove the `.control-hover` qualifier for the selector that finds things to update on chart hover. This was used in #2005, but we later removed that feature.

/cc @meiqimichelle 
