### PR TITLE
Various table format adjustments

### DIFF
--- a/_how-it-works/corporate-income-tax.md
+++ b/_how-it-works/corporate-income-tax.md
@@ -39,7 +39,7 @@ SOI’s calculations of federal corporate income tax receipts from all returns i
 <table class="article_table article_table-indented article_table-numbers">
   <tr>
     <th rowspan="2" class="article_table-left article_table-enlarge">Industry</th>
-    <th colspan="5" class="article_table-thin">Total receipts (in millions USD)<sup id="fnref:2"><a href="#fn:2" class="footnote">2</a></sup></th>
+    <th colspan="5" class="article_table-thin" markdown="span">Total receipts (in millions USD)[^2]</th>
   </tr>
   <tr>
     <th>2009</th>
@@ -97,7 +97,7 @@ SOI’s calculations of federal corporate income tax receipts from all returns i
     <td>1,944</td>
   </tr>
   <tr class="article_table-head">
-    <td>Petroleum and coal products manufacturing<sup id="fnref:3"><a href="#fn:3" class="footnote">3</a></sup></td>
+    <td>Petroleum and coal products manufacturing<span markdown="span">[^3]</span></td>
     <td>$1,897</td>
     <td>$5,126</td>
     <td>$7,630</td>
@@ -123,11 +123,7 @@ Companies that are not publicly listed are generally not required to publish any
 In 2010, the United States enacted the [Dodd-Frank Act]({{ site.baseurl }}/how-it-works/federal-reforms/#dodd-frank), which requires listed extractive companies to separately disclose information about payments to governments around the world, including their federal corporate income tax payments. The Securities and Exchange Commission is rewriting the rule and has stated that it will be proposed in the spring of 2016. Once finalized, publicly traded companies will report according to the law and the rule.
 
 ## Notes
-<div class="footnotes">
-  <ol>
-    <li id="fn:1"><p>Statistics on corporate income taxes relative to companies performing extractive activities are generally classified under the NAICS Mining major industry. In addition, integrated companies that operate in both the downstream extractive and refining spaces are classified under the NAICS Petroleum and Coal Products Manufacturing major industry. <a href="#fnref:1" class="reversefootnote">↩</a></p></li>
-    <li id="fn:2"><p>Internal Revenue Service, <a href="https://www.irs.gov/uac/SOI-Tax-Stats-Returns-of-Active-Corporations-Table-1">Tax Returns of Active Corporations</a>. All figures are estimates based on samples.<a href="#fnref:2" class="reversefootnote">↩</a></p></li>
-    <li id="fn:3"><p>Petroleum and coal products manufacturing encompasses an additional industry subcategory, <em>Asphalt paving, roofing, other petroleum and coal products</em>, which as exluded because it is outside the scope of EITI.<a href="#fnref:3" class="reversefootnote">↩</a></p></li>
-  </ol>
- </div>
+[^1]: Statistics on corporate income taxes relative to companies performing extractive activities are generally classified under the NAICS Mining major industry. In addition, integrated companies that operate in both the downstream extractive and refining spaces are classified under the NAICS Petroleum and Coal Products Manufacturing major industry.
+[^2]: Internal Revenue Service, [Tax Returns of Active Corporations](https://www.irs.gov/uac/SOI-Tax-Stats-Returns-of-Active-Corporations-Table-1). All figures are estimates based on samples.
+[^3]: Petroleum and coal products manufacturing encompasses an additional industry subcategory, **Asphalt paving, roofing, other petroleum and coal products**, which as exluded because it is outside the scope of EITI.
 

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -98,12 +98,12 @@ $base-accent-color: $mid-blue;
 
 // Padding
 $base-padding: 1.25em; //20px
-$base-padding-lite: $base-padding / 3;
-$base-padding-small: 0.90em;
-$base-padding-base: 1em;
+$base-padding-lite: $base-padding / 3; //6.66px
+$base-padding-small: 0.7em; //11.2px Reduced from .9em
+$base-padding-base: 1em; //16px
 $base-padding-large: 1.875em; //30px
 $base-padding-extra: 3.125em; //50px
-$base-padding-jumbo: 3.8em;
+$base-padding-jumbo: 3.8em; //60.8px
 
 // Padding on rem scale
 $standard-padding: 1.25rem;

--- a/_sass/components/_article-table.scss
+++ b/_sass/components/_article-table.scss
@@ -43,9 +43,8 @@ $max-columns: 10;
   td {
     border: none;
     border-top: 1px solid $gray-lighter;
-    line-height: 1.4;
-    padding: $base-padding-lite;
-    padding-bottom: ($base-padding-lite * 1.7);
+    line-height: 1.3;
+    padding: $base-padding-small;
   }
 
   td p {
@@ -73,7 +72,6 @@ $max-columns: 10;
 
 .article_table-numbers td:first-child {
   text-align: left;
-  text-indent: 1rem;
 }
 
 @for $i from 1 to $max-columns {
@@ -110,12 +108,12 @@ $max-columns: 10;
   &.article_table-head,
   &.article_table-bold {
     td:first-child {
-      text-indent: 0;
+      padding-left: $base-padding-lite;
     }
   }
 
   td:first-child {
-    text-indent: 1rem;
+    padding-left: $base-padding-base;
   }
 }
 

--- a/_sass/components/_footnotes.scss
+++ b/_sass/components/_footnotes.scss
@@ -57,8 +57,8 @@ body {
   @include font-size(0.75);
 
   color: $blue;
-  line-height: $base-font-size;
   font-weight: $weight-book;
+  line-height: $base-font-size;
   vertical-align: super; // 2
 }
 

--- a/_sass/components/_footnotes.scss
+++ b/_sass/components/_footnotes.scss
@@ -54,24 +54,20 @@ body {
 .footnote {
   @include heading('para-sm');
   @extend .link-charlie;
+  @include font-size(0.75);
+
+  color: $blue;
+  line-height: $base-font-size;
+  font-weight: $weight-book;
   vertical-align: super; // 2
 }
 
-sup {
-  padding-left: $base-padding-lite /2;
-  vertical-align: baseline;
+table sup {
+  padding-left: $base-padding-lite / 2;
   position: relative;
   top: 0.2em;
+  vertical-align: baseline;
 }
-
-// $default-offset: 130px;
-
-// *[id^="#fn:"],
-// *[id^="#fnref:"],
-// .hashoffset {
-//   margin-top: -1 * $default-offset;
-//   padding-top: $default-offset;
-// }
 
 [id^="fn:"]:target p {
   font-weight: bold;

--- a/_sass/components/_footnotes.scss
+++ b/_sass/components/_footnotes.scss
@@ -57,6 +57,13 @@ body {
   vertical-align: super; // 2
 }
 
+sup {
+  padding-left: $base-padding-lite /2;
+  vertical-align: baseline;
+  position: relative;
+  top: 0.2em;
+}
+
 // $default-offset: 130px;
 
 // *[id^="#fn:"],


### PR DESCRIPTION
Hopefully this doesn't step on the toes of #2246 …

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/chartfixers-r-us/)

Sample: [Corp income tax table](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/chartfixers-r-us/how-it-works/corporate-income-tax/)

Changes proposed in this pull request:
 - Equalized top and bottom cell padding
 - Changed indenting method to padding-left
 - Added styling for the “sup” class, which enabled me to shift the
superscript numbers slightly down, as well as adding a little spacing
on the left (so they don’t almost hit the adjacent text)
 - Tightened up the table line height a bit

On these tables, we still need to adjust the leading for lines which
have footnotes. (The number forces line heights to be too generous.)

Definitely high likelihood of syntax glitches here! 🤞 

More to come!