### PR TITLE
fix typo in tax revenue section

### DIFF
--- a/_includes/location/national-revenue.html
+++ b/_includes/location/national-revenue.html
@@ -146,7 +146,7 @@
     %}
 
     <div>
-      <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to romote other policy goals.</p>
+      <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to promote other policy goals.</p>
       <p>Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
     </div>
   </section>

--- a/_includes/location/section-revenue.html
+++ b/_includes/location/section-revenue.html
@@ -124,7 +124,7 @@
     <h4>Federal tax revenue</h4>
 
     <div>
-      <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to romote other policy goals.</p>
+      <p>Individuals and corporations (specifically C-corporations) pay income taxes to the IRS. Depending on company income, federal corporate income tax rates can range from 15–35%. Public policy provisions, such as tax expenditures, can decrease corporate income tax and other revenue payments in order to promote other policy goals.</p>
       <p>Learn more about <a href="{{ site.baseurl }}/how-it-works/revenues/#all-lands-and-waters">revenue from extraction on all lands and waters</a>.</p>
     </div>
 


### PR DESCRIPTION
Fixes issue(s) #2401 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/revenue-typo.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/revenue-typo)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/revenue-typo/explore/#federal-tax-revenue)

Changes proposed in this pull request:

- Changes `romote` to `promote`