### PR TITLE
Ensure disabled year selector not selected

### DIFF
--- a/_includes/year-selector.html
+++ b/_includes/year-selector.html
@@ -7,7 +7,7 @@
       {% assign __year = year | to_i %}
       {% assign s_year = _year | to_s %}
       {% if include.empty_years contains s_year %}
-        <option disabled value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }} no data</option>
+        <option disabled value="{{ _year }}">{{ _year }} no data</option>
       {% else %}
         <option value="{{ _year }}" {% if __year == _year %}selected{% endif %}>{{ _year }}</option>
       {% endif %}

--- a/circle.yml
+++ b/circle.yml
@@ -22,4 +22,3 @@ test:
     # - npm run test-html
     # - npm run test-ruby
     - npm run test
-    - bash test-makefile.sh


### PR DESCRIPTION
A year selector could be disabled if there is not data for that year.
This selector should not be disabled too.

Fixes issue(s) #2378

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/ms-fix_year_selector.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/ms-fix_year_selector)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/ms-fix_year_selector/)

/cc relevant people
