### PR TITLE
Restore 404 page, search pagination

### DIFF
--- a/js/components/search.js
+++ b/js/components/search.js
@@ -111,9 +111,9 @@ $( document ).ready(function() {
       var pagesText = {
         from: from + 1,
         to: from + size + 1
-      }
-      $('.loading').remove();
+      };
 
+      $('.loading').remove();
       $('.search-results-count').append( pagesText.from + '-' + pagesText.to + ' of ' + json.hits.total + ' search results');
 
       if (json.hits.total == 0){

--- a/js/components/search.js
+++ b/js/components/search.js
@@ -148,7 +148,8 @@ $( document ).ready(function() {
         );
       });
 
-      $('.search-results-container .search-results-container').append( hits.join('') );
+      $('.search-results-container .search-results-container')
+        .append( hits.join('') );
 
       var paging = {
         needsPrevLink: from > 0,

--- a/js/components/search.js
+++ b/js/components/search.js
@@ -108,8 +108,13 @@ $( document ).ready(function() {
     dataType: 'json'
   })
     .done(function(json) {
+      var pagesText = {
+        from: from + 1,
+        to: from + size + 1
+      }
       $('.loading').remove();
-      $('.search-results-count').append( json.hits.total + ' search results');
+
+      $('.search-results-count').append( pagesText.from + '-' + pagesText.to + ' of ' + json.hits.total + ' search results');
 
       if (json.hits.total == 0){
         $('.search-no-results').show();
@@ -143,7 +148,7 @@ $( document ).ready(function() {
         );
       });
 
-      $('.search-results-container').append( hits.join('') );
+      $('.search-results-container .search-results-container').append( hits.join('') );
 
       var paging = {
         needsPrevLink: from > 0,
@@ -154,8 +159,7 @@ $( document ).ready(function() {
         titleNext: 'Next page of search results'
       };
 
-      $('.search-results-container .search-results-container').append(
-        [ 'Prev', 'Next' ]
+      var links = [ 'Prev', 'Next' ]
           .filter(function(link){ return paging[ 'needs' + link + 'Link' ] })
           .map(function(link){
             return (
@@ -165,6 +169,7 @@ $( document ).ready(function() {
             )
           })
           .join(' | ')
-      );
+
+      $('.search-results-container .search-results-container').append(links);
     });
 });

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -117,7 +117,7 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.9 | https://github.com/wilddeer/stickyfill
+	 * v. 1.1.10 | https://github.com/wilddeer/stickyfill
 	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
 	 *
 	 * MIT License

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -23326,9 +23326,9 @@
 	      var pagesText = {
 	        from: from + 1,
 	        to: from + size + 1
-	      }
-	      $('.loading').remove();
+	      };
 
+	      $('.loading').remove();
 	      $('.search-results-count').append( pagesText.from + '-' + pagesText.to + ' of ' + json.hits.total + ' search results');
 
 	      if (json.hits.total == 0){

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -23363,7 +23363,8 @@
 	        );
 	      });
 
-	      $('.search-results-container .search-results-container').append( hits.join('') );
+	      $('.search-results-container .search-results-container')
+	        .append( hits.join('') );
 
 	      var paging = {
 	        needsPrevLink: from > 0,

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -23323,8 +23323,13 @@
 	    dataType: 'json'
 	  })
 	    .done(function(json) {
+	      var pagesText = {
+	        from: from + 1,
+	        to: from + size + 1
+	      }
 	      $('.loading').remove();
-	      $('.search-results-count').append( json.hits.total + ' search results');
+
+	      $('.search-results-count').append( pagesText.from + '-' + pagesText.to + ' of ' + json.hits.total + ' search results');
 
 	      if (json.hits.total == 0){
 	        $('.search-no-results').show();
@@ -23358,7 +23363,7 @@
 	        );
 	      });
 
-	      $('.search-results-container').append( hits.join('') );
+	      $('.search-results-container .search-results-container').append( hits.join('') );
 
 	      var paging = {
 	        needsPrevLink: from > 0,
@@ -23369,8 +23374,7 @@
 	        titleNext: 'Next page of search results'
 	      };
 
-	      $('.search-results-container .search-results-container').append(
-	        [ 'Prev', 'Next' ]
+	      var links = [ 'Prev', 'Next' ]
 	          .filter(function(link){ return paging[ 'needs' + link + 'Link' ] })
 	          .map(function(link){
 	            return (
@@ -23380,7 +23384,8 @@
 	            )
 	          })
 	          .join(' | ')
-	      );
+
+	      $('.search-results-container .search-results-container').append(links);
 	    });
 	});
 

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -121,7 +121,7 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.9 | https://github.com/wilddeer/stickyfill
+	 * v. 1.1.10 | https://github.com/wilddeer/stickyfill
 	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
 	 *
 	 * MIT License

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -134,7 +134,7 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.9 | https://github.com/wilddeer/stickyfill
+	 * v. 1.1.10 | https://github.com/wilddeer/stickyfill
 	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
 	 *
 	 * MIT License

--- a/pages/404.md
+++ b/pages/404.md
@@ -4,3 +4,46 @@ layout: error
 title: 404
 subtitle: Page not found
 ---
+<div id="additional-404-message" />
+
+<script>
+(function(){
+var redirectMessage = function( oldPath, newPath, pathname, remainingDelay ) {
+	return (
+		'No page found at <a href="' + oldPath.href + '">' + oldPath.pathname + '</a>.<br />' +
+		'Automatically redirecting to <a href="' + newPath + '">' + pathname + '</a> ' +
+		'in ' + remainingDelay + ' seconds.'
+	);
+};
+
+var path = document.location;
+var parentPath = path
+	.pathname
+	.replace( /\/$/, '' ) // remove trailing slash
+	.split( '/' )         // separate into path components
+	.slice( 0, -1 )       // remove the last one
+	.join( '/' );         // rejoin to the parent path
+
+var nextLocation = [
+	path.origin,          // e.g. https://useiti.doi.gov/
+	parentPath,           // parent of page path or /
+	path.search,          // ?query=terms&args=14
+	path.hash             // #someModifier
+].join( '' );
+
+// If we aren't already at a root-level page
+// then redirect to the parent after a short
+// explanatory delay
+var additionalMessage = document.getElementById( 'additional-404-message' );
+var countDown = function( seconds ) {
+	if ( 0 === seconds ) {
+		document.location.replace( nextLocation );
+	}
+
+	additionalMessage.innerHTML = redirectMessage( path, nextLocation, parentPath || '/', seconds );
+	setTimeout( countDown.bind( this, seconds - 1 ), 1000 );
+}
+
+countDown( 5 );
+})();
+</script>


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/restore-error-pages.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/restore-error-pages)

[:sunglasses: PREVIEW search pagination](https://federalist.18f.gov/preview/18F/doi-extractives-data/restore-error-pages/search-results/?q=oil&size=10)

Changes proposed in this pull request:
- restores work by @dmsnell on 404 error pages and search pagination
- **404 preview doesn't work on Federalist 😦  But it does in production** 

/cc @meiqimichelle 

