### PR TITLE
Crop maps

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -19,7 +19,7 @@
   {% assign _viewbox_list = _viewbox | split: ' ' | to_f %}
   {% assign breakpoint_width = _viewbox_list[2] %}
   {% assign _height = _viewbox_list[3] %}
-  {% assign breakpoint_height = _viewbox_list[3] | times:2.5 %}
+  {% assign breakpoint_height = _viewbox_list[3] | times: 2.5 %}
   {% capture is_wide %}
     {% if breakpoint_width > breakpoint_height %}wide{% endif %}
   {% endcapture %}
@@ -32,21 +32,18 @@
 
 {% if is_wide == 'wide' %}
   {% assign media_width = 100 %}
-  {% assign additional_padding = data_dimensions | times: 1.8 %}
-  {% assign padding_bottom = media_width | times: data_dimensions | plus: additional_padding %}
 {% else %}
   {% assign media_width = 65.88078 | to_f %}
-  {% assign additional_padding = data_dimensions | times: 1.8 %}
-  {% assign padding_bottom = media_width | times: data_dimensions | plus: additional_padding %}
 {% endif %}
 
-
+{% assign additional_padding = data_dimensions | times: 1.8 %}
+{% assign padding_bottom = media_width | times: data_dimensions | plus: additional_padding %}
 
 <div is="eiti-tooltip-wrapper"
      tooltip-style="subtle"
      cursor-offset="10"
      class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
-  style="line-height: {{ padding_bottom }}%; padding-bottom: {{ padding_bottom }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
+  style="padding-bottom: {{ padding_bottom }}%;"{% endif %} data-dimensions="{{ _height | divided_by: breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
     {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ include.state }}.svg{% endcapture %}
@@ -119,27 +116,6 @@
   {% endif %}
 
   <svg class="legend-svg"></svg>
-
-<!--   {% if include.toggle %}
-    <h4 class="details-container">
-      <button is="aria-toggle"
-        aria-controls="{{ include.toggle }}"
-        aria-expanded="false">
-          <span class="hide-expanded">
-            <i class="icon icon-plus-sm"></i>
-            {% if include.toggle_text %}
-              {{ include.toggle_text_hidden }}
-            {% else %}Show table{% endif %}
-          </span>
-          <span class="show-expanded">
-            <i class="icon icon-dash-sm"></i>
-            {% if include.toggle_text %}
-              {{ include.toggle_text_visible }}
-            {% else %}Hide table{% endif %}
-          </span>
-      </button>
-    </h4>
-  {% endif %} -->
 </div>
 
 {% if include.toggle %}

--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -26,15 +26,27 @@
   {% assign is_wide = is_wide | strip %}
 {% endif %}
 
-{% if is_wide != 'wide' %}
-  {% assign _width = 65.88078 | to_f %}
+{% capture data_dimensions %}
+  {{ _height | divided_by:breakpoint_width | to_f }}
+{% endcapture %}
+
+{% if is_wide == 'wide' %}
+  {% assign media_width = 100 %}
+  {% assign additional_padding = data_dimensions | times: 1.8 %}
+  {% assign padding_bottom = media_width | times: data_dimensions | plus: additional_padding %}
+{% else %}
+  {% assign media_width = 65.88078 | to_f %}
+  {% assign additional_padding = data_dimensions | times: 1.8 %}
+  {% assign padding_bottom = media_width | times: data_dimensions | plus: additional_padding %}
 {% endif %}
+
+
 
 <div is="eiti-tooltip-wrapper"
      tooltip-style="subtle"
      cursor-offset="10"
      class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
-  style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
+  style="line-height: {{ padding_bottom }}%; padding-bottom: {{ padding_bottom }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
     {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ include.state }}.svg{% endcapture %}
@@ -90,27 +102,6 @@
       <use xlink:href="{{ states_svg }}#state-{{ include.state }}"></use>
     </g>
   </svg>
-
-  {% if include.toggle %}
-    <h4 class="details-container">
-      <button is="aria-toggle"
-        aria-controls="{{ include.toggle }}"
-        aria-expanded="false">
-          <span class="hide-expanded">
-            <i class="icon icon-plus-sm"></i>
-            {% if include.toggle_text %}
-              {{ include.toggle_text_hidden }}
-            {% else %}Show table{% endif %}
-          </span>
-          <span class="show-expanded">
-            <i class="icon icon-dash-sm"></i>
-            {% if include.toggle_text %}
-              {{ include.toggle_text_visible }}
-            {% else %}Hide table{% endif %}
-          </span>
-      </button>
-    </h4>
-  {% endif %}
 </div>
 
 <div class="legend-container {{ is_wide }}">
@@ -129,7 +120,7 @@
 
   <svg class="legend-svg"></svg>
 
-  {% if include.toggle %}
+<!--   {% if include.toggle %}
     <h4 class="details-container">
       <button is="aria-toggle"
         aria-controls="{{ include.toggle }}"
@@ -148,5 +139,26 @@
           </span>
       </button>
     </h4>
-  {% endif %}
+  {% endif %} -->
 </div>
+
+{% if include.toggle %}
+  <h4 class="details-container" style="{% if padding_bottom %}padding-top: {{ padding_bottom }}%{% endif %}">
+    <button is="aria-toggle"
+      aria-controls="{{ include.toggle }}"
+      aria-expanded="false">
+        <span class="hide-expanded">
+          <i class="icon icon-plus-sm"></i>
+          {% if include.toggle_text %}
+            {{ include.toggle_text_hidden }}
+          {% else %}Show table{% endif %}
+        </span>
+        <span class="show-expanded">
+          <i class="icon icon-dash-sm"></i>
+          {% if include.toggle_text %}
+            {{ include.toggle_text_visible }}
+          {% else %}Hide table{% endif %}
+        </span>
+    </button>
+  </h4>
+{% endif %}

--- a/_includes/location/section-ownership.html
+++ b/_includes/location/section-ownership.html
@@ -12,7 +12,7 @@
   {% endif %}
 
   <aside class="map-container" style="width: 100%;">
-    <figure>
+    <figure is="ownership-map">
       <div class="svg-container county map-container wide"{% if __viewbox %}
         style="padding-bottom: {{ __viewbox | svg_viewbox_padding: _width }}%;"{% endif %}>
         <svg class="county ownership map state-page"{% if __viewbox %} viewBox="{{ __viewbox }}"{% endif %}>

--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -16,22 +16,31 @@
   {% assign _viewbox_list = _viewbox | split: ' ' | to_f %}
   {% assign breakpoint_width = _viewbox_list[2] %}
   {% assign _height = _viewbox_list[3] %}
-  {% assign breakpoint_height = _viewbox_list[3] | times:2.5 %}
+  {% assign breakpoint_height = _viewbox_list[3] | times: 2.5 %}
   {% capture is_wide %}
     {% if breakpoint_width > breakpoint_height %}wide{% endif %}
   {% endcapture %}
   {% assign is_wide = is_wide | strip %}
 {% endif %}
 
-{% if is_wide != 'wide' %}
-  {% assign _width = 65.88078 | to_f %}
+{% capture data_dimensions %}
+  {{ _height | divided_by:breakpoint_width | to_f }}
+{% endcapture %}
+
+{% if is_wide == 'wide' %}
+  {% assign media_width = 100 %}
+{% else %}
+  {% assign media_width = 65.88078 | to_f %}
 {% endif %}
+
+{% assign additional_padding = data_dimensions | times: 1.8 %}
+{% assign padding_bottom = media_width | times: data_dimensions | plus: additional_padding %}
 
 <div is="eiti-tooltip-wrapper"
      tooltip-style="subtle"
      cursor-offset="10"
      class="svg-container county map-container {{ is_wide }}"{% if _viewbox %}
-  style="{{ __width }} padding-bottom: {{ _viewbox | svg_viewbox_padding: _width }}%;"{% endif %} data-dimensions="{{ _height | divided_by:breakpoint_width }}">
+  style="padding-bottom: {{ padding_bottom }}%;"{% endif %} data-dimensions="{{ _height | divided_by: breakpoint_width }}">
   <svg class="county map"{% if _viewbox %} viewBox="{{ _viewbox }}"{% endif %}>
     {% capture states_svg %}{{ site.baseurl }}/maps/states/all.svg{% endcapture %}
     {% capture state_svg %}{{ site.baseurl }}/maps/states/{{ include.state }}.svg{% endcapture %}
@@ -133,24 +142,25 @@
 
   <svg class="legend-svg"></svg>
 
-  {% if include.toggle %}
-    <h4 class="details-container">
-      <button is="aria-toggle"
-        aria-controls="{{ include.toggle }}"
-        aria-expanded="false">
-          <span class="hide-expanded">
-            <i class="icon icon-plus-sm"></i>
-            {% if include.toggle_text %}
-              {{ include.toggle_text_hidden }}
-            {% else %}Show table{% endif %}
-          </span>
-          <span class="show-expanded">
-            <i class="icon icon-dash-sm"></i>
-            {% if include.toggle_text %}
-              {{ include.toggle_text_visible }}
-            {% else %}Hide table{% endif %}
-          </span>
-      </button>
-    </h4>
-  {% endif %}
 </div>
+
+{% if include.toggle %}
+  <h4 class="details-container">
+    <button is="aria-toggle"
+      aria-controls="{{ include.toggle }}"
+      aria-expanded="false">
+        <span class="hide-expanded">
+          <i class="icon icon-plus-sm"></i>
+          {% if include.toggle_text %}
+            {{ include.toggle_text_hidden }}
+          {% else %}Show table{% endif %}
+        </span>
+        <span class="show-expanded">
+          <i class="icon icon-dash-sm"></i>
+          {% if include.toggle_text %}
+            {{ include.toggle_text_visible }}
+          {% else %}Hide table{% endif %}
+        </span>
+    </button>
+  </h4>
+{% endif %}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -160,3 +160,7 @@ $greener-land-lightness-bump: lightness($green-land) * $opacity-state;
 $greenest-land-lightness-bump: lightness($green-land) * $opacity-federal;
 $greener-land: darken($green-land, $greener-land-lightness-bump);
 $greenest-land: darken($green-land, $greenest-land-lightness-bump);
+
+
+// SVG
+$svg-map-padding: 3.6%;

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -278,7 +278,8 @@
 
       &.wide {
         @include span-columns(12);
-        height: 130px;
+        height: 43px;
+        margin-top: $base-padding-lite;
         padding: 0;
 
         .legend-svg {

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -109,9 +109,6 @@ data-map {
   button {
     margin-top: $base-padding-lite;
   }
-  // bottom: 0;
-  // margin: 0;
-  // position: absolute;
 }
 
 eiti-data-map {

--- a/_sass/components/_data-map.scss
+++ b/_sass/components/_data-map.scss
@@ -103,9 +103,15 @@ data-map {
 
 // map legend
 .details-container {
-  bottom: 0;
+  display: block;
   margin: 0;
-  position: absolute;
+
+  button {
+    margin-top: $base-padding-lite;
+  }
+  // bottom: 0;
+  // margin: 0;
+  // position: absolute;
 }
 
 eiti-data-map {
@@ -149,7 +155,7 @@ eiti-data-map {
 
 .legend-svg {
   border: none;
-  height: auto;
+  height: 116px;
   padding: 0;
   width: 100%;
 

--- a/_sass/elements/_svg.scss
+++ b/_sass/elements/_svg.scss
@@ -16,6 +16,7 @@
 
   svg {
     left: 0;
+    padding: $svg-map-padding;
     position: absolute;
     top: 0;
   }

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -115,7 +115,7 @@
       maps.each(function () {
         this.cropMap();
       });
-    }
+    };
 
     chartRows.on('click.countyTable', toggleMap);
     chartRows.on('mouseover.countyTable', mouseMap);

--- a/js/components/eiti-data-map-table.js
+++ b/js/components/eiti-data-map-table.js
@@ -111,6 +111,12 @@
       });
     };
 
+    var cropMaps = function () {
+      maps.each(function () {
+        this.cropMap();
+      });
+    }
+
     chartRows.on('click.countyTable', toggleMap);
     chartRows.on('mouseover.countyTable', mouseMap);
     chartRows.on('mouseout.countyTable', mouseMap);
@@ -122,6 +128,8 @@
     svg.on('mouseout.county', function(){
       clearFields();
     });
+
+     d3.select(window).on('resize.crop', cropMaps);
   };
 
   var detached = function() {

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -6,6 +6,12 @@
   var WITHHELD_FLAG = 'Withheld';
   var NO_DATA_FLAG = undefined; // jshint ignore:line
 
+  function pixelize(d) {
+    return String(d).match(/px/)
+      ? d
+      : d + 'px';
+  }
+
   exports.EITIDataMap = document.registerElement('eiti-data-map', {
     prototype: Object.create(
       HTMLElement.prototype,
@@ -29,6 +35,7 @@
             this.isWideView = true;
           }
           this.update('init');
+          this.cropMap()
         }},
 
         setYear: {value: function(year) {
@@ -52,6 +59,24 @@
             .text(year);
 
           this.update();
+        }},
+
+        cropMap: {value: function() {
+          var root = d3.select(this);
+
+          var svgMap = root.select('svg.county.map');
+          var svgContainer = root.select('.svg-container');
+
+          if (!svgMap.empty() && !svgContainer.empty()) {
+            console.log('>>', svgContainer.style('padding-bottom'))
+            svgContainer.style('padding-bottom', function() {
+              console.log(svgMap.node().getBoundingClientRect().height)
+
+              return pixelize(svgMap.node().getBoundingClientRect().height);
+            });
+          } else {
+          console.warn('cannot resize svg county map because it doesn\'t exist')
+          }
         }},
 
         detectWidth: {value: function() {
@@ -281,21 +306,46 @@
           // end horizontal legend shift
 
           // start trim height on map container
-          var svgContainer = d3.select(this)
-            .selectAll('.svg-container[data-dimensions]')
-            .datum(function() {
-              var multiplier = this.classList.contains('wide')
-                ? 100 + 9
-                : 65.88078 + 10;
+          // var svgContainer = d3.select(this)
+          //   .selectAll('.svg-container[data-dimensions]')
+          //   .datum(function() {
+          //     var multiplier = this.classList.contains('wide')
+          //       ? 100
+          //       : 65.88078;
 
-              return +this.getAttribute('data-dimensions') * multiplier;
-            });
+          //     return (+this.getAttribute('data-dimensions') * multiplier) + 1.8;
+          //   });
 
-          function percentage(d) {
-            return d + '%';
-          }
+          // function percentage(d) {
+          //   return d + '%';
+          // }
 
-          svgContainer.style('padding-bottom', percentage);
+          // function pixelize(d) {
+          //   return String(d).match(/px/)
+          //     ? d
+          //     : d + 'px';
+          // }
+
+          // var cropMaps = function () {
+          //   var svgMap = root.select('svg.county.map');
+          //   var svgContainer = root.select('.svg-container');
+
+          //   if (!svgMap.empty() && !svgContainer.empty()) {
+          //     console.log('>>', svgContainer.style('padding-bottom'))
+          //     svgContainer.style('padding-bottom', function() {
+          //       console.log(svgMap.node().getBoundingClientRect().height)
+
+          //       return pixelize(svgMap.node().getBoundingClientRect().height);
+          //     });
+          //   } else {
+          //   console.warn('cannot resize svg county map because it doesn\'t exist')
+          //   }
+          // }
+          // // svgContainer.style('padding-bottom', percentage);
+
+
+
+          // d3.select(window).on('resize.crops', cropMaps);
           // end trim
           if (init) {
             this.setYear('2015');

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -72,7 +72,7 @@
               return pixelize(svgMap.node().getBoundingClientRect().height);
             });
           } else {
-            console.warn('cannot resize svg county map because it doesn\'t exist');
+            console.warn('cannot resize svg map because it doesn\'t exist');
           }
         }},
 

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -305,48 +305,7 @@
           }
           // end horizontal legend shift
 
-          // start trim height on map container
-          // var svgContainer = d3.select(this)
-          //   .selectAll('.svg-container[data-dimensions]')
-          //   .datum(function() {
-          //     var multiplier = this.classList.contains('wide')
-          //       ? 100
-          //       : 65.88078;
 
-          //     return (+this.getAttribute('data-dimensions') * multiplier) + 1.8;
-          //   });
-
-          // function percentage(d) {
-          //   return d + '%';
-          // }
-
-          // function pixelize(d) {
-          //   return String(d).match(/px/)
-          //     ? d
-          //     : d + 'px';
-          // }
-
-          // var cropMaps = function () {
-          //   var svgMap = root.select('svg.county.map');
-          //   var svgContainer = root.select('.svg-container');
-
-          //   if (!svgMap.empty() && !svgContainer.empty()) {
-          //     console.log('>>', svgContainer.style('padding-bottom'))
-          //     svgContainer.style('padding-bottom', function() {
-          //       console.log(svgMap.node().getBoundingClientRect().height)
-
-          //       return pixelize(svgMap.node().getBoundingClientRect().height);
-          //     });
-          //   } else {
-          //   console.warn('cannot resize svg county map because it doesn\'t exist')
-          //   }
-          // }
-          // // svgContainer.style('padding-bottom', percentage);
-
-
-
-          // d3.select(window).on('resize.crops', cropMaps);
-          // end trim
           if (init) {
             this.setYear('2015');
           }

--- a/js/components/eiti-data-map.js
+++ b/js/components/eiti-data-map.js
@@ -35,7 +35,7 @@
             this.isWideView = true;
           }
           this.update('init');
-          this.cropMap()
+          this.cropMap();
         }},
 
         setYear: {value: function(year) {
@@ -68,14 +68,11 @@
           var svgContainer = root.select('.svg-container');
 
           if (!svgMap.empty() && !svgContainer.empty()) {
-            console.log('>>', svgContainer.style('padding-bottom'))
             svgContainer.style('padding-bottom', function() {
-              console.log(svgMap.node().getBoundingClientRect().height)
-
               return pixelize(svgMap.node().getBoundingClientRect().height);
             });
           } else {
-          console.warn('cannot resize svg county map because it doesn\'t exist')
+            console.warn('cannot resize svg county map because it doesn\'t exist');
           }
         }},
 

--- a/js/components/mobile-nav.js
+++ b/js/components/mobile-nav.js
@@ -1,7 +1,9 @@
 (function() {
 
   var pixelize = function(value) {
-    return value + 'px';
+    return String(value).match(/px/)
+      ? value
+      : value + 'px';
   };
 
   var attached = function() {

--- a/js/components/ownership-map.js
+++ b/js/components/ownership-map.js
@@ -1,0 +1,50 @@
+(function() {
+
+  var pixelize = function(value) {
+    return String(value).match(/px/)
+      ? value
+      : value + 'px';
+  };
+
+  var attached = function() {
+    var root = d3.select(this);
+
+    var cropMap = function() {
+      var svgMap = root.select('svg.ownership.map');
+      var svgContainer = root.select('.svg-container');
+
+      if (!svgMap.empty() && !svgContainer.empty()) {
+        console.log('<<', svgContainer.style('padding-bottom'))
+        svgContainer.style('padding-bottom', function() {
+          console.log(svgMap.node().getBoundingClientRect().height)
+
+          return pixelize(svgMap.node().getBoundingClientRect().height);
+        });
+      } else {
+      console.warn('cannot resize svg county map because it doesn\'t exist')
+      }
+    }
+
+    cropMap();
+
+    console.log('attached')
+
+
+    // d3.select(window).on('resize.cropOwnership', cropMap);
+  };
+
+  var detached = function() {
+  };
+
+  document.registerElement('ownership-map', {
+    'extends': 'figure',
+    prototype: Object.create(
+      HTMLElement.prototype,
+      {
+        attachedCallback: {value: attached},
+        detachedCallback: {value: detached}
+      }
+    )
+  });
+
+})();

--- a/js/components/ownership-map.js
+++ b/js/components/ownership-map.js
@@ -18,9 +18,9 @@
           return pixelize(svgMap.node().getBoundingClientRect().height);
         });
       } else {
-        console.warn('cannot resize svg county map because it doesn\'t exist');
+        console.warn('cannot resize svg map because it doesn\'t exist');
       }
-    }
+    };
 
     cropMap();
 

--- a/js/components/ownership-map.js
+++ b/js/components/ownership-map.js
@@ -14,23 +14,17 @@
       var svgContainer = root.select('.svg-container');
 
       if (!svgMap.empty() && !svgContainer.empty()) {
-        console.log('<<', svgContainer.style('padding-bottom'))
         svgContainer.style('padding-bottom', function() {
-          console.log(svgMap.node().getBoundingClientRect().height)
-
           return pixelize(svgMap.node().getBoundingClientRect().height);
         });
       } else {
-      console.warn('cannot resize svg county map because it doesn\'t exist')
+        console.warn('cannot resize svg county map because it doesn\'t exist');
       }
     }
 
     cropMap();
 
-    console.log('attached')
-
-
-    // d3.select(window).on('resize.cropOwnership', cropMap);
+    d3.select(window).on('resize.cropOwnership', cropMap);
   };
 
   var detached = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11652,7 +11652,7 @@
 	            this.isWideView = true;
 	          }
 	          this.update('init');
-	          this.cropMap()
+	          this.cropMap();
 	        }},
 
 	        setYear: {value: function(year) {
@@ -11685,14 +11685,11 @@
 	          var svgContainer = root.select('.svg-container');
 
 	          if (!svgMap.empty() && !svgContainer.empty()) {
-	            console.log('>>', svgContainer.style('padding-bottom'))
 	            svgContainer.style('padding-bottom', function() {
-	              console.log(svgMap.node().getBoundingClientRect().height)
-
 	              return pixelize(svgMap.node().getBoundingClientRect().height);
 	            });
 	          } else {
-	          console.warn('cannot resize svg county map because it doesn\'t exist')
+	            console.warn('cannot resize svg county map because it doesn\'t exist');
 	          }
 	        }},
 
@@ -14041,23 +14038,17 @@
 	      var svgContainer = root.select('.svg-container');
 
 	      if (!svgMap.empty() && !svgContainer.empty()) {
-	        console.log('<<', svgContainer.style('padding-bottom'))
 	        svgContainer.style('padding-bottom', function() {
-	          console.log(svgMap.node().getBoundingClientRect().height)
-
 	          return pixelize(svgMap.node().getBoundingClientRect().height);
 	        });
 	      } else {
-	      console.warn('cannot resize svg county map because it doesn\'t exist')
+	        console.warn('cannot resize svg county map because it doesn\'t exist');
 	      }
 	    }
 
 	    cropMap();
 
-	    console.log('attached')
-
-
-	    // d3.select(window).on('resize.cropOwnership', cropMap);
+	    d3.select(window).on('resize.cropOwnership', cropMap);
 	  };
 
 	  var detached = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11922,48 +11922,7 @@
 	          }
 	          // end horizontal legend shift
 
-	          // start trim height on map container
-	          // var svgContainer = d3.select(this)
-	          //   .selectAll('.svg-container[data-dimensions]')
-	          //   .datum(function() {
-	          //     var multiplier = this.classList.contains('wide')
-	          //       ? 100
-	          //       : 65.88078;
 
-	          //     return (+this.getAttribute('data-dimensions') * multiplier) + 1.8;
-	          //   });
-
-	          // function percentage(d) {
-	          //   return d + '%';
-	          // }
-
-	          // function pixelize(d) {
-	          //   return String(d).match(/px/)
-	          //     ? d
-	          //     : d + 'px';
-	          // }
-
-	          // var cropMaps = function () {
-	          //   var svgMap = root.select('svg.county.map');
-	          //   var svgContainer = root.select('.svg-container');
-
-	          //   if (!svgMap.empty() && !svgContainer.empty()) {
-	          //     console.log('>>', svgContainer.style('padding-bottom'))
-	          //     svgContainer.style('padding-bottom', function() {
-	          //       console.log(svgMap.node().getBoundingClientRect().height)
-
-	          //       return pixelize(svgMap.node().getBoundingClientRect().height);
-	          //     });
-	          //   } else {
-	          //   console.warn('cannot resize svg county map because it doesn\'t exist')
-	          //   }
-	          // }
-	          // // svgContainer.style('padding-bottom', percentage);
-
-
-
-	          // d3.select(window).on('resize.crops', cropMaps);
-	          // end trim
 	          if (init) {
 	            this.setYear('2015');
 	          }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11689,7 +11689,7 @@
 	              return pixelize(svgMap.node().getBoundingClientRect().height);
 	            });
 	          } else {
-	            console.warn('cannot resize svg county map because it doesn\'t exist');
+	            console.warn('cannot resize svg map because it doesn\'t exist');
 	          }
 	        }},
 
@@ -13883,7 +13883,7 @@
 	      maps.each(function () {
 	        this.cropMap();
 	      });
-	    }
+	    };
 
 	    chartRows.on('click.countyTable', toggleMap);
 	    chartRows.on('mouseover.countyTable', mouseMap);
@@ -14042,9 +14042,9 @@
 	          return pixelize(svgMap.node().getBoundingClientRect().height);
 	        });
 	      } else {
-	        console.warn('cannot resize svg county map because it doesn\'t exist');
+	        console.warn('cannot resize svg map because it doesn\'t exist');
 	      }
-	    }
+	    };
 
 	    cropMap();
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11622,6 +11622,12 @@
 	  var WITHHELD_FLAG = 'Withheld';
 	  var NO_DATA_FLAG = undefined; // jshint ignore:line
 
+	  function pixelize(d) {
+	    return String(d).match(/px/)
+	      ? d
+	      : d + 'px';
+	  }
+
 	  exports.EITIDataMap = document.registerElement('eiti-data-map', {
 	    prototype: Object.create(
 	      HTMLElement.prototype,
@@ -11645,6 +11651,7 @@
 	            this.isWideView = true;
 	          }
 	          this.update('init');
+	          this.cropMap()
 	        }},
 
 	        setYear: {value: function(year) {
@@ -11668,6 +11675,24 @@
 	            .text(year);
 
 	          this.update();
+	        }},
+
+	        cropMap: {value: function() {
+	          var root = d3.select(this);
+
+	          var svgMap = root.select('svg.county.map');
+	          var svgContainer = root.select('.svg-container');
+
+	          if (!svgMap.empty() && !svgContainer.empty()) {
+	            console.log('>>', svgContainer.style('padding-bottom'))
+	            svgContainer.style('padding-bottom', function() {
+	              console.log(svgMap.node().getBoundingClientRect().height)
+
+	              return pixelize(svgMap.node().getBoundingClientRect().height);
+	            });
+	          } else {
+	          console.warn('cannot resize svg county map because it doesn\'t exist')
+	          }
 	        }},
 
 	        detectWidth: {value: function() {
@@ -11897,21 +11922,46 @@
 	          // end horizontal legend shift
 
 	          // start trim height on map container
-	          var svgContainer = d3.select(this)
-	            .selectAll('.svg-container[data-dimensions]')
-	            .datum(function() {
-	              var multiplier = this.classList.contains('wide')
-	                ? 100 + 9
-	                : 65.88078 + 10;
+	          // var svgContainer = d3.select(this)
+	          //   .selectAll('.svg-container[data-dimensions]')
+	          //   .datum(function() {
+	          //     var multiplier = this.classList.contains('wide')
+	          //       ? 100
+	          //       : 65.88078;
 
-	              return +this.getAttribute('data-dimensions') * multiplier;
-	            });
+	          //     return (+this.getAttribute('data-dimensions') * multiplier) + 1.8;
+	          //   });
 
-	          function percentage(d) {
-	            return d + '%';
-	          }
+	          // function percentage(d) {
+	          //   return d + '%';
+	          // }
 
-	          svgContainer.style('padding-bottom', percentage);
+	          // function pixelize(d) {
+	          //   return String(d).match(/px/)
+	          //     ? d
+	          //     : d + 'px';
+	          // }
+
+	          // var cropMaps = function () {
+	          //   var svgMap = root.select('svg.county.map');
+	          //   var svgContainer = root.select('.svg-container');
+
+	          //   if (!svgMap.empty() && !svgContainer.empty()) {
+	          //     console.log('>>', svgContainer.style('padding-bottom'))
+	          //     svgContainer.style('padding-bottom', function() {
+	          //       console.log(svgMap.node().getBoundingClientRect().height)
+
+	          //       return pixelize(svgMap.node().getBoundingClientRect().height);
+	          //     });
+	          //   } else {
+	          //   console.warn('cannot resize svg county map because it doesn\'t exist')
+	          //   }
+	          // }
+	          // // svgContainer.style('padding-bottom', percentage);
+
+
+
+	          // d3.select(window).on('resize.crops', cropMaps);
 	          // end trim
 	          if (init) {
 	            this.setYear('2015');
@@ -13872,6 +13922,12 @@
 	      });
 	    };
 
+	    var cropMaps = function () {
+	      maps.each(function () {
+	        this.cropMap();
+	      });
+	    }
+
 	    chartRows.on('click.countyTable', toggleMap);
 	    chartRows.on('mouseover.countyTable', mouseMap);
 	    chartRows.on('mouseout.countyTable', mouseMap);
@@ -13883,6 +13939,8 @@
 	    svg.on('mouseout.county', function(){
 	      clearFields();
 	    });
+
+	     d3.select(window).on('resize.crop', cropMaps);
 	  };
 
 	  var detached = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -55,6 +55,7 @@
 	  __webpack_require__(41);
 	  __webpack_require__(42);
 	  __webpack_require__(8);
+	  __webpack_require__(44);
 
 	  __webpack_require__(7);
 
@@ -13977,7 +13978,9 @@
 	(function() {
 
 	  var pixelize = function(value) {
-	    return value + 'px';
+	    return String(value).match(/px/)
+	      ? value
+	      : value + 'px';
 	  };
 
 	  var attached = function() {
@@ -14047,6 +14050,62 @@
 
 	  document.registerElement('mobile-nav', {
 	    'extends': 'div',
+	    prototype: Object.create(
+	      HTMLElement.prototype,
+	      {
+	        attachedCallback: {value: attached},
+	        detachedCallback: {value: detached}
+	      }
+	    )
+	  });
+
+	})();
+
+
+/***/ },
+/* 44 */
+/***/ function(module, exports) {
+
+	(function() {
+
+	  var pixelize = function(value) {
+	    return String(value).match(/px/)
+	      ? value
+	      : value + 'px';
+	  };
+
+	  var attached = function() {
+	    var root = d3.select(this);
+
+	    var cropMap = function() {
+	      var svgMap = root.select('svg.ownership.map');
+	      var svgContainer = root.select('.svg-container');
+
+	      if (!svgMap.empty() && !svgContainer.empty()) {
+	        console.log('<<', svgContainer.style('padding-bottom'))
+	        svgContainer.style('padding-bottom', function() {
+	          console.log(svgMap.node().getBoundingClientRect().height)
+
+	          return pixelize(svgMap.node().getBoundingClientRect().height);
+	        });
+	      } else {
+	      console.warn('cannot resize svg county map because it doesn\'t exist')
+	      }
+	    }
+
+	    cropMap();
+
+	    console.log('attached')
+
+
+	    // d3.select(window).on('resize.cropOwnership', cropMap);
+	  };
+
+	  var detached = function() {
+	  };
+
+	  document.registerElement('ownership-map', {
+	    'extends': 'figure',
 	    prototype: Object.create(
 	      HTMLElement.prototype,
 	      {

--- a/js/src/state-pages.js
+++ b/js/src/state-pages.js
@@ -9,6 +9,7 @@
   require('../components/year-switcher-section.js');
   require('../components/eiti-data-map-table.js');
   require('../components/eiti-tooltip-wrapper.js');
+  require('../components/ownership-map.js');
 
   require('../components/aria-tabs.js');
 


### PR DESCRIPTION
Fixes issue(s) #1702, #2072 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/crop-maps.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/crop-maps)

[:sunglasses: PREVIEW explore UT](https://federalist.18f.gov/preview/18F/doi-extractives-data/crop-maps/explore/UT/)
[:sunglasses: PREVIEW explore gulf](https://federalist.18f.gov/preview/18F/doi-extractives-data/crop-maps/explore/offshore-gulf)

Changes proposed in this pull request:
- updates jekyll logic rendering `padding-bottom` hack
- adds JS that makes cropping perfect. resizes
- _less than ideal_ because it uses JS, but what was added is pretty lightweight, so hopefully not a huge issue.

/cc @ericronne @meiqimichelle 
