### PR TITLE
Updates disbursements scope to proper year range

### DIFF
--- a/_downloads/disbursements.md
+++ b/_downloads/disbursements.md
@@ -49,7 +49,7 @@ We also have [notes on this data](https://github.com/18F/doi-extractives-data/wi
 
 ## Scope
 
-This dataset includes natural resource disbursements for U.S. federal lands and offshore areas, and Indian lands. It does not include privately-owned lands, or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. It contains disbursement information to funds for fiscal years 2012-2015. Disbursements of revenue due to extractive activities on U.S. federal lands occur monthly; this dataset is a sum of those disbursements by fiscal year.
+This dataset includes natural resource disbursements for U.S. federal lands and offshore areas, and Indian lands. It does not include privately-owned lands or U.S. state lands. The dataset is tracked and managed by the Department of the Interior’s Office of Natural Resources Revenue. It contains disbursement information to funds for fiscal years 2014-2017. Disbursements of revenue from extractive activities on U.S. federal lands occur monthly; this dataset is a sum of those disbursements by fiscal year.
 
 ## Data publication
 


### PR DESCRIPTION
In the process of updating the year ranges for our [data catalog wiki](https://github.com/18F/doi-extractives-data/wiki/Data-Catalog), I noticed the year range in the [disbursements scope](https://revenuedata.doi.gov/downloads/disbursements/#scope) is incorrect. I contemplated removing the year range entirely for maintainability purposes, but I think it's valuable to see the range of data before committing to downloading it.

A next step might be to abstract the year range to variables connected to this data category.

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/year-content-updates/)