### PR TITLE
Links "How does resource extraction result in federal revenue?" home-pg card to #process hash on how page

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@ selector: location
 
           <p class="card-content-subhead">How it works</p>
 
-          <a href="{{ site.baseurl }}/how-it-works"><h3 class="card-title">How does resource extraction result in federal revenue?</h3></a>
+          <a href="{{ site.baseurl }}/how-it-works#process"><h3 class="card-title">How does resource extraction result in federal revenue?</h3></a>
 
           <p>Companies that extract resources on federal land may pay bonuses, rents, royalties, fees, taxes, or other revenues to the federal government.</p>
 


### PR DESCRIPTION
[**Click here and scroll to the truck card, then click. Vroom vroom!**](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/home-card-link-targeting)

This card currently links to the top of the How landing page. I’ve changed it to link to the section which i think answers the posed question more directly.