### PR TITLE
Changed NGL to dark gray, to better stand out from the Gas and Oil bar colors

### DIFF
--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -77,7 +77,7 @@
       }
 
       &.text-header-third {
-        color: darken($green-darkest, 10%);
+        color: $gray-darker;
       }
     }
 
@@ -98,7 +98,7 @@
         }
 
         .bar:nth-child(3) {
-          background-color: darken($green-darkest, 10%);
+          background-color: $gray-darker;
         }
       }
     }


### PR DESCRIPTION
Fixes this checkbox item from #2082:
**NGL wasn't included in the original design. Let's color it $gray-darker (#5c7380, currently #1a2b15)**

Only one item left on that list, but it requires javascript ;) @gemfarmer 
