### PR TITLE
Fixes case study map sizing

### DIFF
--- a/_sass/blocks/case-studies/_content.scss
+++ b/_sass/blocks/case-studies/_content.scss
@@ -34,7 +34,6 @@
 .case_studies-map-container {
   display: block;
   margin: 0 auto;
-  width: 25vh;
 
   eiti-map {
     display: block;


### PR DESCRIPTION
Somewhere along the lines, these maps became puny. This seems to help
beef them up.

[Preview link](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/case-studies-map-sizing/case-studies/pima/)