### PR TITLE
Tweak user groups

### DIFF
--- a/research/14_sprint-inquisitive-impala/research_plan.md
+++ b/research/14_sprint-inquisitive-impala/research_plan.md
@@ -11,17 +11,14 @@ Given that the purpose and content of the Natural Resources Revenue Data site is
 | | How would they they prefer to get this info it in the future? |
 | Test the effectiveness of the new site name. | What do our target users think they can get from the site based on the name & homepage content? |
 
-
 # Methods and desired participants
 
-Over the course of several weeks, we’d like to speak with at least 2-3 individuals from each of the following user groups for 50-minute remote or in-person 1:1 interviews:
+Over the course of several weeks, we’d like to speak with 5-8 individuals from several of the following user groups for 50-minute remote or in-person 1:1 interviews.
 
-- **NGOs:** We hypothesize that these folks need resources revenue data to be better informed in their advocacy work. 
 - **Journalists:** We hypothesize that these folks need resources revenue data to use as source material for related stories.
-- **Academics:** We hypothesize that these folks need resources revenue data to inform related research.
-- **Government policymakers (federal, state, local & tribal):** We hypothesize that these folks need resources revenue data to make more informed policy decisions.
-- **Extractive industry staffers:** We hypothesize that these folks need resources revenue data to **_[?? Need a hypothesis here]_**.
-
+- **Researchers or other data users:** We hypothesize that academics and researchers need resources revenue data to inform their work.
+- **Citizens, advocates, and NGOs:** We hypothesize that resources revenue data can support these folks in their advocacy work.
+- **Policymakers (federal, state, local & tribal):** We hypothesize that these folks need resources revenue data to make more informed policy decisions.
 
 # Recruitment strategy
 
@@ -30,7 +27,6 @@ In order to recruit research participants from our target user groups (both for 
 1. **Contacting members of the Royalty Policy Committee** to ask for their help putting us in touch with members of their organizations who use natural resource revenue data in their day to day work.
 2. **Reaching out to various related interest groups whom Ryan has identified.**
 3. **Setting up a recruiting screener on the site itself,** as well as other related sites that ONRR owns as appropriate/possible.
-
 
 # Discussion guide
 TBD


### PR DESCRIPTION
This research plan looks great — this PR suggests some revisions to the participants section, just to bring the list of user groups slightly more in line with past persona conversations. (I also reduced the target number to 5-8 interviews, because of time.)

/cc @alexpandel @winzenburg 
