### PR TITLE
Replaces link causing in-page redirect

### DIFF
--- a/_how-it-works/default.md
+++ b/_how-it-works/default.md
@@ -101,9 +101,9 @@ selector: list
           <p><a href="{{site.baseurl}}/how-it-works/state-laws-and-regulations/">Learn about state laws</a></p>
         </div>
         <div>
-          <h3 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/tribal-laws-and-regulations/">Tribal laws and regulations</a></h3>
+          <h3 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/#tribal-overview">Tribal laws and regulations</a></h3>
           <p>Extracting natural resources on Indian land and distributing the associated revenue involves a unique set of processes and stakeholders.</p>
-          <p><a href="{{site.baseurl}}/how-it-works/tribal-laws-and-regulations/">Learn about tribal laws</a></p>
+          <p><a href="{{site.baseurl}}/how-it-works/#tribal-overview">Learn about tribal laws</a></p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Fixes #2718

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/tribal-summary/how-it-works/#laws)

Changes proposed in this pull request:

- Replaces link which is currently using a redirect to an id in the same page with a fragment id slug that links to appropriate section of the page. This link should be faster and more direct.

