### PR TITLE
Fix offshore links from state pages

### DIFF
--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -38,7 +38,7 @@
     <!-- Includes link to relevant offshore region, if there is one -->
     {% if page.nearby_offshore_region %}
     <p>
-      {{ state_name }} also borders an offshore area with significant natural resource extraction, which may contribute to the state’s economy. For production and revenue data about offshore extraction near {{ state_name }}, see {{ page.nearby_offshore_region }}.
+      {{ state_name }} also borders an offshore area with significant natural resource extraction, which may contribute to the state’s economy. For production and revenue data about offshore extraction near {{ state_name }}, see {{ page.nearby_offshore_region | liquify }}.
     </p>
     {% endif %}
 

--- a/_states/AK.md
+++ b/_states/AK.md
@@ -18,7 +18,7 @@ state_revenue_year: 2015
 
 locality_name: 'Borough or census area'
 
-nearby_offshore_region: '<a href="{{ site.baseurl }}/offshore-alaska/">offshore Alaska</a>'
+nearby_offshore_region: '<a href="{{ site.baseurl }}/explore/offshore-alaska/">offshore Alaska</a>'
 
 case_study_link: |
     For a detailed view of how oil extraction affects communities in Alaska, read the [North Slope Borough case study]({{ site.baseurl }}/case-studies/north-slope/).

--- a/_states/AL.md
+++ b/_states/AL.md
@@ -7,5 +7,5 @@ FIPS: '01'
 # a custom set of viewbox coordinates
 is_cropped: true
 
-nearby_offshore_region: 'the <a href="../offshore-gulf/">Gulf of Mexico</a>'
+nearby_offshore_region: 'the <a href="{{ site.baseurl }}/explore/offshore-gulf/">Gulf of Mexico</a>'
 ---

--- a/_states/CA.md
+++ b/_states/CA.md
@@ -5,7 +5,7 @@ FIPS: '06'
 
 priority: true
 
-nearby_offshore_region: 'the <a href="{{ site.baseurl }}/offshore-pacific/">Pacific Ocean</a>'
+nearby_offshore_region: 'the <a href="{{ site.baseurl }}/explore/offshore-pacific/">Pacific Ocean</a>'
 
 case_study_link: |
     For a detailed view of how oil extraction affects communities in southern California, read the [Kern County case study]({{ site.baseurl }}/case-studies/kern/).

--- a/_states/FL.md
+++ b/_states/FL.md
@@ -3,5 +3,5 @@ id: FL
 title: Florida
 FIPS: '12'
 
-nearby_offshore_region: 'the <a href="{{ site.baseurl }}/offshore-gulf/">Gulf of Mexico</a>'
+nearby_offshore_region: 'the <a href="{{ site.baseurl }}/explore/offshore-gulf/">Gulf of Mexico</a>'
 ---

--- a/_states/LA.md
+++ b/_states/LA.md
@@ -11,7 +11,7 @@ priority: true
 
 locality_name: 'Parish'
 
-nearby_offshore_region: 'the <a href="{{ site.baseurl }}/offshore-gulf/">Gulf of Mexico</a>'
+nearby_offshore_region: 'the <a href="{{ site.baseurl }}/explore/offshore-gulf/">Gulf of Mexico</a>'
 
 case_study_link: |
     For a detailed view of how natural gas production affects communities in Louisiana, read the [DeSoto Parish case study]({{ site.baseurl }}/case-studies/desoto/).

--- a/_states/MS.md
+++ b/_states/MS.md
@@ -7,6 +7,6 @@ FIPS: '28'
 # a custom set of viewbox coordinates
 is_cropped: true
 
-nearby_offshore_region: 'the <a href="{{ site.baseurl }}/offshore-gulf/">Gulf of Mexico</a>'
+nearby_offshore_region: 'the <a href="{{ site.baseurl }}/explore/offshore-gulf/">Gulf of Mexico</a>'
 
 ---

--- a/_states/TX.md
+++ b/_states/TX.md
@@ -16,7 +16,7 @@ neighbors:
 
 priority: true
 
-nearby_offshore_region: 'the <a href="{{ site.baseurl }}/offshore-gulf/">Gulf of Mexico</a>'
+nearby_offshore_region: 'the <a href="{{ site.baseurl }}/explore/offshore-gulf/">Gulf of Mexico</a>'
 
 case_study_link: |
     For a detailed view of how natural gas extraction affects communities in Texas, read the [case study on Tarrant and Johnson Counties]({{ site.baseurl }}/case-studies/tarrant-and-johnson/).


### PR DESCRIPTION
Fixes issue(s) #2112 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/offshore-link-fix.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/offshore-link-fix)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/offshore-link-fix/)

Changes proposed in this pull request:

- Liquifies the chunk of markdown that links state pages to nearby offshore regions
- Fixes the links on all the state pages that link to offshore regions

/cc anybody!

