### PR TITLE
Moved year selector up to sticky area, ripple-effect tweaks

### DIFF
--- a/_includes/location/national-all-production.html
+++ b/_includes/location/national-all-production.html
@@ -17,15 +17,16 @@
 
   <div class="chart-selector-wrapper">
 
-    {% include year-selector.html year_range=year_range %}
-
-    <p class="chart-description">
-      The Energy Information Administration collects data about energy-related natural resources produced on federal, state, and privately owned lands and waters. This data does not include information about nonenergy minerals.
-      <br>
-      <a href="{{site.baseurl}}/downloads/#all-lands-and-waters">
-        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-      </a>
-    </p>
+    <div class="chart-description">
+      <p>
+        The Energy Information Administration collects data about energy-related natural resources produced on federal, state, and privately owned lands and waters. This data does not include information about nonenergy minerals.
+      </p>
+      <p>
+        <a href="{{site.baseurl}}/downloads/#all-lands-and-waters">
+          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+        </a>
+      </p>
+    </div>
   </div>
 
   {% if all_products %}

--- a/_includes/location/national-federal-production.html
+++ b/_includes/location/national-federal-production.html
@@ -20,15 +20,16 @@
 
     <div class="chart-selector-wrapper">
 
-      {% include year-selector.html year_range=year_range %}
-
-      <p class="chart-description">
-        The Office of Natural Resources Revenue collects detailed data about natural resource {{ "production" | term }} on federal lands and waters.
-        <br>
-        <a href="{{site.baseurl}}/downloads/federal-production/">
-          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-        </a>
-      </p>
+      <div class="chart-description">
+          <p>
+          The Office of Natural Resources Revenue collects detailed data about natural resource {{ "production" | term }} on federal lands and waters.
+          </p>
+        <p>
+          <a href="{{site.baseurl}}/downloads/federal-production/">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+          </a>
+        </p>
+      </div>
     </div>
 
     <div class="chart-list">

--- a/_includes/location/national-gdp.html
+++ b/_includes/location/national-gdp.html
@@ -15,15 +15,16 @@
 
   <div class="chart-selector-wrapper">
 
-    {% include year-selector.html year_range=year_range %}
-
-    <p class="chart-description">
-      Data about {{ "gross domestic product" | term:"Gross domestic product (GDP)" }} comes from the Bureau of Economic Analysis.
-      <br>
-      <a href="{{ site.baseurl }}/downloads/#gdp">
-        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-      </a>
-    </p>
+    <div class="chart-description">
+      <p>
+        Data about {{ "gross domestic product" | term:"Gross domestic product (GDP)" }} comes from the Bureau of Economic Analysis.
+      </p>
+      <p>
+        <a href="{{ site.baseurl }}/downloads/#gdp">
+          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+        </a>
+      </p>
+    </div>
   </div><!-- .chart-selector-wrapper -->
 
   <div class="chart-list">

--- a/_includes/location/national-jobs.html
+++ b/_includes/location/national-jobs.html
@@ -24,12 +24,11 @@
 
       <div class="chart-selector-wrapper">
 
-        {% include year-selector.html year_range=year_range %}
-
         <div class="chart-description">
           <p>
             Wage and salary data, from the Bureau of Labor Statistics, describes the number of people employed in natural resource extraction that receive wages or salaries from companies.
-            <br>
+          </p>
+          <p>
             <a href="{{site.baseurl}}/downloads/#jobs">
               <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
             </a>
@@ -155,15 +154,16 @@
 
       <div class="chart-selector-wrapper">
 
-        {% include year-selector.html year_range=year_range %}
-
-        <p class="chart-description">
+        <div class="chart-description">
+          <p>
             Self-employment data, from the Bureau of Economic Analysis, describes people who work in natural resource extraction, but don't receive wages or salaries because they own their own companies.
-            <br>
+          </p>
+          <p>
             <a href="{{site.baseurl}}/downloads/#jobs">
               <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
             </a>
-        </p>
+          </p>
+        </div>
       </div><!-- .chart-selector-wrapper -->
 
       {% assign _metrics = 'count' | split: ' ' %}

--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -30,7 +30,8 @@
     <p>For details about the laws and policies that govern how rights are awarded to companies and what they pay to extract natural resources on federal land: <a href="{{ site.baseurl }}/how-it-works/coal/">coal</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-oil-gas/">oil and gas</a>, <a href="{{ site.baseurl }}/how-it-works/onshore-renewables/">renewable resources</a>, and <a href="{{ site.baseurl }}/how-it-works/minerals/">hardrock minerals</a>.</p>
 
     <p>The federal government collects different kinds of fees at each phase of natural resource extraction. This chart shows how much federal revenue ONRR collected in {{ year}} for production or potential production of natural resources on federal land, broken down by phase of production.
-      <br>
+    </p>
+    <p>
       <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/" class="data-downloads">
         <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
       </a>
@@ -74,15 +75,16 @@
 
     <div class="chart-selector-wrapper">
 
-      {% include year-selector.html year_range=year_range %}
-
-      <p class="chart-description">
-        Non-tax revenue collected by {{ "ONRR" | term }} often depends on what resources are available on federal land, as well as the laws and regulations about extraction of each resource.
-        <br>
-        <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/" class="data-downloads">
-          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-        </a>
-      </p>
+      <div class="chart-description">
+        <p>
+          Non-tax revenue collected by {{ "ONRR" | term }} often depends on what resources are available on federal land, as well as the laws and regulations about extraction of each resource.
+        </p>
+        <p>
+          <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/" class="data-downloads">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+          </a>
+        </p>
+      </div>
     </div>
     <section class="chart-list">
 

--- a/_includes/location/offshore-region-federal-production.html
+++ b/_includes/location/offshore-region-federal-production.html
@@ -29,13 +29,14 @@
     {% else %}
       <div class="chart-selector-wrapper">
 
-        {% include year-selector.html year_range=year_range %}
-
-        <p class="chart-description">
-          ONRR collects detailed data about natural resources produced in the {{ region_title }}.
-          <br>
-          <a href="{{site.baseurl}}/downloads/federal-production/"><icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation</a>
-        </p>
+        <div class="chart-description">
+          <p>
+            ONRR collects detailed data about natural resources produced in the {{ region_title }}.
+          </p>
+          <p>
+            <a href="{{site.baseurl}}/downloads/federal-production/"><icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation</a>
+          </p>
+        </div>
       </div>
     {% endif %}
 

--- a/_includes/location/offshore-region-revenue.html
+++ b/_includes/location/offshore-region-revenue.html
@@ -83,20 +83,22 @@
             {% endunless %}
           {% endfor %}
 
-          {% include year-selector.html year_range=year_range empty_years=empty_years %}
         {% endif %}
 
         {% if revenue_commodities %}
-          <p class="chart-description">
-            Non-tax revenue collected by ONRR often depends on what resources are available, as well as the laws and regulations about extraction of each resource.
-            <br>
-            <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/"><icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation</a>
-          </p>
-        {% else %}
-          <p class="chart-description{% unless revenue_commodities %} no-selector{% endunless %}">
-            In {{ year }}, the federal government didn't receive any payment for extraction of natural resources on federal land (or lease federal land for that purpose) in {{ region_title }}. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
-          </p>
-        {% endif %}
+          <div class="chart-description">
+            <p>
+              Non-tax revenue collected by ONRR often depends on what resources are available, as well as the laws and regulations about extraction of each resource.
+            </p>
+            <p>
+              <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/"><icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation</a>
+            </p>
+          {% else %}
+            <p class="chart-description{% unless revenue_commodities %} no-selector{% endunless %}">
+              In {{ year }}, the federal government didn't receive any payment for extraction of natural resources on federal land (or lease federal land for that purpose) in {{ region_title }}. <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">Data and documentation <icon class="fa fa-file-text-o u-padding-right"></icon></a>
+            </p>
+          {% endif %}
+        </div>
       </div>
 
       {% if revenue_commodities %}

--- a/_includes/location/section-all-production.html
+++ b/_includes/location/section-all-production.html
@@ -21,17 +21,16 @@
 
   <div class="chart-selector-wrapper">
 
-    {% if all_products %}
-      {% include year-selector.html year_range=year_range %}
-    {% endif %}
-
-    <p class="chart-description{% unless all_products %} no-selector{% endunless %}">
-      The Energy Information Administration collects data about all energy-related natural resources produced on federal, state, and privately owned land.
-      <br>
-      <a href="{{site.baseurl}}/downloads/#all-lands-and-waters">
-        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-      </a>
-    </p>
+    <div class="chart-description{% unless all_products %} no-selector{% endunless %}">
+      <p>
+        The Energy Information Administration collects data about all energy-related natural resources produced on federal, state, and privately owned land.
+      </p>
+      <p>
+        <a href="{{site.baseurl}}/downloads/#all-lands-and-waters">
+          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+        </a>
+      </p>
+    </div>
   </div>
 
   {% if all_products %}

--- a/_includes/location/section-exports.html
+++ b/_includes/location/section-exports.html
@@ -32,7 +32,6 @@
 
     <div class="chart-selector-wrapper">
     {% if export_commodities %}
-      {% include year-selector.html year_range=year_range empty_years=empty_years %}
     {% endif %}
 
     {% if empty_years.size == year_range.size %}
@@ -41,21 +40,24 @@
       {% assign has_exports = false %}
     {% endif %}
 
-      <p class="chart-description{% if export_commodities.size > 1 %}{% else %} no-selector{% endif %}">
-        The U.S. Census Bureau collects information about the top 25 exports in each state.
+      <div class="chart-description{% if export_commodities.size > 1 %}{% else %} no-selector{% endif %}">
+        <p>
+          The U.S. Census Bureau collects information about the top 25 exports in each state.
 
-        {% if exports_total > 0 %}
-          In {{ year }}, one or more natural resources
-          ranked among the top 25 exports from {{ state_name }}.
-        {% else %}
-          In {{ year }}, extractive industries products did not rank
-          among the top 25 exports from {{ state_name }}.
-        {% endif %}
-        <br>
-        <a href="{{site.baseurl}}/downloads/#exports">
-          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-        </a>
-      </p>
+          {% if exports_total > 0 %}
+            In {{ year }}, one or more natural resources
+            ranked among the top 25 exports from {{ state_name }}.
+          {% else %}
+            In {{ year }}, extractive industries products did not rank
+            among the top 25 exports from {{ state_name }}.
+          {% endif %}
+        </p>
+        <p>
+          <a href="{{site.baseurl}}/downloads/#exports">
+            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+          </a>
+        </p>
+      </div>
     </div>
 
     {% assign _format = '$,' %}

--- a/_includes/location/section-federal-production.html
+++ b/_includes/location/section-federal-production.html
@@ -22,21 +22,24 @@
     {% if federal_products_num == 0 %}
     <p>
       The Office of Natural Resources Revenue collects detailed data about natural resources produced on federal land. According to that data, there was no natural resource {{ "production" | term }} on federal land in {{  state_name }} in {{ year }}.
-      <br>
+    </p>
+    <p>
       <a href="{{ site.baseurl }}/downloads/federal-production/" class="data-downloads">
         <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
       </a>
     </p>
     {% else %}
     <div class="chart-selector-wrapper">
-      {% include year-selector.html year_range=year_range %}
-      <p class="chart-description">
+      <div class="chart-description">
+        <p>
           The Office of Natural Resources Revenue collects detailed data about natural resource {{ "production" | term }} on federal land in {{ state_name }}.
-          <br>
+        </p>
+        <p>
           <a href="{{ site.baseurl }}/downloads/federal-production/">
             <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
           </a>
-      </p>
+        </p>
+      </div>
     </div>
     {% endif %}
 

--- a/_includes/location/section-gdp.html
+++ b/_includes/location/section-gdp.html
@@ -22,15 +22,17 @@
           {% assign empty_years = empty_years | push:s_y %}
         {% endunless %}
       {% endfor %}
-      {% include year-selector.html year_range=year_range empty_years=empty_years %}
     {% endif %}
-    <p class="chart-description{% unless gdp %} no-selector{% endunless %}">
-      Data about each state’s {{ "gross domestic product" | term:"Gross domestic product (GDP)" }} comes from the Bureau of Economic Analysis.
-      <br>
-      <a href="{{site.baseurl}}/downloads/#gdp">
-        <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-      </a>
-    </p>
+    <div class="chart-description{% unless gdp %} no-selector{% endunless %}">
+      <p>
+        Data about each state’s {{ "gross domestic product" | term:"Gross domestic product (GDP)" }} comes from the Bureau of Economic Analysis.
+      </p>
+      <p>
+        <a href="{{site.baseurl}}/downloads/#gdp">
+          <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+        </a>
+      </p>
+    </div>
   </div><!-- /.chart-selector-wrapper -->
 
   {% if gdp %}

--- a/_includes/location/section-jobs.html
+++ b/_includes/location/section-jobs.html
@@ -37,13 +37,13 @@
           {% endfor %}
 
           {% assign empty_years = empty_years | join:',' %}
-          {% include year-selector.html year_range=year_range empty_years=empty_years %}
         {% endif %}
 
         <div class="chart-description{% unless jobs %} no-selector{% endunless %}">
           <p>
             Employment data from the Bureau of Labor Statistics describes the number of people who receive wages or salaries from companies.
-            <br>
+          </p>
+          <p>
             <a href="{{site.baseurl}}/downloads/#jobs">
               <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
             </a>
@@ -227,13 +227,13 @@
 
           {% assign empty_years = empty_years | join:',' %}
 
-          {% include year-selector.html year_range=year_range empty_years=empty_years %}
         {% endif %}
 
         <div class="chart-description {% unless self_employment_jobs %} no-selector{% endunless %}">
           <p>
             Self-employment data, from the Bureau of Economic Analysis, describes people who work in natural resource extraction, but don’t receive wages or salaries because they own their own companies.
-            <br>
+          </p>
+          <p>
             <a href="{{site.baseurl}}/downloads/#jobs">
               <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
             </a>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -25,7 +25,8 @@
 
     <p>
       Natural resource extraction can lead to federal revenue in two ways: non-tax revenue and tax revenue. Most USEITI data is about non-tax revenue from extractive industry activities on federal land.
-      <br>
+    </p>
+    <p>
       <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/" class="data-downloads">
         <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
       </a>
@@ -88,15 +89,16 @@
           {% endunless %}
         {% endfor %}
 
-        {% include year-selector.html year_range=year_range empty_years=empty_years %}
-
-        <p class="chart-description">
-          Most non-tax revenue collected by ONRR comes from counties with significant natural resources on federal land.
-          <br>
-          <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/" class="data-downloads">
-            <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
-          </a>
-        </p>
+        <div class="chart-description">
+          <p>
+            Most non-tax revenue collected by ONRR comes from counties with significant natural resources on federal land.
+          </p>
+          <p>
+            <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/" class="data-downloads">
+              <icon class="fa fa-file-text-o u-padding-right"></icon>Data and documentation
+            </a>
+          </p>
+        </div>
       </div>
 
       <section class="county-map-table">
@@ -113,9 +115,9 @@
 
 {% else %}
 
-        <p class="chart-description{% unless revenue_commodities %} no-selector{% endunless %}">
+        <div class="chart-description{% unless revenue_commodities %} no-selector{% endunless %}">
           No natural resources were produced on federal land in {{ state_name }} in {{ year }}, so ONRR did not collect any non-tax revenues.
-        </p>
+        </div>
 
 {% endif %}
 

--- a/_sass/blocks/_chart-list.scss
+++ b/_sass/blocks/_chart-list.scss
@@ -247,20 +247,16 @@
 
   .chart-selector {
     @include chart-selector(left);
+    visibility: hidden;
   }
 
   .chart-description {
-    border-left: 1px solid $mid-gray;
-    float: left;
-    margin-bottom: 0;
-    padding-left: 1.25rem;
-    width: 75%;
 
     &.no-selector {
       border: none;
       float: none;
       padding-left: 0;
-      width: 100%;
+      width: 75%;
     }
 
     a {
@@ -277,10 +273,6 @@
   }
 
   @include respond-to(small-down) {
-    .chart-selector {
-      display: none;
-    }
-
     .chart-description {
       border: 0;
       padding-left: 0;

--- a/_sass/blocks/jekyll-layouts/_state-pages.scss
+++ b/_sass/blocks/jekyll-layouts/_state-pages.scss
@@ -121,7 +121,7 @@
   }
 
   .data-downloads {
-    @include heading(para-sm);
+    @include heading(para-med);
 
     color: $blue;
     text-decoration: none;

--- a/_sass/components/_sticky-headers.scss
+++ b/_sass/components/_sticky-headers.scss
@@ -34,7 +34,7 @@
     @include chart-selector(right);
 
     margin: 0;
-    visibility: hidden;
+    visibility: visible;
 
     @include respond-to(small-down) {
       visibility: visible;


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/stick-shift/explore/)

I introduced at least one bug here (see below), and also created a bit of “cruft,” as it were, but hopefully not too bad :)

---

### Before
![image](https://user-images.githubusercontent.com/9259185/30401087-a2b8657e-989e-11e7-91bc-958c764e671a.png)

---

### After
![image](https://user-images.githubusercontent.com/9259185/30401120-bc2ab71e-989e-11e7-94ea-4e8b154da4da.png)

---

### Glitch which seems to be new (in at least this texas "no data" selector)
![image](https://user-images.githubusercontent.com/9259185/30401201-00aa857c-989f-11e7-8401-92274ffe121f.png)
