### PR TITLE
Add county-level no data qualifier

### DIFF
--- a/_includes/county-map.html
+++ b/_includes/county-map.html
@@ -108,8 +108,7 @@
         {{ include.caption }}
       </figcaption>
       <figcaption class="legend-no-data" aria-hidden="true">
-        There is no data for {{ state_name }} in <span data-year="{{ year }}" >{{ year }}</span>.
-        Select a new year to populate the map.
+        There is no county-level data for {{ state_name }} in <span data-year="{{ year }}" >{{ year }}</span>.
       </figcaption>
       <figcaption class="legend-withheld" aria-hidden="true">
         County-level data for <span data-year="{{ year }}" >{{ year }}</span> is withheld.


### PR DESCRIPTION
See issue(s) #2067 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/no-county-data.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/no-county-data)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/no-county-data/)

Changes proposed in this pull request:

- Add `county-level` to the no-data state for county maps, to be more precise and accurate

/cc @shawnbot @meiqimichelle 

