### PR TITLE
Shrinks logo on mobile, padding adjs, renames "eiti" logo style to "nrrd"

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,7 +1,7 @@
 @import 'lib/font-awesome/font-awesome/variables';
 
 // Logos
-$eiti-logo-width: 250px;
+$nrrd-logo-width: 220px;
 
 // Typography
 $weight-light: 300; // (Lato Light) use

--- a/_sass/blocks/_header.scss
+++ b/_sass/blocks/_header.scss
@@ -47,12 +47,12 @@ header,
 
 .header-left {
  @include span-columns(6);
- margin-bottom: $base-padding-base;
+    margin-bottom: $base-padding-base;
 
  @include respond-to(medium-up) {
     @include span-columns(3);
-    margin-bottom: 0;
-    margin-top: 2rem;
+      margin-bottom: 0;
+      margin-top: 2rem;
  }
 }
 

--- a/_sass/blocks/_header.scss
+++ b/_sass/blocks/_header.scss
@@ -25,7 +25,7 @@
 
 header,
 .header {
-  margin-top: $base-padding-base;
+  margin-top: $base-padding;
 }
 
 .header-image_link {
@@ -38,7 +38,7 @@ header,
 
 .header-image {
   max-width: 316px;
-  width: $eiti-logo-width;
+  width: $nrrd-logo-width;
 
   @include respond-to(medium-up) {
     width: auto;
@@ -47,7 +47,7 @@ header,
 
 .header-left {
    @include span-columns(6);
-   margin-bottom: $base-padding;
+   margin-bottom: $base-padding-base;
 
    @include respond-to(medium-up) {
       @include span-columns(3);

--- a/_sass/blocks/_header.scss
+++ b/_sass/blocks/_header.scss
@@ -46,11 +46,11 @@ header,
 }
 
 .header-left {
- @include span-columns(6);
+  @include span-columns(6);
     margin-bottom: $base-padding-base;
 
- @include respond-to(medium-up) {
-    @include span-columns(3);
+    @include respond-to(medium-up) {
+      @include span-columns(3);
       margin-bottom: 0;
       margin-top: 2rem;
  }

--- a/_sass/blocks/_header.scss
+++ b/_sass/blocks/_header.scss
@@ -47,12 +47,12 @@ header,
 
 .header-left {
   @include span-columns(6);
-    margin-bottom: $base-padding-base;
+  margin-bottom: $base-padding-base;
 
-    @include respond-to(medium-up) {
-      @include span-columns(3);
-      margin-bottom: 0;
-      margin-top: 2rem;
+  @include respond-to(medium-up) {
+    @include span-columns(3);
+    margin-bottom: 0;
+    margin-top: 2rem;
  }
 }
 

--- a/_sass/blocks/_header.scss
+++ b/_sass/blocks/_header.scss
@@ -46,14 +46,14 @@ header,
 }
 
 .header-left {
-   @include span-columns(6);
-   margin-bottom: $base-padding-base;
+ @include span-columns(6);
+ margin-bottom: $base-padding-base;
 
-   @include respond-to(medium-up) {
-      @include span-columns(3);
-      margin-bottom: 0;
-      margin-top: 2rem;
-   }
+ @include respond-to(medium-up) {
+    @include span-columns(3);
+    margin-bottom: 0;
+    margin-top: 2rem;
+ }
 }
 
 .header-right {


### PR DESCRIPTION
Fixes issue with logo hitting hamburger menu on small mobile devices.

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/Logo-responsive-adjustments/)

A couple of additional minor tweaks (eg vertical alignment) can be made later, eg when we implement a revised search (#2403), and if we replace icons such as the hamburger with svg files (#2284)