### PR TITLE
Replaces "Downloads" link with "Download data"

### DIFF
--- a/_includes/layout/footer.html
+++ b/_includes/layout/footer.html
@@ -16,7 +16,7 @@
 
       <div class="footer-bottom-right">
         <p class="footer-para_callout">
-          <a class="link-beta" href="{{ site.baseurl }}/downloads/">Downloads<icon class="icon-cloud icon-padded_after"></icon></a>
+          <a class="link-beta" href="{{ site.baseurl }}/downloads/">Download data<icon class="icon-cloud icon-padded_after"></icon></a>
         </p>
       </div>
 

--- a/_includes/layout/header.html
+++ b/_includes/layout/header.html
@@ -17,7 +17,7 @@
       </li>
       <span class="header-nav_item_link_spacer"> | </span>
       <li class="header-nav_item_top">
-        <a class="header-nav_item_link_top {% if page.permalink contains '/downloads/' %}active{% endif %}" href="{{ site.baseurl }}/downloads/">Downloads</a>
+        <a class="header-nav_item_link_top {% if page.permalink contains '/downloads/' %}active{% endif %}" href="{{ site.baseurl }}/downloads/">Download data</a>
       </li>
 
       <li class="header-nav_item_top">

--- a/_includes/layout/nav-drawer.html
+++ b/_includes/layout/nav-drawer.html
@@ -29,7 +29,7 @@
         <a class="nav_drawer-nav_item_link" href="{{ site.baseurl }}/case-studies/">Case Studies</a>
       </li>
       <li class="nav_drawer-nav_item nav_drawer-nav_item_bottom {% if page.permalink contains '/downloads/' %}active{% endif %}">
-        <a class="nav_drawer-nav_item_link" href="{{ site.baseurl }}/downloads/">Downloads</a>
+        <a class="nav_drawer-nav_item_link" href="{{ site.baseurl }}/downloads/">Download data</a>
       </li>
       <li class="nav_drawer-nav_item nav_drawer-nav_item_bottom" title="Open glossary">
         <a href="javascript:void(0)" class="nav_drawer-nav_item_link js-glossary-toggle" alt="this is the glossary drawer">Glossary</a>

--- a/_sass/blocks/_nav-drawer.scss
+++ b/_sass/blocks/_nav-drawer.scss
@@ -52,7 +52,7 @@ $nav-drawer-height: 593px;
   font-weight: $weight-light;
   letter-spacing: initial;
   padding-bottom: $base-padding;
-  text-transform: capitalize;
+  text-transform: none;
 }
 
 .nav_drawer-break {


### PR DESCRIPTION
Fixes #2676 

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/doi-extractives-data/microcopy/)

Changes proposed in this pull request:

- Changes header, footer, and mobile nav item from "Downloads" to "Download data" for clarity
- Changes mobile nav styling so that it no longer enforces title case on utility menu items (changes `text-transform: capitalize` to `text-transform: none`).
