### PR TITLE
Remove redundant link in employment section

### DIFF
--- a/explore/index.html
+++ b/explore/index.html
@@ -122,8 +122,6 @@ nav_items:
 
       <p>USEITI economic impact data covers {{ "gross domestic product" | term:"Gross domestic product (GDP)" }} and two different types of jobs data.</p>
 
-      <p>To learn more about direct energy employment across all sectors of the U.S. economy, another useful resource is <a href="https://www.energy.gov/jobstrategycouncil/downloads/2017-us-energy-employment-report">2017 U.S. Energy and Employment Report</a> from the Department of Energy.</p>
-
       {% include location/national-gdp.html %}
 
       {% include location/national-jobs.html %}


### PR DESCRIPTION
Fixes issue(s) #2330 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/dedupe-employment-report.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/dedupe-employment-report)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/dedupe-employment-report/)

Changes proposed in this pull request:

- Removes Energy and Employment report from "Economic Impact" intro (there's another link in a sub-section that's more immediately relevant)

/cc @gemfarmer 
