### PR TITLE
Add optional docker support.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ We love all friendly contributions, and we welcome your ideas about how to make 
 To ensure a welcoming environment for our projects, our staff follows the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md); contributors should do the same. Please also check out the [18F Open Source Policy]( https://github.com/18f/open-source-policy).
 
 * [Running and testing the site](#running-and-testing-the-site)
+    - [Using Docker (optional)](#using-docker-optional)
+    - [Troubleshooting](#troubleshooting)
     - [Data and database](#data-and-database)
     - [Deployment](#deployment)
     - [Styleguide](#styleguide)
@@ -26,7 +28,53 @@ This site is made with [Jekyll]. To run it locally, clone this repository then:
 1. Run the web server: `./serve`. **Note:** If you are working on a core layout page, you can speed up this process by running `./serve-fast`. This runs an incomplete version of the site that might be ideal for certain tasks.
 1. Visit the local site at [http://localhost:4000/site/](http://localhost:4000/site/)
 
-## Troubleshooting
+### Using Docker (optional)
+
+Instead of installing dependencies yourself and running different commands
+in separate terminal sessions, you may want to use Docker, which
+only requires installing [Docker Community Edition][docker]
+and running one command in one terminal window.
+
+If you are on Windows, you will also need `bash`, which you can probably
+get most easily by installing [git for Windows][].
+
+To get up and running with Docker, run:
+
+```
+bash docker-update.sh
+docker-compose up
+```
+
+Then visit http://localhost:4000/ in your browser.
+
+Whenever you make changes to any files, the proper static assets
+will be rebuilt, and your changes will show up on the site.
+
+#### Running commands via Docker
+
+If you want to run commands like `npm`, `make`, or `sqlite3`, the easiest
+way to do this is by running a shell inside the main container:
+
+```
+docker-compose run app bash
+```
+
+Once you do this, you'll be in an interactive shell within the main
+container, and can run any commands you need.
+
+#### Updating the Docker container
+
+Whenever you update the repository using e.g. `git pull`, run
+`bash docker-update.sh` again to rebuild the Docker container and
+fetch any new dependencies.
+
+#### Uninstalling or resetting the Docker container
+
+If you decide that Docker isn't for you, or if your Docker setup somehow
+becomes broken and you're not sure how to fix it, run
+`docker-compose down -v`.
+
+### Troubleshooting
 
 Sometimes the site doesn't build properly. Likely this is an issue with the built version of the site (`_site`). To attempt to fix this, consider running one of the following commands:
 - `./re-serve`: removes `_site` and runs `./serve`
@@ -172,3 +220,6 @@ By submitting a pull request, you agree to comply with the policies on our [LICE
 > This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 >
 > All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+
+[docker]: https://www.docker.com/community-edition
+[git for Windows]: https://git-for-windows.github.io/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.2.3
+
+# https://nodejs.org/en/download/package-manager/
+
+RUN apt-get update && \
+    curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
+    apt-get install -y nodejs zip
+
+WORKDIR /
+
+RUN npm install -g yarn
+
+ENV PATH "$PATH:./node_modules/.bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.2.3
 # https://nodejs.org/en/download/package-manager/
 
 RUN apt-get update && \
-    curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
     apt-get install -y nodejs sqlite3
 
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:2.2.3
 
 RUN apt-get update && \
     curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
-    apt-get install -y nodejs zip
+    apt-get install -y nodejs sqlite3
 
 WORKDIR /
 

--- a/Makefile
+++ b/Makefile
@@ -641,6 +641,7 @@ $(db): \
 	tables/federal_production \
 	tables/all_production \
 	tables/company_revenue \
+	tables/tribal_revenue \
 	tables/jobs \
 	tables/gdp \
 	tables/exports \

--- a/_config.yml
+++ b/_config.yml
@@ -71,6 +71,9 @@ exclude:
   - data/land-stats
   - maps/data
   - maps/land/*.json
+  # Docker stuff
+  - Dockerfile
+  - 'docker-*.yml'
 
 include:
   - /build.log

--- a/circle.yml
+++ b/circle.yml
@@ -22,3 +22,4 @@ test:
     # - npm run test-html
     # - npm run test-ruby
     - npm run test
+    - bash test-makefile.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,6 @@ services:
     stop_signal: SIGKILL
 volumes:
   node-modules:
+  styleguide-template-node-modules:
   root:
   bundle:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+services:
+  app:
+    extends:
+      file: docker-services.yml
+      service: base_app
+    command: jekyll serve --force_polling --watch --incremental --host 0.0.0.0 --port 4000 --trace
+    ports:
+      - 4000:4000
+  webpack:
+    extends:
+      file: docker-services.yml
+      service: base_app
+    command: webpack --watch --watch-poll
+    stop_signal: SIGKILL
+volumes:
+  node-modules:
+  root:
+  bundle:

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -12,4 +12,5 @@ services:
       - LANG=C.UTF-8
       - LANGUAGE=C.UTF-8
       - LC_ALL=C.UTF-8
+      - NPM_CMD=yarn
     working_dir: /doi

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -5,6 +5,7 @@ services:
     volumes:
       - .:/doi
       - node-modules:/doi/node_modules/
+      - styleguide-template-node-modules:/doi/styleguide-template/node_modules/
       - root:/root/
       - bundle:/usr/local/bundle/
     environment:

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  base_app:
+    build: .
+    volumes:
+      - .:/doi
+      - node-modules:/doi/node_modules/
+      - root:/root/
+      - bundle:/usr/local/bundle/
+    environment:
+      - LANG=C.UTF-8
+      - LANGUAGE=C.UTF-8
+      - LC_ALL=C.UTF-8
+    working_dir: /doi

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -12,5 +12,8 @@ services:
       - LANG=C.UTF-8
       - LANGUAGE=C.UTF-8
       - LC_ALL=C.UTF-8
-      - NPM_CMD=yarn
+#     For some reason using yarn mis-symlinks the tito binary to
+#     nestly's really old version of tito, instead of the immediate
+#     dependency in node_modules, so we'll use npm instead.
+#      - NPM_CMD=yarn
     working_dir: /doi

--- a/docker-update.sh
+++ b/docker-update.sh
@@ -2,12 +2,5 @@
 
 set -e
 
-if [ ! -f /usr/local/bundle/bin/bundler ]; then
-  gem install bundler
-fi
-
-yarn
-bundle install
-
-cd styleguide-template
-yarn
+docker-compose build
+docker-compose run --rm app bash update.sh

--- a/docker-update.sh
+++ b/docker-update.sh
@@ -8,3 +8,6 @@ fi
 
 yarn
 bundle install
+
+cd styleguide-template
+yarn

--- a/docker-update.sh
+++ b/docker-update.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+set -e
+
+if [ ! -f /usr/local/bundle/bin/bundler ]; then
+  gem install bundler
+fi
+
+yarn
+bundle install

--- a/test-makefile.sh
+++ b/test-makefile.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+set -e
+
+export DIR=_data
+export ORIG_DIR=.original-_data
+
+echo "Copying ${DIR} to ${ORIG_DIR}..."
+
+rm -rf ${ORIG_DIR}
+cp -R _data ${ORIG_DIR}
+
+echo "Rebuilding ${DIR}..."
+
+make clean
+make db
+make site-data
+
+cleanup() {
+  rm -rf ${DIR}
+  mv ${ORIG_DIR} ${DIR}
+}
+
+echo
+
+if diff -u -r ${DIR} ${ORIG_DIR}; then
+  echo "Rebuilding ${DIR} resulted in no changes to any files. Nice."
+  cleanup
+else
+  echo "Alas, rebuilding ${DIR} resulted in changes to some files. See"
+  echo "above diff output for more details."
+  cleanup
+  exit 1
+fi

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+set -e
+
+if ! which bundler > /dev/null; then
+  gem install bundler
+fi
+
+: ${NPM_CMD:=npm}
+
+${NPM_CMD} install
+bundle install
+
+cd styleguide-template
+${NPM_CMD} install


### PR DESCRIPTION
This attempts to add optional support for developing with Docker, which potentially reduces the barrier to entry, as people only need to install Docker rather than the proper version of node, ruby, and other dependencies.

Note that unlike the other config files, the Docker setup uses Node 6, in anticipation of #2357.

## How to try out this PR

Follow the instructions I've added to `CONTRIBUTING.md`! If you're confused by anything, others will be too, so we should fix those instructions as needed.

## To do

- [x] Ensure that Jekyll doesn't copy docker-related files into `_site`.
- [x] Add documentation.
- [x] ~~Add support for developing the style guide.~~ Spun this out into #2355.
- [x] Add support for working on the site data.
