### PR TITLE
Adds link to DOE energy employment reports

### DIFF
--- a/_layouts/state-page.html
+++ b/_layouts/state-page.html
@@ -167,6 +167,10 @@ nav_items:
       {% unless page.offshore == true %}
       <section id="economic-impact">
         <h2>Economic impact</h2>
+        
+        <p>USEITI economic impact data covers {{ "gross domestic product" | term:"Gross domestic product (GDP)" }} and two different types of jobs data.</p>
+        
+        <p>To learn more about direct energy employment across all sectors of the U.S. economy, another useful resource is <a href="https://www.energy.gov/jobstrategycouncil/downloads/2017-us-energy-employment-report">2017 U.S. Energy and Employment Report</a> from the Department of Energy. This report has a separate <a href="https://www.energy.gov/sites/prod/files/2017/01/f34/us-energy-jobs-states-2017.pdf">state-by-state analysis of energy employment</a>.</p>
         {% if page.state_impact %}
         {{ page.state_impact | liquify | markdownify }}
 

--- a/explore/index.html
+++ b/explore/index.html
@@ -119,6 +119,10 @@ nav_items:
       <section id="economic-impact">
 
       <h2>Economic impact</h2>
+      
+      <p>USEITI economic impact data covers {{ "gross domestic product" | term:"Gross domestic product (GDP)" }} and two different types of jobs data.</p>
+      
+      <p>To learn more about direct energy employment across all sectors of the U.S. economy, another useful resource is <a href="https://www.energy.gov/jobstrategycouncil/downloads/2017-us-energy-employment-report">2017 U.S. Energy and Employment Report</a> from the Department of Energy.</p>
 
       {% include location/national-gdp.html %}
 


### PR DESCRIPTION
For #2213 .

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/add-doe-employment-link.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/add-doe-employment-link)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/add-doe-employment-link/)

- Adds link to DOE energy employment report to national jobs page and state pages

## Looks like this on the national page:
<img width="777" alt="screenshot 2017-04-19 15 31 30" src="https://cloud.githubusercontent.com/assets/4827522/25205625/739abc46-2518-11e7-84b6-dde40b2a0710.png">

## And looks like this on the state pages:
<img width="777" alt="screenshot 2017-04-19 15 31 19" src="https://cloud.githubusercontent.com/assets/4827522/25205631/792acc5a-2518-11e7-9314-7cd6a52f9722.png">


/cc @gemfarmer @coreycaitlin 
