### PR TITLE
Removes manually curated production ranking and redirect link loop

### DIFF
--- a/explore/index.html
+++ b/explore/index.html
@@ -109,9 +109,7 @@ nav_items:
 
         <h2 class="state-page-overview">Production</h2>
 
-        <p>The United States produces more natural gas and oil than any other country, and ranks second in the world for production of coal. The U.S. also ranks second in the world for renewable energy production, with a total of 9.56 quadrillion BTUs of renewable energy production in 2015.</p>
-
-        <p>Among nonenergy minerals, the U.S. ranks fifth in the world for production of gold (200 metric tons) and copper (1.25 million metric tons), and ninth for iron (56 million metric tons). Learn more about <a href="{{ site.baseurl }}/how-it-works/production/">natural resource production in the U.S.</a></p>
+        <p>The United States is among the world's top producers of natural gas, oil, and coal. The U.S. is also a global leader in renewable energy production.</p>
 
         {% include location/national-all-production.html %}
 


### PR DESCRIPTION
Fixes #2735 and #2750 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/explore-production-updates/explore/#production)

Changes proposed in this pull request:

- Removes manually curated 2015 data and global ranking references from [opening production paragraph](https://revenuedata.doi.gov/explore/#production)
- Removes link causing infinite redirect loop

This is a temporary fix. I will continue to work on the wording of this opening paragraph to add value without including data references that must be maintained manually.
