### PR TITLE
Overflow sticky-header-wrapper

### DIFF
--- a/_sass/components/_sticky.scss
+++ b/_sass/components/_sticky.scss
@@ -1,7 +1,6 @@
 .sticky {
   background: $white;
   max-height: 100vh;
-  overflow: auto;
   padding-top: $standard-padding-lite;
   position: -webkit-sticky;
   position: sticky;


### PR DESCRIPTION
* Prevents active `select` element from getting cut off

No issue, was a pretty quick fix!

**Screenshots**
_Before_:
<img width="375" alt="screen shot 2018-03-27 at 3 00 32 pm" src="https://user-images.githubusercontent.com/1421848/37988901-1788220c-31d0-11e8-91de-0e1faa9726dc.png">

_After_:
<img width="380" alt="screen shot 2018-03-27 at 3 00 16 pm" src="https://user-images.githubusercontent.com/1421848/37988910-1e109ff0-31d0-11e8-9ce9-612ce7f005b6.png">

Preview link: https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/ab-overflow-year-selector/

Changes proposed in this pull request:

- Removes `overflow: auto` declaration from `.sticky` class to prevent active select element from getting cut off

