### PR TITLE
Fix tooltip edge bug

### DIFF
--- a/js/components/eiti-tooltip-wrapper.js
+++ b/js/components/eiti-tooltip-wrapper.js
@@ -102,6 +102,8 @@
 
             if (svgWidth <= tooltipWidth + x) {
               return pixelize(event.layerX - tooltipWidth - CURSOR_OFFSET);
+            } else if (x < 0) {
+              return pixelize(event.layerX + tooltipWidth + CURSOR_OFFSET);
             } else {
               return pixelize(x);
             }
@@ -114,6 +116,8 @@
 
             if (svgHeight <= tooltipHeight + y) {
               return pixelize(event.layerY - tooltipHeight - CURSOR_OFFSET);
+            } else if (y < 0) {
+              return pixelize(event.layerY + tooltipHeight + CURSOR_OFFSET);
             } else {
               return pixelize(y);
             }

--- a/js/lib/homepage.min.js
+++ b/js/lib/homepage.min.js
@@ -303,6 +303,8 @@
 
 	            if (svgWidth <= tooltipWidth + x) {
 	              return pixelize(event.layerX - tooltipWidth - CURSOR_OFFSET);
+	            } else if (x < 0) {
+	              return pixelize(event.layerX + tooltipWidth + CURSOR_OFFSET);
 	            } else {
 	              return pixelize(x);
 	            }
@@ -315,6 +317,8 @@
 
 	            if (svgHeight <= tooltipHeight + y) {
 	              return pixelize(event.layerY - tooltipHeight - CURSOR_OFFSET);
+	            } else if (y < 0) {
+	              return pixelize(event.layerY + tooltipHeight + CURSOR_OFFSET);
 	            } else {
 	              return pixelize(y);
 	            }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -134,7 +134,7 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.9 | https://github.com/wilddeer/stickyfill
+	 * v. 1.1.10 | https://github.com/wilddeer/stickyfill
 	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
 	 *
 	 * MIT License
@@ -863,6 +863,8 @@
 
 	            if (svgWidth <= tooltipWidth + x) {
 	              return pixelize(event.layerX - tooltipWidth - CURSOR_OFFSET);
+	            } else if (x < 0) {
+	              return pixelize(event.layerX + tooltipWidth + CURSOR_OFFSET);
 	            } else {
 	              return pixelize(x);
 	            }
@@ -875,6 +877,8 @@
 
 	            if (svgHeight <= tooltipHeight + y) {
 	              return pixelize(event.layerY - tooltipHeight - CURSOR_OFFSET);
+	            } else if (y < 0) {
+	              return pixelize(event.layerY + tooltipHeight + CURSOR_OFFSET);
 	            } else {
 	              return pixelize(y);
 	            }


### PR DESCRIPTION
Fixes issue(s) #2118 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/tooltip-corners.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/tooltip-corners)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/tooltip-corners/)

Changes proposed in this pull request:
- added a tiny amount of JS to prevent tooltips from invading the left and top edges of map svg boxes

/cc @coreycaitlin 

