### PR TITLE
Change coal sidebar

### DIFF
--- a/_includes/how-it-works/coal_intro.html
+++ b/_includes/how-it-works/coal_intro.html
@@ -7,6 +7,8 @@
 
   <p class="revenues_subpage-intro_text">The Department of the Interior is responsible for 570 million acres of federal land with coal resources. This responsibility comes from the Mineral Leasing Act of 1920 and the Mineral Leasing Act for Acquired Lands of 1947, as amended.</p>
 
+  <p class="revenues_subpage-intro_text">In 2013, the United States was the world’s second largest coal producer after China. The U.S. has significant available coal reserves: There are 19.7 billion {{ "short tons" | term:"tons" }} of recoverable reserves in active mines, and another 479.9 billion short tons that could be mined with current technologies.</p>
+
   <!-- <a class="revenues_subpage-download" href="#"><i class="icon-cloud"></i> Download PDF</a> -->
 </div>
 

--- a/_includes/how-it-works/coal_steps.html
+++ b/_includes/how-it-works/coal_steps.html
@@ -3,7 +3,7 @@
   <div accordion="coal-dyk" accordion-item class="revenues_subpage-dyk">
 
     <h2 class="revenues_subpage-dyk_heading">Did you know?</h2>
-    <p class="revenues_subpage-dyk_text">In 2013, the U.S. was the world’s second largest coal producer after China. <span accordion-content>The U.S. has significant available coal reserves. There are 19.7 billion short tons of recoverable reserves in active mines, and another 479.9 billion short tons that could be mined with current technologies.</span></p>
+    <p class="revenues_subpage-dyk_text">“Fair market value” is determined differently by different state offices. <span accordion-content><br/>BLM guidance allows for flexibility in how state offices estimate fair market value, according to the Government Accountability Office (GAO). Some offices only consider recent comparable sites, while others also estimate future revenue. The GAO report also found that some state offices were falling short on documenting and reviewing fair market value determinations.</span></p>
     <button class="revenues_subpage_dyk-link" accordion-text>
       <span class='accordion-more'>more</span>
       <span class='accordion-less'>less</span>
@@ -83,6 +83,7 @@
             <li><a href="http://www.blm.gov/style/medialib/blm/co/field_offices/uncompahgre_field/documents/lands___minerals.Par.35163.File.dat/2012-0301%20BLM%20Coal%20Overview%20North%20Fork.pdf">BLM Coal Resources: Uncompahgre Field Office (PDF)</a></li>
             <li><a href="http://www.blm.gov/wy/st/en/programs/energy/Coal_Resources/coalfaqs/competitive_leasing.print.html">Competitive Leasing</a></li>
             <li><a href="http://www.blm.gov/wy/st/en/programs/energy/Coal_Resources/PRB_Coal/history.html">Powder River Basin Coal: History of the Coal Program</a></li>
+            <li><a href="http://gao.gov/assets/660/659801.pdf">GAO Report: Coal Leasing (PDF)</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
Fixes issue(s) #1165 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/fair-market-value.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/fair-market-value)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/fair-market-value/)

Changes proposed in this pull request:

- Moves the old "did you know" content in the coal diving graphic up to the intro
- Replaces it with the content of the sidebar on page 41 of the 2015 Exec. Summary
- Adds a link in the "Further reading" section at the bottom of the coal diving graphic


