### PR TITLE
update to term and glossary mapping and display

### DIFF
--- a/_data/production_units.yml
+++ b/_data/production_units.yml
@@ -2,14 +2,15 @@
 mcf:
   long: mcf
   short: mcf
+  term: mcf
 tons:
   long: tons
   short: tons
   term: ton
 short tons:
-  long: short tons
-  short: short tons
-  term: short ton
+  long: tons
+  short: tons
+  term: ton
 # oil and gas
 bbl:
   long: barrels
@@ -22,12 +23,11 @@ barrels:
 gal:
   long: gallons
   short: gal
-  term: gallon
 # units of energy
 kilowatt hours:
   short: kWh
   long: kilowatt hours
-  term: kilowatt hour
+  term: kilowatt hour (kWh)
 mwh:
   short: Mwh
   long: megawatt hours
@@ -44,19 +44,17 @@ electrical generation, thousands of pounds:
   long: thousand pounds
   suffix: energy
   title: electrical generation
-  term: pound (lb)
 direct utilization, millions of btus:
   short: MMBTUs
   long: million BTUs
   suffix: energy
   title: direct use
-  term: BTU
 electrical generation, kilowatt hours:
   short: kWh
   long: kilowatt hours
   suffix: energy
   title: electrical generation
-  term: kilowatt hour
+  term: Kilowatt hour (kWh)
 electrical generation, other:
   short: units
   long: units
@@ -67,25 +65,21 @@ direct use, millions of gallons:
   long: million gallons
   suffix: energy
   title: direct use
-  term: gallon
 direct utilization, hundreds of gallons:
   short: cgal
   long: hundred gallons
   suffix: energy
   title: direct use
-  term: gallon
 Geothermal - Direct Utilization, Other (cgal):
   short: cgal
   long: hundred gallons
   suffix: energy
   title: direct use
-  term: gallon
 cgal:
   short: cgal
   long: hundred gallons
   suffix: energy
   title: direct use
-  term: gallon
 sulfur:
   short: sulfur
   long: sulfur
@@ -95,8 +89,7 @@ sulfur:
 tickets/pounds:
   short: lbs
   long: tickets/pounds
-tons- equivalent:
+tons - equivalent:
   short: tons
   long: equivalent tons
   term: ton
-

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -39,7 +39,7 @@
       {% assign units = product[1].units | downcase %}
       {% assign short_units = units_map[units].short | default: units %}
       {% assign long_units = units_map[units].long | default: units %}
-      {% assign term_units = units_map[units].term | default: long_units %}
+      {% assign term_units = units_map[units].term %}
       {% assign units_suffix = units_map[units].suffix | default: '' %}
 
 

--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -67,7 +67,7 @@
         <figcaption id="all-production-figures-{{ product_slug }}">
           <span class="caption-data">
             <span class="eiti-bar-chart-y-value" data-format=",">{{ volume | default: 0 | intcomma }}</span>
-            {{ long_units | term: term_units }} of
+            {{ long_units | term: term_units, site.data.terms }} of
             {{ product_name | downcase | suffix: units_suffix }} were produced in
             <span class="eiti-bar-chart-x-value">{{ year }}</span>.
           </span>

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -85,7 +85,7 @@
           <figcaption id="national-federal-production-figures-{{ product_slug }}">
             <span class="caption-data">
               <span class="eiti-bar-chart-y-value" data-format=",">{{ volume | default: 0 | intcomma }}</span>
-                {{ long_units | term: term_units }} of {{ product_name | downcase | suffix: units_suffix }} were
+                {{ long_units | term: term_units, site.data.terms }} of {{ product_name | downcase | suffix: units_suffix }} were
                 produced on federal land in
                 <span class="eiti-bar-chart-x-value">{{ year }}</span>.
             </span>

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -57,7 +57,7 @@
       {% assign units = product[1].units | downcase %}
       {% assign short_units = units_map[units].short | default: units %}
       {% assign long_units = units_map[units].long | default: units %}
-      {% assign term_units = units_map[units].term | default: long_units %}
+      {% assign term_units = units_map[units].term %}
       {% assign units_suffix = units_map[units].suffix | default: '' %}
       {% assign units_title = units_map[units].title %}
 

--- a/_includes/location/offshore-region-federal-production.html
+++ b/_includes/location/offshore-region-federal-production.html
@@ -49,6 +49,7 @@
       {% assign units = product[1].units | downcase | default: 'units' %}
       {% assign short_units = units_map[units].short | default: units %}
       {% assign long_units = units_map[units].long | default: units %}
+      {% assign term_units = units_map[units].term %}
       {% assign units_suffix = units_map[units].suffix | default: '' %}
       {% assign units_title = units_map[units].title %}
 
@@ -82,7 +83,7 @@
                 <span class="caption-data">
                   <span class="eiti-bar-chart-y-value"
                         data-format=",">{{ volume | default: 0 | intcomma }}</span>
-                  {{ long_units | term }} of {{ product_name | downcase | suffix: units_suffix }} were
+                  {{ long_units | term: term_units }} of {{ product_name | downcase | suffix: units_suffix }} were
                   produced in the {{ region_title }} in
                   <span class="eiti-bar-chart-x-value">{{ year }}</span>.
                 </span>

--- a/_includes/location/offshore-region-federal-production.html
+++ b/_includes/location/offshore-region-federal-production.html
@@ -83,7 +83,7 @@
                 <span class="caption-data">
                   <span class="eiti-bar-chart-y-value"
                         data-format=",">{{ volume | default: 0 | intcomma }}</span>
-                  {{ long_units | term: term_units }} of {{ product_name | downcase | suffix: units_suffix }} were
+                  {{ long_units | term: term_units, site.data.terms }} of {{ product_name | downcase | suffix: units_suffix }} were
                   produced in the {{ region_title }} in
                   <span class="eiti-bar-chart-x-value">{{ year }}</span>.
                 </span>

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -73,7 +73,7 @@
         <figcaption id="state-all-production-figures-{{ product_slug }}">
           <span class="caption-data">
             <span class="eiti-bar-chart-y-value" data-format=",">{{ volume | default: 0 | intcomma }}</span>
-            {{ long_units | term: term_units }} of
+            {{ long_units | term: term_units, site.data.terms }} of
             {{ product_name | downcase | suffix: units_suffix }}
             were produced in
             {{ state_name }} in

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -45,7 +45,7 @@
       {% assign units = product[1].units | downcase | default: 'units' %}
       {% assign short_units = units_map[units].short | default: units %}
       {% assign long_units = units_map[units].long | default: units %}
-      {% assign term_units = units_map[units].term | default: long_units %}
+      {% assign term_units = units_map[units].term %}
       {% assign units_suffix = units_map[units].suffix | default: '' %}
 
     <section id="state-all-production-{{ product_slug }}" class="chart-item">

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -66,7 +66,7 @@
       {% assign units = product[1].units | downcase | default: 'units' %}
       {% assign short_units = units_map[units].short | default: units %}
       {% assign long_units = units_map[units].long | default: units %}
-      {% assign term_units = units_map[units].term | default: long_units %}
+      {% assign term_units = units_map[units].term %}
       {% assign units_suffix = units_map[units].suffix | default: '' %}
       {% assign units_title = units_map[units].title %}
 

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -100,7 +100,7 @@
                 <span class="caption-data">
                   <span class="eiti-bar-chart-y-value"
                         data-format=",">{{ volume | default: 0 | intcomma }}</span>
-                  {{ long_units | term: term_units }} of {{ product_name | downcase | suffix: units_suffix }} were
+                  {{ long_units | term: term_units, site.data.terms }} of {{ product_name | downcase | suffix: units_suffix }} were
                   produced on federal land in {{ state_name }} in
                   <span class="eiti-bar-chart-x-value">{{ year }}</span>.
                 </span>

--- a/_plugins/glossary.rb
+++ b/_plugins/glossary.rb
@@ -8,7 +8,7 @@ module EITI
 
     def term_str(str, term, terms = nil, term_class = nil)
       if terms
-        terms_available = terms.map { |term| term[0].downcase }
+        terms_available = terms.map { |t| t[0].downcase }
         if terms_available.include? term
           term_html(str, term, term_class)
         else
@@ -42,7 +42,7 @@ module EITI
       #   word
       #   <icon class="icon-book"></icon>
       # </span>
-      term = term || str
+      term ||= str
       term_str(str, term, terms, term_class)
     end
 

--- a/_plugins/glossary.rb
+++ b/_plugins/glossary.rb
@@ -24,9 +24,7 @@ module EITI
       #   <icon class="icon-book"></icon>
       # </span>
       if !term
-        return "<span class='term' data-term='#{str}' \
-          title='Click to define' tabindex='0'>#{str}<icon \
-          class='icon-book'></icon></span>"
+        return str
       else
         return "<span class='term' data-term='#{term}' \
           title='Click to define' tabindex='0'>#{str}<icon \
@@ -56,9 +54,7 @@ module EITI
       #   <icon class="icon-book"></icon>
       # </span>
       if !term
-        return "<span class='term term-end' data-term='#{str}' \
-          title='Click to define' tabindex='0'>#{str}<icon \
-          class='icon-book'></icon></span>"
+        return str
       else
         return "<span class='term term-end' data-term='#{term}' \
           title='Click to define' tabindex='0'>#{str}<icon \

--- a/_plugins/glossary.rb
+++ b/_plugins/glossary.rb
@@ -1,6 +1,25 @@
 module EITI
   module Glossary
-    def term(str, term = nil)
+    def term_html(str, term, term_class = nil)
+      "<span class='term #{term_class}' data-term='#{term}' \
+                title='Click to define' tabindex='0'>#{str}<icon \
+                class='icon-book'></icon></span>"
+    end
+
+    def term_str(str, term, terms = nil, term_class = nil)
+      if terms
+        terms_available = terms.map { |term| term[0].downcase }
+        if terms_available.include? term
+          term_html(str, term, term_class)
+        else
+          str
+        end
+      else
+        term_html(str, term, term_class)
+      end
+    end
+
+    def term(str, term = nil, terms = nil, term_class = nil)
       ##
       # Converts a string to a glossary link with book icon.
       #
@@ -23,43 +42,12 @@ module EITI
       #   word
       #   <icon class="icon-book"></icon>
       # </span>
-      if !term
-        return str
-      else
-        return "<span class='term' data-term='#{term}' \
-          title='Click to define' tabindex='0'>#{str}<icon \
-          class='icon-book'></icon></span>"
-      end
+      term = term || str
+      term_str(str, term, terms, term_class)
     end
 
-    def term_end(str, term = nil)
-      ##
-      # Same as term, but eliminates margin to the right of the book icon
-      #
-      # Usage:
-      # {{ "word" | term }} >>>
-      # <span class="term"
-      #       data-term="word"
-      #       title="Click to define"
-      #       tabindex="0">
-      #   word
-      #   <icon class="icon-book"></icon>
-      # </span>
-      # {{ "word" | term:"alternative def" }} >>>
-      # <span class="term"
-      #       data-term="alternative def"
-      #       title="Click to define"
-      #       tabindex="0" >
-      #   word
-      #   <icon class="icon-book"></icon>
-      # </span>
-      if !term
-        return str
-      else
-        return "<span class='term term-end' data-term='#{term}' \
-          title='Click to define' tabindex='0'>#{str}<icon \
-          class='icon-book'></icon></span>"
-      end
+    def term_end(str, term = nil, terms = nil)
+      term(str, term, terms, 'term-end')
     end
   end
 end


### PR DESCRIPTION
Fixes issue(s) https://github.com/18F/doi-extractives-data/issues/2319

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/glossary-term.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/glossary-term)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/glossary-term/)

Changes proposed in this pull request:

- Changes to the relationship between the terms and production units YML files to know when an term in the glossary does not exist and then render differently accordingly.
