### PR TITLE
Megachart Oil & gas fix

### DIFF
--- a/_includes/location/revenue-type-row-oilgas.html
+++ b/_includes/location/revenue-type-row-oilgas.html
@@ -46,7 +46,7 @@
 
     {% if revenue_types.Oil.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">
-      <strong class="text-header text-header-first">Oil<br></strong>
+      <strong class="text-header text-header-first">Oil</strong>
       {{
         revenue_types.Oil.Royalties[year]
         | default: 0
@@ -56,13 +56,13 @@
 
     {% if revenue_types.Gas.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">
-      <strong class="text-header text-header-second">Gas<br></strong>
+      <strong class="text-header text-header-second">Gas</strong>
       {{ revenue_types.Gas.Royalties[year] | default: 0 | intcomma_dollar }}</span>
     {% endif %}
 
     {% if revenue_types.NGL.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">
-      <strong class="text-header text-header-third">NGL<br></strong>
+      <strong class="text-header text-header-third">NGL</strong>
       {{ revenue_types.NGL.Royalties[year] | default: 0 | intcomma_dollar }}</span>
     {% endif %}
   </td>

--- a/_sass/blocks/state-pages/_arrow-box.scss
+++ b/_sass/blocks/state-pages/_arrow-box.scss
@@ -134,6 +134,9 @@ $ab-border-thick: 4px;
         float: right;
       }
     }
+    .table-arrow_box-subheader-value {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes issue(s) https://github.com/18F/doi-extractives-data/issues/2262

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/megachart-text-fix)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/megachart-text-fix/)

Changes proposed in this pull request:

- Removed `<br>` tag after oil, gas and NGL
- Added styles to help with visual display

/cc @ericronne @gemfarmer 
