### PR TITLE
Fix anchor links in state intros

### DIFF
--- a/_data/commodity_names.yml
+++ b/_data/commodity_names.yml
@@ -1,7 +1,10 @@
 All: All commodities
+"Crude Oil": Crude oil
 CO2: Carbon dioxide
 Geothermal: Geothermal energy
 Hardrock: Hardrock minerals
+"Natural Gas": Natural gas
 NGL: Natural gas liquids
+Wind: Wind energy
 "Wood and wood-derived fuels": Wood-derived fuel
 "Conventional Hydroelectric": Hydroelectric

--- a/_includes/location/key-all-production.html
+++ b/_includes/location/key-all-production.html
@@ -7,7 +7,7 @@
   {{ include.location_name }} leads the nation in production of:
     <ul>
     {% for product in top_all_products %}
-    <li><a href="#all-production-{{ product.product | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }}% of U.S. production</li>
+    <li><a href="#all-production-{{ product.name | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }}% of U.S. production</li>
       {% if forloop.index == include.top %}{% break %}{% endif %}
     {% endfor %}
     </ul>

--- a/_includes/location/key-all-production.html
+++ b/_includes/location/key-all-production.html
@@ -7,7 +7,7 @@
   {{ include.location_name }} leads the nation in production of:
     <ul>
     {% for product in top_all_products %}
-    <li><a href="#all-production-{{ product.name | slugify }}">{{ product.name | lookup: commodity_names }}</a>: {{ product.percent | floor }}% of U.S. production</li>
+    <li>{{ product.name | lookup: commodity_names }}: {{ product.percent | floor }}% of U.S. production</li>
       {% if forloop.index == include.top %}{% break %}{% endif %}
     {% endfor %}
     </ul>

--- a/_includes/location/key-all-production.html
+++ b/_includes/location/key-all-production.html
@@ -7,7 +7,7 @@
   {{ include.location_name }} leads the nation in production of:
     <ul>
     {% for product in top_all_products %}
-    <li><a href="#all-production-{{ product.name | slugify }}">{{ product.name }}</a>: {{ product.percent | floor }}% of U.S. production</li>
+    <li><a href="#all-production-{{ product.name | slugify }}">{{ product.name | lookup: commodity_names }}</a>: {{ product.percent | floor }}% of U.S. production</li>
       {% if forloop.index == include.top %}{% break %}{% endif %}
     {% endfor %}
     </ul>

--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -17,7 +17,7 @@
       %}
     </p>
 
-    <!-- If the state leads US production for any commodities, those commodities are listed along with percentage of US production. -->
+    <!-- If the state leads U.S. production for any commodities, those commodities are listed along with percentage of US production. -->
     <p>
       {%
         include location/key-all-production.html


### PR DESCRIPTION
Progress on issue(s) #1764 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/link-check.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/link-check)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/link-check/)

Changes proposed in this pull request:

- Pull correct commodity names into state intros
- Remove links to production commodities 

/cc @meiqimichelle 
