### PR TITLE
Adds subnavigation items for disbursements subheadings

### DIFF
--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -28,7 +28,7 @@
     %}
   {% endif %}
 
-  <h3 id="lwcf">Land and Water Conservation Fund</h3>
+  <h4 id="lwcf">Land and Water Conservation Fund</h4>
 
   <p>{{ "ONRR" | term }} disburses revenue to the <a href="https://www.nps.gov/subjects/lwcf/index.htm">Land and Water Conservation Fund</a> (LWCF) according to federal law. However, these funds are subject to congressional appropriations. Some of the money disbursed from ONRR to the fund is spent on LWCF projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $900 million each year, but congressional appropriations to LWCF projects have been limited to between $149 million and $573 million each year since 1999.</p>
 
@@ -49,7 +49,7 @@
     </li>
   </ul>
 
-  <h3 id="hpf">Historic Preservation Fund</h3>
+  <h4 id="hpf">Historic Preservation Fund</h4>
 
   <p>Like the LWCF, money in the Historic Preservation Fund is subject to congressional appropriations. Some of it is spent on historic preservation projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $150 million each year, but annual appropriations have declined from $94 million to less than $60 million since 2001.</p>
 

--- a/explore/index.html
+++ b/explore/index.html
@@ -25,6 +25,13 @@ nav_items:
         title: Federal tax revenue
   - name: federal-disbursements
     title: Disbursements
+    subnav_items:
+      - name: by-fund
+        title: Disbursements by fund
+      - name: lwcf
+        title: Land and Water Conservation Fund
+      - name: hpf
+        title: Historic Preservation Fund
   - name: economic-impact
     title: Economic impact
     subnav_items:

--- a/explore/index.html
+++ b/explore/index.html
@@ -28,10 +28,6 @@ nav_items:
     subnav_items:
       - name: by-fund
         title: Disbursements by fund
-      - name: lwcf
-        title: Land and Water Conservation Fund
-      - name: hpf
-        title: Historic Preservation Fund
   - name: economic-impact
     title: Economic impact
     subnav_items:


### PR DESCRIPTION
Fixes issue #

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/explore-subnav/)

Changes proposed in this pull request:

- We're missing [subnavigation items for Disbursements](https://revenuedata.doi.gov/explore/#federal-disbursements). Other sections have subnav items for `h3`s.
- Adds subnavigation items for Disbursements section of explore data
