### PR TITLE
Fix extent line rounding bug

### DIFF
--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -35,7 +35,7 @@
   var barHeight = bottom - top;
 
   var extentPercent = 0.05; // 5%
-  var extentMarginOfError = 0.10 // 10%. Read as +/- the value created by extentPercent
+  var extentMarginOfError = 0.10; // 10%. Read as +/- the value created by extentPercent
   extentMargin = barHeight * extentPercent;
   top += extentMargin;
   var extentTop = top - extentMargin;
@@ -96,7 +96,7 @@
     )(ceilMax);
     var ceilIsLargerThanValue = sigFigCeil > +ymax;
     var ceilIsntTooBig = ( sigFigCeil / +ymax ) <= (1 + extentMarginOfError + extentPercent);
-    var justRight = ceilIsLargerThanValue && ceilIsntTooBig
+    var justRight = ceilIsLargerThanValue && ceilIsntTooBig;
     return justRight ? sigFig : '';
   };
 

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -35,6 +35,7 @@
   var barHeight = bottom - top;
 
   var extentPercent = 0.05; // 5%
+  var extentMarginOfError = 0.10 // 10%. Read as +/- the value created by extentPercent
   extentMargin = barHeight * extentPercent;
   top += extentMargin;
   var extentTop = top - extentMargin;
@@ -93,14 +94,16 @@
       sigFig,
       eiti.format.siValue
     )(ceilMax);
-    var isLessThan = sigFigCeil <= +ymax;
-    return !isLessThan ? sigFig : '';
+    var ceilIsLargerThanValue = sigFigCeil > +ymax;
+    var ceilIsntTooBig = ( sigFigCeil / +ymax ) <= (1 + extentMarginOfError + extentPercent);
+    var justRight = ceilIsLargerThanValue && ceilIsntTooBig
+    return justRight ? sigFig : '';
   };
 
   var setSigFigs = function(ymax, ceilMax) {
     var sigFigs = '';
     var SF = 0;
-    while (sigFigs.length < 1) {
+    while (sigFigs.length < 3) {
       SF++;
       sigFigs = crawlCeil(ymax, ceilMax, SF);
     }

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13252,7 +13252,7 @@ module.exports = function(){
   var barHeight = bottom - top;
 
   var extentPercent = 0.05; // 5%
-  var extentMarginOfError = 0.10 // 10%. Read as +/- the value created by extentPercent
+  var extentMarginOfError = 0.10; // 10%. Read as +/- the value created by extentPercent
   extentMargin = barHeight * extentPercent;
   top += extentMargin;
   var extentTop = top - extentMargin;
@@ -13313,7 +13313,7 @@ module.exports = function(){
     )(ceilMax);
     var ceilIsLargerThanValue = sigFigCeil > +ymax;
     var ceilIsntTooBig = ( sigFigCeil / +ymax ) <= (1 + extentMarginOfError + extentPercent);
-    var justRight = ceilIsLargerThanValue && ceilIsntTooBig
+    var justRight = ceilIsLargerThanValue && ceilIsntTooBig;
     return justRight ? sigFig : '';
   };
 

--- a/js/lib/state-pages.min.js
+++ b/js/lib/state-pages.min.js
@@ -13252,6 +13252,7 @@ module.exports = function(){
   var barHeight = bottom - top;
 
   var extentPercent = 0.05; // 5%
+  var extentMarginOfError = 0.10 // 10%. Read as +/- the value created by extentPercent
   extentMargin = barHeight * extentPercent;
   top += extentMargin;
   var extentTop = top - extentMargin;
@@ -13310,14 +13311,16 @@ module.exports = function(){
       sigFig,
       eiti.format.siValue
     )(ceilMax);
-    var isLessThan = sigFigCeil <= +ymax;
-    return !isLessThan ? sigFig : '';
+    var ceilIsLargerThanValue = sigFigCeil > +ymax;
+    var ceilIsntTooBig = ( sigFigCeil / +ymax ) <= (1 + extentMarginOfError + extentPercent);
+    var justRight = ceilIsLargerThanValue && ceilIsntTooBig
+    return justRight ? sigFig : '';
   };
 
   var setSigFigs = function(ymax, ceilMax) {
     var sigFigs = '';
     var SF = 0;
-    while (sigFigs.length < 1) {
+    while (sigFigs.length < 3) {
       SF++;
       sigFigs = crawlCeil(ymax, ceilMax, SF);
     }


### PR DESCRIPTION
Fixes issue(s) #2320 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/rounding.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/rounding)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/rounding/)
[:sunglasses: PREVIEW problematic AK example](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/rounding/explore/AK/#employment)


Changes proposed in this pull request:
- Modifies the algorithm that generates the value of the dotted extent line on the bar charts. It now ensures that the line value is greater than the max bar value, but **isn't** more than 15% larger than that value.

I created a variable, [`extentMarginOfError`](https://github.com/18F/doi-extractives-data/compare/dev...rounding#diff-568326d8af87934a011aa6ba03a806b8R38), that can be modified to reduce are increase the accepted margin of error. Most extent line values appear to be somewhere between 4.5–7% larger than the maximum bar value without this treatment, but some values will creep up to the 15% range, and in the rare case 20-40%. 

Personally, I think that 15% makes sense as a margin because it culls the crazy large values that make no sense, but leaves the values that _kinda_ make sense unchanged. In my mind `1.75 bbl` is more suspicious than `1.8 bbl` as a value. Ping me if this isn't clear or you want me to elaborate more.

/cc @coreycaitlin 
