### PR TITLE
Increased contrast of map greens

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -154,8 +154,8 @@ $form-border-radius: $base-border-radius;
 $form-box-shadow-focus: 0 0 0 2px $form-border-color-hover;
 
 // Map legend
-$opacity-federal: 0.35;
-$opacity-state: 0.2;
+$opacity-federal: 0.45;
+$opacity-state: 0.25;
 $legend-row-height: 1em;
 
 $greener-land-lightness-bump: lightness($green-land) * $opacity-state;


### PR DESCRIPTION
Did a quick-and-dirty opacity adjustment on the black (darkening) layer. At some point, it would be good to rebuild this so colors could be spec’d individually, with hex values. This would allow for greater flexibility, and enable us to create maps and other visualizations with more than three colors.