### PR TITLE
Mobile sticky nav

### DIFF
--- a/_includes/layout/_mobile-nav.html
+++ b/_includes/layout/_mobile-nav.html
@@ -1,3 +1,0 @@
-<ul accordion="mobile-nav" accordion-desktop="false">
-	<li accordion-item accordion-open="true">Some item</li>
-</ul>

--- a/_includes/layout/_mobile-nav.html
+++ b/_includes/layout/_mobile-nav.html
@@ -1,0 +1,3 @@
+<ul accordion="mobile-nav" accordion-desktop="false">
+	<li accordion-item accordion-open="true">Some item</li>
+</ul>

--- a/_includes/layout/mobile-nav.html
+++ b/_includes/layout/mobile-nav.html
@@ -1,33 +1,40 @@
 {% if layout.nav_items %}
-	{% assign selector_nav_items = layout.nav_items %}
+  {% assign selector_nav_items = layout.nav_items %}
 {% else %}
-	{% assign selector_nav_items = page.nav_items %}
+  {% assign selector_nav_items = page.nav_items %}
 {% endif %}
 
-<div class="mobile-nav sticky" accordion="mobile-nav" accordion-desktop="false">
-	<div accordion-item accordion-open="false">
-		<h3 class="mobile-nav-header">Top</h3>
-		<button class="accordion-button" accordion-button><span class="sr-only">Toggle for {{term[0]}}</span></button>
-		<div class="accordion-content">
-			<ul>
-			  {% if selector_nav_items %}
-			    {% for item in selector_nav_items %}
-			      {% if item.name == selector_nav_items[0].name %}
-			        <a href="#{{item.name}}" data-nav-item="{{item.name}}" data-active="true">{{item.title}}</a>
-			      {% else %}
-			        <a href="#{{item.name}}" data-nav-item="{{item.name}}">{{item.title}}</a>
-			      {% endif %}
+<div is="mobile-nav" class="mobile-nav sticky" accordion="mobile-nav">
+  <h3 class="mobile-nav-header">{{ state_name }}</h3>
+  <button is="aria-toggle"
+    aria-controls="mobile-nav-content"
+    aria-expanded="false">
+      <span class="hide-expanded">
+        <icon class="icon icon-chevron-sm-down"></icon>
+      </span>
+      <span class="show-expanded">
+        <icon class="icon icon-chevron-sm-up"></icon>
+      </span>
+  </button>
+  <div id="mobile-nav-content" class="mobile-nav-list-items">
+    <ul>
+      {% if selector_nav_items %}
+        {% for item in selector_nav_items %}
+            {% if item.name == selector_nav_items[0].name %}
+              <a href="#{{item.name}}" class="mobile-nav-list-item">{{item.title}}</a>
+            {% else %}
+              <a href="#{{item.name}}" class="mobile-nav-list-item">{{item.title}}</a>
+            {% endif %}
 
-			      {% if item.subnav_items %}
-			        <ul>
-			          {% for subnav_item in item.subnav_items %}
-			            <a href="#{{subnav_item.name}}" data-nav-item="{{subnav_item.name}}">{{subnav_item.title}}</a>
-			          {% endfor %}
-			        </ul>
-			      {% endif %}
-			    {% endfor %}
-			  {% endif %}
-			</ul>
-		</div>
-	</div>
+            {% if item.subnav_items %}
+              <ul>
+                {% for subnav_item in item.subnav_items %}
+                  <a class="mobile-nav-sublist-item" href="#{{subnav_item.name}}">{{subnav_item.title}}</a>
+                {% endfor %}
+              </ul>
+            {% endif %}
+        {% endfor %}
+      {% endif %}
+    </ul>
+  </div>
 </div>

--- a/_includes/layout/mobile-nav.html
+++ b/_includes/layout/mobile-nav.html
@@ -7,7 +7,7 @@
 {% assign region_name = state_name | default: region_title %}
 {% assign mobile_nav_title = include.mobile_nav_title | default: region_name %}
 
-<div is="mobile-nav" class="mobile-nav sticky" accordion="mobile-nav">
+<div is="mobile-nav" class="mobile-nav sticky">
   <button is="aria-toggle"
     aria-controls="mobile-nav-content"
     aria-expanded="false"

--- a/_includes/layout/mobile-nav.html
+++ b/_includes/layout/mobile-nav.html
@@ -1,0 +1,33 @@
+{% if layout.nav_items %}
+	{% assign selector_nav_items = layout.nav_items %}
+{% else %}
+	{% assign selector_nav_items = page.nav_items %}
+{% endif %}
+
+<div class="mobile-nav sticky" accordion="mobile-nav" accordion-desktop="false">
+	<div accordion-item accordion-open="false">
+		<h3 class="mobile-nav-header">Top</h3>
+		<button class="accordion-button" accordion-button><span class="sr-only">Toggle for {{term[0]}}</span></button>
+		<div class="accordion-content">
+			<ul>
+			  {% if selector_nav_items %}
+			    {% for item in selector_nav_items %}
+			      {% if item.name == selector_nav_items[0].name %}
+			        <a href="#{{item.name}}" data-nav-item="{{item.name}}" data-active="true">{{item.title}}</a>
+			      {% else %}
+			        <a href="#{{item.name}}" data-nav-item="{{item.name}}">{{item.title}}</a>
+			      {% endif %}
+
+			      {% if item.subnav_items %}
+			        <ul>
+			          {% for subnav_item in item.subnav_items %}
+			            <a href="#{{subnav_item.name}}" data-nav-item="{{subnav_item.name}}">{{subnav_item.title}}</a>
+			          {% endfor %}
+			        </ul>
+			      {% endif %}
+			    {% endfor %}
+			  {% endif %}
+			</ul>
+		</div>
+	</div>
+</div>

--- a/_includes/layout/mobile-nav.html
+++ b/_includes/layout/mobile-nav.html
@@ -4,7 +4,6 @@
   {% assign selector_nav_items = page.nav_items %}
 {% endif %}
 
-{% assign region_name = state_name | default: region_title %}
 {% assign mobile_nav_title = include.mobile_nav_title | default: region_name %}
 
 <div is="mobile-nav" class="mobile-nav sticky">

--- a/_includes/layout/mobile-nav.html
+++ b/_includes/layout/mobile-nav.html
@@ -4,15 +4,19 @@
   {% assign selector_nav_items = page.nav_items %}
 {% endif %}
 
+{% assign region_name = state_name | default: region_title %}
+{% assign mobile_nav_title = include.mobile_nav_title | default: region_name %}
+
 <div is="mobile-nav" class="mobile-nav sticky" accordion="mobile-nav">
-  <h3 class="mobile-nav-header">{{ state_name }}</h3>
   <button is="aria-toggle"
     aria-controls="mobile-nav-content"
-    aria-expanded="false">
-      <span class="hide-expanded">
+    aria-expanded="false"
+    class="flex-row">
+      <h3 class="mobile-nav-header flex-row-flex">{{ mobile_nav_title }}</h3>
+      <span class="hide-expanded flex-row-icon">
         <icon class="icon icon-chevron-sm-down"></icon>
       </span>
-      <span class="show-expanded">
+      <span class="show-expanded flex-row-icon">
         <icon class="icon icon-chevron-sm-up"></icon>
       </span>
   </button>

--- a/_includes/layout/mobile-nav.html
+++ b/_includes/layout/mobile-nav.html
@@ -4,7 +4,7 @@
   {% assign selector_nav_items = page.nav_items %}
 {% endif %}
 
-{% assign mobile_nav_title = include.mobile_nav_title | default: region_name %}
+{% assign mobile_nav_title = include.mobile_nav_title | default: state_name | default: region_name | default: 'Explore Data' %}
 
 <div is="mobile-nav" class="mobile-nav sticky">
   <button is="aria-toggle"
@@ -24,15 +24,21 @@
       {% if selector_nav_items %}
         {% for item in selector_nav_items %}
             {% if item.name == selector_nav_items[0].name %}
-              <a href="#{{item.name}}" class="mobile-nav-list-item">{{item.title}}</a>
+              <a href="#{{item.name}}"
+                 mobile-nav-item="{{item.name}}"
+                 class="mobile-nav-list-item">{{item.title}}</a>
             {% else %}
-              <a href="#{{item.name}}" class="mobile-nav-list-item">{{item.title}}</a>
+              <a href="#{{item.name}}"
+                 mobile-nav-item="{{item.name}}"
+                 class="mobile-nav-list-item">{{item.title}}</a>
             {% endif %}
 
             {% if item.subnav_items %}
               <ul>
                 {% for subnav_item in item.subnav_items %}
-                  <a class="mobile-nav-sublist-item" href="#{{subnav_item.name}}">{{subnav_item.title}}</a>
+                  <a class="mobile-nav-sublist-item"
+                     mobile-nav-item="{{subnav_item.name}}"
+                     href="#{{subnav_item.name}}">{{subnav_item.title}}</a>
                 {% endfor %}
               </ul>
             {% endif %}

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -116,7 +116,11 @@
   </section><!-- /#federal-revenue -->
 
   <section>
-    <h3 id="federal-tax-revenue">Federal tax revenue</h3>
+    {%
+      include sticky-header.html
+      header_text='Federal tax revenue'
+      header_id='federal-tax-revenue'
+    %}
 
     <div>
       <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to romote other policy goals.</p>

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -13,7 +13,7 @@
 
   <section id="federal-revenue">
 
-    <h3 class="sticky">Revenue from extraction on federal land</h3>
+    <h3 class="sticky sticky-header-wrapper">Revenue from extraction on federal land</h3>
 
     <p>When companies extract natural resources on federal lands and waters, they pay royalties, rents, bonuses, and other fees, much like they would to any landowner. This non-tax revenue is collected and reported by the Office of Natural Resources Revenue (ONRR).</p>
 

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -11,9 +11,13 @@
 
   <p>Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.</p>
 
-  <section id="federal-revenue">
+  <section>
 
-    <h3 class="sticky sticky-header-wrapper">Revenue from extraction on federal land</h3>
+    {%
+      include sticky-header.html
+      header_id='federal-revenue'
+      header_text='Revenue from extraction on federal land'
+    %}
 
     <p>When companies extract natural resources on federal lands and waters, they pay royalties, rents, bonuses, and other fees, much like they would to any landowner. This non-tax revenue is collected and reported by the Office of Natural Resources Revenue (ONRR).</p>
 

--- a/_includes/location/offshore-region-revenue.html
+++ b/_includes/location/offshore-region-revenue.html
@@ -58,7 +58,6 @@
 
   <section>
 
-  <!-- year_range: {{ year_range }} -->
     {%
       include sticky-header.html
       header_text='Federal revenue by offshore area'

--- a/_includes/location/offshore-region-revenue.html
+++ b/_includes/location/offshore-region-revenue.html
@@ -15,7 +15,10 @@
 
   <section id="revenue-by-resource">
 
-    <h3>Federal revenue by resource</h3>
+    {%
+      include sticky-header.html
+      header_text='Federal revenue by resource'
+    %}
 
     <p>Laws and policies govern how rights are awarded to companies and what they pay to extract natural resources on the Outer Continental Shelf. For details, read more about the processes for <a href="{{ site.baseurl }}/how-it-works/offshore-oil-gas/">offshore oil and gas</a> or <a href="{{ site.baseurl }}/how-it-works/offshore-renewables/">offshore renewable energy</a>.</p>
 
@@ -53,11 +56,13 @@
   </section>
   <!-- #revenue-by-resource -->
 
-  <section id="revenue-by-area">
+  <section>
 
+  <!-- year_range: {{ year_range }} -->
     {%
       include sticky-header.html
       header_text='Federal revenue by offshore area'
+      header_id='revenue-by-area'
       year_range=year_range
       selector=true
     %}
@@ -86,7 +91,7 @@
           </p>
         {% else %}
           <p class="chart-description{% unless revenue_commodities %} no-selector{% endunless %}">
-            In {{ year }}, the federal government didn't receive any payment for extraction of natural resources on federal land (or lease federal land for that purpose) in {{ state_name }}. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+            In {{ year }}, the federal government didn't receive any payment for extraction of natural resources on federal land (or lease federal land for that purpose) in {{ region_title }}. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
           </p>
         {% endif %}
       </div>

--- a/_includes/location/section-disbursements.html
+++ b/_includes/location/section-disbursements.html
@@ -1,6 +1,9 @@
 <section id="federal-disbursements" class="disbursements">
 
-  <h3>Federal disbursements</h3>
+  {%
+    include sticky-header.html
+    header_text='Federal disbursements'
+  %}
 
   <p>After collecting revenue from natural resource extraction, the Office of Natural Resources Revenue distributes that money to different agencies, funds, and local governments for public use. This process is called “disbursement.”</p>
   <p>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -121,8 +121,13 @@
   </section>
   <!-- #federal-revenue -->
 
-  <section id="state-local-revenue" class="state revenue">
-    <h3{% if page.opt_in == true %} class="sticky"{% endif %}>State revenue</h3>
+  <section class="state revenue">
+
+    {%
+      include sticky-header.html
+      header_text='State revenue'
+      header_id='state-local-revenue'
+    %}
 
     {% if page.opt_in == true %}
       {% include location/opt-in/state-revenues.html location_id=state_id %}

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -13,7 +13,11 @@
 
   <section id="federal-revenue">
 
-    <h3{% if revenue_commodities %} class="sticky sticky-header-wrapper"{% endif %}>Federal revenue</h3>
+    {%
+      include sticky-header.html
+      header_id='federal-revenue'
+      header_text='Federal revenue'
+    %}
 
     <p>
       Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -13,7 +13,7 @@
 
   <section id="federal-revenue">
 
-    <h3{% if revenue_commodities %} class="sticky"{% endif %}>Federal revenue</h3>
+    <h3{% if revenue_commodities %} class="sticky sticky-header-wrapper"{% endif %}>Federal revenue</h3>
 
     <p>
       Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.

--- a/_includes/sticky-header.html
+++ b/_includes/sticky-header.html
@@ -1,9 +1,9 @@
 {% assign header_text = include.header_text %}
-{% assign year_range = include.year_range %}
-{% assign empty_years = include.empty_years %}
-{% assign selector = include.selector %}
+{% assign year_range = include.year_range | default: year_range %}
+{% assign empty_years = include.empty_years | default: empty_years %}
+{% assign selector = include.selector | default: selector %}
 {% assign header_id = include.header_id %}
-{% assign header_size = include.header_size | 'h3' %}
+{% assign header_size = include.header_size | default: 'h3' %}
 
 {% if header_size == 'h2' %}
   <h2 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper flex-row">

--- a/_includes/sticky-header.html
+++ b/_includes/sticky-header.html
@@ -6,24 +6,24 @@
 {% assign header_size = include.header_size | 'h3' %}
 
 {% if header_size == 'h2' %}
-  <h2 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper">
-    <span>{{ header_text }}</span>
+  <h2 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper flex-row">
+    <span class="flex-row-flex">{{ header_text }}</span>
     {% if selector %}
-      {% include year-selector.html year_range=year_range %}
+      {% include year-selector.html year_range=year_range class_name="flex-row-icon" %}
     {% endif %}
   </h2>
 {% elsif header_size == 'h4' %}
-  <h4 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper">
-    <span>{{ header_text }}</span>
+  <h4 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper flex-row">
+    <span class="flex-row-flex">{{ header_text }}</span>
     {% if selector %}
-      {% include year-selector.html year_range=year_range %}
+      {% include year-selector.html year_range=year_range class_name="flex-row-icon" %}
     {% endif %}
   </h4>
 {% else %}
-  <h3 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper">
-    <span>{{ header_text }}</span>
+  <h3 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper flex-row">
+    <span class="flex-row-flex">{{ header_text }}</span>
     {% if selector %}
-      {% include year-selector.html year_range=year_range %}
+      {% include year-selector.html year_range=year_range class_name="flex-row-icon" %}
     {% endif %}
   </h3>
 {% endif %}

--- a/_includes/sticky-header.html
+++ b/_includes/sticky-header.html
@@ -1,28 +1,27 @@
 {% assign header_text = include.header_text %}
 {% assign year_range = include.year_range | default: year_range %}
 {% assign empty_years = include.empty_years | default: empty_years %}
-{% assign selector = include.selector | default: selector %}
 {% assign header_id = include.header_id %}
 {% assign header_size = include.header_size | default: 'h3' %}
 
 {% if header_size == 'h2' %}
   <h2 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper flex-row">
     <span class="flex-row-flex">{{ header_text }}</span>
-    {% if selector %}
+    {% if include.selector %}
       {% include year-selector.html year_range=year_range class_name="flex-row-icon" %}
     {% endif %}
   </h2>
 {% elsif header_size == 'h4' %}
   <h4 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper flex-row">
     <span class="flex-row-flex">{{ header_text }}</span>
-    {% if selector %}
+    {% if include.selector %}
       {% include year-selector.html year_range=year_range class_name="flex-row-icon" %}
     {% endif %}
   </h4>
 {% else %}
   <h3 {% if header_id %}id='{{ header_id }}'{% endif %} class="sticky sticky-header-wrapper flex-row">
     <span class="flex-row-flex">{{ header_text }}</span>
-    {% if selector %}
+    {% if include.selector %}
       {% include year-selector.html year_range=year_range class_name="flex-row-icon" %}
     {% endif %}
   </h3>

--- a/_includes/year-selector.html
+++ b/_includes/year-selector.html
@@ -1,7 +1,7 @@
 {% if include.year_range %}
   {% assign _year_list = include.year_range | to_list | reverse %}
 
-  <select class="chart-selector">
+  <select class="chart-selector{% if include.class_name %} {{ include.class_name }}{% endif %}">
     {% if include.empty_years %}<!-- empty years: {{ include.empty_years | jsonify }} -->{% endif %}
     {% for _year in _year_list %}
       {% assign __year = year | to_i %}

--- a/_layouts/offshore-region.html
+++ b/_layouts/offshore-region.html
@@ -45,6 +45,9 @@ nav_items:
           </p>
       </section>
 
+      <!-- include state pages mobile navigation -->
+      {% include layout/mobile-nav.html %}
+
       <section id="production">
         <h2>Production</h2>
 

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -78,7 +78,7 @@ nav_items:
 
 <main id="state-{{ state_id }}" class="container-page-wrapper layout-state-pages">
   <section class="container">
-    {% include layout/mobile-nav.html %}
+
     <div>
       <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore data</a>
       /
@@ -92,6 +92,10 @@ nav_items:
         {% include location/section-overview.html %}
 
       </section>
+
+      <!-- <section> -->
+        {% include layout/mobile-nav.html %}
+      <!-- </section> -->
 
       <section id="production">
         <h2>Production</h2>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -93,9 +93,7 @@ nav_items:
 
       </section>
 
-      <!-- <section> -->
-        {% include layout/mobile-nav.html %}
-      <!-- </section> -->
+      {% include layout/mobile-nav.html %}
 
       <section id="production">
         <h2>Production</h2>

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -115,7 +115,12 @@ nav_items:
         {% include location/section-federal-production.html %}
 
         {% if page.state_land %}
-          <h3 id="state-production">Production on state land in {{ state_name }}</h3>
+          {% assign header_text = 'Production on state land in {{ state_name }}' | liquify %}
+          {%
+            include sticky-header.html
+            header_text=header_text
+            header_id='state-production'
+          %}
           {{ page.state_land | liquify | markdownify }}
         {% endif %}
         {% if page.state_land_production %}
@@ -131,8 +136,13 @@ nav_items:
 
         {% include location/section-disbursements.html %}
 
-        <section id="state-disbursements" class="disbursements">
-          <h3{% if page.opt_in == true %} class="sticky"{% endif %}>State disbursements</h3>
+        <section class="disbursements">
+
+          {%
+            include sticky-header.html
+            header_text='State disbursements'
+            header_id='state-disbursements'
+          %}
 
           {% if page.opt_in == true %}
             {% include location/opt-in/state-disbursements.html location_id=state_id %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -78,6 +78,7 @@ nav_items:
 
 <main id="state-{{ state_id }}" class="container-page-wrapper layout-state-pages">
   <section class="container">
+    {% include layout/mobile-nav.html %}
     <div>
       <a class="breadcrumb" href="{{ site.baseurl }}/explore/">Explore data</a>
       /

--- a/_sass/_grid.scss
+++ b/_sass/_grid.scss
@@ -31,6 +31,8 @@ $massive-up: new-breakpoint(min-width $massive);
     @media only screen and (min-width: $tiny) { @content; }
   } @else if $media == tiny-to-small {
     @media only screen and (min-width: $tiny) and (max-width: $small) { @content; }
+  } @else if $media == small-down {
+    @media only screen and (max-width: $small) { @content; }
   } @else if $media == small-up {
     @media only screen and (min-width: $small) { @content; }
   } @else if $media == small-to-medium {

--- a/_sass/blocks/_all.scss
+++ b/_sass/blocks/_all.scss
@@ -41,6 +41,7 @@
 @import 'state-pages/info-tabs';
 @import 'state-pages/arrow-box';
 @import 'state-pages/iconic-nav';
+@import 'state-pages/mobile-nav';
 
 // About
 //

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -146,18 +146,6 @@
 .chart-selector-wrapper {
   display: inline-block;
 
-  @include respond-to(small-down) {
-    .chart-selector {
-      display: none;
-    }
-
-    .chart-description {
-      border: 0;
-      padding-left: 0;
-      width: 100%;
-    }
-  }
-
   .chart-selector {
     @include chart-selector(left);
   }
@@ -186,6 +174,18 @@
       &:active {
         text-decoration: underline;
       }
+    }
+  }
+
+  @include respond-to(small-down) {
+    .chart-selector {
+      display: none;
+    }
+
+    .chart-description {
+      border: 0;
+      padding-left: 0;
+      width: 100%;
     }
   }
 }

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -176,6 +176,18 @@
       }
     }
   }
+
+  @include respond-to(small-down) {
+    .chart-selector {
+      display: none;
+    }
+
+    .chart-description {
+      border: 0;
+      padding-left: 0;
+      width: 100%;
+    }
+  }
 }
 
 .row-container {

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -146,6 +146,18 @@
 .chart-selector-wrapper {
   display: inline-block;
 
+  @include respond-to(small-down) {
+    .chart-selector {
+      display: none;
+    }
+
+    .chart-description {
+      border: 0;
+      padding-left: 0;
+      width: 100%;
+    }
+  }
+
   .chart-selector {
     @include chart-selector(left);
   }
@@ -174,18 +186,6 @@
       &:active {
         text-decoration: underline;
       }
-    }
-  }
-
-  @include respond-to(small-down) {
-    .chart-selector {
-      display: none;
-    }
-
-    .chart-description {
-      border: 0;
-      padding-left: 0;
-      width: 100%;
     }
   }
 }

--- a/_sass/blocks/state-pages/_mobile-nav.scss
+++ b/_sass/blocks/state-pages/_mobile-nav.scss
@@ -1,92 +1,100 @@
-.layout-state-pages {
-  .mobile-nav {
-    background-color: $white;
-    border-bottom: 2px solid $light-green;
-    padding: 0;
-    width: 100%;
-    z-index: 9001;
+.layout-state-pages .mobile-nav {
+  background-color: $white;
+  border-bottom: 2px solid $light-green;
+  padding: 0;
+  width: 100%;
+  z-index: 9001;
 
-    @include respond-to(medium-up) {
+  @include respond-to(medium-up) {
+    display: none;
+  }
+
+  &.full-screen {
+    left: 0 !important;
+    right: 0 !important;
+    width: 100% !important;
+  }
+
+  &.container-page-inner-wrapper {
+    @include container-page-inner-wrapper();
+  }
+
+  .mobile-nav-header {
+    border: 0 !important;
+    display: inline-block;
+    margin: 0 !important;
+    padding-bottom: $standard-padding-lite !important;
+    padding-left: 0;
+    padding-top: $standard-padding-lite !important;
+    vertical-align: text-top;
+  }
+
+  button {
+    background: transparent;
+    float: right;
+    margin-bottom: inherit;
+    margin-top: inherit;
+  }
+
+
+  ul,
+  li {
+    display: block;
+  }
+
+  ul {
+    padding-left: 0;
+  }
+
+  .mobile-nav-list-items {
+    border-top: 2px solid $light-green;
+    display: block;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    width: 100%;
+
+    > ul {
+      margin: 0;
+    }
+
+    &[aria-hidden="true"] {
       display: none;
     }
+  }
 
-    .mobile-nav-header {
-      border: 0 !important;
-      display: inline-block;
-      margin: 0 !important;
-      padding-bottom: $standard-padding-lite !important;
-      padding-left: 0;
-      padding-top: $standard-padding-lite !important;
-      vertical-align: text-top;
+  .mobile-nav-list-item,
+  .mobile-nav-sublist-item {
+    @include h3-bar;
+
+    border-bottom: 1px solid $gray-lighter;
+    display: block;
+    padding: $base-padding-lite * 2;
+    text-decoration: none;
+
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: underline;
     }
+  }
 
-    button {
-      background: transparent;
-      float: right;
-      margin-bottom: inherit;
-      margin-top: inherit;
+  .mobile-nav-list-item {
+    @include heading('h5');
+
+    border-top: 2px solid $gray-light;
+    margin: 0;
+    padding-left: $base-padding;
+
+    &:first-of-type {
+      border-top: 0;
     }
+  }
 
+  .mobile-nav-sublist-item {
+    @include heading('para-md');
 
-    ul,
-    li {
-      display: block;
-    }
-
-    ul {
-      padding-left: 0;
-    }
-
-    .mobile-nav-list-items {
-      border-top: 2px solid $light-green;
-      display: block;
-      overflow-y: auto;
-      -webkit-overflow-scrolling: touch;
-      width: 100%;
-
-      > ul {
-        margin: 0;
-      }
-
-      &[aria-hidden="true"] {
-        display: none;
-      }
-    }
-
-    .mobile-nav-list-item,
-    .mobile-nav-sublist-item {
-      @include h3-bar;
-
-      border-bottom: 1px solid $gray-lighter;
-      display: block;
-      padding: $base-padding-lite * 2;
-      text-decoration: none;
-
-      &:hover,
-      &:focus,
-      &:active {
-        text-decoration: underline;
-      }
-    }
-
-    .mobile-nav-list-item {
-      @include heading('h5');
-
-      border-top: 2px solid $gray-light;
-      margin: 0;
-      padding-left: $base-padding;
-
-      &:first-of-type {
-        border-top: 0;
-      }
-    }
-
-    .mobile-nav-sublist-item {
-      @include heading('para-md');
-
-      font-weight: $weight-book;
-      margin: 0;
-      padding-left: 2 * $base-padding;
-    }
+    font-weight: $weight-book;
+    margin: 0;
+    padding-left: 2 * $base-padding;
   }
 }

--- a/_sass/blocks/state-pages/_mobile-nav.scss
+++ b/_sass/blocks/state-pages/_mobile-nav.scss
@@ -38,6 +38,8 @@
     .mobile-nav-list-items {
       border-top: 2px solid $light-green;
       display: block;
+      overflow-y: auto;
+      width: 100%;
 
       &[aria-hidden="true"] {
         display: none;

--- a/_sass/blocks/state-pages/_mobile-nav.scss
+++ b/_sass/blocks/state-pages/_mobile-nav.scss
@@ -49,8 +49,8 @@
   .mobile-nav-list-items {
     border-top: 2px solid $light-green;
     display: block;
-    overflow-y: auto;
     -webkit-overflow-scrolling: touch;
+    overflow-y: auto;
     width: 100%;
 
     > ul {

--- a/_sass/blocks/state-pages/_mobile-nav.scss
+++ b/_sass/blocks/state-pages/_mobile-nav.scss
@@ -54,8 +54,9 @@
     .mobile-nav-sublist-item {
       @include h3-bar;
 
+      border-bottom: 1px solid $gray-lighter;
       display: block;
-      padding: $base-padding-lite;
+      padding: $base-padding-lite * 2;
       text-decoration: none;
 
       &:hover,
@@ -68,16 +69,19 @@
     .mobile-nav-list-item {
       @include heading('h5');
 
-      border-bottom: 2px solid $gray-light;
+      border-top: 2px solid $gray-light;
       margin: 0;
       padding-left: $base-padding;
+
+      &:first-of-type {
+        border-top: 0;
+      }
     }
 
     .mobile-nav-sublist-item {
       @include heading('para-md');
 
-      border-bottom: 1px solid $gray-light;
-      font-size: $weight-book;
+      font-weight: $weight-book;
       margin: 0;
       padding-left: 2 * $base-padding;
     }

--- a/_sass/blocks/state-pages/_mobile-nav.scss
+++ b/_sass/blocks/state-pages/_mobile-nav.scss
@@ -41,6 +41,10 @@
       overflow-y: auto;
       width: 100%;
 
+      > ul {
+        margin: 0;
+      }
+
       &[aria-hidden="true"] {
         display: none;
       }

--- a/_sass/blocks/state-pages/_mobile-nav.scss
+++ b/_sass/blocks/state-pages/_mobile-nav.scss
@@ -1,0 +1,25 @@
+.layout-state-pages {
+  .mobile-nav {
+    background-color: $gray-light;
+    width: 100%;
+    z-index: 9001;
+
+    @include respond-to(medium-up) {
+      display: none;
+    }
+
+    .mobile-nav-header {
+      display: inline-block;
+      margin: 0 !important;
+    }
+
+
+    ul {
+      display: block;
+    }
+
+    a {
+      text-decoration: none;
+    }
+  }
+}

--- a/_sass/blocks/state-pages/_mobile-nav.scss
+++ b/_sass/blocks/state-pages/_mobile-nav.scss
@@ -1,6 +1,8 @@
 .layout-state-pages {
   .mobile-nav {
-    background-color: $gray-light;
+    background-color: $white;
+    border-bottom: 2px solid $light-green;
+    padding: 0;
     width: 100%;
     z-index: 9001;
 
@@ -9,17 +11,69 @@
     }
 
     .mobile-nav-header {
+      border: 0 !important;
       display: inline-block;
       margin: 0 !important;
+      padding-top: $base-padding-lite;
+      vertical-align: text-top;
+    }
+
+    button {
+      background: transparent;
+      float: right;
+      margin-bottom: $base-padding-lite;
+      margin-top: $base-padding-lite;
     }
 
 
-    ul {
+    ul,
+    li {
       display: block;
     }
 
-    a {
+    ul {
+      padding-left: 0;
+    }
+
+    .mobile-nav-list-items {
+      border-top: 2px solid $light-green;
+      display: block;
+
+      &[aria-hidden="true"] {
+        display: none;
+      }
+    }
+
+    .mobile-nav-list-item,
+    .mobile-nav-sublist-item {
+      @include h3-bar;
+
+      display: block;
+      padding: $base-padding-lite;
       text-decoration: none;
+
+      &:hover,
+      &:focus,
+      &:active {
+        text-decoration: underline;
+      }
+    }
+
+    .mobile-nav-list-item {
+      @include heading('h5');
+
+      border-bottom: 2px solid $gray-light;
+      margin: 0;
+      padding-left: $base-padding;
+    }
+
+    .mobile-nav-sublist-item {
+      @include heading('para-md');
+
+      border-bottom: 1px solid $gray-light;
+      font-size: $weight-book;
+      margin: 0;
+      padding-left: 2 * $base-padding;
     }
   }
 }

--- a/_sass/blocks/state-pages/_mobile-nav.scss
+++ b/_sass/blocks/state-pages/_mobile-nav.scss
@@ -76,6 +76,10 @@
     &:active {
       text-decoration: underline;
     }
+
+    &[aria-hidden=true] {
+      display: none;
+    }
   }
 
   .mobile-nav-list-item {

--- a/_sass/blocks/state-pages/_mobile-nav.scss
+++ b/_sass/blocks/state-pages/_mobile-nav.scss
@@ -14,15 +14,17 @@
       border: 0 !important;
       display: inline-block;
       margin: 0 !important;
-      padding-top: $base-padding-lite;
+      padding-bottom: $standard-padding-lite !important;
+      padding-left: 0;
+      padding-top: $standard-padding-lite !important;
       vertical-align: text-top;
     }
 
     button {
       background: transparent;
       float: right;
-      margin-bottom: $base-padding-lite;
-      margin-top: $base-padding-lite;
+      margin-bottom: inherit;
+      margin-top: inherit;
     }
 
 
@@ -39,6 +41,7 @@
       border-top: 2px solid $light-green;
       display: block;
       overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
       width: 100%;
 
       > ul {

--- a/_sass/components/_all.scss
+++ b/_sass/components/_all.scss
@@ -23,3 +23,4 @@
 @import 'sticky';
 @import 'tooltip';
 @import 'sticky-headers';
+@import 'flex-row';

--- a/_sass/components/_flex-row.scss
+++ b/_sass/components/_flex-row.scss
@@ -1,0 +1,19 @@
+.flex-row {
+	display: flex;
+	flex-direction: row;
+	padding: 0;
+	width: 100%;
+
+	.flex-row-flex {
+		align-self: center;
+		padding-right: $base-padding-lite;
+		text-align: left;
+		width: 100%;
+	}
+
+	.flex-row-icon {
+		align-self: center;
+		height: inherit;
+		padding-right: $base-padding-lite;
+	}
+}

--- a/_sass/components/_flex-row.scss
+++ b/_sass/components/_flex-row.scss
@@ -1,19 +1,19 @@
 .flex-row {
-	display: flex;
-	flex-direction: row;
-	padding: 0;
-	width: 100%;
+  display: flex;
+  flex-direction: row;
+  padding: 0;
+  width: 100%;
 
-	.flex-row-flex {
-		align-self: center;
-		padding-right: $base-padding-lite;
-		text-align: left;
-		width: 100%;
-	}
+  .flex-row-flex {
+    align-self: center;
+    padding-right: $base-padding-lite;
+    text-align: left;
+    width: 100%;
+  }
 
-	.flex-row-icon {
-		align-self: center;
-		height: inherit;
-		padding-right: $base-padding-lite;
-	}
+  .flex-row-icon {
+    align-self: center;
+    height: inherit;
+    padding-right: $base-padding-lite;
+  }
 }

--- a/_sass/components/_sticky-headers.scss
+++ b/_sass/components/_sticky-headers.scss
@@ -1,5 +1,6 @@
 .sticky-header-wrapper {
-  padding-top: 2 * $standard-padding-lite;
+  padding-bottom: $standard-padding-lite !important;
+  padding-top: $standard-padding-lite !important;
   top: 45px;
 
   @include respond-to(medium-up) {
@@ -11,11 +12,11 @@
     vertical-align: sub;
 
     @include respond-to(tiny-down) {
-      width: 70%;
+      width: 65%;
     }
 
     @include respond-to(tiny-to-small) {
-      width: 75%;
+      width: 70%;
     }
 
     @include respond-to(small-to-medium) {

--- a/_sass/components/_sticky-headers.scss
+++ b/_sass/components/_sticky-headers.scss
@@ -36,5 +36,9 @@
 
     margin: 0;
     visibility: hidden;
+
+    @include respond-to(small-down) {
+      visibility: visible;
+    }
   }
 }

--- a/_sass/components/_sticky-headers.scss
+++ b/_sass/components/_sticky-headers.scss
@@ -1,5 +1,10 @@
 .sticky-header-wrapper {
   padding-top: 2 * $standard-padding-lite;
+  top: 47px;
+
+  @include respond-to(medium-up) {
+    top: 0;
+  }
 
   span {
     vertical-align: sub;

--- a/_sass/components/_sticky-headers.scss
+++ b/_sass/components/_sticky-headers.scss
@@ -1,7 +1,7 @@
 .sticky-header-wrapper {
   padding-bottom: $standard-padding-lite !important;
   padding-top: $standard-padding-lite !important;
-  top: 45px;
+  top: 42px;
 
   @include respond-to(medium-up) {
     top: 0;

--- a/_sass/components/_sticky-headers.scss
+++ b/_sass/components/_sticky-headers.scss
@@ -1,6 +1,6 @@
 .sticky-header-wrapper {
   padding-top: 2 * $standard-padding-lite;
-  top: 47px;
+  top: 45px;
 
   @include respond-to(medium-up) {
     top: 0;

--- a/_sass/components/_sticky-headers.scss
+++ b/_sass/components/_sticky-headers.scss
@@ -7,7 +7,20 @@
   }
 
   span {
+    display: inline-block;
     vertical-align: sub;
+
+    @include respond-to(tiny-down) {
+      width: 70%;
+    }
+
+    @include respond-to(tiny-to-small) {
+      width: 75%;
+    }
+
+    @include respond-to(small-to-medium) {
+      width: 80%;
+    }
   }
 
   &.stuck {

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -52,6 +52,35 @@
   }
 }
 
+
+@mixin container-page-inner-wrapper() {
+  @extend .container;
+  padding-left: $base-padding;
+  padding-right: $base-padding;
+
+
+  @include respond-to(small-to-huge) {
+    padding-left: $page-padding;
+    padding-right: $page-padding;
+  }
+
+  @include respond-to(huge-plus) {
+    padding-left: $page-padding;
+    padding-right: $page-padding;
+    max-width: $max-width;
+  }
+
+  @include respond-to(huge-plus-up) {
+    padding-left: auto;
+    padding-right: auto;
+  }
+}
+
+.container-page-inner-wrapper {
+  @include container-page-inner-wrapper();
+}
+
+
 %container-side {
 
   @include span-columns(12);

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -65,9 +65,9 @@
   }
 
   @include respond-to(huge-plus) {
+    max-width: $max-width;
     padding-left: $page-padding;
     padding-right: $page-padding;
-    max-width: $max-width;
   }
 
   @include respond-to(huge-plus-up) {

--- a/_sass/mixins/_selectors.scss
+++ b/_sass/mixins/_selectors.scss
@@ -13,6 +13,7 @@
   height: initial;
   margin-right: $standard-padding;
   margin-top: $standard-padding-lite;
+  min-width: 85px;
   padding-left: 0.5rem;
   padding-right: 1.5rem;
 }

--- a/explore/index.html
+++ b/explore/index.html
@@ -91,6 +91,8 @@ nav_items:
 
     <div class="container-left-9">
 
+      {% include layout/mobile-nav.html %}
+
       <section id="production">
 
         <h2 class="state-page-overview">Production</h2>

--- a/js/components/aria-toggle.js
+++ b/js/components/aria-toggle.js
@@ -51,11 +51,11 @@
           return toggle(this, expanded);
         }},
 
-        expand: {value: function(expanded) {
+        expand: {value: function() {
           return expand(this);
         }},
 
-        collapse: {value: function(expanded) {
+        collapse: {value: function() {
           return collapse(this);
         }},
 

--- a/js/components/aria-toggle.js
+++ b/js/components/aria-toggle.js
@@ -55,6 +55,10 @@
           return expand(this);
         }},
 
+        collapse: {value: function(expanded) {
+          return collapse(this);
+        }},
+
         detachedCallback: {value: function() {
           this.removeEventListener('click', click);
         }},

--- a/js/components/mobile-nav.js
+++ b/js/components/mobile-nav.js
@@ -6,16 +6,27 @@
 
   var attached = function() {
     var root = d3.select(this);
-    var win = d3.select(win);
+    var win = d3.select(window);
+    var doc = d3.select(document);
     var navIsFull = false;
 
     var collapsedHeaderHeight = root.node().getBoundingClientRect().height;
     var links = root.selectAll('a');
     var toggles = root.selectAll('[is="aria-toggle"]');
+    var navItems = root.selectAll('[mobile-nav-item]');
 
     var button = root.select('button');
 
     var content = root.select('#mobile-nav-content');
+
+    navItems.each(function () {
+      var item = d3.select(this);
+      var itemID = item.attr('mobile-nav-item');
+      var elementDoesntExists = doc.select('#' + itemID).empty();
+      if (elementDoesntExists) {
+        item.attr('aria-hidden', true);
+      }
+    });
 
     var jump = function() {
       toggles.each(function() {
@@ -51,12 +62,8 @@
     }
 
     links.on('click.nav', jump);
-
     button.on('click.toggle', resize);
-
-    window.addEventListener('resize', function(){
-      eiti.util.throttle(resize, 100);
-    });
+    win.on('resize.sticky', eiti.util.throttle(resize, 100));
   };
 
   var detached = function() {

--- a/js/components/mobile-nav.js
+++ b/js/components/mobile-nav.js
@@ -46,8 +46,8 @@
         .classed('full-screen', fullScreen)
         .classed('container-page-inner-wrapper', fullScreen);
 
-      navIsFull = !navIsFull
-    }
+      navIsFull = !navIsFull;
+    };
 
     var resize = function(e) {
       var windowHeight  = window.innerHeight || e.clientHeight;
@@ -59,7 +59,7 @@
           makeFullScreen(true);
         }
       }
-    }
+    };
 
     links.on('click.nav', jump);
     button.on('click.toggle', resize);

--- a/js/components/mobile-nav.js
+++ b/js/components/mobile-nav.js
@@ -1,0 +1,34 @@
+(function() {
+
+  var attached = function() {
+    var root = d3.select(this);
+
+    var links = root.selectAll('a');
+    var toggles = root.selectAll('[is="aria-toggle"]');
+
+    var jump = function() {
+      toggles.each(function() {
+        this.collapse();
+      });
+    };
+
+    links.on('click.nav', function() {
+      jump();
+    });
+  };
+
+  var detached = function() {
+  };
+
+  document.registerElement('mobile-nav', {
+    'extends': 'div',
+    prototype: Object.create(
+      HTMLElement.prototype,
+      {
+        attachedCallback: {value: attached},
+        detachedCallback: {value: detached}
+      }
+    )
+  });
+
+})();

--- a/js/components/mobile-nav.js
+++ b/js/components/mobile-nav.js
@@ -7,6 +7,7 @@
   var attached = function() {
     var root = d3.select(this);
     var win = d3.select(win);
+    var navIsFull = false;
 
     var collapsedHeaderHeight = root.node().getBoundingClientRect().height;
     var links = root.selectAll('a');
@@ -20,21 +21,38 @@
       toggles.each(function() {
         this.collapse();
       });
+      makeFullScreen(false, false);
     };
+
+    var makeFullScreen = function (toggle, fullScreen) {
+      var fullScreen = fullScreen || false;
+
+      if (toggle) {
+        fullScreen = !navIsFull;
+      }
+
+      root
+        .classed('full-screen', fullScreen)
+        .classed('container-page-inner-wrapper', fullScreen);
+
+      navIsFull = !navIsFull
+    }
 
     var resize = function(e) {
       var windowHeight  = window.innerHeight || e.clientHeight;
       var newHeight = windowHeight - collapsedHeaderHeight;
       content.style('height', pixelize(newHeight));
+
+      if (d3.event.type === 'click' || d3.event.type === 'touch') {
+        if (root.classed('stuck')) {
+          makeFullScreen(true);
+        }
+      }
     }
 
-    links.on('click.nav', function() {
-      jump();
-    });
+    links.on('click.nav', jump);
 
-    button.on('click.open', function() {
-      resize();
-    })
+    button.on('click.toggle', resize);
 
     window.addEventListener('resize', function(){
       eiti.util.throttle(resize, 100);

--- a/js/components/mobile-nav.js
+++ b/js/components/mobile-nav.js
@@ -6,6 +6,8 @@
 
   var attached = function() {
     var root = d3.select(this);
+    var win = d3.select(win);
+
     var collapsedHeaderHeight = root.node().getBoundingClientRect().height;
     var links = root.selectAll('a');
     var toggles = root.selectAll('[is="aria-toggle"]');
@@ -21,7 +23,7 @@
     };
 
     var resize = function(e) {
-      var windowHeight  = window.innerHeight|| e.clientHeight;
+      var windowHeight  = window.innerHeight || e.clientHeight;
       var newHeight = windowHeight - collapsedHeaderHeight;
       content.style('height', pixelize(newHeight));
     }
@@ -33,6 +35,10 @@
     button.on('click.open', function() {
       resize();
     })
+
+    window.addEventListener('resize', function(){
+      eiti.util.throttle(resize, 100);
+    });
   };
 
   var detached = function() {

--- a/js/components/mobile-nav.js
+++ b/js/components/mobile-nav.js
@@ -28,15 +28,8 @@
       }
     });
 
-    var jump = function() {
-      toggles.each(function() {
-        this.collapse();
-      });
-      makeFullScreen(false, false);
-    };
-
     var makeFullScreen = function (toggle, fullScreen) {
-      var fullScreen = fullScreen || false;
+      fullScreen = fullScreen || false;
 
       if (toggle) {
         fullScreen = !navIsFull;
@@ -47,6 +40,13 @@
         .classed('container-page-inner-wrapper', fullScreen);
 
       navIsFull = !navIsFull;
+    };
+
+    var jump = function() {
+      toggles.each(function() {
+        this.collapse();
+      });
+      makeFullScreen(false, false);
     };
 
     var resize = function(e) {

--- a/js/components/mobile-nav.js
+++ b/js/components/mobile-nav.js
@@ -1,10 +1,18 @@
 (function() {
 
+  var pixelize = function(value) {
+    return value + 'px';
+  };
+
   var attached = function() {
     var root = d3.select(this);
-
+    var collapsedHeaderHeight = root.node().getBoundingClientRect().height;
     var links = root.selectAll('a');
     var toggles = root.selectAll('[is="aria-toggle"]');
+
+    var button = root.select('button');
+
+    var content = root.select('#mobile-nav-content');
 
     var jump = function() {
       toggles.each(function() {
@@ -12,9 +20,19 @@
       });
     };
 
+    var resize = function(e) {
+      var windowHeight  = window.innerHeight|| e.clientHeight;
+      var newHeight = windowHeight - collapsedHeaderHeight;
+      content.style('height', pixelize(newHeight));
+    }
+
     links.on('click.nav', function() {
       jump();
     });
+
+    button.on('click.open', function() {
+      resize();
+    })
   };
 
   var detached = function() {

--- a/js/components/sticky.js
+++ b/js/components/sticky.js
@@ -23,7 +23,6 @@
   );
 
   var watch = function() {
-    console.log('throttled reszie')
     stickies.forEach(function(sticky) {
       var atTop = d3.select(sticky).style('position') == 'fixed';
       var isStuck = sticky.classList.contains('stuck');

--- a/js/components/sticky.js
+++ b/js/components/sticky.js
@@ -4,6 +4,7 @@
   var sticky = require('stickyfill')();
   var stickies = [];
   var doc = d3.select(document);
+  var win = d3.select(window);
 
   [].forEach.call(
     document.querySelectorAll('.sticky'),
@@ -22,8 +23,9 @@
   );
 
   var watch = function() {
+    console.log('throttled reszie')
     stickies.forEach(function(sticky) {
-      var atTop = d3.select(sticky).style('position');
+      var atTop = d3.select(sticky).style('position') == 'fixed';
       var isStuck = sticky.classList.contains('stuck');
 
       if (atTop && !isStuck) {
@@ -35,7 +37,7 @@
   };
 
   doc.on('scroll.sticky', eiti.util.throttle(watch, 100));
-  doc.on('resize.sticky', eiti.util.throttle(watch, 100));
+  win.on('resize.sticky', eiti.util.throttle(watch, 100));
 
   watch();
 

--- a/js/components/sticky.js
+++ b/js/components/sticky.js
@@ -23,7 +23,7 @@
 
   var watch = function() {
     stickies.forEach(function(sticky) {
-      var atTop = Number(sticky.getBoundingClientRect().top) === 0;
+      var atTop = d3.select(sticky).style('position');
       var isStuck = sticky.classList.contains('stuck');
 
       if (atTop && !isStuck) {

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -68,6 +68,7 @@
 	  var sticky = __webpack_require__(4)();
 	  var stickies = [];
 	  var doc = d3.select(document);
+	  var win = d3.select(window);
 
 	  [].forEach.call(
 	    document.querySelectorAll('.sticky'),
@@ -86,8 +87,9 @@
 	  );
 
 	  var watch = function() {
+	    console.log('throttled reszie')
 	    stickies.forEach(function(sticky) {
-	      var atTop = d3.select(sticky).style('position');
+	      var atTop = d3.select(sticky).style('position') == 'fixed';
 	      var isStuck = sticky.classList.contains('stuck');
 
 	      if (atTop && !isStuck) {
@@ -99,7 +101,7 @@
 	  };
 
 	  doc.on('scroll.sticky', eiti.util.throttle(watch, 100));
-	  doc.on('resize.sticky', eiti.util.throttle(watch, 100));
+	  win.on('resize.sticky', eiti.util.throttle(watch, 100));
 
 	  watch();
 

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -87,7 +87,6 @@
 	  );
 
 	  var watch = function() {
-	    console.log('throttled reszie')
 	    stickies.forEach(function(sticky) {
 	      var atTop = d3.select(sticky).style('position') == 'fixed';
 	      var isStuck = sticky.classList.contains('stuck');

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -87,7 +87,7 @@
 
 	  var watch = function() {
 	    stickies.forEach(function(sticky) {
-	      var atTop = Number(sticky.getBoundingClientRect().top) === 0;
+	      var atTop = d3.select(sticky).style('position');
 	      var isStuck = sticky.classList.contains('stuck');
 
 	      if (atTop && !isStuck) {

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -90,7 +90,7 @@
 
 	  var watch = function() {
 	    stickies.forEach(function(sticky) {
-	      var atTop = Number(sticky.getBoundingClientRect().top) === 0;
+	      var atTop = d3.select(sticky).style('position');
 	      var isStuck = sticky.classList.contains('stuck');
 
 	      if (atTop && !isStuck) {

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -90,7 +90,6 @@
 	  );
 
 	  var watch = function() {
-	    console.log('throttled reszie')
 	    stickies.forEach(function(sticky) {
 	      var atTop = d3.select(sticky).style('position') == 'fixed';
 	      var isStuck = sticky.classList.contains('stuck');

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -71,6 +71,7 @@
 	  var sticky = __webpack_require__(4)();
 	  var stickies = [];
 	  var doc = d3.select(document);
+	  var win = d3.select(window);
 
 	  [].forEach.call(
 	    document.querySelectorAll('.sticky'),
@@ -89,8 +90,9 @@
 	  );
 
 	  var watch = function() {
+	    console.log('throttled reszie')
 	    stickies.forEach(function(sticky) {
-	      var atTop = d3.select(sticky).style('position');
+	      var atTop = d3.select(sticky).style('position') == 'fixed';
 	      var isStuck = sticky.classList.contains('stuck');
 
 	      if (atTop && !isStuck) {
@@ -102,7 +104,7 @@
 	  };
 
 	  doc.on('scroll.sticky', eiti.util.throttle(watch, 100));
-	  doc.on('resize.sticky', eiti.util.throttle(watch, 100));
+	  win.on('resize.sticky', eiti.util.throttle(watch, 100));
 
 	  watch();
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11585,11 +11585,11 @@
 	          return toggle(this, expanded);
 	        }},
 
-	        expand: {value: function(expanded) {
+	        expand: {value: function() {
 	          return expand(this);
 	        }},
 
-	        collapse: {value: function(expanded) {
+	        collapse: {value: function() {
 	          return collapse(this);
 	        }},
 
@@ -13964,8 +13964,8 @@
 	        .classed('full-screen', fullScreen)
 	        .classed('container-page-inner-wrapper', fullScreen);
 
-	      navIsFull = !navIsFull
-	    }
+	      navIsFull = !navIsFull;
+	    };
 
 	    var resize = function(e) {
 	      var windowHeight  = window.innerHeight || e.clientHeight;
@@ -13977,7 +13977,7 @@
 	          makeFullScreen(true);
 	        }
 	      }
-	    }
+	    };
 
 	    links.on('click.nav', jump);
 	    button.on('click.toggle', resize);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -102,7 +102,6 @@
 	  );
 
 	  var watch = function() {
-	    console.log('throttled reszie')
 	    stickies.forEach(function(sticky) {
 	      var atTop = d3.select(sticky).style('position') == 'fixed';
 	      var isStuck = sticky.classList.contains('stuck');
@@ -13925,16 +13924,27 @@
 
 	  var attached = function() {
 	    var root = d3.select(this);
-	    var win = d3.select(win);
+	    var win = d3.select(window);
+	    var doc = d3.select(document);
 	    var navIsFull = false;
 
 	    var collapsedHeaderHeight = root.node().getBoundingClientRect().height;
 	    var links = root.selectAll('a');
 	    var toggles = root.selectAll('[is="aria-toggle"]');
+	    var navItems = root.selectAll('[mobile-nav-item]');
 
 	    var button = root.select('button');
 
 	    var content = root.select('#mobile-nav-content');
+
+	    navItems.each(function () {
+	      var item = d3.select(this);
+	      var itemID = item.attr('mobile-nav-item');
+	      var elementDoesntExists = doc.select('#' + itemID).empty();
+	      if (elementDoesntExists) {
+	        item.attr('aria-hidden', true);
+	      }
+	    });
 
 	    var jump = function() {
 	      toggles.each(function() {
@@ -13970,12 +13980,8 @@
 	    }
 
 	    links.on('click.nav', jump);
-
 	    button.on('click.toggle', resize);
-
-	    window.addEventListener('resize', function(){
-	      eiti.util.throttle(resize, 100);
-	    });
+	    win.on('resize.sticky', eiti.util.throttle(resize, 100));
 	  };
 
 	  var detached = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -59,6 +59,7 @@
 	  __webpack_require__(7);
 
 	  __webpack_require__(3);
+	  __webpack_require__(43);
 
 	  // exporting instance of OpenListNav because openListNav is
 	  // referenced in the markup:
@@ -101,7 +102,7 @@
 
 	  var watch = function() {
 	    stickies.forEach(function(sticky) {
-	      var atTop = Number(sticky.getBoundingClientRect().top) === 0;
+	      var atTop = d3.select(sticky).style('position');
 	      var isStuck = sticky.classList.contains('stuck');
 
 	      if (atTop && !isStuck) {
@@ -11587,6 +11588,10 @@
 	          return expand(this);
 	        }},
 
+	        collapse: {value: function(expanded) {
+	          return collapse(this);
+	        }},
+
 	        detachedCallback: {value: function() {
 	          this.removeEventListener('click', click);
 	        }},
@@ -13904,6 +13909,46 @@
 
 	})(this);
 
+
+
+/***/ },
+/* 43 */
+/***/ function(module, exports) {
+
+	(function() {
+
+	  var attached = function() {
+	    var root = d3.select(this);
+
+	    var links = root.selectAll('a');
+	    var toggles = root.selectAll('[is="aria-toggle"]');
+
+	    var jump = function() {
+	      toggles.each(function() {
+	        this.collapse();
+	      });
+	    };
+
+	    links.on('click.nav', function() {
+	      jump();
+	    });
+	  };
+
+	  var detached = function() {
+	  };
+
+	  document.registerElement('mobile-nav', {
+	    'extends': 'div',
+	    prototype: Object.create(
+	      HTMLElement.prototype,
+	      {
+	        attachedCallback: {value: attached},
+	        detachedCallback: {value: detached}
+	      }
+	    )
+	  });
+
+	})();
 
 
 /***/ }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -83,6 +83,7 @@
 	  var sticky = __webpack_require__(4)();
 	  var stickies = [];
 	  var doc = d3.select(document);
+	  var win = d3.select(window);
 
 	  [].forEach.call(
 	    document.querySelectorAll('.sticky'),
@@ -101,8 +102,9 @@
 	  );
 
 	  var watch = function() {
+	    console.log('throttled reszie')
 	    stickies.forEach(function(sticky) {
-	      var atTop = d3.select(sticky).style('position');
+	      var atTop = d3.select(sticky).style('position') == 'fixed';
 	      var isStuck = sticky.classList.contains('stuck');
 
 	      if (atTop && !isStuck) {
@@ -114,7 +116,7 @@
 	  };
 
 	  doc.on('scroll.sticky', eiti.util.throttle(watch, 100));
-	  doc.on('resize.sticky', eiti.util.throttle(watch, 100));
+	  win.on('resize.sticky', eiti.util.throttle(watch, 100));
 
 	  watch();
 
@@ -13923,6 +13925,8 @@
 
 	  var attached = function() {
 	    var root = d3.select(this);
+	    var win = d3.select(win);
+
 	    var collapsedHeaderHeight = root.node().getBoundingClientRect().height;
 	    var links = root.selectAll('a');
 	    var toggles = root.selectAll('[is="aria-toggle"]');
@@ -13938,7 +13942,7 @@
 	    };
 
 	    var resize = function(e) {
-	      var windowHeight  = window.innerHeight|| e.clientHeight;
+	      var windowHeight  = window.innerHeight || e.clientHeight;
 	      var newHeight = windowHeight - collapsedHeaderHeight;
 	      content.style('height', pixelize(newHeight));
 	    }
@@ -13950,6 +13954,10 @@
 	    button.on('click.open', function() {
 	      resize();
 	    })
+
+	    window.addEventListener('resize', function(){
+	      eiti.util.throttle(resize, 100);
+	    });
 	  };
 
 	  var detached = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13917,11 +13917,19 @@
 
 	(function() {
 
+	  var pixelize = function(value) {
+	    return value + 'px';
+	  };
+
 	  var attached = function() {
 	    var root = d3.select(this);
-
+	    var collapsedHeaderHeight = root.node().getBoundingClientRect().height;
 	    var links = root.selectAll('a');
 	    var toggles = root.selectAll('[is="aria-toggle"]');
+
+	    var button = root.select('button');
+
+	    var content = root.select('#mobile-nav-content');
 
 	    var jump = function() {
 	      toggles.each(function() {
@@ -13929,9 +13937,19 @@
 	      });
 	    };
 
+	    var resize = function(e) {
+	      var windowHeight  = window.innerHeight|| e.clientHeight;
+	      var newHeight = windowHeight - collapsedHeaderHeight;
+	      content.style('height', pixelize(newHeight));
+	    }
+
 	    links.on('click.nav', function() {
 	      jump();
 	    });
+
+	    button.on('click.open', function() {
+	      resize();
+	    })
 	  };
 
 	  var detached = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13926,6 +13926,7 @@
 	  var attached = function() {
 	    var root = d3.select(this);
 	    var win = d3.select(win);
+	    var navIsFull = false;
 
 	    var collapsedHeaderHeight = root.node().getBoundingClientRect().height;
 	    var links = root.selectAll('a');
@@ -13939,21 +13940,38 @@
 	      toggles.each(function() {
 	        this.collapse();
 	      });
+	      makeFullScreen(false, false);
 	    };
+
+	    var makeFullScreen = function (toggle, fullScreen) {
+	      var fullScreen = fullScreen || false;
+
+	      if (toggle) {
+	        fullScreen = !navIsFull;
+	      }
+
+	      root
+	        .classed('full-screen', fullScreen)
+	        .classed('container-page-inner-wrapper', fullScreen);
+
+	      navIsFull = !navIsFull
+	    }
 
 	    var resize = function(e) {
 	      var windowHeight  = window.innerHeight || e.clientHeight;
 	      var newHeight = windowHeight - collapsedHeaderHeight;
 	      content.style('height', pixelize(newHeight));
+
+	      if (d3.event.type === 'click' || d3.event.type === 'touch') {
+	        if (root.classed('stuck')) {
+	          makeFullScreen(true);
+	        }
+	      }
 	    }
 
-	    links.on('click.nav', function() {
-	      jump();
-	    });
+	    links.on('click.nav', jump);
 
-	    button.on('click.open', function() {
-	      resize();
-	    })
+	    button.on('click.toggle', resize);
 
 	    window.addEventListener('resize', function(){
 	      eiti.util.throttle(resize, 100);

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13946,15 +13946,8 @@
 	      }
 	    });
 
-	    var jump = function() {
-	      toggles.each(function() {
-	        this.collapse();
-	      });
-	      makeFullScreen(false, false);
-	    };
-
 	    var makeFullScreen = function (toggle, fullScreen) {
-	      var fullScreen = fullScreen || false;
+	      fullScreen = fullScreen || false;
 
 	      if (toggle) {
 	        fullScreen = !navIsFull;
@@ -13965,6 +13958,13 @@
 	        .classed('container-page-inner-wrapper', fullScreen);
 
 	      navIsFull = !navIsFull;
+	    };
+
+	    var jump = function() {
+	      toggles.each(function() {
+	        this.collapse();
+	      });
+	      makeFullScreen(false, false);
 	    };
 
 	    var resize = function(e) {

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -13,6 +13,7 @@
   require('../components/aria-tabs.js');
 
   require('../components/sticky.js');
+  require('../components/mobile-nav.js');
 
   // exporting instance of OpenListNav because openListNav is
   // referenced in the markup:


### PR DESCRIPTION
Fixes issue(s) #2084 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/mobile_nav.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/mobile_nav)

[:sunglasses: PREVIEW national](https://federalist.18f.gov/preview/18F/doi-extractives-data/mobile-nav/explore/)
[:mountain: PREVIEW opt-in state (MT)](https://federalist.18f.gov/preview/18F/doi-extractives-data/mobile-nav/explore/MT/)
[:mountain_snow: PREVIEW non-opt-in state (UT)](https://federalist.18f.gov/preview/18F/doi-extractives-data/mobile-nav/explore/UT/)
[:ocean: PREVIEW offshore region](https://federalist.18f.gov/preview/18F/doi-extractives-data/mobile-nav/explore/offshore-gulf/)

Changes proposed in this pull request:
- added a sticky navigation for mobile
- updated header hierarchy to make all nav items sticky

/cc @ericronne @meiqimichelle 
