### PR TITLE
[WIP] Pre footer design

### DIFF
--- a/_how-it-works/the-process/coal.html
+++ b/_how-it-works/the-process/coal.html
@@ -31,6 +31,6 @@ permalink: /how-it-works/coal/
   {% include how-it-works/coal_involved.html %}
 </div>
 
-<div class="revenues_page-footer">
+<div class="pre-footer">
   {% include how-it-works/footer.html %}
 </div>

--- a/_how-it-works/the-process/minerals.html
+++ b/_how-it-works/the-process/minerals.html
@@ -34,6 +34,6 @@ permalink: /how-it-works/minerals/
   {% include how-it-works/minerals_involved.html %}
 </div>
 
-<div class="revenues_page-footer">
+<div class="pre-footer">
   {% include how-it-works/footer.html %}
 </div>

--- a/_how-it-works/the-process/offshore-oil-gas.html
+++ b/_how-it-works/the-process/offshore-oil-gas.html
@@ -46,7 +46,7 @@ permalink: /how-it-works/offshore-oil-gas/
       {% include how-it-works/offshore_oil_gas_involved.html %}
   </div>
 
-  <div class="revenues_page-footer">
+  <div class="pre-footer">
 
       {% include how-it-works/footer.html %}
 

--- a/_how-it-works/the-process/offshore-renewables.html
+++ b/_how-it-works/the-process/offshore-renewables.html
@@ -44,7 +44,7 @@ permalink: /how-it-works/offshore-renewables/
   {% include how-it-works/offshore_renewables_involved.html %}
 </div>
 
-<div class="revenues_page-footer">
+<div class="pre-footer">
   {% include how-it-works/footer.html %}
 </div>
 

--- a/_how-it-works/the-process/onshore-oil-gas.html
+++ b/_how-it-works/the-process/onshore-oil-gas.html
@@ -46,7 +46,7 @@ permalink: /how-it-works/onshore-oil-gas/
   {% include how-it-works/onshore_oil_gas_involved.html %}
 </div>
 
-<div class="revenues_page-footer">
+<div class="pre-footer">
 
     {% include how-it-works/footer.html %}
 

--- a/_how-it-works/the-process/onshore-renewables.html
+++ b/_how-it-works/the-process/onshore-renewables.html
@@ -44,6 +44,6 @@ permalink: /how-it-works/onshore-renewables/
     {% include how-it-works/onshore_renewables_involved.html %}
 </div>
 
-<div class="revenues_page-footer">
+<div class="pre-footer">
     {% include how-it-works/footer.html %}
 </div>

--- a/_includes/case-studies/_selector.html
+++ b/_includes/case-studies/_selector.html
@@ -1,5 +1,5 @@
 <div class="case_studies_intro-select {{include.screen}}">
-  <select {% if page.permalink == '/case-studies/' %}class="select-dark-gray" {% endif %}id="case_studies-selector" onchange="window.location = '{{ site.baseurl }}/case-studies/' + this.value + '/'">
+  <select class="select-dark-gray"{% if page.permalink == '/case-studies/' %} {% endif %}id="case_studies-selector" onchange="window.location = '{{ site.baseurl }}/case-studies/' + this.value + '/'">
     <option
     {% if page.permalink == '/case-studies/' %}selected{% endif %}
     value="#">Choose a case study</option>

--- a/_includes/case-studies/footer.html
+++ b/_includes/case-studies/footer.html
@@ -1,0 +1,6 @@
+<section class="container-page-wrapper">
+
+  <h3>Browse this section:</h3>
+  {% include case-studies/_selector.html %}
+
+</section>

--- a/_layouts/case-studies-landing.html
+++ b/_layouts/case-studies-landing.html
@@ -41,6 +41,11 @@ layout: default
     </nav>
 
   </div>
+
 </section>
 
 <script type="text/javascript" src="{{ site.baseurl }}/js/lib/narrative.min.js" charset="utf-8"></script>
+
+<div class="pre-footer">
+  {% include case-studies/footer.html %}
+</div>

--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -88,3 +88,7 @@ layout: default
 {% if page.selector %}
   <script type="text/javascript" src="{{ site.baseurl }}/js/lib/narrative.min.js" charset="utf-8"></script>
 {% endif %}
+
+<div class="pre-footer">
+  {% include case-studies/footer.html %}
+</div>

--- a/_sass/blocks/how-it-works/_footer.scss
+++ b/_sass/blocks/how-it-works/_footer.scss
@@ -1,4 +1,4 @@
-.revenues_page-footer {
+.pre-footer {
   background-color: $gray-pale;
   margin: 0;
   padding-bottom: $base-padding-extra;

--- a/_sass/blocks/how-it-works/_footer.scss
+++ b/_sass/blocks/how-it-works/_footer.scss
@@ -2,7 +2,7 @@
   background-color: $gray-pale;
   margin: 0;
   padding-bottom: $base-padding-extra;
-  padding-top: $base-padding-jumbo;
+  padding-top: $base-padding-extra;
 
   ul {
     padding-left: 0;

--- a/_sass/print/_how-it-works.scss
+++ b/_sass/print/_how-it-works.scss
@@ -1,4 +1,4 @@
-.revenues_page-footer,
+.pre-footer,
 .revenues_subpage-involved_video,
 .break {
   display: none !important;


### PR DESCRIPTION
_Not looking for a merge here yet; merely want to get your eyes on this revised component._

### In my recent style hunt through the site, i noticed that the section-nav footer on the "diving graphics" pages is a little wonky. To wit …

![image](https://user-images.githubusercontent.com/9259185/33137060-8405f68c-cf6c-11e7-8d89-24d59c157505.png)

### I've also noticed that it's easy for me (admittedly just one user!) to miss this nav element altogether. So i cleaned it up and made it into a "pre-footer" component, with a gray background …

[**Preview link**](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/pre-footer-design/how-it-works/offshore-oil-gas/) (scroll to bottom)

![image](https://user-images.githubusercontent.com/9259185/33137548-d8f76026-cf6d-11e7-9485-75c92bb22f70.png)

### It then struck me that case studies might benefit from the same treatment (its landing page has a 70%+ bounce rate), so i created a version for that …

[**Preview link**](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/pre-footer-design/case-studies/campbell/) (scroll to bottom)
![image](https://user-images.githubusercontent.com/9259185/33138201-8dfe2fc6-cf6f-11e7-8331-3e3eb0b636b9.png)

**Note**: In applying the dark-background selector style for the case studies pre-footer, i also changed the right-side selector (currently light-gray bg). Not necessarily the most elegant solution, but it makes it harder to miss. Can **possibly** address such finery later, but new design is out of scope. This component is more of an accidental artifact of my style-normalizing process.