### PR TITLE
Generically format large numbers

### DIFF
--- a/_how-it-works/default.md
+++ b/_how-it-works/default.md
@@ -123,10 +123,9 @@ selector: list
 
 {% assign disbursements = site.data.federal_disbursements.US["American Indian Tribes"].All %}
 {% assign disbursement_year = site.data.years.disbursements | to_s | default: default_year %}
-
         <div>
           <h3 class="h3 landing-heading"><a href="{{site.baseurl}}/how-it-works/tribal-revenue/">Tribal revenue</a></h3>
-          <p>Natural resources are increasingly a key source of income for many Native American tribes. In {{ disbursement_year }}, {{ "ONRR" | term }} and {{ "OST" | term }} disbursed {{ disbursements[disbursement_year] | divided_by: 1000000 | round | intcomma_dollar }} million to tribes and allottees.</p>
+          <p>Natural resources are increasingly a key source of income for many Native American tribes. In {{ disbursement_year }}, {{ "ONRR" | term }} and {{ "OST" | term }} disbursed {{ disbursements[disbursement_year] | intword | intcomma_dollar }} to tribes and allottees.</p>
           <p><a href="{{site.baseurl}}/how-it-works/tribal-revenue/">Learn about tribal revenues</a></p>
         </div>
 

--- a/_plugins/humanize.rb
+++ b/_plugins/humanize.rb
@@ -138,9 +138,8 @@ module Jekyll
         large_number = 10 ** exponent
 
         if value < large_number * 1000
-          return "%#{value}.1f #{text}" % (value / large_number.to_f)
+          return "%.1f #{text}" % (value / large_number.to_f)
         end
-
       end
 
       return value


### PR DESCRIPTION
Fixes #2753

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/ab-format-number-fix/how-it-works)

Changes proposed in this pull request:

* Fixes bug in intword method in humanize.rb
* Large numbers will now format as a float with one decimal
and their appropriate scale unit