### PR TITLE
Remove problematic style from map style

### DIFF
--- a/_sass/elements/_svg.scss
+++ b/_sass/elements/_svg.scss
@@ -28,18 +28,3 @@ svg use {
   stroke: inherit;
   stroke-width: inherit;
 }
-
-.feature {
-  stroke: none !important;
-}
-
-.mesh {
-  fill: none !important;
-  stroke: $gray-dark !important;
-  stroke-width: 1 !important;
-}
-
-.bbox {
-  fill: none;
-  stroke: $red;
-}

--- a/_sass/elements/_svg.scss
+++ b/_sass/elements/_svg.scss
@@ -30,7 +30,6 @@ svg use {
 }
 
 .feature {
-  fill: $gray-pale !important;
   stroke: none !important;
 }
 


### PR DESCRIPTION
There was a problematic style added during styleguide coding.

Fixes #2626 

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/map_style_fix/)
