### PR TITLE
Fixes typo in CO opt-in description

### DIFF
--- a/_data/opt_in_state_streams.yml
+++ b/_data/opt_in_state_streams.yml
@@ -1,6 +1,6 @@
 CO:
   "COGCC Levy": A rate imposed on the market value of all oil and natural gas produced, saved, sold, or transported to address environmental response needs. This levy is directed to the Colorado Oil and Gas Conservation Commission (COGCC).
-  "Ad Valorem Taxes": Ad valorem taxes are collected and distributed by counties. Ad velorem taxes are reported by Production Year in Colorado.
+  "Ad Valorem Taxes": Ad valorem taxes are collected and distributed by counties. Ad valorem taxes are reported by Production Year in Colorado.
 MT:
   "Electrical Energy Producers' License Tax": This figure is estimated based on EIA data.
 WY:


### PR DESCRIPTION

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/optin-typo/)

Changes proposed in this pull request:

- Fixes typo in CO opt-in ad valorem description 
