### PR TITLE
Use different _config.yml for dev and federalist

### DIFF
--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,0 +1,64 @@
+exclude:
+  # top-level log
+  - '*.log'
+  # markdown files
+  - CONTRIBUTING.md
+  - ISSUE_TEMPLATE.md
+  - LICENSE.md
+  - PULL_REQUEST_TEMPLATE.md
+  - README.md
+  # ruby dependency files
+  - Gemfile*
+  # KSS (style guide) config and template
+  - kss-config.json
+  - styleguide-template
+  - nrrd-design-system
+  # Node depenencies
+  - node_modules
+  - package.json
+  # unit tests
+  - test
+  - circle.yml
+  # webpack configuration
+  - webpack.config.js
+  - css
+  - img
+  # all of the source (unbuilt) JS files
+  - js
+  # shell and other scripts
+  - '*.sh'
+  - '*.rb'
+  - data/**/*.md
+  - data/**/*.yml
+  - data/all-production/*/*.?sv
+  - data/bin
+  - data/geo/input
+  - data/gdp
+  - data/jobs
+  - maps/lib
+  # data tools and SQLite databases
+  - '*.db*'
+  - .env
+  - data/**/*.csv
+  - data/**/*.js
+  - data/**/*.md
+  - data/**/*.ndjson
+  - data/**/*.sql
+  - data/**/*.svg
+  - data/env.example
+  - data/README.md
+  - data/company-revenue/input
+  - data/geo/input
+  - data/jobs/bls
+  - data/land-stats
+  # Docker stuff
+  - Dockerfile
+  - 'docker-*.yml'
+  # Makefiles
+  - Makefile
+  - '**/Makefile'
+  - maps/data
+  - maps/land/*.json
+  - serve*
+  - re-serve*
+  - public

--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,6 @@ exclude:
   - maps/land/*.json
   - serve*
   - re-serve*
-  - public
 
 include:
   - /build.log

--- a/scripts/jekyll-watch.js
+++ b/scripts/jekyll-watch.js
@@ -25,7 +25,7 @@ function run(cwd, command, args) {
 }
 
 function runJekyll() {
-  return run('/doi', 'jekyll', ['build', '--incremental'])
+  return run('/doi', 'jekyll', ['build', '--incremental', '--config', '_config.yml,_config-dev.yml'])
 }
 
 // Make it easy for Docker to terminate us.


### PR DESCRIPTION
During development, we use a system of docker, express, and jekyll to make the environment run on different machines. However, in doing so we told jekyll to ignore the /public directory so that it could be managed by webpack & express. On Federalist, there is no Express server so jekyll needs to include /public when it builds the site.

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/jekyll-public/)

Changes proposed in this pull request:

- Add `_config-dev.yml` for use with docker

