### PR TITLE
Add USGS links to state production overviews

### DIFF
--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -105,11 +105,20 @@ nav_items:
           location_name=state_name
           year=year
         %}
+        <!-- EIA state profile link -->
         <p>
           The U.S. Energy Information Administration (EIA) publishes a profile of <a href="http://www.eia.gov/state/?sid={{ state_ref }}">{{ state_name }}’s energy production and usage</a>.
         </p>
+        <!-- State production intro (for opt-in states) -->
         {% if page.state_production %}
           {{ page.state_production | liquify | markdownify }}
+        {% else %}
+          <!-- USGS state profile link; only auto-generated for non-opt-in states because this is included in the custom production summary for opt-in states -->
+          {% unless state_id == "DC" %}
+          <p>
+            <strong>Nonenergy minerals:</strong> The U.S. Geological Survey publishes information about nonenergy mineral extraction in the <a href="http://minerals.usgs.gov/minerals/pubs/state/{{ state_id | downcase }}.html">USGS Minerals Yearbook for {{ state_name }}</a>.
+          </p>
+          {% endunless %}
         {% endif %}
 
         {% include location/section-all-production.html %}

--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -99,16 +99,16 @@ nav_items:
 
       <section id="production">
         <h2>Production</h2>
+        <!-- EIA state profile link -->
+        <p>
+          <strong>Energy production:</strong> The U.S. Energy Information Administration publishes a profile of <a href="http://www.eia.gov/state/?sid={{ state_ref }}">energy production and usage in {{ state_name }}</a>.
+        </p>
         {%
           include location/key-all-production-summary.html
           location_id=state_id
           location_name=state_name
           year=year
         %}
-        <!-- EIA state profile link -->
-        <p>
-          The U.S. Energy Information Administration (EIA) publishes a profile of <a href="http://www.eia.gov/state/?sid={{ state_ref }}">{{ state_name }}’s energy production and usage</a>.
-        </p>
         <!-- State production intro (for opt-in states) -->
         {% if page.state_production %}
           {{ page.state_production | liquify | markdownify }}


### PR DESCRIPTION
Fixes issue(s) #2144, in response to notes from the MSG meeting about noting available USGS production data.

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/usgs-links.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/usgs-links)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/usgs-links/)

Changes proposed in this pull request:

- Add some comments to explain the auto-generated link situation in the production summary section
- Add auto-generated links to USGS Mineral Yearbooks for each state, except opt-in states (because it's included in the custom intro for those states) and DC (because there's no Yearbook for DC)

/cc @gemfarmer @meiqimichelle 

