### PR TITLE
migrate to federalist.fr.cloud.gov

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ If you would like to query the local database instance:
 To update site data, run `make site-data`.
 
 ### Deployment
-This site is deployed on [Federalist](https://federalist.18f.gov) whenever a commit it pushed to GitHub. Changes are deployed automatically to the production site when commits are pushed to the `master` branch.
+This site is deployed on [Federalist](https://federalist.fr.cloud.gov/) whenever a commit it pushed to GitHub. Changes are deployed automatically to the production site when commits are pushed to the `master` branch.
 
 If deploying the site to a production environment, make sure to minify the JS files:
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ Fixes issue(s) # .
 
 [![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/BRANCH_NAME)
 
-[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov//preview/18F/doi-extractives-data/BRANCH_NAME/)
+[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/BRANCH_NAME/)
 
 Changes proposed in this pull request:
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ Fixes issue(s) # .
 
 [![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/BRANCH_NAME)
 
-[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/doi-extractives-data/BRANCH_NAME/)
+[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov//preview/18F/doi-extractives-data/BRANCH_NAME/)
 
 Changes proposed in this pull request:
 

--- a/_plugins/federalist-preview.rb
+++ b/_plugins/federalist-preview.rb
@@ -5,7 +5,7 @@ module Jekyll
       # Federalist preview URL for this branch.
       branch = ENV['BRANCH']
       if branch && branch != 'master'
-        site.config['url'] = "https://federalist.18f.gov/preview/18F/doi-extractives-data/#{branch}"
+        site.config['url'] = "https://federalist.fr.cloud.gov//preview/18F/doi-extractives-data/#{branch}"
         puts "*** Federalist URL: <#{site.config['url']}> ***"
       end
     end

--- a/_plugins/federalist-preview.rb
+++ b/_plugins/federalist-preview.rb
@@ -5,7 +5,7 @@ module Jekyll
       # Federalist preview URL for this branch.
       branch = ENV['BRANCH']
       if branch && branch != 'master'
-        site.config['url'] = "https://federalist.fr.cloud.gov//preview/18F/doi-extractives-data/#{branch}"
+        site.config['url'] = "https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/#{branch}"
         puts "*** Federalist URL: <#{site.config['url']}> ***"
       end
     end


### PR DESCRIPTION
Fixes issue(s) #

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/cloud-gov-update.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/cloud-gov-update)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18F/doi-extractives-data/cloud-gov-update/)

Changes proposed in this pull request:
- Updates all instances of `federalist.gsa.gov` to `federalist.fr.cloud.gov`


/cc @meiqimichelle @ericronne 
