### PR TITLE
Show x-axis information in charts where max data size is less < 10

### DIFF
--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -89,6 +89,8 @@
   };
 
   var crawlCeil = function(ymax, ceilMax, i) {
+    var extentMarginOfError = +ymax < 10 ? 4.25 : 0.1;
+    extentPercent = ymax < 10 ? 2 : extentPercent;
     var sigFig = '.' + i + 's';
     var sigFigCeil = +eiti.format.transform(
       sigFig,
@@ -100,6 +102,14 @@
     return justRight ? sigFig : '';
   };
 
+  /**
+   * This function formats a number as the number of significant digits
+   * with its amount (e.g. M for million, K for thousand, etc) abbreviation
+   * For example:
+   * 1,000,000 formats to 1M
+   * @param {Number} ymax
+   * @param {Number} ceilMax ymax + extent of the data set
+   */
   var setSigFigs = function(ymax, ceilMax) {
     var sigFigs = '';
     var SF = 0;
@@ -245,8 +255,6 @@
       }, true);
     }
 
-
-
     var axis = d3.svg.axis()
       .orient('bottom')
       .scale(x)
@@ -274,6 +282,7 @@
       var dataUnits = this.getAttribute('data-units');
       var dataFormat = this.getAttribute('data-format') || '';
 
+      extentPercent = ymax < 10 ? 2.5 : extentPercent;
       var ceilMax = Math.ceil(+ymax * (1 + extentPercent));
       var sigFigs = setSigFigs(ymax, ceilMax);
 

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -182,7 +182,7 @@
       return xdomain.indexOf(d.x) > -1;
     });
 
-    extent = d3.extent(data, function(d) {
+    var extent = d3.extent(data, function(d) {
       return d.y;
     });
 

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -39,7 +39,6 @@
   extentMargin = barHeight * extentPercent;
   top += extentMargin;
   var extentTop = top - extentMargin;
-
   var fullHeight = height + textMargin + extentMargin
     + tickPadding - (2 * baseMargin);
   var extentlessHeight = fullHeight - extentMargin;
@@ -89,8 +88,10 @@
   };
 
   var crawlCeil = function(ymax, ceilMax, i) {
-    var extentMarginOfError = +ymax < 10 ? 4.25 : 0.1;
-    extentPercent = ymax < 10 ? 2 : extentPercent;
+    // When ymax is a value less than 10, the ratio of ceilMax and ymax will never
+    // be less than (1 + extentMarginOfError + extentPercent), and the function will continue
+    // be called in its parent function's while loop.
+
     var sigFig = '.' + i + 's';
     var sigFigCeil = +eiti.format.transform(
       sigFig,
@@ -181,10 +182,21 @@
       return xdomain.indexOf(d.x) > -1;
     });
 
-    var extent = d3.extent(data, function(d) {
+    extent = d3.extent(data, function(d) {
       return d.y;
     });
-    var ymax = extent[1] < 0 ? 0 : extent[1];
+
+    var ymax;
+
+    if (extent[1] && extent[1] < 10) {
+      // If the max size of the dataset is under 10,
+      // increase the size of the ymax so the bar doesnt
+      // scale up to the height of the extent line
+      ymax = 10;
+    } else {
+      ymax = Math.max(0, extent[1]);
+    }
+
     var ymin = 0;
 
     data.sort(function(a, b) {
@@ -229,6 +241,7 @@
         d.height = height(d.y) > baseHeight
           ? height(d.y)
           : baseHeight;
+
         return d.height;
       })
       .attr('y', function(d) {
@@ -240,8 +253,6 @@
       // extend all the way to the bottom of the screen
       .attr('height', barHeight + textMargin + tickPadding)
       .attr('width', barWidth);
-
-    // selection.call(updateSelected, this.x);
 
     // if bars are simply an icon, don't handle mouse events
     // as the bars will be too small!
@@ -282,8 +293,7 @@
       var dataUnits = this.getAttribute('data-units');
       var dataFormat = this.getAttribute('data-format') || '';
 
-      extentPercent = ymax < 10 ? 2.5 : extentPercent;
-      var ceilMax = Math.ceil(+ymax * (1 + extentPercent));
+      var ceilMax = Math.ceil(ymax * (1 + extentPercent));
       var sigFigs = setSigFigs(ymax, ceilMax);
 
       if (dataUnits.indexOf('$') > -1) {


### PR DESCRIPTION
Fixes #2707

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/BRANCH_NAME/)

Screenshot of fix/new issue:
<img width="257" alt="screen shot 2018-04-04 at 3 19 14 pm" src="https://user-images.githubusercontent.com/1421848/38329372-9d76386c-381b-11e8-914a-bfe5ce085e15.png">


Changes proposed in this pull request:

- Hardcode ymax of data sets with a maximum value < 10 to 10.

* Eliminates the need for conditionals that rewrite values of
global vars

* Ensures bar scales height properly and maintains correct distance
from the the extent line


