### PR TITLE
Two changes to how it works pages: removing Indian Trusts link and adding punctuation to list

### DIFF
--- a/_how-it-works/audits-and-assurances.md
+++ b/_how-it-works/audits-and-assurances.md
@@ -58,4 +58,3 @@ The U.S. government is subject to numerous laws governing data publication, incl
 - The [Federal Financial Management Improvement Act of 1996](https://obamawhitehouse.archives.gov/omb/financial_ffs_ffmia) ensures federal financial managements systems provide accurate, reliable, and timely information to government managers.
 - [26 U.S. Code § 6103](https://www.law.cornell.edu/uscode/text/26/6103) requires confidentiality of tax returns and return information.
 - [18 U.S. Code § 1905](https://www.law.cornell.edu/uscode/text/18/1905) punishes disclosure of proprietary information by a government employee.
-- The [Indian Trusts Act of 1882 (PDF)](http://www.bu.edu/bucflp/files/2012/01/Indian-Trusts-Act-No.-2.pdf) establishes rules for private and public trusts.

--- a/_how-it-works/natural-resources/revenues.md
+++ b/_how-it-works/natural-resources/revenues.md
@@ -55,10 +55,10 @@ Lease holders also pay different fees to the Bureau of Land Management, Bureau o
 
 Corporations operating in the extractive industries pay taxes to the IRS on their income. These companies pay federal corporate income taxes regardless of whether they extract natural resources from federal, state, or privately held lands, so long as they have a liability. These companies also pay taxes on income from extracting natural resources and processing them into other products and commodities. There are different types of companies operating in these industries, with different ownership structures, and as a result, they are treated as different taxpayers:
 
-* C-corporations with many shareholders who own the company; these companies pays corporate income taxes to the IRS
-* S-corporations with 100 shareholders or less who own the company; shareholders pay personal income taxes to the IRS
-* Partnerships where two or more members own the business; members individually pay income taxes to the IRS
-* Sole proprietorships with one individual owner; the individual owner pays personal income tax to the IRS
+* C-corporations with many shareholders who own the company; these companies pays corporate income taxes to the IRS.
+* S-corporations with 100 shareholders or less who own the company; shareholders pay personal income taxes to the IRS.
+* Partnerships where two or more members own the business; members individually pay income taxes to the IRS.
+* Sole proprietorships with one individual owner; the individual owner pays personal income tax to the IRS.
 
 Only income taxes from C-corporations are included in the 2015 USEITI Report.
 
@@ -110,4 +110,3 @@ For more details about U.S. and international revenue standards, visit:
 * IRS, [Revenue Classification and Case Building System](http://www.irs.gov/irm/part4/irm_04-001-005.html)
 * International Monetary Fund, [Government Finance Statistics Manual 2014](http://www.imf.org/external/np/sta/gfsm/)
 * International Monetary Fund, [Code of Good Practices on Fiscal Transparency](https://www.imf.org/external/np/fad/trans/code.htm)
-


### PR DESCRIPTION
Fixes issue(s) #2339 and #2338 .

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/proofreading-changes.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/proofreading-changes)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/proofreading-changes)

Changes proposed in this pull request:

- Removes link to the "Indian Trusts Act of 1882" at the bottom of the Audit and Assurances page since it deals with the country of India, not tribes in the United States.
- Adds periods to the complete sentences in the bulleted list on the how it works, revenue page.
