### PR TITLE
Remove comment from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To ensure a welcoming environment for our projects, our staff follows the [18F C
   * [Pull requests](#pull-requests)
 * [Public domain](#public-domain)
 
-<!-- ## Running and testing the site
+## Running and testing the site
 
 ### Using Docker
 


### PR DESCRIPTION
A comment was preventing most of the document showing up in Github, [see file on `dev`](https://github.com/18F/doi-extractives-data/blob/dev/CONTRIBUTING.md).

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/BRANCH_NAME/)