### PR TITLE
Add Colorado link to the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ selector: location
     <div class="container-left-4 explore_home-map-intro">
       <h2 class="h3 explore_home-heading">Learn about extractive industries in each state</h2>
       <p>
-        Explore production, revenue, and economic impact data for each state, as well as additional contextual information and data about several states that chose to participate in deeper reporting: <a href="{{ site.baseurl }}/explore/AK/">Alaska</a>, <a href="{{ site.baseurl }}/explore/CO/">Colorado</a>, <a href="{{ site.baseurl }}/explore/MT/">Montana</a>, and <a href="{{ site.baseurl }}/explore/WY/">Wyoming</a>.
+        Explore production, revenue, and economic impact data for each state, as well as additional contextual information and data about several states that participated in deeper reporting: <a href="{{ site.baseurl }}/explore/AK/">Alaska</a>, <a href="{{ site.baseurl }}/explore/CO/">Colorado</a>, <a href="{{ site.baseurl }}/explore/MT/">Montana</a>, and <a href="{{ site.baseurl }}/explore/WY/">Wyoming</a>.
       </p>
       <figcaption class="state_pages-select">
         <label for="location-selector">Explore data:</label>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ selector: location
     <div class="container-left-4 explore_home-map-intro">
       <h2 class="h3 explore_home-heading">Learn about extractive industries in each state</h2>
       <p>
-        Explore production, revenue, and economic impact data for each state, as well as additional contextual information and data about three states that chose to participate in deeper reporting: <a href="{{ site.baseurl }}/explore/AK/">Alaska</a>, <a href="{{ site.baseurl }}/explore/MT/">Montana</a>, and <a href="{{ site.baseurl }}/explore/WY/">Wyoming</a>.
+        Explore production, revenue, and economic impact data for each state, as well as additional contextual information and data about several states that chose to participate in deeper reporting: <a href="{{ site.baseurl }}/explore/AK/">Alaska</a>, <a href="{{ site.baseurl }}/explore/CO/">Colorado</a>, <a href="{{ site.baseurl }}/explore/MT/">Montana</a>, and <a href="{{ site.baseurl }}/explore/WY/">Wyoming</a>.
       </p>
       <figcaption class="state_pages-select">
         <label for="location-selector">Explore data:</label>


### PR DESCRIPTION
Fixes #2671 

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/add-co/)

Changes proposed in this pull request:

- Add Colorado link to the homepage blurb, and makes the blurb slightly shorter