### PR TITLE
Removed unneccesary comment from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# A sample Gemfile
+
 source "https://rubygems.org"
 
 raise 'Need ruby > 2.1 to run' unless RUBY_VERSION.to_f > 2.1


### PR DESCRIPTION
Gemfile had a placeholder that was never removed. We're using this opportunity to conduct Git training.

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/fake-change.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/fake-change)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/fake-change/)
