### PR TITLE
Brings link/button blue into 508 compliance over $pale-gray

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -64,7 +64,7 @@ $blackest-black: $black;
 
 // v3
 $green: #9fa63b;
-$blue: #157bac;
+$blue: #1478a6;
 $blue-contrast: #096fa0;
 $light-green: #d2e2cb;
 $blue-alt: darken($blue, 5%); //for constrast, darker


### PR DESCRIPTION
Barely noticeable to the naked eye, but here's [what it looks like](https://federalist.18f.gov/preview/18F/doi-extractives-data/springtime-palette-tweak--508/).