### PR TITLE
Hotfix for company revenue pages

### DIFF
--- a/_federal-revenue-by-company/2013.md
+++ b/_federal-revenue-by-company/2013.md
@@ -1,4 +1,4 @@
 ---
 title: Federal Revenue By Company (2013) | Explore Data
-year: 2013
+report_year: 2013
 ---

--- a/_federal-revenue-by-company/2014.md
+++ b/_federal-revenue-by-company/2014.md
@@ -1,4 +1,4 @@
 ---
 title: Federal Revenue By Company (2014) | Explore Data
-year: 2014
+report_year: 2014
 ---

--- a/_federal-revenue-by-company/2015.md
+++ b/_federal-revenue-by-company/2015.md
@@ -1,4 +1,4 @@
 ---
 title: Federal Revenue By Company (2015) | Explore Data
-year: 2015
+report_year: 2015
 ---

--- a/_layouts/federal-revenue-by-company.html
+++ b/_layouts/federal-revenue-by-company.html
@@ -6,7 +6,7 @@ permalink: /how-it-works/federal-revenue-by-company/2015/
 title_display: Federal Revenue by Company
 ---
 
-<section id="companies" data-year="{{ page.year }}" class="explore-subpage container container-margin">
+<section id="companies" data-year="{{ page.report_year }}" class="explore-subpage container container-margin">
   {% include explore-subpage-tabs.html docs=site.federal-revenue-by-company %}
 
   <section class="container-page-wrapper">
@@ -19,13 +19,13 @@ title_display: Federal Revenue by Company
 
         <h1>Federal Revenue by Company</h1>
 
-        <p>Explore revenues on federal lands and waters in {{ page.year }} by commodity, revenue type, and company.</p>
+        <p>Explore revenues on federal lands and waters in {{ page.report_year }} by commodity, revenue type, and company.</p>
 
         <p>This data comes from the Department of the Interior's Office of Natural Resources Revenue and is calendar year data.</p>
 
         <p>Choose a commodity or revenue type to filter the list of revenues. To search for a specific company, start typing the name of the company.</p>
 
-        <a href="{{site.baseurl}}/downloads/federal-revenue-by-company/">
+        <a href="{{ site.baseurl }}/downloads/federal-revenue-by-company/">
           <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
         </a>
       </div>
@@ -41,7 +41,6 @@ title_display: Federal Revenue by Company
           <div class="filters-heading">
             <h2 class="h3">Filter revenue</h2>
           </div>
-
 
           <div class="container-left-6">
             <div id="commodity-filter" class="filter">
@@ -67,7 +66,7 @@ title_display: Federal Revenue by Company
           <span href="#type-selector" class="filter-part" data-key="type">All revenue</span>
           from
           <span href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</span>
-          extraction on federal lands ({{ page.year }})
+          extraction on federal lands ({{ page.report_year }})
         </h1>
 
         <div class="container">
@@ -83,7 +82,7 @@ title_display: Federal Revenue by Company
           <span href="#type-selector" class="filter-part" data-key="type">All revenue</span>
           from
           <span href="#commodity-selector" class="filter-part" data-key="commodity">all commodities</span>
-          extraction on federal lands ({{ page.year }})
+          extraction on federal lands ({{ page.report_year }})
         </h1>
       </div>
 

--- a/js/lib/company-revenue.min.js
+++ b/js/lib/company-revenue.min.js
@@ -557,7 +557,7 @@
 	  if (!year) {
 	    throw new Error('No year found in', root.node());
 	  }
-	  var dataUrl = eiti.data.path + 'company-revenue/output/' + year + '.tsv';
+	  var dataUrl = '../../../data/company-revenue/output/' + year + '.tsv';
 
 	  var model = eiti.explore.model(dataUrl)
 	    .transform(removeRevenueTypePrefix)

--- a/js/pages/company-revenue.js
+++ b/js/pages/company-revenue.js
@@ -54,7 +54,7 @@
   if (!year) {
     throw new Error('No year found in', root.node());
   }
-  var dataUrl = eiti.data.path + 'company-revenue/output/' + year + '.tsv';
+  var dataUrl = '../../../data/company-revenue/output/' + year + '.tsv';
 
   var model = eiti.explore.model(dataUrl)
     .transform(removeRevenueTypePrefix)


### PR DESCRIPTION
Fixes #2196.

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/hotfix-company-revenue.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/hotfix-company-revenue)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/hotfix-company-revenue/federal-revenue-by-company/2015/)

Changes proposed in this pull request:
- [x] Fix template issues in the `federal-revenue-by-company` layout and `explore-subpage-tabs` include
- [x] Fix path issues in the company revenue JS

/cc @mentastc @meiqimichelle @gemfarmer 
