### PR TITLE
fix county sentences

### DIFF
--- a/_includes/location/display-federal-production-county.html
+++ b/_includes/location/display-federal-production-county.html
@@ -46,7 +46,7 @@
               Data about {{ product_name | downcase }} extraction on federal land in {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span> is withheld.
             </span>
             <span class="has-data">
-              <span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> {{ units }} of {{ product_name | downcase | suffix:units_suffix }} were produced in {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span>.
+              <span data-value='{{ product_volume }}'>{{ product_volume | intcomma }}</span> {{ units }} of {{ product_name | downcase | suffix:units_suffix }} were produced on federal land in {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span>.
             </span>
           </td>
       </tr>

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -32,7 +32,7 @@
         <td colspan='3'
             data-year-values='{{ years_values | jsonify }}'
             data-sentence='{{ revenue_amount }}'
-            aria-hidden='true'><span data-value='{{ revenue_amount }}' data-format='$,'>${{ revenue_amount | intcomma }}</span> was collected from {{ county[1].name }} in <span data-year='{{ year }}'>{{ year }}</span>.</td>
+            aria-hidden='true'>Companies paid <span data-value='{{ revenue_amount }}' data-format='$,'>${{ revenue_amount | intcomma }}</span> to extract natural resources on federal land in {{ county[1].name }} {{ locality_name }} in <span data-year='{{ year }}'>{{ year }}</span>.</td>
       </tr>
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
Fixes issue(s) #1976 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/county-sentences.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/county-sentences)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/county-sentences/)

Changes proposed in this pull request:

- Adds "on federal land" to county federal production detail table sentences
- Rephrases federal revenue detail table sentences to include full county name, federal land scope, and direction of revenue

/cc @gemfarmer 
