### PR TITLE
Lato thickened!

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -4,9 +4,9 @@
 $eiti-logo-width: 195px;
 
 // Typography
-$weight-light: 200; // use
-$weight-book: 400; // use
-$weight-bold: 700; // use
+$weight-light: 300; // (Lato Light) use
+$weight-book: 400; // (Lato Regular) use
+$weight-bold: 600; // (Lato Semibold) use
 $line-height-caps: 1.2;
 
 $sans-serif: Lato, 'Helvetica Neue', Helvetica, arial, sans-serif;


### PR DESCRIPTION
Bottom line: safari hates Lato 200, but has no problem rendering Lato
300.

Resolves #875 