### PR TITLE
Include JS in styleguide

### DIFF
--- a/nrrd-design-system/components/_preview.hbs
+++ b/nrrd-design-system/components/_preview.hbs
@@ -13,5 +13,6 @@
   {{{ yield }}}
 </div>
 
+<script src="{{ path '/js/main.min.js' }}"></script>
 </body>
 </html>


### PR DESCRIPTION
By linking to it.

Fixes issue #2522

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/ms-include_js_in_styleguide/)
