### PR TITLE
Deletes one-pixel rule from "Official" banner

### DIFF
--- a/_sass/blocks/_banner.scss
+++ b/_sass/blocks/_banner.scss
@@ -17,7 +17,6 @@
   @include heading('para-sm');
   @include font-size(0.75);
 
-  border-bottom: 1px solid $mid-gray;
   padding: ($base-padding / 2) $base-padding-large;
   text-align: center;
 


### PR DESCRIPTION
Deleted the rule in order to make the style more consistent with the
overall site design