### PR TITLE
Remove padding on bar charts

### DIFF
--- a/js/components/bar-chart-table.js
+++ b/js/components/bar-chart-table.js
@@ -275,23 +275,16 @@
       var min = extent[0];
       var max = extent[1];
       var negative = min < 0;
-      var zero = 0;
       var width = d3.scale.linear()
         .domain(extent)
         .range(range)
         .clamp(true);
 
-      var offset;
       var sizeProperty = 'width';
-      var offsetProperty = 'margin-left';
 
       if (negative) {
         var length = max - min;
-        zero = 100 * (0 - min) / length;
-        offset = d3.scale.linear()
-          .domain([min, 0, max])
-          .range([0, zero, zero])
-          .clamp(true);
+
         width = d3.scale.linear()
           .domain([min, 0, max])
           .range([100 * -min / length, 0, 100 * max / length])
@@ -300,7 +293,6 @@
 
       if (this.orient === 'vertical') {
         sizeProperty = 'height';
-        offsetProperty = 'bottom';
       }
 
       var that = this;
@@ -365,12 +357,6 @@
           });
         } else {
           bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
-        }
-
-        if (offset) {
-          bar.style.setProperty(offsetProperty, offset(value) + '%');
-        } else {
-          bar.style.removeProperty(offsetProperty);
         }
       });
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -12971,23 +12971,16 @@
 	      var min = extent[0];
 	      var max = extent[1];
 	      var negative = min < 0;
-	      var zero = 0;
 	      var width = d3.scale.linear()
 	        .domain(extent)
 	        .range(range)
 	        .clamp(true);
 
-	      var offset;
 	      var sizeProperty = 'width';
-	      var offsetProperty = 'margin-left';
 
 	      if (negative) {
 	        var length = max - min;
-	        zero = 100 * (0 - min) / length;
-	        offset = d3.scale.linear()
-	          .domain([min, 0, max])
-	          .range([0, zero, zero])
-	          .clamp(true);
+
 	        width = d3.scale.linear()
 	          .domain([min, 0, max])
 	          .range([100 * -min / length, 0, 100 * max / length])
@@ -12996,7 +12989,6 @@
 
 	      if (this.orient === 'vertical') {
 	        sizeProperty = 'height';
-	        offsetProperty = 'bottom';
 	      }
 
 	      var that = this;
@@ -13061,12 +13053,6 @@
 	          });
 	        } else {
 	          bar.style.setProperty(sizeProperty, Math.abs(size) + '%');
-	        }
-
-	        if (offset) {
-	          bar.style.setProperty(offsetProperty, offset(value) + '%');
-	        } else {
-	          bar.style.removeProperty(offsetProperty);
 	        }
 	      });
 


### PR DESCRIPTION
Fixes issue(s) #2079

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/bar-padding/)

Changes proposed in this pull request:
- removes offset property that was creating the margin-left and showing the gray pixels to the left of the bars
- @shawnbot do we need that offset anymore?

/cc @ericronne
