### PR TITLE
changed the id attribute to unique_id to avoid conflict with jekyll

### DIFF
--- a/_includes/icon-map.html
+++ b/_includes/icon-map.html
@@ -13,20 +13,20 @@
 
     {% for _region in site.offshore_regions %}
       <g class="offshore states features">
-        <use xlink:href="{{ _offshore_svg }}#{{ _region.id }}"></use>
+        <use xlink:href="{{ _offshore_svg }}#{{ _region.unique_id }}"></use>
       </g>
 
-      {% if location_id == _region.id %}
+      {% if location_id == _region.unique_id %}
         <g class="offshore-area state feature">
-          <use xlink:href="{{ _offshore_svg }}#{{ _region.id }}"></use>
+          <use xlink:href="{{ _offshore_svg }}#{{ _region.unique_id }}"></use>
         </g>
       {% endif %}
     {% endfor %}
 
     {% for _state in site.states %}
-      {% if location_id == _state.id %}
+      {% if location_id == _state.unique_id %}
         <g class="state feature">
-          <use xlink:href="{{ _states_svg }}#state-{{ _state.id }}"></use>
+          <use xlink:href="{{ _states_svg }}#state-{{ _state.unique_id }}"></use>
         </g>
         {% break %}
       {% endif %}

--- a/_offshore_regions/alaska.md
+++ b/_offshore_regions/alaska.md
@@ -1,5 +1,5 @@
 ---
-id: alaska
+unique_id: alaska
 title: Alaska offshore region
 permalink: /explore/offshore-alaska/
 

--- a/_offshore_regions/atlantic.md
+++ b/_offshore_regions/atlantic.md
@@ -1,5 +1,5 @@
 ---
-id: atlantic
+unique_id: atlantic
 title: Atlantic Ocean
 permalink: /explore/offshore-atlantic/
 

--- a/_offshore_regions/gulf.md
+++ b/_offshore_regions/gulf.md
@@ -1,5 +1,5 @@
 ---
-id: gulf
+unique_id: gulf
 title: Gulf of Mexico
 permalink: /explore/offshore-gulf/
 

--- a/_offshore_regions/pacific.md
+++ b/_offshore_regions/pacific.md
@@ -1,5 +1,5 @@
 ---
-id: pacific
+unique_id: pacific
 title: Pacific Ocean
 permalink: /explore/offshore-pacific/
 

--- a/_states/AK.md
+++ b/_states/AK.md
@@ -1,5 +1,5 @@
 ---
-id: AK
+unique_id: AK
 title: Alaska
 FIPS: '02'
 

--- a/_states/AL.md
+++ b/_states/AL.md
@@ -1,5 +1,5 @@
 ---
-id: AL
+unique_id: AL
 title: Alabama
 FIPS: '01'
 

--- a/_states/AR.md
+++ b/_states/AR.md
@@ -1,5 +1,5 @@
 ---
-id: AR
+unique_id: AR
 title: Arkansas
 FIPS: '05'
 ---

--- a/_states/AZ.md
+++ b/_states/AZ.md
@@ -1,5 +1,5 @@
 ---
-id: AZ
+unique_id: AZ
 title: Arizona
 FIPS: '04'
 

--- a/_states/CA.md
+++ b/_states/CA.md
@@ -1,5 +1,5 @@
 ---
-id: CA
+unique_id: CA
 title: California
 FIPS: '06'
 

--- a/_states/CO.md
+++ b/_states/CO.md
@@ -1,5 +1,5 @@
 ---
-id: CO
+unique_id: CO
 title: Colorado
 FIPS: 08
 

--- a/_states/CT.md
+++ b/_states/CT.md
@@ -1,5 +1,5 @@
 ---
-id: CT
+unique_id: CT
 title: Connecticut
 FIPS: 09
 

--- a/_states/DC.md
+++ b/_states/DC.md
@@ -1,5 +1,5 @@
 ---
-id: DC
+unique_id: DC
 title: Washington, DC
 FIPS: '11'
 

--- a/_states/DE.md
+++ b/_states/DE.md
@@ -1,5 +1,5 @@
 ---
-id: DE
+unique_id: DE
 title: Delaware
 FIPS: '10'
 

--- a/_states/FL.md
+++ b/_states/FL.md
@@ -1,5 +1,5 @@
 ---
-id: FL
+unique_id: FL
 title: Florida
 FIPS: '12'
 

--- a/_states/GA.md
+++ b/_states/GA.md
@@ -1,5 +1,5 @@
 ---
-id: GA
+unique_id: GA
 title: Georgia
 FIPS: '13'
 

--- a/_states/HI.md
+++ b/_states/HI.md
@@ -1,5 +1,5 @@
 ---
-id: HI
+unique_id: HI
 title: Hawaii
 FIPS: '15'
 

--- a/_states/IA.md
+++ b/_states/IA.md
@@ -1,5 +1,5 @@
 ---
-id: IA
+unique_id: IA
 title: Iowa
 FIPS: '19'
 

--- a/_states/ID.md
+++ b/_states/ID.md
@@ -1,5 +1,5 @@
 ---
-id: ID
+unique_id: ID
 title: Idaho
 FIPS: '16'
 

--- a/_states/IL.md
+++ b/_states/IL.md
@@ -1,5 +1,5 @@
 ---
-id: IL
+unique_id: IL
 title: Illinois
 FIPS: '17'
 

--- a/_states/IN.md
+++ b/_states/IN.md
@@ -1,5 +1,5 @@
 ---
-id: IN
+unique_id: IN
 title: Indiana
 FIPS: '18'
 

--- a/_states/KS.md
+++ b/_states/KS.md
@@ -1,5 +1,5 @@
 ---
-id: KS
+unique_id: KS
 title: Kansas
 FIPS: '20'
 

--- a/_states/KY.md
+++ b/_states/KY.md
@@ -1,5 +1,5 @@
 ---
-id: KY
+unique_id: KY
 title: Kentucky
 FIPS: '21'
 

--- a/_states/LA.md
+++ b/_states/LA.md
@@ -1,5 +1,5 @@
 ---
-id: LA
+unique_id: LA
 title: Louisiana
 FIPS: '22'
 

--- a/_states/MA.md
+++ b/_states/MA.md
@@ -1,5 +1,5 @@
 ---
-id: MA
+unique_id: MA
 title: Massachusetts
 FIPS: '25'
 

--- a/_states/MD.md
+++ b/_states/MD.md
@@ -1,5 +1,5 @@
 ---
-id: MD
+unique_id: MD
 title: Maryland
 FIPS: '24'
 

--- a/_states/ME.md
+++ b/_states/ME.md
@@ -1,5 +1,5 @@
 ---
-id: ME
+unique_id: ME
 title: Maine
 FIPS: '23'
 

--- a/_states/MI.md
+++ b/_states/MI.md
@@ -1,5 +1,5 @@
 ---
-id: MI
+unique_id: MI
 title: Michigan
 FIPS: '26'
 

--- a/_states/MN.md
+++ b/_states/MN.md
@@ -1,5 +1,5 @@
 ---
-id: MN
+unique_id: MN
 title: Minnesota
 FIPS: '27'
 

--- a/_states/MO.md
+++ b/_states/MO.md
@@ -1,5 +1,5 @@
 ---
-id: MO
+unique_id: MO
 title: Missouri
 FIPS: '29'
 

--- a/_states/MS.md
+++ b/_states/MS.md
@@ -1,5 +1,5 @@
 ---
-id: MS
+unique_id: MS
 title: Mississippi
 FIPS: '28'
 

--- a/_states/MT.md
+++ b/_states/MT.md
@@ -1,5 +1,5 @@
 ---
-id: MT
+unique_id: MT
 title: Montana
 FIPS: '30'
 

--- a/_states/NC.md
+++ b/_states/NC.md
@@ -1,5 +1,5 @@
 ---
-id: NC
+unique_id: NC
 title: North Carolina
 FIPS: '37'
 

--- a/_states/ND.md
+++ b/_states/ND.md
@@ -1,5 +1,5 @@
 ---
-id: ND
+unique_id: ND
 title: North Dakota
 FIPS: '38'
 

--- a/_states/NE.md
+++ b/_states/NE.md
@@ -1,5 +1,5 @@
 ---
-id: NE
+unique_id: NE
 title: Nebraska
 FIPS: '31'
 

--- a/_states/NH.md
+++ b/_states/NH.md
@@ -1,5 +1,5 @@
 ---
-id: NH
+unique_id: NH
 title: New Hampshire
 FIPS: '33'
 

--- a/_states/NJ.md
+++ b/_states/NJ.md
@@ -1,5 +1,5 @@
 ---
-id: NJ
+unique_id: NJ
 title: New Jersey
 FIPS: '34'
 

--- a/_states/NM.md
+++ b/_states/NM.md
@@ -1,5 +1,5 @@
 ---
-id: NM
+unique_id: NM
 title: New Mexico
 FIPS: '35'
 

--- a/_states/NV.md
+++ b/_states/NV.md
@@ -1,5 +1,5 @@
 ---
-id: NV
+unique_id: NV
 title: Nevada
 FIPS: '32'
 

--- a/_states/NY.md
+++ b/_states/NY.md
@@ -1,5 +1,5 @@
 ---
-id: NY
+unique_id: NY
 title: New York
 FIPS: '36'
 

--- a/_states/OH.md
+++ b/_states/OH.md
@@ -1,5 +1,5 @@
 ---
-id: OH
+unique_id: OH
 title: Ohio
 FIPS: '39'
 

--- a/_states/OK.md
+++ b/_states/OK.md
@@ -1,5 +1,5 @@
 ---
-id: OK
+unique_id: OK
 title: Oklahoma
 FIPS: '40'
 

--- a/_states/OR.md
+++ b/_states/OR.md
@@ -1,5 +1,5 @@
 ---
-id: OR
+unique_id: OR
 title: Oregon
 FIPS: '41'
 

--- a/_states/PA.md
+++ b/_states/PA.md
@@ -1,5 +1,5 @@
 ---
-id: PA
+unique_id: PA
 title: Pennsylvania
 FIPS: '42'
 

--- a/_states/RI.md
+++ b/_states/RI.md
@@ -1,5 +1,5 @@
 ---
-id: RI
+unique_id: RI
 title: Rhode Island
 FIPS: '44'
 

--- a/_states/SC.md
+++ b/_states/SC.md
@@ -1,5 +1,5 @@
 ---
-id: SC
+unique_id: SC
 title: South Carolina
 FIPS: '45'
 

--- a/_states/SD.md
+++ b/_states/SD.md
@@ -1,5 +1,5 @@
 ---
-id: SD
+unique_id: SD
 title: South Dakota
 FIPS: '46'
 

--- a/_states/TN.md
+++ b/_states/TN.md
@@ -1,5 +1,5 @@
 ---
-id: TN
+unique_id: TN
 title: Tennessee
 FIPS: '47'
 

--- a/_states/TX.md
+++ b/_states/TX.md
@@ -1,5 +1,5 @@
 ---
-id: TX
+unique_id: TX
 title: Texas
 FIPS: '48'
 

--- a/_states/UT.md
+++ b/_states/UT.md
@@ -1,5 +1,5 @@
 ---
-id: UT
+unique_id: UT
 title: Utah
 FIPS: '49'
 

--- a/_states/VA.md
+++ b/_states/VA.md
@@ -1,5 +1,5 @@
 ---
-id: VA
+unique_id: VA
 title: Virginia
 FIPS: '51'
 

--- a/_states/VT.md
+++ b/_states/VT.md
@@ -1,5 +1,5 @@
 ---
-id: VT
+unique_id: VT
 title: Vermont
 FIPS: '50'
 

--- a/_states/WA.md
+++ b/_states/WA.md
@@ -1,5 +1,5 @@
 ---
-id: WA
+unique_id: WA
 title: Washington
 FIPS: '53'
 

--- a/_states/WI.md
+++ b/_states/WI.md
@@ -1,5 +1,5 @@
 ---
-id: WI
+unique_id: WI
 title: Wisconsin
 FIPS: '55'
 

--- a/_states/WV.md
+++ b/_states/WV.md
@@ -1,5 +1,5 @@
 ---
-id: WV
+unique_id: WV
 title: West Virginia
 FIPS: '54'
 

--- a/_states/WY.md
+++ b/_states/WY.md
@@ -1,5 +1,5 @@
 ---
-id: WY
+unique_id: WY
 title: Wyoming
 FIPS: '56'
 


### PR DESCRIPTION
Fixes #2677 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/2677-fix-mini-maps-id-issue/)

Changes proposed in this pull request:

- Change the ID attribute in states and offshore-areas to unique_id
- this fixes the conflict of jekyll overriding the id attribute of collection items
-
