### PR TITLE
Address Chrome lag issues

### DIFF
--- a/_how-it-works/aml-fees.md
+++ b/_how-it-works/aml-fees.md
@@ -60,7 +60,7 @@ For more information:
 
 <img src="{{ site.baseurl }}/img/AML_disbursements.svg" alt="Chart shows the amount of total funds in the AML reclamation program in 2016, 10.7 billion. 8.2 billion of that total has been disbursed. 2.5 billion of that total has not been disbursed." class="article_img-100 u-margin-top u-margin-bottom">
 
-The AML database ([e-AMLIS](https://amlis.osmre.gov/Default.aspx)) only accounts for construction costs. It doesn't include other work on which a state or tribe may spend AML funds that are necessary for the reclamation of a site, such as the costs of identification, site assessments, and contracting, nor does it include other types of spending, such as set-asides and emergency projects ([30 U.S. Code § 1231 describes other types of spending](https://www.law.cornell.edu/uscode/text/30/1231)). 
+The AML database ([e-AMLIS](https://amlis.osmre.gov/Default.aspx)) only accounts for construction costs. It doesn't include other work on which a state or tribe may spend AML funds that are necessary for the reclamation of a site, such as the costs of identification, site assessments, and contracting, nor does it include other types of spending, such as set-asides and emergency projects ([30 U.S. Code § 1231 describes other types of spending](https://www.law.cornell.edu/uscode/text/30/1231)).
 
 ## AML revenue and disbursements
 

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -117,13 +117,20 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.1 | https://github.com/wilddeer/stickyfill
+	 * v. 1.1.9 | https://github.com/wilddeer/stickyfill
 	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
 	 *
 	 * MIT License
 	 */
+	/*!
+	* Stickyfill -- `position: sticky` polyfill
+	* v. 1.1.4 | https://github.com/wilddeer/stickyfill
+	* Copyright Oleg Korsunsky | http://wd.dizaina.net/
+	*
+	* MIT License
+	*/
 
-	module.exports = (function(doc, win) {
+	 module.exports = (function(doc, win) {
 	    if (!doc) {
 	        doc = document;
 	    }
@@ -131,7 +138,7 @@
 	    if (!win) {
 	        win = window;
 	    }
-	    
+
 	    var watchArray = [],
 	        scroll,
 	        initialized = false,
@@ -176,7 +183,7 @@
 	    }
 
 	    function mergeObjects(targetObj, sourceObject) {
-	        for (key in sourceObject) {
+	        for (var key in sourceObject) {
 	            if (sourceObject.hasOwnProperty(key)) {
 	                targetObj[key] = sourceObject[key];
 	            }
@@ -200,7 +207,7 @@
 	            rebuild();
 	            return;
 	        }
-	        
+
 	        if (win.pageYOffset != scroll.top) {
 	            updateScrollPos();
 	            recalcAllPos();
@@ -247,7 +254,7 @@
 	    }
 
 	    function initElement(el) {
-	        if (isNaN(parseFloat(el.computed.top)) || el.isCell) return;
+	        if (isNaN(parseFloat(el.computed.top)) || el.isCell || el.computed.display == 'none') return;
 
 	        el.inited = true;
 
@@ -373,7 +380,8 @@
 	                marginBottom: computedStyle.marginBottom,
 	                marginLeft: computedStyle.marginLeft,
 	                marginRight: computedStyle.marginRight,
-	                cssFloat: computedStyle.cssFloat
+	                cssFloat: computedStyle.cssFloat,
+	                display: computedStyle.display
 	            },
 	            numeric = {
 	                top: parseNumeric(computedStyle.top),
@@ -399,7 +407,7 @@
 	            },
 	            nodeOffset = getElementOffset(node),
 	            parentOffset = getElementOffset(parentNode),
-	            
+
 	            parent = {
 	                node: parentNode,
 	                css: {
@@ -496,8 +504,8 @@
 	        updateScrollPos();
 	        initAll();
 
-	        win.addEventListener('scroll', onScroll);
-	        win.addEventListener('wheel', onWheel);
+	        win.addEventListener('scroll', onScroll, { passive: true });
+	        win.addEventListener('wheel', onWheel, { passive: true });
 
 	        //watch for width changes
 	        win.addEventListener('resize', rebuild);
@@ -515,11 +523,11 @@
 	        if (!initialized) return;
 
 	        deinitAll();
-	        
+
 	        for (var i = watchArray.length - 1; i >= 0; i--) {
 	            watchArray[i] = getElementParams(watchArray[i].node);
 	        }
-	        
+
 	        initAll();
 	    }
 
@@ -537,7 +545,7 @@
 
 	    function stop() {
 	        pause();
-	        deinitAll(); 
+	        deinitAll();
 	    }
 
 	    function kill() {
@@ -588,7 +596,8 @@
 	        stop: stop,
 	        kill: kill
 	    };
-	})
+	});
+
 
 /***/ },
 /* 5 */

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -121,13 +121,20 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.1 | https://github.com/wilddeer/stickyfill
+	 * v. 1.1.9 | https://github.com/wilddeer/stickyfill
 	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
 	 *
 	 * MIT License
 	 */
+	/*!
+	* Stickyfill -- `position: sticky` polyfill
+	* v. 1.1.4 | https://github.com/wilddeer/stickyfill
+	* Copyright Oleg Korsunsky | http://wd.dizaina.net/
+	*
+	* MIT License
+	*/
 
-	module.exports = (function(doc, win) {
+	 module.exports = (function(doc, win) {
 	    if (!doc) {
 	        doc = document;
 	    }
@@ -135,7 +142,7 @@
 	    if (!win) {
 	        win = window;
 	    }
-	    
+
 	    var watchArray = [],
 	        scroll,
 	        initialized = false,
@@ -180,7 +187,7 @@
 	    }
 
 	    function mergeObjects(targetObj, sourceObject) {
-	        for (key in sourceObject) {
+	        for (var key in sourceObject) {
 	            if (sourceObject.hasOwnProperty(key)) {
 	                targetObj[key] = sourceObject[key];
 	            }
@@ -204,7 +211,7 @@
 	            rebuild();
 	            return;
 	        }
-	        
+
 	        if (win.pageYOffset != scroll.top) {
 	            updateScrollPos();
 	            recalcAllPos();
@@ -251,7 +258,7 @@
 	    }
 
 	    function initElement(el) {
-	        if (isNaN(parseFloat(el.computed.top)) || el.isCell) return;
+	        if (isNaN(parseFloat(el.computed.top)) || el.isCell || el.computed.display == 'none') return;
 
 	        el.inited = true;
 
@@ -377,7 +384,8 @@
 	                marginBottom: computedStyle.marginBottom,
 	                marginLeft: computedStyle.marginLeft,
 	                marginRight: computedStyle.marginRight,
-	                cssFloat: computedStyle.cssFloat
+	                cssFloat: computedStyle.cssFloat,
+	                display: computedStyle.display
 	            },
 	            numeric = {
 	                top: parseNumeric(computedStyle.top),
@@ -403,7 +411,7 @@
 	            },
 	            nodeOffset = getElementOffset(node),
 	            parentOffset = getElementOffset(parentNode),
-	            
+
 	            parent = {
 	                node: parentNode,
 	                css: {
@@ -500,8 +508,8 @@
 	        updateScrollPos();
 	        initAll();
 
-	        win.addEventListener('scroll', onScroll);
-	        win.addEventListener('wheel', onWheel);
+	        win.addEventListener('scroll', onScroll, { passive: true });
+	        win.addEventListener('wheel', onWheel, { passive: true });
 
 	        //watch for width changes
 	        win.addEventListener('resize', rebuild);
@@ -519,11 +527,11 @@
 	        if (!initialized) return;
 
 	        deinitAll();
-	        
+
 	        for (var i = watchArray.length - 1; i >= 0; i--) {
 	            watchArray[i] = getElementParams(watchArray[i].node);
 	        }
-	        
+
 	        initAll();
 	    }
 
@@ -541,7 +549,7 @@
 
 	    function stop() {
 	        pause();
-	        deinitAll(); 
+	        deinitAll();
 	    }
 
 	    function kill() {
@@ -592,7 +600,8 @@
 	        stop: stop,
 	        kill: kill
 	    };
-	})
+	});
+
 
 /***/ },
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -134,13 +134,20 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.1 | https://github.com/wilddeer/stickyfill
+	 * v. 1.1.9 | https://github.com/wilddeer/stickyfill
 	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
 	 *
 	 * MIT License
 	 */
+	/*!
+	* Stickyfill -- `position: sticky` polyfill
+	* v. 1.1.4 | https://github.com/wilddeer/stickyfill
+	* Copyright Oleg Korsunsky | http://wd.dizaina.net/
+	*
+	* MIT License
+	*/
 
-	module.exports = (function(doc, win) {
+	 module.exports = (function(doc, win) {
 	    if (!doc) {
 	        doc = document;
 	    }
@@ -148,7 +155,7 @@
 	    if (!win) {
 	        win = window;
 	    }
-	    
+
 	    var watchArray = [],
 	        scroll,
 	        initialized = false,
@@ -193,7 +200,7 @@
 	    }
 
 	    function mergeObjects(targetObj, sourceObject) {
-	        for (key in sourceObject) {
+	        for (var key in sourceObject) {
 	            if (sourceObject.hasOwnProperty(key)) {
 	                targetObj[key] = sourceObject[key];
 	            }
@@ -217,7 +224,7 @@
 	            rebuild();
 	            return;
 	        }
-	        
+
 	        if (win.pageYOffset != scroll.top) {
 	            updateScrollPos();
 	            recalcAllPos();
@@ -264,7 +271,7 @@
 	    }
 
 	    function initElement(el) {
-	        if (isNaN(parseFloat(el.computed.top)) || el.isCell) return;
+	        if (isNaN(parseFloat(el.computed.top)) || el.isCell || el.computed.display == 'none') return;
 
 	        el.inited = true;
 
@@ -390,7 +397,8 @@
 	                marginBottom: computedStyle.marginBottom,
 	                marginLeft: computedStyle.marginLeft,
 	                marginRight: computedStyle.marginRight,
-	                cssFloat: computedStyle.cssFloat
+	                cssFloat: computedStyle.cssFloat,
+	                display: computedStyle.display
 	            },
 	            numeric = {
 	                top: parseNumeric(computedStyle.top),
@@ -416,7 +424,7 @@
 	            },
 	            nodeOffset = getElementOffset(node),
 	            parentOffset = getElementOffset(parentNode),
-	            
+
 	            parent = {
 	                node: parentNode,
 	                css: {
@@ -513,8 +521,8 @@
 	        updateScrollPos();
 	        initAll();
 
-	        win.addEventListener('scroll', onScroll);
-	        win.addEventListener('wheel', onWheel);
+	        win.addEventListener('scroll', onScroll, { passive: true });
+	        win.addEventListener('wheel', onWheel, { passive: true });
 
 	        //watch for width changes
 	        win.addEventListener('resize', rebuild);
@@ -532,11 +540,11 @@
 	        if (!initialized) return;
 
 	        deinitAll();
-	        
+
 	        for (var i = watchArray.length - 1; i >= 0; i--) {
 	            watchArray[i] = getElementParams(watchArray[i].node);
 	        }
-	        
+
 	        initAll();
 	    }
 
@@ -554,7 +562,7 @@
 
 	    function stop() {
 	        pause();
-	        deinitAll(); 
+	        deinitAll();
 	    }
 
 	    function kill() {
@@ -605,7 +613,8 @@
 	        stop: stop,
 	        kill: kill
 	    };
-	})
+	});
+
 
 /***/ },
 /* 5 */,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "list.js": "^1.1.1",
     "object-assign": "^4.1.0",
     "pty.js": "github:chjj/pty.js",
-    "stickyfill": "^1.1.1",
+    "stickyfill": "github:18f/stickyfill#master",
     "svg4everybody": "github:18f/svg4everybody#non-symbol",
     "svgeo": "^0.3.5",
     "topojson": "github:mbostock/topojson#oversize",


### PR DESCRIPTION
Fixes issue(s) #2111 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/lag-issues.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/lag-issues)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/lag-issues/explore/)

This PR addresses the lag issues that we were seeing on Chrome browsers. If you look in the console, you should no longer see a warning message telling us that the main thread was delayed and encouraging us to use passive event listeners on the `wheel` and `scroll` events.

As an extension of this, I submitted [a PR to the main stickyfill repo](https://github.com/wilddeer/stickyfill/pull/55). Usage of the stickyfill npm module will be doubly delayed as we need [webmodules/stickyfill](https://github.com/webmodules/stickyfill/blob/master/index.js), a repo that has been modified to support the module `require` method, to add any updates to wilddeer/stickyfill to the npm module `stickyfill` 

Changes proposed in this pull request:
- Updated [18F/stickyfill](https://github.com/18F/stickyfill) module to support `{ passive: true }` on event listeners.
- Updated 18F/stickyfill to support npm module `require` references.
- Require new module in EITI set of node modules

/cc @meiqimichelle 

