### PR TITLE
Removes incorrect phone number from data retrieval contact info

### DIFF
--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -1,7 +1,6 @@
 data_retrieval:
     name: Data Retrieval
     email: onrrdatarequests@onrr.gov
-    phone: (303) 231-3162
 
 information_data_management:
     name: Information and Data Management

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -1,1 +1,1 @@
-<p>Do you need {{ "ONRR" | term }} data that isn't here? Contact our {{ site.data.contact.data_retrieval.name }} team at <a href="mailto:{{ site.data.contact.data_retrieval.email }}">{{ site.data.contact.data_retrieval.email }}</a> or {{ site.data.contact.data_retrieval.phone }}.</p>
+<p>Do you need {{ "ONRR" | term }} data that isn't here? Contact our {{ site.data.contact.data_retrieval.name }} team at <a href="mailto:{{ site.data.contact.data_retrieval.email }}">{{ site.data.contact.data_retrieval.email }}</a>.</p>


### PR DESCRIPTION
I discovered that the phone number we pulled over from the statistics site is no longer correct. This update removes the phone number and leaves just the email address for the data retrieval team.
