### PR TITLE
Onshore/offshore revenue explanations on the national page

### DIFF
--- a/_includes/location/revenue-process-table.html
+++ b/_includes/location/revenue-process-table.html
@@ -133,7 +133,36 @@
       {% endfor %}
 
       <tbody>
-        {% if include.offshore %}
+        {% if national_page %}
+          <tr>
+            <th class="table-arrow_box-subcategory">Offshore</th>
+            <td>
+              <strong>Bonus:</strong> The amount offered by the highest bidder
+            </td>
+            <td>
+              <strong>$7</strong> or <strong>$11</strong> annual rent per acre, increasing over time up to <strong>$44</strong> per acre in some cases
+            </td>
+            <td>
+              <strong>12.5%</strong>, <strong>16.67%</strong>, or
+              <strong>18.75%</strong> of production value
+            </td>
+            <td></td>
+          </tr>
+          <tr>
+            <th class="table-arrow_box-subcategory">Onshore</th>
+            <td>
+              <strong>Bonus:</strong> The amount offered by the highest bidder
+            </td>
+            <td>
+              <strong>$1.50</strong> annual rent per acre for 5 years<br/>
+              <strong>$2</strong> annual rent per acre thereafter
+            </td>
+            <td>
+              <strong>12.5%</strong> of production value
+            </td>
+            <td></td>
+          </tr>
+        {% elsif include.offshore %}
           <tr>
             <th class="table-arrow_box-subcategory">Offshore</th>
             <td>


### PR DESCRIPTION
Fixes issue(s) #1955 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/onshore-rates-fix.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/onshore-rates-fix)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/onshore-rates-fix/)

Changes proposed in this pull request:

- The oil & gas revenue explanations for BOTH onshore and offshore revenue are now shown in the megachart on the national explore data page

/cc @meiqimichelle or @gemfarmer 

