### PR TITLE
Right-aligns numbers in disbursement charts

### DIFF
--- a/_includes/location/opt-in/state-disbursements.html
+++ b/_includes/location/opt-in/state-disbursements.html
@@ -39,7 +39,7 @@
           {{ fund_name }}
         {% endif %}
       </td>
-      <td data-value="{{ fund_dollars }}"
+      <td class="numeric" data-value="{{ fund_dollars }}"
         data-year-values='{{ fund_sources.All | jsonify }}'>
         {{ fund_dollars | default: 0 | intcomma_dollar }}
       </td>

--- a/_includes/location/opt-in/state-revenues.html
+++ b/_includes/location/opt-in/state-revenues.html
@@ -57,7 +57,7 @@
           {{ stream_name }}
         {% endif %}
       </td>
-      <td data-value="{{ stream_dollars }}"
+      <td class="numeric" data-value="{{ stream_dollars }}"
         data-year-values='{{ stream_sources.Total | jsonify }}'>
         {{ stream_dollars | default: 0 | intcomma_dollar }}
       </td>

--- a/_sass/components/_bar-chart-table.scss
+++ b/_sass/components/_bar-chart-table.scss
@@ -51,11 +51,6 @@
     width: 0.75rem;
   }
 
-  .numeric,
-  [data-value] {
-    text-align: left;
-  }
-
   th.numeric {
     text-align: right;
   }


### PR DESCRIPTION
Numbers in tables should be right aligned, for easier visual scanning.

 - [x] Nat’l chart
 - [x] Opt-in state charts (#2569, need @msecret’s css help here, thx!)