### PR TITLE
Megachart negatives numbers

### DIFF
--- a/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/tribal-laws-and-regulations.md
@@ -177,7 +177,7 @@ In the tables below, revenue may be grouped differently depending on the stage o
       {% for revenue_type in page.revenue_types %}
         {% assign _revenue_type = revenue_type[0] %}
         {% assign _revenue = commodity[1][_revenue_type] %}
-      <td class="numeric">{% if _revenue %}${{ _revenue | intcomma }}{% else %}-{% endif %}</td>
+      <td class="numeric">{% if _revenue %}{{ _revenue | intcomma_dollar }}{% else %}-{% endif %}</td>
       {% endfor %}
     </tr>
   {% endfor %}

--- a/_includes/location/display-disbursements.html
+++ b/_includes/location/display-disbursements.html
@@ -24,9 +24,9 @@
           </td>
         {% endif %}
 
-        <td class="numeric" data-value="{{ _values.All[include.year] | default: 0 }}">${{ _values.All[include.year] | round | intcomma }}</td>
-        <td class="numeric" data-value="{{ _values.Onshore[include.year] | default: 0 }}">${{ _values.Onshore[include.year] | round | intcomma }}</td>
-        <td class="numeric" data-value="{{ _values.Offshore[include.year] | default: 0 }}">${{ _values.Offshore[include.year] | round | intcomma }}</td>
+        <td class="numeric" data-value="{{ _values.All[include.year] | default: 0 }}">{{ _values.All[include.year] | round | intcomma_dollar }}</td>
+        <td class="numeric" data-value="{{ _values.Onshore[include.year] | default: 0 }}">{{ _values.Onshore[include.year] | round | intcomma_dollar }}</td>
+        <td class="numeric" data-value="{{ _values.Offshore[include.year] | default: 0 }}">{{ _values.Offshore[include.year] | round | intcomma_dollar }}</td>
       </tr>
       {% endif %}
     {% endfor %}

--- a/_includes/location/display-federal-revenue-county.html
+++ b/_includes/location/display-federal-revenue-county.html
@@ -34,17 +34,17 @@
                  data-year-values='{{ years_values | jsonify }}'></div>{{ county[1].name }}</td>
       <td data-value-text='{{ revenue_amount }}'
           data-year-values='{{ years_values | jsonify }}'
-          data-format='$,'>${{ revenue_amount | intcomma }}</td>
+          data-format='$,'>{{ revenue_amount | intcomma_dollar }}</td>
       <td class='numberless'
             data-series='volume'
             data-value='{{ revenue_amount }}'
-            data-year-values='{{ years_values | jsonify }}'>{{ revenue_amount | intcomma }}</td>
+            data-year-values='{{ years_values | jsonify }}'>{{ revenue_amount | intcomma_dollar }}</td>
     </tr>
     <tr data-fips='{{ fips }}'>
         <td colspan='3'
             data-year-values='{{ years_values | jsonify }}'
             data-sentence='{{ revenue_amount }}'
-            aria-hidden='true'>Companies paid <span data-value='{{ revenue_amount }}' data-format='$,'>${{ revenue_amount | intcomma }}</span> to extract natural resources on federal land in {{ county[1].name }} {{ locality_name }} in <span data-year='{{ year }}'>{{ year }}</span>.</td>
+            aria-hidden='true'>Companies paid <span data-value='{{ revenue_amount }}' data-format='$,'>{{ revenue_amount | intcomma_dollar }}</span> to extract natural resources on federal land in {{ county[1].name }} {{ locality_name }} in <span data-year='{{ year }}'>{{ year }}</span>.</td>
       </tr>
     {% endif %}
   {% endfor %}

--- a/_includes/location/display-gdp.html
+++ b/_includes/location/display-gdp.html
@@ -10,7 +10,7 @@
   {% for _year in include.values %}
     <tr>
       <td>{{ _year[0] }}</td>
-      <td class="numeric" data-series="gdp" data-value="{{ _year[1].dollars }}">${{ _year[1].dollars | intcomma }}</td>
+      <td class="numeric" data-series="gdp" data-value="{{ _year[1].dollars }}">{{ _year[1].dollars | intcomma_dollar }}</td>
       {% if include.percent %}
       <td class="numeric" data-series="percent" data-value="{{ _year[1].percent }}">{{ _year[1].percent | percent }}%</td>
       {% endif %}

--- a/_includes/location/key-revenue.html
+++ b/_includes/location/key-revenue.html
@@ -4,9 +4,9 @@
 
 In {{ include.year }},
 natural resource extraction on federal land in
-{{ include.location_name }} generated 
+{{ include.location_name }} generated
   {% if revenue_total %}
-    <a href="#revenue">${{ revenue_total | intcomma }} in federal revenue</a>.
+    <a href="#revenue">{{ revenue_total | intcomma_dollar }} in federal revenue</a>.
   {% else %}
     no federal revenue.
   {% endif %}

--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -9,7 +9,7 @@
     <strong>
       {% if disbursements %}
       In {{ disbursement_year }}, ONRR disbursed a total of
-      ${{ disbursements.All.All[disbursement_year] | round | intcomma }}.
+      {{ disbursements.All.All[disbursement_year] | round | intcomma_dollar }}.
       {% endif %}
     </strong></p>
   <p>

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -49,7 +49,7 @@
           <span class="caption-data">
             In <span class="eiti-bar-chart-x-value">{{ year }}</span>,
             extractive industries accounted for
-            <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">${{ gdp[year].dollars | intcomma }}</span>, or
+            <span class="eiti-bar-chart-y-value" data-format="{{ _format }}">{{ gdp[year].dollars | intcomma_dollar }}</span>, or
             {{ gdp[year].percent | percent }}%
             of GDP.
           </span>

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -108,7 +108,7 @@
             </eiti-bar-chart>
             <figcaption id="revenue-figures-{{ commodity_slug }}">
               <span class="caption-data">
-                Companies paid <span class="eiti-bar-chart-y-value" data-format="$,">${{ annual_revenue[year] | default: 0 | intcomma }}</span> to produce {{ commodity_name | downcase }} on federal land in <span class="eiti-bar-chart-x-value">{{ year }}</span>.
+                Companies paid <span class="eiti-bar-chart-y-value" data-format="$,">{{ annual_revenue[year] | default: 0 | intcomma_dollar }}</span> to produce {{ commodity_name | downcase }} on federal land in <span class="eiti-bar-chart-x-value">{{ year }}</span>.
               </span>
               <span class="caption-no-data" aria-hidden="true">
                 There is no data about revenue from production of {{ commodity_name | downcase }} on federal land in

--- a/_includes/location/offshore-federal-revenue-area.html
+++ b/_includes/location/offshore-federal-revenue-area.html
@@ -33,7 +33,7 @@
           <span class="caption-data">
             Companies paid
             <span class="eiti-bar-chart-y-value"
-                  data-format="$,">${{ current_revenue | intcomma }}</span>
+                  data-format="$,">{{ current_revenue | intcomma_dollar }}</span>
             to produce natural resources in the {{ region_title }} in
             <span class="eiti-bar-chart-x-value">{{ year }}</span>.
           </span>

--- a/_includes/location/opt-in/state-disbursements.html
+++ b/_includes/location/opt-in/state-disbursements.html
@@ -41,7 +41,7 @@
       </td>
       <td data-value="{{ fund_dollars }}"
         data-year-values='{{ fund_sources.All | jsonify }}'>
-        ${{ fund_dollars | default: 0 | intcomma }}
+        {{ fund_dollars | default: 0 | intcomma_dollar }}
       </td>
     </tr>
     {% if fund_info %}
@@ -57,6 +57,6 @@
 {% if page.state_saving_spending %}
   <h4 id="saving-and-spending">Saving and spending revenue from extraction</h4>
   <p>Many states choose to establish permanent mineral trust funds, which can help governments dependent on revenue from natural resources smooth revenue and investments across boom and bust cycles.</p>
-  
+
   {{ page.state_saving_spending | liquify | markdownify }}
 {% endif %}

--- a/_includes/location/opt-in/state-revenues.html
+++ b/_includes/location/opt-in/state-revenues.html
@@ -20,7 +20,7 @@
 <p>
   In {{ revenue_year }}, the state of
   {{ state_name }} collected
-  <strong>${{ revenue_total | default: 0 | intcomma }}
+  <strong>{{ revenue_total | default: 0 | intcomma_dollar }}
   in state revenue from natural resource extraction</strong>
   (this includes both tax and non-tax revenue). Counties also collect and distribute their own revenue from natural resource extraction.
 </p>
@@ -59,7 +59,7 @@
       </td>
       <td data-value="{{ stream_dollars }}"
         data-year-values='{{ stream_sources.Total | jsonify }}'>
-        ${{ stream_dollars | default: 0 | intcomma }}
+        {{ stream_dollars | default: 0 | intcomma_dollar }}
       </td>
     </tr>
     {% if stream_info %}

--- a/_includes/location/revenue-type-row-oilgas.html
+++ b/_includes/location/revenue-type-row-oilgas.html
@@ -12,7 +12,7 @@
   %}
   <th scope="row" rowspan="2" data-value="{{ total }}" name="#revenue-{{ commodity_name | slugify }}" class="table-arrow_box-subheader">
     <strong>Oil &amp; Gas </strong><br>
-    <strong class="table-arrow_box-subheader-value">${{ total | intcomma }}</strong>
+    <strong class="table-arrow_box-subheader-value">{{ total | intcomma_dollar }}</strong>
   </th>
   {% assign oilgas_bonus_total = values.Bonus[year] | default: 0
     | plus: revenue_types.Oil.Bonus[year]
@@ -22,7 +22,7 @@
   <td rowspan="2" data-value="{{
     oilgas_bonus_total | default: 0
   }}" class="table-arrow_box-value">
-    <span class="text table-arrow_box-subheader-value">${{ oilgas_bonus_total | default: 0 | intcomma }}</span>
+    <span class="text table-arrow_box-subheader-value">{{ oilgas_bonus_total | default: 0 | intcomma_dollar }}</span>
   </td>
   {% assign oilgas_rents_total = values.Rents[year] | default: 0
     | plus: revenue_types.Oil.Rents[year]
@@ -32,7 +32,7 @@
   <td rowspan="2" data-value="{{
     oilgas_rents_total | default: 0
   }}" class="table-arrow_box-value">
-    <span class="text table-arrow_box-subheader-value">${{ oilgas_rents_total | default: 0 | intcomma }}</span>
+    <span class="text table-arrow_box-subheader-value">{{ oilgas_rents_total | default: 0 | intcomma_dollar }}</span>
   </td>
   <td class="{% if multiple_bars %}bars{% endif %} table-arrow_box-value" data-value="{{
     revenue_types.Oil.Royalties[year] | default: 0
@@ -47,23 +47,23 @@
     {% if revenue_types.Oil.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">
       <strong class="text-header text-header-first">Oil<br></strong>
-      ${{
+      {{
         revenue_types.Oil.Royalties[year]
         | default: 0
-        | intcomma
+        | intcomma_dollar
       }}</span>
     {% endif %}
 
     {% if revenue_types.Gas.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">
       <strong class="text-header text-header-second">Gas<br></strong>
-      ${{ revenue_types.Gas.Royalties[year] | default: 0 | intcomma }}</span>
+      {{ revenue_types.Gas.Royalties[year] | default: 0 | intcomma_dollar }}</span>
     {% endif %}
 
     {% if revenue_types.NGL.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">
       <strong class="text-header text-header-third">NGL<br></strong>
-      ${{ revenue_types.NGL.Royalties[year] | default: 0 | intcomma }}</span>
+      {{ revenue_types.NGL.Royalties[year] | default: 0 | intcomma_dollar }}</span>
     {% endif %}
   </td>
 
@@ -72,5 +72,5 @@
     | plus: revenue_types.Gas['Other Revenues'][year]
     | plus: revenue_types.NGL['Other Revenues'][year]
   %}
-  <td rowspan="2" data-value="{{ oilgas_other_total }}" class="table-arrow_box-value"><span class="text table-arrow_box-subheader-value">${{ oilgas_other_total | intcomma }}</span></td>
+  <td rowspan="2" data-value="{{ oilgas_other_total }}" class="table-arrow_box-value"><span class="text table-arrow_box-subheader-value">{{ oilgas_other_total | intcomma_dollar }}</span></td>
 </tr>

--- a/_includes/location/revenue-type-row.html
+++ b/_includes/location/revenue-type-row.html
@@ -4,7 +4,7 @@
   <tr>
     <th scope="row" data-value="{{ total }}" name="#revenue-{{ commodity_name | slugify }}" class="table-arrow_box-subheader">
       <strong>{{ commodity_name | lookup: site.data.commodity_names }}</strong><br>
-      <strong class="table-arrow_box-subheader-value">${{ total | intcomma }}</strong>
+      <strong class="table-arrow_box-subheader-value">{{ total | intcomma_dollar }}</strong>
     </th>
     {% for revenue_type in revenue_type_names %}
       {% if revenue_type == 'Other Revenues' %}
@@ -16,10 +16,10 @@
         %}
         <td data-value="{{
           total_other_revenues | default: 0
-        }}" class="table-arrow_box-value table-arrow_box-text"><span class="text table-arrow_box-subheader-value">${{
+        }}" class="table-arrow_box-value table-arrow_box-text"><span class="text table-arrow_box-subheader-value">{{
           total_other_revenues
           | default: 0
-          | intcomma
+          | intcomma_dollar
         }}</span>
         {% if national_page and commodity_name == 'All' %}
           <br/>
@@ -30,10 +30,10 @@
       {% else %}
         <td data-value="{{
             values[revenue_type][year] | default: 0
-        }}" class="table-arrow_box-value"><span class="text table-arrow_box-subheader-value">${{
+        }}" class="table-arrow_box-value"><span class="text table-arrow_box-subheader-value">{{
           commodity[1][revenue_type][year]
           | default: 0
-          | intcomma
+          | intcomma_dollar
         }}</span></td>
       {% endif %}
     {% endfor %}

--- a/_plugins/humanize.rb
+++ b/_plugins/humanize.rb
@@ -53,7 +53,7 @@ module Jekyll
 
     end
 
-    def intcomma(value, delimiter=",")
+    def intcomma(value, delimiter = ',')
       ##
       # Converts an integer to a string containing commas every three digits.
       # For example, 3000 becomes '3,000' and 45000 becomes '45,000'.

--- a/_plugins/humanize.rb
+++ b/_plugins/humanize.rb
@@ -1,3 +1,6 @@
+require 'pry'
+require 'rb-readline'
+
 module Jekyll
 
   module Humanize
@@ -72,6 +75,28 @@ module Jekyll
       copy = orig.strip
       copy = orig.gsub(/^(-?\d+)(\d{3})/, "\\1#{delimiter}\\2")
       orig == copy ? copy : intcomma(copy, delimiter)
+    end
+
+
+        ##
+      # Extends int_dollar to add a dollar sign to values.
+      #
+      # Usage:
+      # {{ post.content | number_of_words }} >>> 12345
+      # {{ post.negative | number_of_words }} >>> -12345
+      # {{ post.content | number_of_words | intcomma }} >>> '12,345'
+      # {{ post.negative | number_of_words | intcomma }} >>> '-12,345'
+      # {{ post.content | number_of_words | intcomma: '.' }} >>> '12.345'
+      # {{ post.negative | number_of_words | intcomma_dollar }} >>> '-$12,345'
+      # {{ post.content | number_of_words | intcomma_dollar: '.' }} >>> '$12.345'
+    def intcomma_dollar(value, delimiter=",")
+      incomma_value = intcomma(value, delimiter)
+      first_char = incomma_value.to_s[0]
+      value = if (first_char == '-') || (first_char == '–')
+                incomma_value.to_s.insert(1, '$')
+              else
+                "$#{incomma_value}"
+              end
     end
 
     INTWORD_HELPERS = [

--- a/_plugins/humanize.rb
+++ b/_plugins/humanize.rb
@@ -1,3 +1,6 @@
+require 'pry'
+require 'rb-readline'
+
 module Jekyll
 
   module Humanize
@@ -74,8 +77,8 @@ module Jekyll
       orig == copy ? copy : intcomma(copy, delimiter)
     end
 
-
-        ##
+    def intcomma_dollar(value, delimiter=",")
+      ##
       # Extends int_dollar to add a dollar sign to values.
       #
       # Usage:
@@ -86,14 +89,14 @@ module Jekyll
       # {{ post.content | number_of_words | intcomma: '.' }} >>> '12.345'
       # {{ post.negative | number_of_words | intcomma_dollar }} >>> '-$12,345'
       # {{ post.content | number_of_words | intcomma_dollar: '.' }} >>> '$12.345'
-    def intcomma_dollar(value, delimiter=",")
+
       incomma_value = intcomma(value, delimiter)
       first_char = incomma_value.to_s[0]
-      value = if (first_char == '-') || (first_char == '–')
-                incomma_value.to_s.insert(1, '$')
-              else
-                "$#{incomma_value}"
-              end
+      if (first_char == '-') || (first_char == '–')
+        "($#{incomma_value.to_s[1..-1]})"
+      else
+        "$#{incomma_value}"
+      end
     end
 
     INTWORD_HELPERS = [

--- a/_plugins/humanize.rb
+++ b/_plugins/humanize.rb
@@ -1,6 +1,3 @@
-require 'pry'
-require 'rb-readline'
-
 module Jekyll
 
   module Humanize

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -123,7 +123,11 @@
   // negative values
   [data-value^="-"] .bar {
     background: transparent;
-    border: 1px solid;
+    border: 1px solid $gray-light;
+
+    .bar {
+      display: none;
+    }
   }
 
   [data-value-text]:not(.numeric) {


### PR DESCRIPTION
Fixes issue(s) #1900 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/negatives.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/negatives)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/negatives/explore/#federal-revenue)

Changes proposed in this pull request:
- Added `intcomma_dollar` filter to make it so that negative numbers would read `-$XXX` instead of `$-XXX` 
- Changes style in accordance with @ericronne's mocks. I did not add italics because we don't have a Lato light italic font and because of that it looks _weird_:

<img width="715" alt="screen shot 2017-03-29 at 5 21 02 pm" src="https://cloud.githubusercontent.com/assets/4803473/24510443/dcecf4a6-152e-11e7-87f0-81a7d9c5a141.png">


/cc @meiqimichelle 
