### PR TITLE
Update opt-in state data

### DIFF
--- a/_data/opt_in_state_revenues/MT.yml
+++ b/_data/opt_in_state_revenues/MT.yml
@@ -2,86 +2,126 @@ streams:
   All:
     Total:
       '2014': 446883245
+      '2016': 246887799
     General Fund:
       '2014': 176559116
+      '2016': 79155245
     County Share / Government:
       '2014': 133478180
+      '2016': 69980227
     Common Schools:
       '2014': 34725031
+      '2016': 18008101
     Coal Trust Fund:
       '2014': 28838092
+      '2016': 30179274
     State Share:
       '2014': 12276757
+      '2016': 13047282
     State School Oil & Gas Distribution:
       '2014': 11773273
+      '2016': 1394905
     Long Range Building:
       '2014': 6921142
+      '2016': 7243026
     Oil and Natural Gas Conservation Account Tax:
       '2014': 4732701
+      '2016': 1534356
     State Orphan Share Fund:
       '2014': 3583888
+      '2016': 1281080
     State Natural Resources Projects:
       '2014': 3369568
+      '2016': 1712375
     Montana University System:
       '2014': 3219424
+      '2016': 1150801
     Public Land Trust:
       '2014': 3157313
+      '2016': 585518
     Shared Account:
       '2014': 3149120
+      '2016': 3295577
     Board of Oil & Gas Conservation:
       '2014': 2505508
+      '2016': 812294
     State Natural Resources Operations:
       '2014': 2454052
+      '2016': 877214
     Coal Board:
       '2014': 2129440
+      '2016': 3434905
     Hard Rock Debt Service:
       '2014': 1185166
+      '2016': 693982
     Natural Resources Operations:
       '2014': 976019
+      '2016': 571515
     Park Acquisition Trust:
       '2014': 732488
+      '2016': 766554
     Renewable Resource Debt Service:
       '2014': 547924
+      '2016': 573406
     Hazardous Waste/CERCLA special revenue account:
       '2014': 372716
+      '2016': 387182
     Environmental Quality Protection Fund:
       '2014': 372716
+      '2016': 387182
     Groundwater Assessment Account:
       '2014': 366000
+      '2016': 366000
     Cultural and Aesthetic Projects:
       '2014': 363360
+      '2016': 380259
     Hard Rock Mining:
       '2014': 348578
+      '2016': 204112
     CERCLA Debt Service:
       '2014': 272106
+      '2016': 270425
     Coal & Uranium Program:
       '2014': 250000
+      '2016': 250000
     Water Storage Special Revenue Account:
       '2014': 150000
+      '2016': 150000
     Public Buildings:
       '2014': 66684
+      '2016': 13957
     School of Mines:
       '2014': 60168
     Pine Hills School:
       '2014': 45007
+      '2016': 2966
     Montana State University Morrill:
       '2014': 32738
+      '2016': 7186
     University of Montana:
       '2014': 24086
+      '2016': 960
     State Normal School:
       '2014': 18609
+      '2016': 5047
     Agricultural Experiment Station:
       '2014': 12990
+      '2016': 12204
     School for Deaf and Blind:
       '2014': 8840
+      '2016': 16486
     Department of Transportation:
       '2014': 7468
+      '2016': 1270
     Department of Natural Resources Conservation - Water Resources Division:
       '2014': 5659
+      '2016': 134918
     Montana State University 2nd Grant:
       '2014': 2087
+      '2016': 8
     Veterans Home Income:
       '2014': 1913
+      '2016': 1224
     'Department of Fish, Wildlife, & Parks':
       '2014': 210
     Galen State Hospital:
@@ -89,154 +129,227 @@ streams:
   Oil & Natural Gas Production Tax:
     Total:
       '2014': 236496773
+      '2016': 84972199
     General Fund:
       '2014': 109606216
+      '2016': 39083500
     County Share / Government:
       '2014': 95997576
+      '2016': 37900038
     State School Oil & Gas Distribution:
       '2014': 11773273
+      '2016': 1394905
     Oil and Natural Gas Conservation Account Tax:
       '2014': 4732701
+      '2016': 1534356
     State Orphan Share Fund:
       '2014': 3583888
+      '2016': 1281080
     Montana University System:
       '2014': 3219424
+      '2016': 1150801
     State Natural Resources Projects:
       '2014': 2624135
+      '2016': 938011
     Board of Oil & Gas Conservation:
       '2014': 2505508
+      '2016': 812294
     State Natural Resources Operations:
       '2014': 2454052
+      '2016': 877214
   Coal Severance Tax:
     Total:
       '2014': 57676185
+      '2016': 60358549
     Coal Trust Fund:
       '2014': 28838092
+      '2016': 30179274
     General Fund:
       '2014': 14744619
+      '2016': 14235548
     Long Range Building:
       '2014': 6921142
+      '2016': 7243026
     Shared Account:
       '2014': 3149120
+      '2016': 3295577
     Coal Board:
       '2014': 2129440
+      '2016': 3434905
     Park Acquisition Trust:
       '2014': 732488
+      '2016': 766554
     Renewable Resource Debt Service:
       '2014': 547924
+      '2016': 573406
     Cultural and Aesthetic Projects:
       '2014': 363360
+      '2016': 380259
     Coal & Uranium Program:
       '2014': 250000
+      '2016': 250000
   U.S. Mineral Royalties:
     Total:
       '2014': 36991806
+      '2016': 22345284
     General Fund:
       '2014': 27743855
+      '2016': 16758963
     County Share / Government:
       '2014': 9247951
+      '2016': 5586321
   Oil Royalty:
     Total:
       '2014': 20014889
+      '2016': 7388547
     Common Schools:
       '2014': 17611249
+      '2016': 6801850
     Public Land Trust:
       '2014': 2395262
+      '2016': 560953
     Public Buildings:
       '2014': 6711
+      '2016': 2816
     Department of Transportation:
       '2014': 1421
     Galen State Hospital:
       '2014': 142
     'Department of Fish, Wildlife, & Parks':
       '2014': 105
+    School for Deaf and Blind:
+      '2016': 12295
+    Department of Natural Resources Conservation - Water Resources Division:
+      '2016': 8436
+    Veterans Home Income:
+      '2016': 1214
+    Montana State University Morrill:
+      '2016': 949
+    Montana State University 2nd Grant:
+      '2016': 35
   Coal Gross Proceeds:
     Total:
       '2014': 18812015
+      '2016': 20756877
     County Share / Government:
       '2014': 10043732
+      '2016': 10777732
     State Share:
       '2014': 8768283
+      '2016': 9979145
   Metal Mines Gross Proceeds:
     Total:
       '2014': 16813993
+      '2016': 14686751
     County Share / Government:
       '2014': 13635986
+      '2016': 11996094
     State Share:
       '2014': 3178007
+      '2016': 2690657
   Metalliferous Mines License Tax:
     Total:
       '2014': 13943131
+      '2016': 8164498
     General Fund:
       '2014': 7947585
+      '2016': 4221465
     County Share / Government:
       '2014': 3485783
+      '2016': 2473424
     Hard Rock Debt Service:
       '2014': 1185166
+      '2016': 693982
     Natural Resources Operations:
       '2014': 976019
+      '2016': 571515
     Hard Rock Mining:
       '2014': 348578
+      '2016': 204112
   Abandoned Mine Land Fees:
     Total:
       '2014': 12568841
+      '2016': 4429969
     General Fund:
       '2014': 12568841
+      '2016': 4429969
   Coal Royalties:
     Total:
       '2014': 8130763
+      '2016': 9124779
     Common Schools:
       '2014': 8130763
+      '2016': 9124779
   Wind Generation Property Tax:
     Total:
       '2014': 7787065
+      '2016': 7998776
   Electrical Energy Producers' License Tax:
     Total:
       '2014': 3948000
+      '2016': 425800
     General Fund:
       '2014': 3948000
+      '2016': 425800
   Oil & Gas Bonus Income:
     Total:
       '2014': 3709204
+      '2016': 138629
     Common Schools:
       '2014': 3076764
+      '2016': 12365
     Public Land Trust:
       '2014': 626640
     Montana State University Morrill:
       '2014': 2160
     Public Buildings:
       '2014': 1960
+      '2016': 30
     School of Mines:
       '2014': 880
     University of Montana:
       '2014': 800
+    Department of Natural Resources Conservation - Water Resources Division:
+      '2016': 126234
   Oil & Gas Rental Income:
     Total:
       '2014': 3035589
+      '2016': 976081
     Common Schools:
       '2014': 2816126
+      '2016': 948333
     Public Land Trust:
       '2014': 48688
+      '2016': 9492
     School of Mines:
       '2014': 41301
     Public Buildings:
       '2014': 33403
+      '2016': 3721
     Pine Hills School:
       '2014': 28981
+      '2016': 1116
     Montana State University Morrill:
       '2014': 18411
+      '2016': 440
     State Normal School:
       '2014': 17012
+      '2016': 2505
     University of Montana:
       '2014': 11286
+      '2016': 960
     School for Deaf and Blind:
       '2014': 5940
+      '2016': 3300
     Agricultural Experiment Station:
       '2014': 4847
+      '2016': 4847
     Department of Transportation:
       '2014': 3911
+      '2016': 1270
     Department of Natural Resources Conservation - Water Resources Division:
       '2014': 2095
+      '2016': 124
     Veterans Home Income:
       '2014': 1913
     Montana State University 2nd Grant:
@@ -246,67 +359,96 @@ streams:
   Resource Indemnity & Ground Water Asssessment Tax (RIGWAT):
     Total:
       '2014': 2278971
+      '2016': 2335153
     State Natural Resources Projects:
       '2014': 745433
+      '2016': 774364
     Hazardous Waste/CERCLA special revenue account:
       '2014': 372716
+      '2016': 387182
     Environmental Quality Protection Fund:
       '2014': 372716
+      '2016': 387182
     Groundwater Assessment Account:
       '2014': 366000
+      '2016': 366000
     CERCLA Debt Service:
       '2014': 272106
+      '2016': 270425
     Water Storage Special Revenue Account:
       '2014': 150000
+      '2016': 150000
   Gas Royalty:
     Total:
       '2014': 1654445
+      '2016': 555103
     Common Schools:
       '2014': 1587749
+      '2016': 533525
     Public Land Trust:
       '2014': 43168
+      '2016': 8757
     Montana State University Morrill:
       '2014': 8552
+      '2016': 5798
     Agricultural Experiment Station:
       '2014': 5803
+      '2016': 2677
     Public Buildings:
       '2014': 5020
+      '2016': 3270
     Department of Natural Resources Conservation - Water Resources Division:
       '2014': 1854
+      '2016': 28
     State Normal School:
       '2014': 1297
+      '2016': 442
     Department of Transportation:
       '2014': 1001
     'Department of Fish, Wildlife, & Parks':
       '2014': 2
+    School for Deaf and Blind:
+      '2016': 597
+    Veterans Home Income:
+      '2016': 9
   Miscellaneous Mines Net Proceeds:
     Total:
       '2014': 1397619
+      '2016': 1624098
     County Share / Government:
       '2014': 1067152
+      '2016': 1246618
     State Share:
       '2014': 330467
+      '2016': 377480
   Oil & Gas Penalty Income:
     Total:
       '2014': 1350124
+      '2016': 499808
     Common Schools:
       '2014': 1254421
+      '2016': 482157
     Public Buildings:
       '2014': 19071
+      '2016': 3743
     Public Land Trust:
       '2014': 18979
+      '2016': 5268
     School of Mines:
       '2014': 17988
     Pine Hills School:
       '2014': 16026
+      '2016': 1850
     University of Montana:
       '2014': 12000
     Montana State University Morrill:
       '2014': 3615
     School for Deaf and Blind:
       '2014': 2900
+      '2016': 11
     Agricultural Experiment Station:
       '2014': 2340
+      '2016': 4679
     Department of Natural Resources Conservation - Water Resources Division:
       '2014': 1710
     Montana State University 2nd Grant:
@@ -315,39 +457,58 @@ streams:
       '2014': 363
     State Normal School:
       '2014': 300
+      '2016': 2100
   Condensate Royalty:
     Total:
       '2014': 165897
+      '2016': 24839
     Common Schools:
       '2014': 141316
+      '2016': 23410
     Public Land Trust:
       '2014': 24577
+      '2016': 1047
     'Department of Fish, Wildlife, & Parks':
       '2014': 3
+    School for Deaf and Blind:
+      '2016': 284
+    Department of Natural Resources Conservation - Water Resources Division:
+      '2016': 96
+    Veterans Home Income:
+      '2016': 1
   Coal Rentals / Bonuses:
     Total:
       '2014': 49515
+      '2016': 49535
     Common Schools:
       '2014': 49515
+      '2016': 49535
   Land Use Licenses Rental Income:
     Total:
       '2014': 14810
+      '2016': 15507
     Common Schools:
       '2014': 14810
+      '2016': 15507
   Non-Metalliferous Mineral Leases Royalty Income:
     Total:
       '2014': 12545
+      '2016': 18
     Common Schools:
       '2014': 12385
     Public Buildings:
       '2014': 160
+      '2016': 18
   Non-Metalliferous Mineral Leases Rental Income:
     Total:
       '2014': 10556
+      '2016': 5430
     Common Schools:
       '2014': 10196
+      '2016': 5070
     Public Buildings:
       '2014': 360
+      '2016': 360
   Oil & Gas Surface Damages:
     Total:
       '2014': 9950
@@ -363,8 +524,10 @@ streams:
   Metalliferous Mineral Lease Rental Income:
     Total:
       '2014': 2842
+      '2016': 277
     Common Schools:
       '2014': 2842
+      '2016': 277
   Metalliferous Mineral Lease Royalty Income:
     Total:
       '2014': 1029
@@ -373,289 +536,408 @@ streams:
   Land Use Licenses Royalty Income:
     Total:
       '2014': 1000
+      '2016': 11292
     Common Schools:
       '2014': 1000
+      '2016': 11292
 funds:
   Total:
     All:
       '2014': 446883245
+      '2016': 246887799
     Oil & Natural Gas Production Tax:
       '2014': 236496773
+      '2016': 84972199
     Coal Severance Tax:
       '2014': 57676185
+      '2016': 60358549
     U.S. Mineral Royalties:
       '2014': 36991806
+      '2016': 22345284
     Oil Royalty:
       '2014': 20014889
+      '2016': 7388547
     Coal Gross Proceeds:
       '2014': 18812015
+      '2016': 20756877
     Metal Mines Gross Proceeds:
       '2014': 16813993
+      '2016': 14686751
     Metalliferous Mines License Tax:
       '2014': 13943131
+      '2016': 8164498
     Abandoned Mine Land Fees:
       '2014': 12568841
+      '2016': 4429969
     Coal Royalties:
       '2014': 8130763
+      '2016': 9124779
     Wind Generation Property Tax:
       '2014': 7787065
+      '2016': 7998776
     Electrical Energy Producers' License Tax:
       '2014': 3948000
+      '2016': 425800
     Oil & Gas Bonus Income:
       '2014': 3709204
+      '2016': 138629
     Oil & Gas Rental Income:
       '2014': 3035589
+      '2016': 976081
     Resource Indemnity & Ground Water Asssessment Tax (RIGWAT):
       '2014': 2278971
+      '2016': 2335153
     Gas Royalty:
       '2014': 1654445
+      '2016': 555103
     Miscellaneous Mines Net Proceeds:
       '2014': 1397619
+      '2016': 1624098
     Oil & Gas Penalty Income:
       '2014': 1350124
+      '2016': 499808
     Condensate Royalty:
       '2014': 165897
+      '2016': 24839
     Coal Rentals / Bonuses:
       '2014': 49515
+      '2016': 49535
     Land Use Licenses Rental Income:
       '2014': 14810
+      '2016': 15507
     Non-Metalliferous Mineral Leases Royalty Income:
       '2014': 12545
+      '2016': 18
     Non-Metalliferous Mineral Leases Rental Income:
       '2014': 10556
+      '2016': 5430
     Oil & Gas Surface Damages:
       '2014': 9950
     Oil & Gas Seismic Permits:
       '2014': 5688
     Metalliferous Mineral Lease Rental Income:
       '2014': 2842
+      '2016': 277
     Metalliferous Mineral Lease Royalty Income:
       '2014': 1029
     Land Use Licenses Royalty Income:
       '2014': 1000
+      '2016': 11292
   General Fund:
     All:
       '2014': 176559116
+      '2016': 79155245
     Oil & Natural Gas Production Tax:
       '2014': 109606216
+      '2016': 39083500
     U.S. Mineral Royalties:
       '2014': 27743855
+      '2016': 16758963
     Coal Severance Tax:
       '2014': 14744619
+      '2016': 14235548
     Abandoned Mine Land Fees:
       '2014': 12568841
+      '2016': 4429969
     Metalliferous Mines License Tax:
       '2014': 7947585
+      '2016': 4221465
     Electrical Energy Producers' License Tax:
       '2014': 3948000
+      '2016': 425800
   County Share / Government:
     All:
       '2014': 133478180
+      '2016': 69980227
     Oil & Natural Gas Production Tax:
       '2014': 95997576
+      '2016': 37900038
     Metal Mines Gross Proceeds:
       '2014': 13635986
+      '2016': 11996094
     Coal Gross Proceeds:
       '2014': 10043732
+      '2016': 10777732
     U.S. Mineral Royalties:
       '2014': 9247951
+      '2016': 5586321
     Metalliferous Mines License Tax:
       '2014': 3485783
+      '2016': 2473424
     Miscellaneous Mines Net Proceeds:
       '2014': 1067152
+      '2016': 1246618
   Common Schools:
     All:
       '2014': 34725031
+      '2016': 18008101
     Oil Royalty:
       '2014': 17611249
+      '2016': 6801850
     Coal Royalties:
       '2014': 8130763
+      '2016': 9124779
     Oil & Gas Bonus Income:
       '2014': 3076764
+      '2016': 12365
     Oil & Gas Rental Income:
       '2014': 2816126
+      '2016': 948333
     Gas Royalty:
       '2014': 1587749
+      '2016': 533525
     Oil & Gas Penalty Income:
       '2014': 1254421
+      '2016': 482157
     Condensate Royalty:
       '2014': 141316
+      '2016': 23410
     Coal Rentals / Bonuses:
       '2014': 49515
+      '2016': 49535
     Land Use Licenses Rental Income:
       '2014': 14810
+      '2016': 15507
     Non-Metalliferous Mineral Leases Royalty Income:
       '2014': 12385
     Non-Metalliferous Mineral Leases Rental Income:
       '2014': 10196
+      '2016': 5070
     Oil & Gas Surface Damages:
       '2014': 9177
     Oil & Gas Seismic Permits:
       '2014': 5688
     Metalliferous Mineral Lease Rental Income:
       '2014': 2842
+      '2016': 277
     Metalliferous Mineral Lease Royalty Income:
       '2014': 1029
     Land Use Licenses Royalty Income:
       '2014': 1000
+      '2016': 11292
   Coal Trust Fund:
     Coal Severance Tax:
       '2014': 28838092
+      '2016': 30179274
     All:
       '2014': 28838092
+      '2016': 30179274
   State Share:
     All:
       '2014': 12276757
+      '2016': 13047282
     Coal Gross Proceeds:
       '2014': 8768283
+      '2016': 9979145
     Metal Mines Gross Proceeds:
       '2014': 3178007
+      '2016': 2690657
     Miscellaneous Mines Net Proceeds:
       '2014': 330467
+      '2016': 377480
   State School Oil & Gas Distribution:
     Oil & Natural Gas Production Tax:
       '2014': 11773273
+      '2016': 1394905
     All:
       '2014': 11773273
+      '2016': 1394905
   Long Range Building:
     Coal Severance Tax:
       '2014': 6921142
+      '2016': 7243026
     All:
       '2014': 6921142
+      '2016': 7243026
   Oil and Natural Gas Conservation Account Tax:
     Oil & Natural Gas Production Tax:
       '2014': 4732701
+      '2016': 1534356
     All:
       '2014': 4732701
+      '2016': 1534356
   State Orphan Share Fund:
     Oil & Natural Gas Production Tax:
       '2014': 3583888
+      '2016': 1281080
     All:
       '2014': 3583888
+      '2016': 1281080
   State Natural Resources Projects:
     All:
       '2014': 3369568
+      '2016': 1712375
     Oil & Natural Gas Production Tax:
       '2014': 2624135
+      '2016': 938011
     Resource Indemnity & Ground Water Asssessment Tax (RIGWAT):
       '2014': 745433
+      '2016': 774364
   Montana University System:
     Oil & Natural Gas Production Tax:
       '2014': 3219424
+      '2016': 1150801
     All:
       '2014': 3219424
+      '2016': 1150801
   Public Land Trust:
     All:
       '2014': 3157313
+      '2016': 585518
     Oil Royalty:
       '2014': 2395262
+      '2016': 560953
     Oil & Gas Bonus Income:
       '2014': 626640
     Oil & Gas Rental Income:
       '2014': 48688
+      '2016': 9492
     Gas Royalty:
       '2014': 43168
+      '2016': 8757
     Condensate Royalty:
       '2014': 24577
+      '2016': 1047
     Oil & Gas Penalty Income:
       '2014': 18979
+      '2016': 5268
   Shared Account:
     Coal Severance Tax:
       '2014': 3149120
+      '2016': 3295577
     All:
       '2014': 3149120
+      '2016': 3295577
   Board of Oil & Gas Conservation:
     Oil & Natural Gas Production Tax:
       '2014': 2505508
+      '2016': 812294
     All:
       '2014': 2505508
+      '2016': 812294
   State Natural Resources Operations:
     Oil & Natural Gas Production Tax:
       '2014': 2454052
+      '2016': 877214
     All:
       '2014': 2454052
+      '2016': 877214
   Coal Board:
     Coal Severance Tax:
       '2014': 2129440
+      '2016': 3434905
     All:
       '2014': 2129440
+      '2016': 3434905
   Hard Rock Debt Service:
     Metalliferous Mines License Tax:
       '2014': 1185166
+      '2016': 693982
     All:
       '2014': 1185166
+      '2016': 693982
   Natural Resources Operations:
     Metalliferous Mines License Tax:
       '2014': 976019
+      '2016': 571515
     All:
       '2014': 976019
+      '2016': 571515
   Park Acquisition Trust:
     Coal Severance Tax:
       '2014': 732488
+      '2016': 766554
     All:
       '2014': 732488
+      '2016': 766554
   Renewable Resource Debt Service:
     Coal Severance Tax:
       '2014': 547924
+      '2016': 573406
     All:
       '2014': 547924
+      '2016': 573406
   Hazardous Waste/CERCLA special revenue account:
     Resource Indemnity & Ground Water Asssessment Tax (RIGWAT):
       '2014': 372716
+      '2016': 387182
     All:
       '2014': 372716
+      '2016': 387182
   Environmental Quality Protection Fund:
     Resource Indemnity & Ground Water Asssessment Tax (RIGWAT):
       '2014': 372716
+      '2016': 387182
     All:
       '2014': 372716
+      '2016': 387182
   Groundwater Assessment Account:
     Resource Indemnity & Ground Water Asssessment Tax (RIGWAT):
       '2014': 366000
+      '2016': 366000
     All:
       '2014': 366000
+      '2016': 366000
   Cultural and Aesthetic Projects:
     Coal Severance Tax:
       '2014': 363360
+      '2016': 380259
     All:
       '2014': 363360
+      '2016': 380259
   Hard Rock Mining:
     Metalliferous Mines License Tax:
       '2014': 348578
+      '2016': 204112
     All:
       '2014': 348578
+      '2016': 204112
   CERCLA Debt Service:
     Resource Indemnity & Ground Water Asssessment Tax (RIGWAT):
       '2014': 272106
+      '2016': 270425
     All:
       '2014': 272106
+      '2016': 270425
   Coal & Uranium Program:
     Coal Severance Tax:
       '2014': 250000
+      '2016': 250000
     All:
       '2014': 250000
+      '2016': 250000
   Water Storage Special Revenue Account:
     Resource Indemnity & Ground Water Asssessment Tax (RIGWAT):
       '2014': 150000
+      '2016': 150000
     All:
       '2014': 150000
+      '2016': 150000
   Public Buildings:
     All:
       '2014': 66684
+      '2016': 13957
     Oil & Gas Rental Income:
       '2014': 33403
+      '2016': 3721
     Oil & Gas Penalty Income:
       '2014': 19071
+      '2016': 3743
     Oil Royalty:
       '2014': 6711
+      '2016': 2816
     Gas Royalty:
       '2014': 5020
+      '2016': 3270
     Oil & Gas Bonus Income:
       '2014': 1960
+      '2016': 30
     Non-Metalliferous Mineral Leases Rental Income:
       '2014': 360
+      '2016': 360
     Non-Metalliferous Mineral Leases Royalty Income:
       '2014': 160
+      '2016': 18
   School of Mines:
     All:
       '2014': 60168
@@ -668,60 +950,89 @@ funds:
   Pine Hills School:
     All:
       '2014': 45007
+      '2016': 2966
     Oil & Gas Rental Income:
       '2014': 28981
+      '2016': 1116
     Oil & Gas Penalty Income:
       '2014': 16026
+      '2016': 1850
   Montana State University Morrill:
     All:
       '2014': 32738
+      '2016': 7186
     Oil & Gas Rental Income:
       '2014': 18411
+      '2016': 440
     Gas Royalty:
       '2014': 8552
+      '2016': 5798
     Oil & Gas Penalty Income:
       '2014': 3615
     Oil & Gas Bonus Income:
       '2014': 2160
+    Oil Royalty:
+      '2016': 949
   University of Montana:
     All:
       '2014': 24086
+      '2016': 960
     Oil & Gas Penalty Income:
       '2014': 12000
     Oil & Gas Rental Income:
       '2014': 11286
+      '2016': 960
     Oil & Gas Bonus Income:
       '2014': 800
   State Normal School:
     All:
       '2014': 18609
+      '2016': 5047
     Oil & Gas Rental Income:
       '2014': 17012
+      '2016': 2505
     Gas Royalty:
       '2014': 1297
+      '2016': 442
     Oil & Gas Penalty Income:
       '2014': 300
+      '2016': 2100
   Agricultural Experiment Station:
     All:
       '2014': 12990
+      '2016': 12204
     Gas Royalty:
       '2014': 5803
+      '2016': 2677
     Oil & Gas Rental Income:
       '2014': 4847
+      '2016': 4847
     Oil & Gas Penalty Income:
       '2014': 2340
+      '2016': 4679
   School for Deaf and Blind:
     All:
       '2014': 8840
+      '2016': 16486
     Oil & Gas Rental Income:
       '2014': 5940
+      '2016': 3300
     Oil & Gas Penalty Income:
       '2014': 2900
+      '2016': 11
+    Oil Royalty:
+      '2016': 12295
+    Gas Royalty:
+      '2016': 597
+    Condensate Royalty:
+      '2016': 284
   Department of Transportation:
     All:
       '2014': 7468
+      '2016': 1270
     Oil & Gas Rental Income:
       '2014': 3911
+      '2016': 1270
     Oil Royalty:
       '2014': 1421
     Gas Royalty:
@@ -733,24 +1044,43 @@ funds:
   Department of Natural Resources Conservation - Water Resources Division:
     All:
       '2014': 5659
+      '2016': 134918
     Oil & Gas Rental Income:
       '2014': 2095
+      '2016': 124
     Gas Royalty:
       '2014': 1854
+      '2016': 28
     Oil & Gas Penalty Income:
       '2014': 1710
+    Oil & Gas Bonus Income:
+      '2016': 126234
+    Oil Royalty:
+      '2016': 8436
+    Condensate Royalty:
+      '2016': 96
   Montana State University 2nd Grant:
     All:
       '2014': 2087
+      '2016': 8
     Oil & Gas Rental Income:
       '2014': 1675
     Oil & Gas Penalty Income:
       '2014': 412
+    Oil Royalty:
+      '2016': 35
   Veterans Home Income:
     Oil & Gas Rental Income:
       '2014': 1913
     All:
       '2014': 1913
+      '2016': 1224
+    Oil Royalty:
+      '2016': 1214
+    Gas Royalty:
+      '2016': 9
+    Condensate Royalty:
+      '2016': 1
   'Department of Fish, Wildlife, & Parks':
     All:
       '2014': 210

--- a/_data/opt_in_state_revenues/WY.yml
+++ b/_data/opt_in_state_revenues/WY.yml
@@ -2,111 +2,161 @@ streams:
   All:
     Total:
       '2015': 3169341371
+      '2016': 2126209645
     Cities/Towns/Counties:
       '2015': 1038379517
+      '2016': 706592752
     Legislative Royalty Impact Assistance Account / Budget Reserve:
       '2015': 534613030
+      '2016': 299085414
     Permanent Mineral Trust Fund:
       '2015': 308438273
+      '2016': 168906202
     School Foundation:
       '2015': 251827747
+      '2016': 182837225
     School District Capital Construction:
       '2015': 228955844
+      '2016': 215827963
     General Fund:
       '2015': 215654798
+      '2016': 188978371
     Permanent Land Funds (largely benefitting Common Schools):
       '2015': 196753056
+      '2016': 151509283
     WY Highway Fund:
       '2015': 68729000
+      '2016': 68729000
     Abandoned Mine Land Funds Reserve Account:
       '2015': 49916169
+      '2016': 52913417
     WY Water Development Account I:
       '2015': 19297500
+      '2016': 19297500
     Capital Construction Account:
       '2015': 16661500
+      '2016': 16661500
     Permanent Land Income Funds (largely benefitting Common Schools):
       '2015': 15668838
     University of Wyoming:
       '2015': 13365000
+      '2016': 13365000
     State Aid County Roads:
       '2015': 4495000
+      '2016': 4495000
     Highway Fund County Roads:
       '2015': 4455000
+      '2016': 4455000
     WY Water Development Account 2:
       '2015': 3255000
+      '2016': 3255000
     Community Colleges:
       '2015': 1600000
+      '2016': 1600000
     DEQ Leaking Underground Storage Tanks:
       '2015': 1080943
+      '2016': 9865813
     WY Water Development Account 3:
       '2015': 775000
+      '2016': 775000
   Ad Valorem Taxes:
     Total:
       '2015': 996807296
+      '2016': 665425933
     Cities/Towns/Counties:
       '2015': 996807296
+      '2016': 665425933
   Severance Tax:
     Total:
       '2015': 981984161
+      '2016': 533620938
     Permanent Mineral Trust Fund:
       '2015': 308438273
+      '2016': 168906202
     General Fund:
       '2015': 210084399
+      '2016': 185476491
     Legislative Royalty Impact Assistance Account / Budget Reserve:
       '2015': 208463390
+      '2016': 110875432
     Cities/Towns/Counties:
       '2015': 20351500
+      '2016': 20351500
     WY Water Development Account I:
       '2015': 19297500
+      '2016': 19297500
     WY Highway Fund:
       '2015': 6711500
+      '2016': 6711500
     State Aid County Roads:
       '2015': 4495000
+      '2016': 4495000
     Capital Construction Account:
       '2015': 3611500
+      '2016': 3611500
     WY Water Development Account 2:
       '2015': 3255000
+      '2016': 3255000
     DEQ Leaking Underground Storage Tanks:
       '2015': 1080943
+      '2016': 9865813
     WY Water Development Account 3:
       '2015': 775000
+      '2016': 775000
   Federal Mineral Royalties:
     Total:
       '2015': 689273387
+      '2016': 482343207
     Legislative Royalty Impact Assistance Account / Budget Reserve:
       '2015': 326149640
+      '2016': 188209982
     School Foundation:
       '2015': 251827747
+      '2016': 182837225
     WY Highway Fund:
       '2015': 60142500
+      '2016': 60142500
     Cities/Towns/Counties:
       '2015': 18562500
+      '2016': 18562500
     University of Wyoming:
       '2015': 13365000
+      '2016': 13365000
     Capital Construction Account:
       '2015': 7425000
+      '2016': 7425000
     School District Capital Construction:
       '2015': 5346000
+      '2016': 5346000
     Highway Fund County Roads:
       '2015': 4455000
+      '2016': 4455000
     General Fund:
       '2015': 2000000
+      '2016': 2000000
   Federal Coal Lease Bonuses:
     Total:
       '2015': 224709844
+      '2016': 219581963
     School District Capital Construction:
       '2015': 215609844
+      '2016': 210481963
     Capital Construction Account:
       '2015': 5625000
+      '2016': 5625000
     WY Highway Fund:
       '2015': 1875000
+      '2016': 1875000
     Community Colleges:
       '2015': 1600000
+      '2016': 1600000
   State Royalties (In-Scope Commodities):
     Total:
       '2015': 222220146
+      '2016': 164815844
     Permanent Land Funds (largely benefitting Common Schools):
       '2015': 196753056
+      '2016': 147755639
     Permanent Land Income Funds (largely benefitting Common Schools):
       '2015': 15668838
     School District Capital Construction:
@@ -116,114 +166,169 @@ streams:
   AML Fees:
     Total:
       '2015': 49916169
+      '2016': 52913417
     Abandoned Mine Land Funds Reserve Account:
       '2015': 49916169
+      '2016': 52913417
   Wind Generation Tax:
     Total:
       '2015': 4430368
+      '2016': 3754699
     Cities/Towns/Counties:
       '2015': 2658221
+      '2016': 2252819
     General Fund:
       '2015': 1772147
+      '2016': 1501880
+  Special Use Lease & Wind Energy Lease:
+    Total:
+      '2016': 3753644
+    Permanent Land Funds (largely benefitting Common Schools):
+      '2016': 3753644
 funds:
   Total:
     All:
       '2015': 3169341371
+      '2016': 2126209645
     Ad Valorem Taxes:
       '2015': 996807296
+      '2016': 665425933
     Severance Tax:
       '2015': 981984161
+      '2016': 533620938
     Federal Mineral Royalties:
       '2015': 689273387
+      '2016': 482343207
     Federal Coal Lease Bonuses:
       '2015': 224709844
+      '2016': 219581963
     State Royalties (In-Scope Commodities):
       '2015': 222220146
+      '2016': 164815844
     AML Fees:
       '2015': 49916169
+      '2016': 52913417
     Wind Generation Tax:
       '2015': 4430368
+      '2016': 3754699
+    Special Use Lease & Wind Energy Lease:
+      '2016': 3753644
   Cities/Towns/Counties:
     All:
       '2015': 1038379517
+      '2016': 706592752
     Ad Valorem Taxes:
       '2015': 996807296
+      '2016': 665425933
     Severance Tax:
       '2015': 20351500
+      '2016': 20351500
     Federal Mineral Royalties:
       '2015': 18562500
+      '2016': 18562500
     Wind Generation Tax:
       '2015': 2658221
+      '2016': 2252819
   Legislative Royalty Impact Assistance Account / Budget Reserve:
     All:
       '2015': 534613030
+      '2016': 299085414
     Federal Mineral Royalties:
       '2015': 326149640
+      '2016': 188209982
     Severance Tax:
       '2015': 208463390
+      '2016': 110875432
   Permanent Mineral Trust Fund:
     Severance Tax:
       '2015': 308438273
+      '2016': 168906202
     All:
       '2015': 308438273
+      '2016': 168906202
   School Foundation:
     Federal Mineral Royalties:
       '2015': 251827747
+      '2016': 182837225
     All:
       '2015': 251827747
+      '2016': 182837225
   School District Capital Construction:
     All:
       '2015': 228955844
+      '2016': 215827963
     Federal Coal Lease Bonuses:
       '2015': 215609844
+      '2016': 210481963
     State Royalties (In-Scope Commodities):
       '2015': 8000000
     Federal Mineral Royalties:
       '2015': 5346000
+      '2016': 5346000
   General Fund:
     All:
       '2015': 215654798
+      '2016': 188978371
     Severance Tax:
       '2015': 210084399
+      '2016': 185476491
     Federal Mineral Royalties:
       '2015': 2000000
+      '2016': 2000000
     State Royalties (In-Scope Commodities):
       '2015': 1798252
     Wind Generation Tax:
       '2015': 1772147
+      '2016': 1501880
   Permanent Land Funds (largely benefitting Common Schools):
     State Royalties (In-Scope Commodities):
       '2015': 196753056
+      '2016': 147755639
     All:
       '2015': 196753056
+      '2016': 151509283
+    Special Use Lease & Wind Energy Lease:
+      '2016': 3753644
   WY Highway Fund:
     All:
       '2015': 68729000
+      '2016': 68729000
     Federal Mineral Royalties:
       '2015': 60142500
+      '2016': 60142500
     Severance Tax:
       '2015': 6711500
+      '2016': 6711500
     Federal Coal Lease Bonuses:
       '2015': 1875000
+      '2016': 1875000
   Abandoned Mine Land Funds Reserve Account:
     AML Fees:
       '2015': 49916169
+      '2016': 52913417
     All:
       '2015': 49916169
+      '2016': 52913417
   WY Water Development Account I:
     Severance Tax:
       '2015': 19297500
+      '2016': 19297500
     All:
       '2015': 19297500
+      '2016': 19297500
   Capital Construction Account:
     All:
       '2015': 16661500
+      '2016': 16661500
     Federal Mineral Royalties:
       '2015': 7425000
+      '2016': 7425000
     Federal Coal Lease Bonuses:
       '2015': 5625000
+      '2016': 5625000
     Severance Tax:
       '2015': 3611500
+      '2016': 3611500
   Permanent Land Income Funds (largely benefitting Common Schools):
     State Royalties (In-Scope Commodities):
       '2015': 15668838
@@ -232,35 +337,49 @@ funds:
   University of Wyoming:
     Federal Mineral Royalties:
       '2015': 13365000
+      '2016': 13365000
     All:
       '2015': 13365000
+      '2016': 13365000
   State Aid County Roads:
     Severance Tax:
       '2015': 4495000
+      '2016': 4495000
     All:
       '2015': 4495000
+      '2016': 4495000
   Highway Fund County Roads:
     Federal Mineral Royalties:
       '2015': 4455000
+      '2016': 4455000
     All:
       '2015': 4455000
+      '2016': 4455000
   WY Water Development Account 2:
     Severance Tax:
       '2015': 3255000
+      '2016': 3255000
     All:
       '2015': 3255000
+      '2016': 3255000
   Community Colleges:
     Federal Coal Lease Bonuses:
       '2015': 1600000
+      '2016': 1600000
     All:
       '2015': 1600000
+      '2016': 1600000
   DEQ Leaking Underground Storage Tanks:
     Severance Tax:
       '2015': 1080943
+      '2016': 9865813
     All:
       '2015': 1080943
+      '2016': 9865813
   WY Water Development Account 3:
     Severance Tax:
       '2015': 775000
+      '2016': 775000
     All:
       '2015': 775000
+      '2016': 775000

--- a/_includes/location/opt-in/state-disbursements.html
+++ b/_includes/location/opt-in/state-disbursements.html
@@ -10,6 +10,15 @@
   {{ page.state_disbursements | liquify | markdownify }}
 {% endif %}
 
+<h4>Distribution of {{ state_name }} state revenues ({{ revenue_year }})</h4>
+
+<p>
+  In {{ revenue_year }}, the state of
+  {{ state_name }} distributed
+  <strong>{{ revenue_total | default: 0 | intcomma_dollar }}
+  in state revenue from natural resource extraction</strong> to state and local funds.
+</p>
+
 <table is="bar-chart-table" class="table-basic"
   {% if include.id %}id="{{ include.id }}"{% endif %}>
   <thead>

--- a/_includes/location/opt-in/state-revenues.html
+++ b/_includes/location/opt-in/state-revenues.html
@@ -10,12 +10,7 @@
   {{ page.state_revenue | liquify | markdownify }}
 {% endif %}
 
-<!-- This link only works if the file is named correctly. -->
-<p>
-  <a href="{{site.baseurl}}/downloads/USEITI_{{ state_name }}_revenue_streams.pdf">
-    <icon class="fa fa-file-text-o u-padding-right"></icon>Download: {{ state_name }} revenue streams (PDF)
-  </a>
-</p>
+<h4>{{ state_name }} revenue streams ({{ revenue_year }})</h4>
 
 <p>
   In {{ revenue_year }}, the state of
@@ -25,11 +20,18 @@
   (this includes both tax and non-tax revenue). Counties also collect and distribute their own revenue from natural resource extraction.
 </p>
 
+<!-- This link only works if the file is named correctly. -->
+<p>
+  <a href="{{site.baseurl}}/downloads/USEITI_{{ state_name }}_revenue_streams.pdf">
+    <icon class="fa fa-file-text-o u-padding-right"></icon>Download: {{ state_name }} revenue streams (PDF)
+  </a>
+</p>
+
 <table is="bar-chart-table" class="table-basic"
   {% if include.id %}id="{{ include.id }}"{% endif %}>
   <thead>
     <tr>
-      <th><strong>State revenue stream</strong></th>
+      <th><strong>Revenue stream</strong></th>
       <th class="num"><strong>Amount collected</strong></th>
     </tr>
   </thead>

--- a/_states/WY.md
+++ b/_states/WY.md
@@ -52,7 +52,7 @@ state_saving_spending: |
 state_impact: |
     The extractive industries play an important role in Wyoming’s economy — particularly in Campbell County's Powder River Basin and in Sublette County. For more information about employment in Wyoming, the [Department of Workforce Services](http://www.wyomingworkforce.org/) has published [long-term industry and occupational projections for 2014 to 2024](http://doe.state.wy.us/lmi/projections/2016/projections_2014-2024.htm).
 
-    Because of relatively high annual wages (compared to other industries), extractive industries contribute a greater percentage of personal income than jobs. In 2014, annual wages from extractive industries made up about 18% (or $1.64 billion) of total annual wages in the state. The average annual wage for extractive-industry jobs in Wyoming in 2016 was $84,451, or almost twice the statewide average wage of $43,813.
+    Because of relatively high annual wages (compared to other industries), extractive industries contribute a greater percentage of personal income than jobs. In 2016, annual wages from extractive industries made up about 18% (or $1.6 billion) of total annual wages in the state. The average annual wage for extractive-industry jobs in Wyoming in 2016 was $84,451, or almost twice the statewide average wage of $43,813.
 ---
 
 <!-- State governance -->

--- a/_states/WY.md
+++ b/_states/WY.md
@@ -18,11 +18,11 @@ state_production: |
 
     Northeastern Wyoming holds the Powder River Basin, which contains eight of the ten largest coal mines in the country. Wyoming's natural gas production is centered in the Green River Basin in southwestern Wyoming. Crude oil production takes place in the Niobrara Shale (in southeastern Wyoming), the Powder River Basin, and the Green River oil shale.
 
-    Wyoming produces about 70% of the uranium mined in the U.S. To learn more about uranium mining nationwide, see the EIA’s [annual domestic uranium production report](http://www.eia.gov/uranium/production/annual/).
+    Wyoming is one of the centers of uranium production in the U.S. To learn more about uranium mining nationwide, see the EIA’s [annual domestic uranium production report](http://www.eia.gov/uranium/production/annual/).
 
-    In 2014, Wyoming produced 2.4% of U.S. wind energy. Particularly in the southeast part of the state, there's significant potential for increased wind energy production and several large-scale wind energy projects are in development.
+    In 2016, Wyoming produced 1.9% of U.S. wind energy. Particularly in the southeast part of the state, there's significant potential for increased wind energy production and several large-scale wind energy projects are in development.
 
-    **Nonenergy minerals:** In 2011, Wyoming's nonenergy mineral production was valued at over $2.14 billion. Notably, Wyoming produces more trona (the chief source of [soda ash](http://minerals.usgs.gov/minerals/pubs/commodity/soda_ash/)) than any other state, and the largest deposit of trona in the world sits under Sweetwater County in Wyoming. For details about what other minerals are extracted, see the [USGS Minerals Yearbook for Wyoming](http://minerals.usgs.gov/minerals/pubs/state/wy.html).
+    **Nonenergy minerals:** In 2013, Wyoming's nonenergy mineral production was valued at over $2.26 billion. Notably, Wyoming produces more trona (the chief source of [soda ash](http://minerals.usgs.gov/minerals/pubs/commodity/soda_ash/)) than any other state, and the largest deposit of trona in the world sits under Sweetwater County in Wyoming. For details about what other minerals are extracted, see the [USGS Minerals Yearbook for Wyoming](http://minerals.usgs.gov/minerals/pubs/state/wy.html).
 state_land: |
     The state government of Wyoming administers 3.4 million surface acres of land (about 5.5% of the state) and 3.9 million {{ "mineral acres" | term_end }}. For detailed information about land ownership in each county, see the [Wyoming Statewide Parcel Viewer](http://gis.wyo.gov/parcels/).
 state_land_production: |
@@ -32,11 +32,11 @@ state_land_production: |
 state_revenue: |
     Revenue from natural resource extraction on federal, state, and private land is a primary source of income for the state of Wyoming.
 
-    In production year 2014, all 23 of Wyoming’s counties had taxable mineral production, though over 60% percent of revenue from mineral production came from Campbell, Sublette, and Sweetwater counties. In general, the state of Wyoming collects revenue from extraction in the form of severance taxes and counties collect revenue from extraction through ad valorem taxes.
+    In production year 2016, all 23 of Wyoming’s counties had taxable mineral production, though over 70% percent of the taxable value of mineral production came from Campbell, Sublette, and Sweetwater counties. In general, the state of Wyoming collects revenue from extraction in the form of severance taxes and counties collect revenue from extraction through ad valorem taxes.
 state_revenue_sustainability: |
     ![Bar graph comparing Wyoming natural resources revenue to total Wyoming General Fund revenue from 2004-2014. Total revenue rose from just under $800 billion in 2005 to over $1,200 billion in 2008, then fell to about $1,000 billion in 2009 and 2010 before rising to about $1,300 billion by 2014. Natural resources revenues followed a similar pattern, and accounted for more than a third and less than half of general fund revenues each year.]({{ site.baseurl }}/img/WY_revenue_sustainability.svg)
 
-    In 2014, natural resource revenue streams contributed almost half of the state’s total general fund revenues. Over the last decade, Wyoming’s general fund revenues from extractive industries have doubled from $315 million to $640 million, and the percentage of total general fund revenues from extraction has increased 8%, fluctuating between a low of 33% (in 2009) and a high of 46% (in 2014). Severance tax revenues hold particular importance for Wyoming, and account for up to a quarter of general fund revenues.
+    In 2016, natural resource revenue streams contributed 34% of the state’s total general fund revenues. Wyoming’s general fund revenues from extractive industries have fluctuated from $315 million in 2005 to $640 million in 2014 and back down to $337 million in 2016. The percentage of total general fund revenues from extraction has also fluctuated between a low of 33% (in 2009) and a high of 46% (in 2014). Severance tax revenues hold particular importance for Wyoming, and have accounted for between 13% and 20% of general fund revenues in the last decade.
 
     To read more about the impact of revenue from extractive industries on Wyoming’s general fund, including future projections, see reports produced by Wyoming's [Consensus Revenue Estimating Group](http://eadiv.state.wy.us/creg/creg.html).
 state_tax_expenditures: |
@@ -48,11 +48,11 @@ state_disbursements: |
 
     At the local level, county tax collectors collect all property taxes on production and distribute them within their own jurisdictions.
 state_saving_spending: |
-    The state of Wyoming saves about 68% of severance tax revenue and 39% of federal mineral royalty revenues. These two revenue streams are Wyoming's two largest sources of revenue from natural resource extraction. Wyoming saves revenue by contributing to the Budget Reserve Account and the Permanent Wyoming Mineral Trust Fund. Interest from the Permanent Wyoming Mineral Trust Fund goes to the General Fund.
+    In 2016, the state of Wyoming saved about 52% of severance tax revenue and 27% of federal mineral royalty revenues. These two revenue streams are Wyoming's two largest sources of revenue from natural resource extraction. Wyoming saves revenue by contributing to the Budget Reserve Account and the Permanent Wyoming Mineral Trust Fund. Interest from the Permanent Wyoming Mineral Trust Fund goes to the General Fund.
 state_impact: |
     The extractive industries play an important role in Wyoming’s economy — particularly in Campbell County's Powder River Basin and in Sublette County. For more information about employment in Wyoming, the [Department of Workforce Services](http://www.wyomingworkforce.org/) has published [long-term industry and occupational projections for 2014 to 2024](http://doe.state.wy.us/lmi/projections/2016/projections_2014-2024.htm).
 
-    Because of relatively high annual wages (compared to other industries), extractive industries contribute a greater percentage of personal income than jobs. In 2014, annual wages from extractive industries made up about 18% (or $2.4 billion) of total annual wages in the state. The average annual wage for extractive-industry jobs in Wyoming in 2014 was $88,198, or almost twice the statewide average wage of $46,492.
+    Because of relatively high annual wages (compared to other industries), extractive industries contribute a greater percentage of personal income than jobs. In 2014, annual wages from extractive industries made up about 18% (or $1.64 billion) of total annual wages in the state. The average annual wage for extractive-industry jobs in Wyoming in 2016 was $84,451, or almost twice the statewide average wage of $43,813.
 ---
 
 <!-- State governance -->
@@ -61,7 +61,7 @@ state_impact: |
 
 The state of Wyoming regulates extraction and interacts with extractive industry companies in Montana, particularly when they're operating on state or private land.
 
-The [Wyoming Department of Revenue](http://revenue.wyo.gov/) assesses, collects, manages, and distributes revenue from companies engaged in extraction of oil, natural gas, coal, and other natural resources in Wyoming. At the local level, gounty governments directly collect ad valorem taxes related to extraction. The Department of Revenue publishes:
+The [Wyoming Department of Revenue](http://revenue.wyo.gov/) assesses, collects, manages, and distributes revenue from companies engaged in extraction of oil, natural gas, coal, and other natural resources in Wyoming. At the local level, county governments directly collect ad valorem taxes related to extraction. The Department of Revenue publishes:
 
 * [Annual reports](http://revenue.wyo.gov/dor-annual-reports)
 * [Rules and regulations](http://revenue.wyo.gov/home/rules-and-regulations-by-chapter)
@@ -85,14 +85,14 @@ The [Wyoming Department of Environmental Quality](http://deq.wyoming.gov/) (DEQ)
 * The [Air Quality Division](http://deq.wyoming.gov/aqd/) issues air quality permits, particularly in the Upper Green River Basin.
 * The [Water Quality Division](http://deq.wyoming.gov/wqd/) works to ensure the proper disposal of wastewater, and monitors water quality. It also permits underground injections of wastewater, reclaims discharge impoundments related to coal bed methane production, and works with the Oil and Gas Conservation Commission and Land Quality Division to regulate underground wastewater injection through the [Underground Injection Control Program](http://deq.wyoming.gov/wqd/underground-injection-control/). The Water Quality Division also maintains its own list of [rules and regulations](http://deq.wyoming.gov/wqd/resources/rules-regs/).
 * The [Solid and Hazardous Waste Division](http://deq.wyoming.gov/shwd/) inspects hazardous waste storage and disposal.
-* The [Land Quality Division](http://deq.wyoming.gov/lqd/) regulates surface mining operations and surface operations for underground mines, works to ensure reclamation following mining, establishes reclamation bond amounts, and holds reclamation bonds on mine operations. It publishes an [annual report (PDF)](http://deq.wyoming.gov/media/uploads/admin/annual_report_2014.pdf) that includes bond amounts.
+* The [Land Quality Division](http://deq.wyoming.gov/lqd/) regulates surface mining operations and surface operations for underground mines, works to ensure reclamation following mining, establishes reclamation bond amounts, and holds reclamation bonds on mine operations. It publishes an [annual report (PDF)](http://deq.wyoming.gov/media/uploads/admin/2016-annual-report.pdf) that includes bond amounts.
 * The [Abandoned Mine Land Division](http://deq.wyoming.gov/aml/) administers the federal AML program for coal and select hardrock reclamation projects.
 
 The [Wyoming State Geological Survey](http://www.wsgs.wyo.gov/) also provides geological information about natural resources.
 
 ### State laws and regulations
 
-Wyoming’s constitution includes an [article governing mining](http://legisweb.state.wy.us/NXT/gateway.dll/2016%20Wyoming%20Statutes/2016%20Constitution/1/10?f=templates&fn=default.htm&vid=Publish:10.1048/Enu).
+Wyoming’s constitution includes an [article governing mining](http://legisweb.state.wy.us/NXT/gateway.dll/2016%20Wyoming%20Statutes/2016%20Constitution/1/10?f=templates&fn=default.htm&vid=Publish:10.1048/Enu), Article 9, which created the Office of the Inspector of Mines and a school of mines, directs the legislature to provide for the development and operation of mines, and secures the right of action for injuries.
 
 The [Wyoming Statutes Annotated](http://www.lexisnexis.com/hottopics/wystatutes/) have several sections that govern natural resource extraction, including:
 
@@ -134,6 +134,6 @@ Prior to 2001, the Sublette County Rural Health Care District had two all-volunt
 
 #### Reclamation costs
 
-Wyoming has been “certified” by the federal Abandoned Mine Land (AML) Reclamation program, meaning it has reclaimed its identified high-priority abandoned coal mine areas. It also means AML funds, which are sourced from fees paid by coal mine operators, can be used for a wider range of purposes beyond reclamation, including abandoned hardrock mine sites. The program currently estimates that Wyoming has $52 million in unreclaimed coal AML sites and $686,000 in unreclaimed non-coal AML sites (such as uranium mining sites). To learn more about recently completed projects and projects underway, search for Wyoming Annual Evaluation Reports in the [OSMRE Oversight Document Database](http://odocs.osmre.gov/).
+Wyoming has been “certified” by the federal Abandoned Mine Land (AML) Reclamation program, meaning it has reclaimed its identified high-priority abandoned coal mine areas. It also means AML funds, which are sourced from fees paid by coal mine operators, can be used for a wider range of purposes beyond reclamation, including abandoned hardrock mine sites. The program currently estimates that Wyoming has $77 million in unreclaimed coal AML sites and $18 million in unreclaimed non-coal AML sites (such as uranium mining sites). To learn more about recently completed projects and projects underway, search for Wyoming Annual Evaluation Reports in the [OSMRE Oversight Document Database](http://odocs.osmre.gov/).
 
 See [state agencies](#state-agencies) for additional statewide reclamation activities.

--- a/_states/WY.md
+++ b/_states/WY.md
@@ -5,7 +5,7 @@ FIPS: '56'
 
 opt_in: true
 
-state_revenue_year: 2015
+state_revenue_year: 2016
 
 # is_cropped forces the default county map view to use
 # a custom set of viewbox coordinates

--- a/data/state/opt-in/MT/revenue-distribution.tsv
+++ b/data/state/opt-in/MT/revenue-distribution.tsv
@@ -28,3 +28,32 @@ Year	Revenue Stream	Type	Total	General Fund	State Share	County Share / Governmen
 2014	Land Use Licenses Royalty Income	Royalty/Rent/Bonus	$1,000				$1,000.00																																																	
 2014	Micaceous Mines License Tax	License Tax	$-	$-																																																				
 2014	All	All	$446,883,245	$176,559,116	$12,276,757	$133,478,180	$34,725,031	$28,838,092	$11,773,273	$6,921,142	$4,732,701	$3,583,888	$3,369,568	$3,219,424	$3,157,313	$3,149,120	$2,505,508	$2,454,052	$2,129,440	$1,185,166	$976,019	$732,488	$547,924	$372,716	$372,716	$366,000	$363,360	$348,578	$272,106	$250,000	$150,000	$66,684	$60,168	$45,007	$32,738	$24,086	$18,609	$12,990	$8,840	$7,468	$5,659	$2,087	$1,913	$210	$42	$-	$-	$-	$-	$-	$-	$-	$-	$-	$-	$-   
+2016	Oil & Natural Gas Production Tax	 Production Tax 	$84,972,199.00	$39,083,500.00		$37,900,038.00			$1,394,905.00		$1,534,356.00	$1,281,080.00	$938,011.00	$1,150,801.00			$812,294.00	$877,214.00																																						
+2016	Coal Severance Tax	 Ad Valorem 	$60,358,549	$14,235,548				$30,179,274		$7,243,026						$3,295,577			$3,434,905			$766,554	$573,406				$380,259			$250,000																										
+2016	U.S. Mineral Royalties	 Federal Revenue 	$22,345,284	$16,758,963		$5,586,321																																																		
+2016	Oil Royalty	 Royalty/Rent/Bonus 	$7,388,547				$6,801,850.02								$560,953.22																	$2,815.99			$948.54				$12,294.73		$8,435.53	$35.23	$1,213.84													
+2016	Coal Gross Proceeds	 Ad Valorem 	$20,756,877		$9,979,145.00	$10,777,732																																																		
+2016	Metal Mines Gross Proceeds	 Ad Valorem 	$14,686,751		$2,690,657	$11,996,094																																																		
+2016	 Metalliferous Mines License Tax 	 Production Tax 	$8,164,498	$4,221,465		$2,473,424														$693,982	$571,515							$204,112																												
+2016	 Abandoned Mine Land Fees 	 Federal Revenue 	$4,429,969	$4,429,969																																																				
+2016	 Coal Royalties 	 Royalty/Rent/Bonus 	$9,124,779				$9,124,778.67																																																	
+2016	 Wind Generation Property Tax 	 Ad Valorem 	$7,998,776																																																					
+2016	 Electrical Energy Producers' License Tax 	 License Tax 	$425,800	$425,800																																																				
+2016	 Oil & Gas Bonus Income 	 Royalty/Rent/Bonus 	$138,629				$12,365.35																									$30.00									$126,234.08															
+2016	 Oil & Gas Rental Income 	 Royalty/Rent/Bonus 	$976,081				$948,333.35								$9,491.89																	$3,720.50		$1,116.02	$439.90	$960.00	$2,505.00	$4,847.44	$3,300.00	$1,270.48	$123.72	-$27.17														
+2016	Resource Indemnity & Ground Water Asssessment Tax (RIGWAT)	 Production Tax 	$2,335,153										$774,364											$387,182	$387,182	$366,000			$270,425		$150,000																									
+2016	Gas Royalty	 Royalty/Rent/Bonus 	$555,103				$533,525.21								$8,757.10																	$3,269.93			$5,797.64		$442.13	$2,677.11	$597.21		$27.85		$8.71													
+2016	Miscellaneous Mines Net Proceeds	 Ad Valorem 	$1,624,098		$377,480	$1,246,618																																																		
+2016	Oil & Gas Penalty Income	 Penalty 	$499,808				$482,157.37								$5,268.11																	$3,743.25		$1,850.00			$2,100.00	$4,679.08	$10.60																	
+2016	Condensate Royalty	 Royalty/Rent/Bonus 	$24,839				$23,410.17								$1,047.34																								$283.55		$96.32		$1.28													
+2016	Coal Rentals / Bonuses	 Royalty/Rent/Bonus 	$49,535				$49,535.43																																																	
+2016	Land Use Licenses Rental Income	 Royalty/Rent/Bonus 	$15,507				$15,507.13																																																	
+2016	Non-Metalliferous Mineral Leases Royalty Income	 Royalty/Rent/Bonus 	$18																													$17.50																								
+2016	Non-Metalliferous Mineral Leases Rental Income	 Royalty/Rent/Bonus 	$5,430				$5,070.00																									$360.00																								
+2016	Oil & Gas Surface Damages 	 Royalty/Rent/Bonus 	$ -				$ -																																$ -																	
+2016	Oil & Gas Seismic Permits	 Royalty/Rent/Bonus 	$ -				$ -																																																	
+2016	Metalliferous Mineral Lease Rental Income	 Royalty/Rent/Bonus 	$277				$277.08																																																	
+2016	Metalliferous Mineral Lease Royalty Income	 Royalty/Rent/Bonus 	$ -				$ -																																																	
+2016	Land Use Licenses Royalty Income	 Royalty/Rent/Bonus 	$11,292				$11,291.50																																																	
+2016	Micaceous Mines License Tax	 License Tax 	$ -	$ -																																																				
+2016	All	All	$246,887,799	$79,155,245	$13,047,282	$69,980,227	$18,008,101	$30,179,274	$1,394,905	$7,243,026	$1,534,356	$1,281,080	$1,712,375	$1,150,801	$585,518	$3,295,577	$812,294	$877,214	$3,434,905	$693,982	$571,515	$766,554	$573,406	$387,182	$387,182	$366,000	$380,259	$204,112	$270,425	$250,000	$150,000	$13,957	$ -	$2,966	$7,186	$960	$5,047	$12,204	$16,486	$1,270	$134,918	$8	$1,224													

--- a/data/state/opt-in/WY/revenue-distribution.tsv
+++ b/data/state/opt-in/WY/revenue-distribution.tsv
@@ -6,4 +6,13 @@ Year	Revenue Stream	Year Type	Source	Type	Total	General Fund	Permanent Mineral T
 2015	Wind Generation Tax	Fiscal Year	FY2015 Department of Revenue Annual Report	Production Tax	$ 4,430,368	$ 1,772,147			$ 2,658,221																
 2015	AML Fees	Fiscal Year	OSMRE FY2015 Grant Distribution Report	Federal Revenue Stream	$ 49,916,169																				$ 49,916,169
 2015	Ad Valorem Taxes	Production Year	FY2015 Department of Revenue Annual Report	Ad Valorem Taxes	$ 996,807,296				$ 996,807,296																
-2015	All				$ 3,169,341,371	$ 215,654,798	$ 308,438,273	$ -	$ 1,038,379,517	$ 534,613,030	$ 19,297,500	$ 3,255,000	$ 775,000	$ 1,080,943	$ 68,729,000	$ 16,661,500	$ 4,495,000	$ 13,365,000	$ 251,827,747	$ 4,455,000	$ 228,955,844	$ 1,600,000	$ 196,753,056	$ 15,668,838	$ 49,916,169 
+2015	All				$ 3,169,341,371	$ 215,654,798	$ 308,438,273	$ -	$ 1,038,379,517	$ 534,613,030	$ 19,297,500	$ 3,255,000	$ 775,000	$ 1,080,943	$ 68,729,000	$ 16,661,500	$ 4,495,000	$ 13,365,000	$ 251,827,747	$ 4,455,000	$ 228,955,844	$ 1,600,000	$ 196,753,056	$ 15,668,838	$ 49,916,169
+2016	Severance Tax	PY for revenue total and FY for distributions	 CREG January 2017 Report 	 Production Tax 	$533,620,938.00	$185,476,491.00	$168,906,202.00		$20,351,500.00	$110,875,432.00	$19,297,500.00	$3,255,000.00	$775,000.00	$9,865,813.00	$6,711,500.00	$3,611,500.00	$4,495,000.00								
+2016	Federal Mineral Royalties	Fiscal Year	 CREG January 2017 Report 	 Federal Revenue Stream 	$482,343,207.00	$2,000,000.00			$18,562,500.00	$188,209,982.00					$60,142,500.00	$7,425,000.00		$13,365,000.00	$182,837,225.00	$4,455,000.00	$5,346,000.00				
+2016	Federal Coal Lease Bonuses	Fiscal Year	 CREG January 2017 Report 	 Federal Revenue Stream 	$219,581,963.00										$1,875,000.00	$5,625,000.00					$210,481,963.00	$1,600,000.00			
+2016	State Royalties (In-Scope Commodities)	Fiscal Year	 WY Office of State Lands Strategic Plan Annual Report FY2016  	 Royalty 	$164,815,844.00																		$147,755,639.00		
+2016	Wind Generation Tax	Fiscal Year	 FY2016 Department of Revenue Annual Report 	 Production Tax 	$3,754,699.00	$1,501,880.00			$2,252,819.00																
+2016	AML Fees	Fiscal Year	 OSMRE FY2016 Grant Distribution Report 	 Federal Revenue Stream 	$52,913,417.00																				$52,913,417.00
+2016	Ad Valorem Taxes	Fiscal Year	 FY2016 Department of Revenue Annual Report 	 Ad Valorem Taxes 	$665,425,933.00				$665,425,933.00																
+2016	Special Use Lease & Wind Energy Lease 	Production Year	 WY Office of State Lands Strategic Plan Annual Report FY2016 	 Royalty  	$3,753,644.00																		$3,753,644.00		
+2016	All				$2,126,209,645.00	$188,978,371.00	$168,906,202.00		$706,592,752.00	$299,085,414.00	$19,297,500.00	$3,255,000.00	$775,000.00	$9,865,813.00	$68,729,000.00	$16,661,500.00	$4,495,000.00	$13,365,000.00	$182,837,225.00	$4,455,000.00	$215,827,963.00	$1,600,000.00	$151,509,283.00		$52,913,417.00


### PR DESCRIPTION
Starts issue(s) #2486 

[![CircleCI](https://circleci.com/gh/18F/doi-extractives-data/tree/update_optin_state_data.svg?style=svg)](https://circleci.com/gh/18F/doi-extractives-data/tree/update_optin_state_data)


 **Moved this checklist to #2486**

## Wyoming

- [x] State revenue chart [🏇 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/update_optin_state_data/explore/WY/#state-local-revenue) - 2016 data, but needs validation
- [x] State disbursements  [🏇 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/update_optin_state_data/explore/WY/#state-disbursements) - 2016 data, but needs validation
- [x] Content updates ([source; limited access](https://drive.google.com/drive/folders/13ZJPUWeZbUs7kFQzNEGVvUSyalwPiPLi))
- [ ] Static charts — update or remove

## Montana

- [ ] State revenue chart [🐻 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/update_optin_state_data/explore/MT/#state-local-revenue) - still showing 2014 data
- [ ] State disbursements  [🐻 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/update_optin_state_data/explore/MT/#state-disbursements) - still showing 2014 data
- [ ] Content updates ([source; limited access](https://drive.google.com/drive/folders/1pWiMDMIbSLsxv-tyRIVSiGRF8ETu9SRB)) - #2584 
- [ ] Static charts — update or remove

## Alaska

- [ ] State revenue chart [🐟 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/update_optin_state_data/explore/AK/#state-local-revenue) - showing 2015 data
- [ ] State disbursements  [🐟 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/update_optin_state_data/explore/AK/#state-disbursements) - showing 2015 data
- [ ] Content updates ([source; limited access](https://drive.google.com/drive/folders/1siHtT_1_rz4W4supWyYkPZuCzQooAGCu)) - #2585
- [ ] Static charts — update or remove
 