### PR TITLE
Update state revenue link in intro section on state pages

### DIFF
--- a/_how-it-works/default.md
+++ b/_how-it-works/default.md
@@ -82,36 +82,32 @@ selector: list
       <h3 id="production" class="h3-bar">Production</h3>
       <p class="landing-intro_link">The U.S. is a world leader in producing natural resources, including oil, gas, coal, renewable energy, and nonenergy minerals.</p>
       <p><a href="{{site.baseurl}}/how-it-works/production/">Learn about production</a></p>
-      <div class="container landing-section">
-        <div>
-          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/offshore-oil-gas/">Oil and gas</a></h4>
-          <div class="landing-oil_gas">
+      <div class="container landing-section landing-section-with-graphics">
+        <div class="landing-oil_gas">
+          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/offshore-oil-gas/">Oil and gas</a>{% include svg/how-main-icon-oil.svg %}</h4>
+          <div>
             <p>Oil and gas (or natural gas) are fossil fuels that form underground on land and under the ocean. In 2014, the U.S. produced more petroleum and natural gas than any other country.</p>
-            {% include svg/how-main-icon-oil.svg %}
             <p><a href="{{site.baseurl}}/how-it-works/offshore-oil-gas/">Learn about oil and gas</a></p>
           </div>
         </div>
-        <div>
-          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/coal/">Coal</a></h4>
-          <div class="landing-coal">
+        <div class="landing-coal">
+          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/coal/">Coal</a>{% include svg/how-main-icon-coal.svg %}</h4>
+          <div>
             <p>Miners extract coal through surface and subsurface mining. In 2014, the U.S. was the world’s second largest coal producer after China.</p>
-            {% include svg/how-main-icon-coal.svg %}
             <p><a href="{{site.baseurl}}/how-it-works/coal/">Learn about coal</a></p>
           </div>
         </div>
-        <div>
-          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/minerals/">Nonenergy minerals</a></h4>
-            <div class="landing-minerals">
+        <div class="landing-minerals">
+          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/minerals/">Nonenergy minerals</a>{% include svg/how-main-icon-hardrock.svg %}</h4>
+            <div>
             <p>Gold, copper, and iron are the main sources of nonenergy mineral revenues. In 2013, U.S. metal production totaled $32 billion.</p>
-            {% include svg/how-main-icon-hardrock.svg %}
             <p><a href="{{site.baseurl}}/how-it-works/minerals/">Learn about nonenergy minerals</a></p>
           </div>
         </div>
-        <div>
-          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/onshore-renewables/">Renewable energy</a></h4>
-          <div class="landing-renewables">
+        <div class="landing-renewables">
+          <h4 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/onshore-renewables/">Renewable energy</a>{% include svg/how-main-icon-wind.svg %}</h4>
+          <div>
             <p>Renewable energy resources — including geothermal, solar, wind, biomass, and hydrokinetic energy — comprised about 10% of U.S. energy consumption in 2015.</p>
-            {% include svg/how-main-icon-wind.svg %}
             <p><a href="{{site.baseurl}}/how-it-works/onshore-renewables/">Learn about renewable energy</a></p>
           </div>
         </div>

--- a/_includes/location/section-overview.html
+++ b/_includes/location/section-overview.html
@@ -45,7 +45,7 @@
     <!-- Blurb for opt-in states -->
     {% if is_opt_in_state %}
       <p>
-        The state of {{ state_name }} chose to participate in an extended USEITI reporting process, so this page includes additional <a href="#state-revenue">state revenue</a> and <a href="#state-disbursements">disbursements</a> data, as well as contextual information about <a href="#state-governance">state governance</a> of natural resources.
+        The state of {{ state_name }} chose to participate in an extended USEITI reporting process, so this page includes additional <a href="#state-local-revenue">state revenue</a> and <a href="#state-disbursements">disbursements</a> data, as well as contextual information about <a href="#state-governance">state governance</a> of natural resources.
       </p>
       {% if page.state_optin_intro %}
         {{ page.state_optin_intro | liquify | markdownify }}

--- a/_sass/blocks/_landing.scss
+++ b/_sass/blocks/_landing.scss
@@ -69,15 +69,16 @@
 }
 
 .landing-section.landing-section-with-graphics {
-  .landing-heading  {
+  .landing-heading {
     position: relative;
   }
+
   svg {
     bottom: 0;
-    position: absolute;
-    right: 0;
     margin-right: 15px;
     max-height: 100%;
+    position: absolute;
+    right: 0;
     width: 55px;
 
     path {
@@ -88,7 +89,7 @@
   .landing-minerals {
     svg {
       margin-top: 46px;
-        top: -36px;
+      top: -36px;
     }
   }
 
@@ -103,12 +104,10 @@
   p {
     width: auto;
   }
-  
   @include respond-to(medium-up) {
     .landing-minerals {
       svg {
-        margin-top: 46px;
-          top: 50px;
+        top: 50px;
       }
     }
     .landing-coal {
@@ -120,14 +119,17 @@
     div {
       position: relative;
     }
+
     .landing-heading {
       position: initial;
     }
+
     svg {
+      height: auto;
       top: 50px;
       width: auto;
-      height: auto;
     }
+
     p {
       padding-right: 150px;
     }

--- a/_sass/blocks/_landing.scss
+++ b/_sass/blocks/_landing.scss
@@ -68,40 +68,74 @@
   }
 }
 
-.landing-section + .h3-bar {
-  padding-top: 4rem;
-}
-
-.landing-oil_gas,
-.landing-coal,
-.landing-minerals,
-.landing-renewables {
+.landing-section.landing-section-with-graphics {
+  .landing-heading  {
+    position: relative;
+  }
   svg {
-    float: right;
-    margin-right: 20px;
+    bottom: 0;
+    position: absolute;
+    right: 0;
+    margin-right: 15px;
+    max-height: 100%;
+    width: 55px;
 
     path {
       fill: $neutral-gray;
     }
   }
 
+  .landing-minerals {
+    svg {
+      margin-top: 46px;
+        top: -36px;
+    }
+  }
+
+  .landing-coal {
+    svg {
+      margin-right: 15px;
+      margin-top: 30px;
+      top: -20px;
+    }
+  }
+
   p {
-    float: left;
-    width: 57%;
+    width: auto;
+  }
+  
+  @include respond-to(medium-up) {
+    .landing-minerals {
+      svg {
+        margin-top: 46px;
+          top: 50px;
+      }
+    }
+    .landing-coal {
+      svg {
+        margin-top: 30px;
+        top: 50px;
+      }
+    }
+    div {
+      position: relative;
+    }
+    .landing-heading {
+      position: initial;
+    }
+    svg {
+      top: 50px;
+      width: auto;
+      height: auto;
+    }
+    p {
+      padding-right: 150px;
+    }
   }
 }
 
-.landing-minerals {
-  svg {
-    margin-top: 46px;
-  }
-}
-
-.landing-coal {
-  svg {
-    margin-right: 0;
-    margin-top: 30px;
-  }
+.landing-section + .h3-bar {
+  padding-top: 4rem;
 }
 
 .landing-intro_link {

--- a/_sass/blocks/_landing.scss
+++ b/_sass/blocks/_landing.scss
@@ -110,12 +110,14 @@
         top: 50px;
       }
     }
+
     .landing-coal {
       svg {
         margin-top: 30px;
         top: 50px;
       }
     }
+
     div {
       position: relative;
     }


### PR DESCRIPTION
Fixes issue(s) https://github.com/18F/doi-extractives-data/issues/2318

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/state-revnue-link.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/state-revnue-link)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/state-revnue-link/)

Changes proposed in this pull request:

- Updated the anchor link for state revenue 
