### PR TITLE
Add makefile test script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,3 +22,4 @@ test:
     # - npm run test-html
     # - npm run test-ruby
     - npm run test
+    - bash test-makefile.sh

--- a/test-makefile.sh
+++ b/test-makefile.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+set -e
+
+export DIR=_data
+export ORIG_DIR=.original-_data
+
+echo "Copying ${DIR} to ${ORIG_DIR}..."
+
+rm -rf ${ORIG_DIR}
+cp -R _data ${ORIG_DIR}
+
+echo "Rebuilding ${DIR}..."
+
+make clean
+make db
+make site-data
+
+cleanup() {
+  rm -rf ${DIR}
+  mv ${ORIG_DIR} ${DIR}
+}
+
+echo
+
+if diff -u -r ${DIR} ${ORIG_DIR}; then
+  echo "Rebuilding ${DIR} resulted in no changes to any files. Nice."
+  cleanup
+else
+  echo "Alas, rebuilding ${DIR} resulted in changes to some files. See"
+  echo "above diff output for more details."
+  cleanup
+  exit 1
+fi


### PR DESCRIPTION
**Note:** This is a PR against #2351, not `dev`, since that PR fixes things that make this test actually pass.

This adds a script called `test-makefile.sh` that just makes a copy of `_data`, then re-runs `make db` and `make site-data`, and ensures there are no differences between the new `_data` and its original/copy. It's the kind of thing that would have caught the regression in #2353, ensures that `data` is always in sync with `_data`, and could also be useful whenever we decide to refactor the Makefile or any of the scripts/tools it uses.

@gemfarmer does this seem like it'd be useful?

## To do

- [ ] Document this in the "tests" section of `CONTRIBUTING.md`.
