### PR TITLE
Adds stickfill-web-module

### DIFF
--- a/js/components/sticky.js
+++ b/js/components/sticky.js
@@ -1,7 +1,7 @@
 (function(exports) {
   'use strict';
 
-  var sticky = require('stickyfill')();
+  var sticky = require('stickyfill-web-module')();
   var stickies = [];
   var doc = d3.select(document);
   var win = d3.select(window);

--- a/js/lib/explore.min.js
+++ b/js/lib/explore.min.js
@@ -117,8 +117,8 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.10 | https://github.com/wilddeer/stickyfill
-	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
+	 * v. 1.1.11 | https://github.com/18F/stickyfill
+	 * Copyright Brian Hedberg | 
 	 *
 	 * MIT License
 	 */

--- a/js/lib/narrative.min.js
+++ b/js/lib/narrative.min.js
@@ -121,8 +121,8 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.10 | https://github.com/wilddeer/stickyfill
-	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
+	 * v. 1.1.11 | https://github.com/18F/stickyfill
+	 * Copyright Brian Hedberg | 
 	 *
 	 * MIT License
 	 */

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -134,8 +134,8 @@
 
 	/*!
 	 * Stickyfill -- `position: sticky` polyfill
-	 * v. 1.1.10 | https://github.com/wilddeer/stickyfill
-	 * Copyright Oleg Korsunsky | http://wd.dizaina.net/
+	 * v. 1.1.11 | https://github.com/18F/stickyfill
+	 * Copyright Brian Hedberg | 
 	 *
 	 * MIT License
 	 */

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "list.js": "^1.1.1",
     "object-assign": "^4.1.0",
     "pty.js": "github:chjj/pty.js",
-    "stickyfill": "github:18f/stickyfill#master",
+    "stickyfill-web-module": "^1.1.11",
     "svg4everybody": "github:18f/svg4everybody#non-symbol",
     "svgeo": "^0.3.5",
     "topojson": "github:mbostock/topojson#oversize",


### PR DESCRIPTION
Fixes issue(s) #2160 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/sticky-web-module.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/sticky-web-module)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/sticky-web-module/)

Changes proposed in this pull request:
- This does not change the functionality of the code it all. It only changes where it is required from. Instead of referencing the 18F/stickyfill repo, it looks at [stickyfill-web-module](https://www.npmjs.com/package/stickyfill-web-module)

/cc @meiqimichelle 

