### PR TITLE
Smart extent line

### DIFF
--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -87,6 +87,13 @@
   var detached = function() {
   };
 
+  var crawlCeil = function(ymax, ceilMax, i) {
+    var sigFig = '.' + i + 's';
+    var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
+    var isLessThan = sigFigCeil <= +ymax;
+    return !isLessThan ? sigFig : '';
+  };
+
   var setSigFigs = function (ymax, ceilMax) {
     var sigFigs = '';
     var SF = 0;
@@ -95,13 +102,6 @@
       sigFigs = crawlCeil(ymax, ceilMax, SF);
     }
     return sigFigs;
-  }
-
-  var crawlCeil = function(ymax, ceilMax, i) {
-    var sigFig = '.' + i + 's';
-    var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
-    var isLessThan = sigFigCeil <= +ymax;
-    return !isLessThan ? sigFig : '';
   };
 
   var update = function() {

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -89,7 +89,10 @@
 
   var crawlCeil = function(ymax, ceilMax, i) {
     var sigFig = '.' + i + 's';
-    var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
+    var sigFigCeil = +eiti.format.transform(
+      sigFig,
+      eiti.format.siValue
+    )(ceilMax);
     var isLessThan = sigFigCeil <= +ymax;
     return !isLessThan ? sigFig : '';
   };
@@ -265,7 +268,10 @@
 
       if (dataUnits.indexOf('$') > -1) {
         dataFormat = eiti.format.transform(
-          eiti.format.transform(sigFigs, eiti.format.transformMetricLong),
+          eiti.format.transform(
+            sigFigs,
+            eiti.format.transformMetricLong
+          ),
           eiti.format.transformDollars
         );
         dataUnits = null;

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -245,14 +245,31 @@
       var dataUnits = this.getAttribute('data-units');
       var dataFormat = this.getAttribute('data-format') || '';
 
+      var sigFigs = '';
+      var ceilMax = Math.ceil(+ymax * (1 + extentPercent))
+
+      function crawlMax(ymax, ceilMax, i) {
+        var sigFig = '.' + i + 's';
+        var lessThan = +eiti.format.transform(sigFig, eiti.format.transformSuffixless)(ceilMax) <= +ymax;
+        if (!lessThan) {
+          sigFigs = sigFig;
+        }
+      };
+
+      var SF = 0;
+      while (sigFigs.length < 1) {
+        SF++
+        crawlMax(ymax, ceilMax, SF);
+      }
+
       if (dataUnits.indexOf('$') > -1) {
         dataFormat = eiti.format.transform(
-          eiti.format.transform('.1s', eiti.format.transformMetricLong),
+          eiti.format.transform(sigFigs, eiti.format.transformMetricLong),
           eiti.format.transformDollars
         );
         dataUnits = null;
       } else {
-        dataFormat = eiti.format.transform('.1s', eiti.format.transformMetric);
+        dataFormat = eiti.format.transform(sigFigs, eiti.format.transformMetric);
       }
 
       var dataText = dataFormat(Math.ceil(+ymax * (1 + extentPercent)));

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -87,7 +87,22 @@
   var detached = function() {
   };
 
+  var setSigFigs = function (ymax, ceilMax) {
+    var sigFigs = '';
+    var SF = 0;
+    while (sigFigs.length < 1) {
+      SF++;
+      sigFigs = crawlCeil(ymax, ceilMax, SF);
+    }
+    return sigFigs;
+  }
 
+  var crawlCeil = function(ymax, ceilMax, i) {
+    var sigFig = '.' + i + 's';
+    var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
+    var isLessThan = sigFigCeil <= +ymax;
+    return !isLessThan ? sigFig : '';
+  };
 
   var update = function() {
     var root = d3.select(this);
@@ -245,23 +260,8 @@
       var dataUnits = this.getAttribute('data-units');
       var dataFormat = this.getAttribute('data-format') || '';
 
-      var sigFigs = '';
       var ceilMax = Math.ceil(+ymax * (1 + extentPercent));
-
-      function crawlCeil(ymax, ceilMax, i) {
-        var sigFig = '.' + i + 's';
-        var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
-        var isLessThan = sigFigCeil <= +ymax;
-        if (!isLessThan) {
-          sigFigs = sigFig;
-        }
-      };
-
-      var SF = 0;
-      while (sigFigs.length < 1) {
-        SF++;
-        crawlCeil(ymax, ceilMax, SF);
-      }
+      var sigFigs = setSigFigs(ymax, ceilMax);
 
       if (dataUnits.indexOf('$') > -1) {
         dataFormat = eiti.format.transform(
@@ -270,10 +270,13 @@
         );
         dataUnits = null;
       } else {
-        dataFormat = eiti.format.transform(sigFigs, eiti.format.transformMetric);
+        dataFormat = eiti.format.transform(
+          sigFigs,
+          eiti.format.transformMetric
+        );
       }
 
-      var dataText = dataFormat(Math.ceil(+ymax * (1 + extentPercent)));
+      var dataText = dataFormat(ceilMax);
       var extentText = [ dataText, dataUnits ].join(' ');
 
       extentLine.append('text')

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -246,20 +246,21 @@
       var dataFormat = this.getAttribute('data-format') || '';
 
       var sigFigs = '';
-      var ceilMax = Math.ceil(+ymax * (1 + extentPercent))
+      var ceilMax = Math.ceil(+ymax * (1 + extentPercent));
 
-      function crawlMax(ymax, ceilMax, i) {
+      function crawlCeil(ymax, ceilMax, i) {
         var sigFig = '.' + i + 's';
-        var lessThan = +eiti.format.transform(sigFig, eiti.format.transformSuffixless)(ceilMax) <= +ymax;
-        if (!lessThan) {
+        var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
+        var isLessThan = sigFigCeil <= +ymax;
+        if (!isLessThan) {
           sigFigs = sigFig;
         }
       };
 
       var SF = 0;
       while (sigFigs.length < 1) {
-        SF++
-        crawlMax(ymax, ceilMax, SF);
+        SF++;
+        crawlCeil(ymax, ceilMax, SF);
       }
 
       if (dataUnits.indexOf('$') > -1) {

--- a/js/eiti.js
+++ b/js/eiti.js
@@ -430,8 +430,14 @@
     };
   })();
 
-
-  eiti.format.transformSuffixless = (function() {
+  /**
+   * This is a format transform that turns a value
+   * into its si equivalent
+   *
+   * @param {String} str the formatted string
+   * @return {String} the string with a specified number of significant figures
+   */
+  eiti.format.siValue = (function() {
     var suffix = {k: 1000, M: 1000000, G: 1000000000 };
     return function(str) {
       var number;

--- a/js/eiti.js
+++ b/js/eiti.js
@@ -430,6 +430,23 @@
     };
   })();
 
+
+  eiti.format.transformSuffixless = (function() {
+    var suffix = {k: 1000, M: 1000000, G: 1000000000 };
+    return function(str) {
+      var number;
+      str = str.replace(/(\.0+)?([kMG])$/, function(_, zeroes, s) {
+        number = str.replace(s, '').toString() || str;
+        return (+number * suffix[s]);
+      }).replace(/\.0+$/, '');
+      if (number) {
+        return str.slice(number.length, str.length);
+      } else {
+        return str;
+      }
+    };
+  })();
+
   /**
    * Produces international system ("SI")/metric form.
    *

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -21955,8 +21955,14 @@
 	    };
 	  })();
 
-
-	  eiti.format.transformSuffixless = (function() {
+	  /**
+	   * This is a format transform that turns a value
+	   * into its si equivalent
+	   *
+	   * @param {String} str the formatted string
+	   * @return {String} the string with a specified number of significant figures
+	   */
+	  eiti.format.siValue = (function() {
 	    var suffix = {k: 1000, M: 1000000, G: 1000000000 };
 	    return function(str) {
 	      var number;

--- a/js/lib/main.min.js
+++ b/js/lib/main.min.js
@@ -21955,6 +21955,23 @@
 	    };
 	  })();
 
+
+	  eiti.format.transformSuffixless = (function() {
+	    var suffix = {k: 1000, M: 1000000, G: 1000000000 };
+	    return function(str) {
+	      var number;
+	      str = str.replace(/(\.0+)?([kMG])$/, function(_, zeroes, s) {
+	        number = str.replace(s, '').toString() || str;
+	        return (+number * suffix[s]);
+	      }).replace(/\.0+$/, '');
+	      if (number) {
+	        return str.slice(number.length, str.length);
+	      } else {
+	        return str;
+	      }
+	    };
+	  })();
+
 	  /**
 	   * Produces international system ("SI")/metric form.
 	   *

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11041,8 +11041,14 @@
 	    };
 	  })();
 
-
-	  eiti.format.transformSuffixless = (function() {
+	  /**
+	   * This is a format transform that turns a value
+	   * into its si equivalent
+	   *
+	   * @param {String} str the formatted string
+	   * @return {String} the string with a specified number of significant figures
+	   */
+	  eiti.format.siValue = (function() {
 	    var suffix = {k: 1000, M: 1000000, G: 1000000000 };
 	    return function(str) {
 	      var number;
@@ -13399,20 +13405,21 @@
 	      var dataFormat = this.getAttribute('data-format') || '';
 
 	      var sigFigs = '';
-	      var ceilMax = Math.ceil(+ymax * (1 + extentPercent))
+	      var ceilMax = Math.ceil(+ymax * (1 + extentPercent));
 
-	      function crawlMax(ymax, ceilMax, i) {
+	      function crawlCeil(ymax, ceilMax, i) {
 	        var sigFig = '.' + i + 's';
-	        var lessThan = +eiti.format.transform(sigFig, eiti.format.transformSuffixless)(ceilMax) <= +ymax;
-	        if (!lessThan) {
+	        var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
+	        var isLessThan = sigFigCeil <= +ymax;
+	        if (!isLessThan) {
 	          sigFigs = sigFig;
 	        }
 	      };
 
 	      var SF = 0;
 	      while (sigFigs.length < 1) {
-	        SF++
-	        crawlMax(ymax, ceilMax, SF);
+	        SF++;
+	        crawlCeil(ymax, ceilMax, SF);
 	      }
 
 	      if (dataUnits.indexOf('$') > -1) {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13246,6 +13246,13 @@
 	  var detached = function() {
 	  };
 
+	  var crawlCeil = function(ymax, ceilMax, i) {
+	    var sigFig = '.' + i + 's';
+	    var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
+	    var isLessThan = sigFigCeil <= +ymax;
+	    return !isLessThan ? sigFig : '';
+	  };
+
 	  var setSigFigs = function (ymax, ceilMax) {
 	    var sigFigs = '';
 	    var SF = 0;
@@ -13254,13 +13261,6 @@
 	      sigFigs = crawlCeil(ymax, ceilMax, SF);
 	    }
 	    return sigFigs;
-	  }
-
-	  var crawlCeil = function(ymax, ceilMax, i) {
-	    var sigFig = '.' + i + 's';
-	    var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
-	    var isLessThan = sigFigCeil <= +ymax;
-	    return !isLessThan ? sigFig : '';
 	  };
 
 	  var update = function() {

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13246,7 +13246,22 @@
 	  var detached = function() {
 	  };
 
+	  var setSigFigs = function (ymax, ceilMax) {
+	    var sigFigs = '';
+	    var SF = 0;
+	    while (sigFigs.length < 1) {
+	      SF++;
+	      sigFigs = crawlCeil(ymax, ceilMax, SF);
+	    }
+	    return sigFigs;
+	  }
 
+	  var crawlCeil = function(ymax, ceilMax, i) {
+	    var sigFig = '.' + i + 's';
+	    var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
+	    var isLessThan = sigFigCeil <= +ymax;
+	    return !isLessThan ? sigFig : '';
+	  };
 
 	  var update = function() {
 	    var root = d3.select(this);
@@ -13404,23 +13419,8 @@
 	      var dataUnits = this.getAttribute('data-units');
 	      var dataFormat = this.getAttribute('data-format') || '';
 
-	      var sigFigs = '';
 	      var ceilMax = Math.ceil(+ymax * (1 + extentPercent));
-
-	      function crawlCeil(ymax, ceilMax, i) {
-	        var sigFig = '.' + i + 's';
-	        var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
-	        var isLessThan = sigFigCeil <= +ymax;
-	        if (!isLessThan) {
-	          sigFigs = sigFig;
-	        }
-	      };
-
-	      var SF = 0;
-	      while (sigFigs.length < 1) {
-	        SF++;
-	        crawlCeil(ymax, ceilMax, SF);
-	      }
+	      var sigFigs = setSigFigs(ymax, ceilMax);
 
 	      if (dataUnits.indexOf('$') > -1) {
 	        dataFormat = eiti.format.transform(
@@ -13429,10 +13429,13 @@
 	        );
 	        dataUnits = null;
 	      } else {
-	        dataFormat = eiti.format.transform(sigFigs, eiti.format.transformMetric);
+	        dataFormat = eiti.format.transform(
+	          sigFigs,
+	          eiti.format.transformMetric
+	        );
 	      }
 
-	      var dataText = dataFormat(Math.ceil(+ymax * (1 + extentPercent)));
+	      var dataText = dataFormat(ceilMax);
 	      var extentText = [ dataText, dataUnits ].join(' ');
 
 	      extentLine.append('text')

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -11041,6 +11041,23 @@
 	    };
 	  })();
 
+
+	  eiti.format.transformSuffixless = (function() {
+	    var suffix = {k: 1000, M: 1000000, G: 1000000000 };
+	    return function(str) {
+	      var number;
+	      str = str.replace(/(\.0+)?([kMG])$/, function(_, zeroes, s) {
+	        number = str.replace(s, '').toString() || str;
+	        return (+number * suffix[s]);
+	      }).replace(/\.0+$/, '');
+	      if (number) {
+	        return str.slice(number.length, str.length);
+	      } else {
+	        return str;
+	      }
+	    };
+	  })();
+
 	  /**
 	   * Produces international system ("SI")/metric form.
 	   *
@@ -13381,14 +13398,31 @@
 	      var dataUnits = this.getAttribute('data-units');
 	      var dataFormat = this.getAttribute('data-format') || '';
 
+	      var sigFigs = '';
+	      var ceilMax = Math.ceil(+ymax * (1 + extentPercent))
+
+	      function crawlMax(ymax, ceilMax, i) {
+	        var sigFig = '.' + i + 's';
+	        var lessThan = +eiti.format.transform(sigFig, eiti.format.transformSuffixless)(ceilMax) <= +ymax;
+	        if (!lessThan) {
+	          sigFigs = sigFig;
+	        }
+	      };
+
+	      var SF = 0;
+	      while (sigFigs.length < 1) {
+	        SF++
+	        crawlMax(ymax, ceilMax, SF);
+	      }
+
 	      if (dataUnits.indexOf('$') > -1) {
 	        dataFormat = eiti.format.transform(
-	          eiti.format.transform('.1s', eiti.format.transformMetricLong),
+	          eiti.format.transform(sigFigs, eiti.format.transformMetricLong),
 	          eiti.format.transformDollars
 	        );
 	        dataUnits = null;
 	      } else {
-	        dataFormat = eiti.format.transform('.1s', eiti.format.transformMetric);
+	        dataFormat = eiti.format.transform(sigFigs, eiti.format.transformMetric);
 	      }
 
 	      var dataText = dataFormat(Math.ceil(+ymax * (1 + extentPercent)));

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13248,7 +13248,10 @@
 
 	  var crawlCeil = function(ymax, ceilMax, i) {
 	    var sigFig = '.' + i + 's';
-	    var sigFigCeil = +eiti.format.transform(sigFig, eiti.format.siValue)(ceilMax);
+	    var sigFigCeil = +eiti.format.transform(
+	      sigFig,
+	      eiti.format.siValue
+	    )(ceilMax);
 	    var isLessThan = sigFigCeil <= +ymax;
 	    return !isLessThan ? sigFig : '';
 	  };
@@ -13424,7 +13427,10 @@
 
 	      if (dataUnits.indexOf('$') > -1) {
 	        dataFormat = eiti.format.transform(
-	          eiti.format.transform(sigFigs, eiti.format.transformMetricLong),
+	          eiti.format.transform(
+	            sigFigs,
+	            eiti.format.transformMetricLong
+	          ),
 	          eiti.format.transformDollars
 	        );
 	        dataUnits = null;


### PR DESCRIPTION
Fixes issue(s) #2119 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/smart-extent-line.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/smart-extent-line)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/smart-extent-line/explore/)

Changes proposed in this pull request:
- Changes the value assigned to the extent line (dashed line above the bar charts)
- The changed value is the same value, but is the number of significant figures necessary to assure a value that is greater than the value of the highest bar. Most of the values are still 1 significant figure, though there are a few that are much higher

/cc @shawnbot @coreycaitlin 
