### PR TITLE
Use script to install Ruby & JS dependencies in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/*
+public/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,46 @@ To ensure a welcoming environment for our projects, our staff follows the [18F C
 
 ### Using Docker
 
+
+#### Setting up Docker Toolbox for Windows 7 - (Windows Only instructions)
+
+##### Prerequisites
+1. Have Docker Toolbox installed, which includes Oracle VM
+1. You will need admin rights to setup the docker environment. A registry key can disable the admin rights check. Ask IT to disable.
+1. Open Oracle Virtualbox and verify you only have 1 Host Only Adapter
+    1. In the Oracle Virtualbox, select Global Tools
+    2. Select Host Network Manager
+    3. You should be in the Properties view.
+    4. Verify only 1 or 0 adapters are listed.
+    5. if more than 1 disable extra adapters. You should only have 1 enabled to avoid potential errors later.
+1. Also install 'bash' by installing git for Windows.
+1. Clone the repo to a directory in C:\Users. This is automatically shared by Docker.
+
+##### Windows 7 specific steps
+1. Launch Docker Quick Start which should be a shortcut on the Desktop
+2. Once launched switch to your source code directory. "doi-extractives-data"
+3. Although Quick start creates a VM we are going to create our own.
+    * On windows the initial machine usually results in errors. Such as a certificate errors.
+    * Also the machine is not very powerful.
+    * Sometimes the docker terminal crashes. Just restart it if it does.
+4. Make sure you are in your source code directory and run the following commands
+
+```
+docker-machine rm default
+docker-machine ls   # lists all machines, verify default is not listed
+docker-machine create --driver virtualbox --virtualbox-cpu-count 2 --virtualbox-memory 4046  default
+eval "$(docker-machine env default)"
+docker-machine ls   # Note your IP address
+```
+5. Your docker-machine should now be ready to setup the development environment
+
+ * If you get a certificate error run this command from your source code directory
+
+```
+docker-machine regenerate-certs default
+```
+
+##### Docker Development Environment Setup
 Instead of installing dependencies yourself and running different commands
 in separate terminal sessions, you should use Docker, which
 only requires installing [Docker Community Edition][docker]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ To get up and running with Docker, run the following in the project directory.
 
 ```
 docker-compose build
+docker-compose run --rm jekyll bash scripts/update-deps.sh
 docker-compose up
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,8 @@ FROM circleci/ruby:2.2-node
 USER root
 
 WORKDIR /doi
-COPY package*.json /doi/
-COPY Gemfile* /doi/
 
 RUN apt-get update && \
-    apt-get install -y sqlite3 && \
-    bundle install && \
-    npm install
+    apt-get install -y sqlite3
 
 ENV PATH "$PATH:./node_modules/.bin"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,7 @@ services:
     ports:
       - 3000:3000
 volumes:
-  node-modules:
   root:
   bundle:
   public:
-  styleguide:
+  node-modules:

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -4,10 +4,10 @@ services:
     build: .
     volumes:
       - .:/doi
-      - node-modules:/doi/node_modules/
       - root:/root/
-      - bundle:/usr/local/bundle/
       - public:/doi/public
+      - bundle:/usr/local/bundle/
+      - node-modules:/doi/node_modules
     environment:
       - EIA_API_KEY
       - LANG=C.UTF-8

--- a/package.json
+++ b/package.json
@@ -11,11 +11,10 @@
     "node": ">=8"
   },
   "scripts": {
+    "prestart": "if [ ! -d node_modules ]; then npm install; fi",
     "build": "rm -rf _site; bundle exec jekyll build",
     "federalist": "webpack && npm run release-styleguide",
-    "start": "bundle exec jekyll serve --incremental",
     "start-states": "bundle exec jekyll serve --incremental --config _config.yml,_maps.yml",
-    "restart": "rm -rf _site && npm run start",
     "test": "mocha test/*.js test/**/*.js",
     "test-html": "bundle exec htmlproof --disable-external _site",
     "test-ruby": "bundle exec rubydoctest _plugins/eiti_*.rb",

--- a/scripts/update-deps.sh
+++ b/scripts/update-deps.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+bundle install
+npm install


### PR DESCRIPTION
We were trying to do some clever things so that new devs
would only have to run docker-compose up but the way
docker mounts volumes meant that the node deps were
missing (even though they still had to wait through
all the installation time). This way the user has to
execute three commands when they pull down the repo
but should be able to get to a successful running
project without any errors.

Fixes #<PUT ISSUE NUM HERE>

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/BRANCH_NAME/)

Changes proposed in this pull request:

-
-
-
