### PR TITLE
Style cleanup

### DIFF
--- a/_includes/layout/header.html
+++ b/_includes/layout/header.html
@@ -32,10 +32,10 @@
       <li class="header-nav_item {% if page.permalink contains '/about/' %}active{% endif %}">
         <a class="header-nav_item_link" href="{{ site.baseurl }}/about/">About USEITI</a>
       </li>
-      <li class="header-nav_item {% if page.permalink contains '/how-it-works/' %}active{% endif %}">
+      <li class="header-nav_item {% if page.permalink contains '/how-it-works/' or layout.nav_name == 'how-it-works' %}active{% endif %}">
         <a class="header-nav_item_link" href="{{ site.baseurl }}/how-it-works/">How It Works</a>
       </li>
-      <li class="header-nav_item {% if page.permalink contains '/explore/' %}active{% endif %}">
+      <li class="header-nav_item {% if page.permalink contains '/explore/' or layout.nav_name == 'explore' %}active{% endif %}">
         <a class="header-nav_item_link" href="{{ site.baseurl }}/explore/">Explore Data</a>
       </li>
       <li class="header-nav_item {% if page.permalink contains '/case-studies/' %}active{% endif %}">

--- a/_includes/year-selector.html
+++ b/_includes/year-selector.html
@@ -1,5 +1,5 @@
 {% if include.year_range %}
-  {% assign _year_list = include.year_range | to_list %}
+  {% assign _year_list = include.year_range | to_list | reverse %}
 
   <select class="chart-selector">
     {% if include.empty_years %}<!-- empty years: {{ include.empty_years | jsonify }} -->{% endif %}

--- a/_layouts/federal-revenue-by-company.html
+++ b/_layouts/federal-revenue-by-company.html
@@ -1,6 +1,7 @@
 ---
 title: Federal Revenue by Company | How it Works
 layout: default
+nav_name: 'how-it-works'
 permalink: /how-it-works/federal-revenue-by-company/2015/
 title_display: Federal Revenue by Company
 ---

--- a/_layouts/offshore-region.html
+++ b/_layouts/offshore-region.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+nav_name: 'explore'
 nav_items:
   - name: overview
     title: Top

--- a/_layouts/offshore-region.html
+++ b/_layouts/offshore-region.html
@@ -38,8 +38,7 @@ nav_items:
 
     <div class="container-left-9">
 
-      <section id="overview">
-        <h2 class="state-page-overview">Overview</h2>
+      <section id="overview" class="section-top">
           <p>
             Unlike land (which can be owned by states, local governments, corporations, or private individuals), the waters and submerged lands of the {{ "Outer Continental Shelf" | term }} are entirely administered by the federal government. This means that all <a href="{{ site.baseurl }}/how-it-works/offshore-oil-gas/">offshore drilling</a> and <a href="{{ site.baseurl }}/how-it-works/offshore-renewables/">renewable energy generation</a> takes place in federal waters.
           </p>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -85,8 +85,7 @@ nav_items:
 
     <div class="container-left-9">
 
-      <section id="overview">
-        <h2 class="state-page-overview">Overview</h2>
+      <section id="overview" class="section-top">
 
         {% include location/section-overview.html %}
 

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+nav_name: 'explore'
 nav_items:
   - name: overview
     title: Top

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -1,3 +1,7 @@
+.section-top {
+  margin-top: 1rem;
+}
+
 .layout-state-pages {
   padding-bottom: $standard-padding-fluffed;
 

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -149,7 +149,7 @@ eiti-data-map {
 
 .legend-svg {
   border: none;
-  height: 215px;
+  height: auto;
   padding: 0;
   width: 200px;
 
@@ -165,7 +165,7 @@ eiti-data-map {
   padding-top: $standard-padding-lite;
 
   .legend-svg.horizontal {
-    height: 50px;
+    max-height: 50px;
   }
 }
 

--- a/_sass/elements/_maps.scss
+++ b/_sass/elements/_maps.scss
@@ -39,6 +39,12 @@ svg.map {
 
   @include svg-use('.feature:not([fill])') {
     fill-opacity: 0;
+
+    &:hover,
+    &:focus,
+    &:active {
+      fill-opacity: 0.25;
+    }
   }
 
   @include svg-use('.county.feature:not([fill])') {


### PR DESCRIPTION
For #2070, #2073, #2069 

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/style-cleanup/)

Changes proposed in this pull request:
- removes overview from state pages, offshore #2073 
- Reverse order of year selectors	
- make nation-level maps on explore and homepage darker on hover
- reduce legend height near county maps
- makes nav items bolded on state-level explore pages #2070 

/cc @ericronne 
