### PR TITLE
Megachart table cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 _site
 *.db
 node_modules
+tmp

--- a/_includes/location/revenue-type-row-oilgas.html
+++ b/_includes/location/revenue-type-row-oilgas.html
@@ -21,7 +21,7 @@
   %}
   <td rowspan="2" data-value="{{
     oilgas_bonus_total | default: 0
-  }}">
+  }}" class="table-arrow_box-value">
     <span class="text table-arrow_box-subheader-value">${{ oilgas_bonus_total | default: 0 | intcomma }}</span>
   </td>
   {% assign oilgas_rents_total = values.Rents[year] | default: 0
@@ -31,10 +31,10 @@
   %}
   <td rowspan="2" data-value="{{
     oilgas_rents_total | default: 0
-  }}">
+  }}" class="table-arrow_box-value">
     <span class="text table-arrow_box-subheader-value">${{ oilgas_rents_total | default: 0 | intcomma }}</span>
   </td>
-  <td class="{% if multiple_bars %}bars{% endif %}" data-value="{{
+  <td class="{% if multiple_bars %}bars{% endif %} table-arrow_box-value" data-value="{{
     revenue_types.Oil.Royalties[year] | default: 0
   }}">
     <span data-value="{{
@@ -72,5 +72,5 @@
     | plus: revenue_types.Gas['Other Revenues'][year]
     | plus: revenue_types.NGL['Other Revenues'][year]
   %}
-  <td rowspan="2" data-value="{{ oilgas_other_total }}"><span class="text table-arrow_box-subheader-value">${{ oilgas_other_total | intcomma }}</span></td>
+  <td rowspan="2" data-value="{{ oilgas_other_total }}" class="table-arrow_box-value"><span class="text table-arrow_box-subheader-value">${{ oilgas_other_total | intcomma }}</span></td>
 </tr>

--- a/_includes/location/revenue-type-row-oilgas.html
+++ b/_includes/location/revenue-type-row-oilgas.html
@@ -46,7 +46,7 @@
 
     {% if revenue_types.Oil.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">
-      <strong class="text-header text-header-first">Oil</strong>
+      <strong class="text-header text-header-first">Oil<br></strong>
       ${{
         revenue_types.Oil.Royalties[year]
         | default: 0
@@ -56,13 +56,13 @@
 
     {% if revenue_types.Gas.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">
-      <strong class="text-header text-header-second">Gas</strong>
+      <strong class="text-header text-header-second">Gas<br></strong>
       ${{ revenue_types.Gas.Royalties[year] | default: 0 | intcomma }}</span>
     {% endif %}
 
     {% if revenue_types.NGL.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">
-      <strong class="text-header text-header-third">NGL</strong>
+      <strong class="text-header text-header-third">NGL<br></strong>
       ${{ revenue_types.NGL.Royalties[year] | default: 0 | intcomma }}</span>
     {% endif %}
   </td>

--- a/_includes/location/revenue-type-row.html
+++ b/_includes/location/revenue-type-row.html
@@ -16,7 +16,7 @@
         %}
         <td data-value="{{
           total_other_revenues | default: 0
-        }}"><span class="text table-arrow_box-subheader-value">${{
+        }}" class="table-arrow_box-value"><span class="text table-arrow_box-subheader-value">${{
           total_other_revenues
           | default: 0
           | intcomma
@@ -30,7 +30,7 @@
       {% else %}
         <td data-value="{{
             values[revenue_type][year] | default: 0
-        }}"><span class="text table-arrow_box-subheader-value">${{
+        }}" class="table-arrow_box-value"><span class="text table-arrow_box-subheader-value">${{
           commodity[1][revenue_type][year]
           | default: 0
           | intcomma

--- a/_includes/location/revenue-type-row.html
+++ b/_includes/location/revenue-type-row.html
@@ -16,7 +16,7 @@
         %}
         <td data-value="{{
           total_other_revenues | default: 0
-        }}" class="table-arrow_box-value"><span class="text table-arrow_box-subheader-value">${{
+        }}" class="table-arrow_box-value table-arrow_box-text"><span class="text table-arrow_box-subheader-value">${{
           total_other_revenues
           | default: 0
           | intcomma

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -114,7 +114,7 @@ $ab-border-thick: 4px;
     }
 
     td {
-      padding: 20px 10px 0;
+      padding: 20px 10px 0 0;
     }
 
     icon {

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -126,6 +126,14 @@ $ab-border-thick: 4px;
 
   .table-arrow_box-value {
     text-align: right;
+
+    &.table-arrow_box-text {
+      text-align: left;
+
+      .table-arrow_box-subheader-value {
+        float: right;
+      }
+    }
   }
 }
 

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -84,11 +84,10 @@ $ab-border-thick: 4px;
   }
 
   tbody td {
-    padding: 10px;
+    padding: 10px 10px 25px 10px;
   }
 
   .table-arrow_box-subcategory,
-  .table-arrow_box-category,
   .table-arrow_box-subheader {
     @include heading('para-sm');
   }
@@ -104,9 +103,8 @@ $ab-border-thick: 4px;
   }
 
   .table-arrow_box-category {
-    border-bottom: $ab-border-thin solid $ab-color-primary;
-    border-top: 25px solid $white;
-    color: $gray-dark;
+    border-top: $ab-border-thin solid $ab-color-primary;
+    color: $gray-darker;
     font-weight: $weight-bold;
     letter-spacing: 1px;
     text-transform: uppercase;
@@ -116,7 +114,7 @@ $ab-border-thick: 4px;
     }
 
     td {
-      padding-left: 0;
+      padding: 20px 10px 0px 0px;
     }
 
     icon {

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -125,11 +125,16 @@ $ab-border-thick: 4px;
       font-size: 20px;
     }
   }
+
+  .table-arrow_box-value {
+    text-align: right;
+  }
 }
 
 .table-arrow_box-asterisk {
   @include font-size(0.75);
   line-height: 0;
+  text-align: left;
 }
 
 

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -84,7 +84,7 @@ $ab-border-thick: 4px;
   }
 
   tbody td {
-    padding: 10px 10px 25px 10px;
+    padding: 10px 10px 25px;
   }
 
   .table-arrow_box-subcategory,
@@ -114,7 +114,7 @@ $ab-border-thick: 4px;
     }
 
     td {
-      padding: 20px 10px 0 0;
+      padding: 20px 10px 0;
     }
 
     icon {

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -114,7 +114,7 @@ $ab-border-thick: 4px;
     }
 
     td {
-      padding: 20px 10px 0px 0px;
+      padding: 20px 10px 0 0;
     }
 
     icon {


### PR DESCRIPTION
For #2218 .

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/table-cleanup.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/table-cleanup)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/table-cleanup/explore/#revenue)

Changes proposed in this pull request:

- Right-aligns values
- Inserts break after split-bar names so they don't run into each other anymore (!)
-

/cc @ericronne 
