### PR TITLE
Refactor some redirects

### DIFF
--- a/_explore/economic-impact/exports.html
+++ b/_explore/economic-impact/exports.html
@@ -1,6 +1,0 @@
----
-title: Exports | Explore Data
-layout: redirect
-permalink: /explore/exports/
-redirect_url: /explore/
----

--- a/_explore/economic-impact/gdp.html
+++ b/_explore/economic-impact/gdp.html
@@ -1,6 +1,0 @@
----
-title: Explore | Gross Domestic Product
-layout: redirect
-permalink: /explore/gdp/
-redirect_url: /explore/#gdp
----

--- a/_explore/economic-impact/jobs.html
+++ b/_explore/economic-impact/jobs.html
@@ -1,6 +1,0 @@
----
-title: Jobs | Explore Data
-layout: redirect
-permalink: /explore/jobs/
-redirect_url: /explore/#employment
----

--- a/_explore/production/production-all-lands.html
+++ b/_explore/production/production-all-lands.html
@@ -1,6 +1,0 @@
----
-title: All Lands Production | Explore Data
-layout: redirect
-permalink: /explore/all-lands-production/
-redirect_url: /explore/#all-production
----

--- a/_explore/production/production-federal.html
+++ b/_explore/production/production-federal.html
@@ -1,6 +1,0 @@
----
-title: Federal Production | Explore Data
-layout: redirect
-permalink: /explore/federal-production/
-redirect_url: /explore/#federal-production
----

--- a/_explore/revenue/corporate-income-tax.md
+++ b/_explore/revenue/corporate-income-tax.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-permalink: /explore/corporate-income-tax/
-redirect_url: /how-it-works/corporate-income-tax/
----

--- a/_explore/revenue/disbursements.md
+++ b/_explore/revenue/disbursements.md
@@ -1,6 +1,0 @@
----
-title: Disbursements | Explore Data
-layout: redirect
-permalink: /explore/disbursements/
-redirect_url: /explore/#federal-disbursements
----

--- a/_explore/revenue/federal-revenue-by-location.html
+++ b/_explore/revenue/federal-revenue-by-location.html
@@ -1,6 +1,0 @@
----
-title: Federal Revenue by Location
-layout: redirect
-permalink: /explore/federal-revenue-by-location/
-redirect_url: /explore/#revenue
----

--- a/_how-it-works/corporate-income-tax.md
+++ b/_how-it-works/corporate-income-tax.md
@@ -10,6 +10,7 @@ tag:
 - Tax receipts
 - Corporate filings
 permalink: /how-it-works/corporate-income-tax/
+redirect_from: /explore/corporate-income-tax/
 breadcrumb:
   - title: How it works
     permalink: /how-it-works/

--- a/explore/index.html
+++ b/explore/index.html
@@ -1,6 +1,14 @@
 ---
 layout: default
 permalink: /explore/
+redirect_from:
+  - /explore/exports/
+  - /explore/gdp/
+  - /explore/jobs/
+  - /explore/all-lands-production/
+  - /explore/federal-production/
+  - /explore/disbursements/
+  - /explore/federal-revenue-by-location/
 id: US
 title: Explore data
 national_page: true


### PR DESCRIPTION
We currently handle redirects in two ways: through standalone files [like this one](https://github.com/18F/doi-extractives-data/blob/dev/_explore/economic-impact/exports.html), and through the `redirect_from` gem, which uses the frontmatter of the destination page, [like so](https://github.com/18F/doi-extractives-data/blob/dev/_how-it-works/laws-and-regulations/state-laws-and-regulations.md).

The `/_explore/` folder is an artifact of an old site architecture (circa 2015), and predates when we started using the `redirect_from` gem.

This PR tackles the low-hanging fruit in that folder by replacing relatively simple redirect files with `redirect_from` entries in the frontmatter of the appropriate destination files. There were a couple I couldn't figure out quickly, so I left them as-is for now.

The catch is that `redirect_from` doesn't seem to work in Federalist previews. As far as I can tell. So I'm not sure quite how to test that this is working as intended. Thoughts @jeremiak or @msecret?

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/refactor-redirects/)