### PR TITLE
Relocates disbursements sub-fund data to archive section

### DIFF
--- a/_data/fund_names.yml
+++ b/_data/fund_names.yml
@@ -12,7 +12,7 @@ Land & Water Conservation:
   description: Provides matching grants to states and local governments to buy and develop public outdoor recreation areas across the 50 states. See below for more information about this fund.
 Historic Preservation:
   name: Historic Preservation Fund
-  description: Helps preserve US historical and archaeological sites and cultural heritage through grants to state and tribal historic preservation offices. See below for more information about this fund.
+  description: Helps preserve U.S. historical and archaeological sites and cultural heritage through grants to state and tribal historic preservation offices. See below for more information about this fund.
 American Indian Tribes:
   name: American Indian tribes
   description: ONRR disburses 100% of revenue collected from resource extraction on American Indian lands back to the Indian tribes and individual Indian landowners.

--- a/_downloads/disbursements.md
+++ b/_downloads/disbursements.md
@@ -17,6 +17,8 @@ nav_items:
         title: Onshore
       - name: offshore
         title: Offshore
+  - name: archive
+    title: Archive
   - name: contact-us
     title: Contact us
 selector: list
@@ -80,11 +82,34 @@ _Historic Preservation Fund_ This fund helps preserve U.S. historical and archae
 
 _States_ States receive federal Outer Continental Shelf revenue in two ways:
 
-
 1. 27% of revenue from leases in the 8(g) Zone (the first three nautical miles of the Outer Continental Shelf) are shared with states.
 2. 37.5% of revenue from certain leases in the Gulf of Mexico are shared with Alabama, Louisiana, Mississippi, and Texas.
 
 _Other_ Certain offshore funds are directed back to the federal agencies that administer these lands (e.g., BOEM and BSEE) to help cover the agencies’ operational costs.
+
+## Archive
+
+In the past, this site has offered detailed data for disbursements distributed from other funds. For example, the data below
+
+### Land and Water Conservation Fund
+
+{{ "ONRR" | term }} disburses revenue to the [Land and Water Conservation Fund (LWCF)](https://www.nps.gov/subjects/lwcf/index.htm) according to federal law. However, these funds are subject to congressional appropriations. Some of the money disbursed from ONRR to the fund is spent on LWCF projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $900 million each year, but congressional appropriations to LWCF projects have been limited to between $149 million and $573 million each year since 1999.
+
+To see how much was disbursed to states, sub-funds, and other projects each year, see the following datasets.
+
+* [American Battlefield Protection Program, 2011-2015 data]({{ site.baseurl }}/data/disbursements/lwcf/abpp.tsv) (TSV): Details about the location, acreage, and grant amounts of each battlefield funded through the [American Battlefield Protection Program](https://www.nps.gov/abpp/index.htm), a National Parks Service program that preserves the land where historic American battles were fought.
+
+* [Cooperative Endangered Species Conservation Fund, 2011-2015 data]({{ site.baseurl }}/data/disbursements/lwcf/cescf.tsv) (TSV): List of individual projects and locations funded through the [Cooperative Endangered Species Conservation Fund](https://www.fws.gov/endangered/grants/), a [Fish and Wildlife Service](https://www.fws.gov/) program for conservation planning and acquisition of vital habitat for threatened and endangered species.
+
+* [State and local grants, 2011-2016 data]({{ site.baseurl }}/data/disbursements/lwcf/grants.tsv) (TSV): Details about the location, amount, and purpose of all Land and Water Conservation Fund grants to state and local governments.
+
+* [Land acquisitions, 2011-2016 data]({{ site.baseurl }}/data/disbursements/lwcf/land-acquisition.tsv) (TSV): Details about the location, budget, acreage, and purpose of each federal land acquisition funded by the Land and Water Conservation Fund.
+
+### Historic Preservation Fund
+
+Like the LWCF, money in the Historic Preservation Fund is subject to congressional appropriations. Some of it is spent on historic preservation projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $150 million each year, but annual appropriations have declined from $94 million to less than $60 million since 2001.
+
+To see how much was disbursed to each state for preservation projects, see [Historic Preservation grants, 2011-2016]({{ site.baseurl }}/data/disbursements/historic-preservation.tsv) (TSV).
 
 ## Contact us
 

--- a/_downloads/disbursements.md
+++ b/_downloads/disbursements.md
@@ -89,7 +89,7 @@ _Other_ Certain offshore funds are directed back to the federal agencies that ad
 
 ## Archive
 
-In the past, this site has offered detailed data for disbursements distributed from other funds. For example, the data below
+In the past, this site has offered detailed data for disbursements distributed from other funds. For example, the data below details disbursements to sub-funds of the Land and Water Conservation Fund and the Historic Preservation Fund.
 
 ### Land and Water Conservation Fund
 

--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -29,4 +29,26 @@
     %}
   {% endif %}
 
+  <h4 id="lwcf">Land and Water Conservation Fund</h4>
+
+  <p>{{ "ONRR" | term }} disburses revenue to the <a href="https://www.nps.gov/subjects/lwcf/index.htm">Land and Water Conservation Fund</a> (LWCF) according to federal law. However, these funds are subject to congressional appropriations. Some of the money disbursed from ONRR to the fund is spent on LWCF projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $900 million each year, but congressional appropriations to LWCF projects have been limited to between $149 million and $573 million each year since 1999.</p>
+
+  <p>
+    <a href="{{site.baseurl}}/downloads/disbursements/#land-and-water-conservation-fund">
+      <object type="image/svg+xml" data="{{site.baseurl}}/public/img/icons/file-text-o.svg" class="u-padding-right icon-small">
+      </object>Data archive
+    </a>
+  </p>
+
+  <h4 id="hpf">Historic Preservation Fund</h4>
+
+  <p>Like the LWCF, money in the Historic Preservation Fund is subject to congressional appropriations. Some of it is spent on historic preservation projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $150 million each year, but annual appropriations have declined from $94 million to less than $60 million since 2001.</p>
+
+  <p>
+    <a href="{{site.baseurl}}/downloads/disbursements/#historic-preservation-fund">
+      <object type="image/svg+xml" data="{{site.baseurl}}/public/img/icons/file-text-o.svg" class="u-padding-right icon-small">
+      </object>Data archive
+    </a>
+  </p>
+
 </section>

--- a/_includes/location/national-disbursements.html
+++ b/_includes/location/national-disbursements.html
@@ -29,31 +29,4 @@
     %}
   {% endif %}
 
-  <h4 id="lwcf">Land and Water Conservation Fund</h4>
-
-  <p>{{ "ONRR" | term }} disburses revenue to the <a href="https://www.nps.gov/subjects/lwcf/index.htm">Land and Water Conservation Fund</a> (LWCF) according to federal law. However, these funds are subject to congressional appropriations. Some of the money disbursed from ONRR to the fund is spent on LWCF projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $900 million each year, but congressional appropriations to LWCF projects have been limited to between $149 million and $573 million each year since 1999.</p>
-
-  <p>To see how much was disbursed to states, sub-funds, and other projects each year, see the following datasets:</p>
-
-  <ul>
-    <li>
-      <a href="{{ site.baseurl }}/data/disbursements/lwcf/abpp.tsv">American Battlefield Protection Program, 2011-2015 data (TSV)</a>: Details about the location, acreage, and grant amounts of each battlefield funded through the <a href="https://www.nps.gov/abpp/index.htm">American Battlefield Protection Program</a>, a National Parks Service program that preserves the land where historic American battles were fought.
-    </li>
-    <li>
-      <a href="{{ site.baseurl }}/data/disbursements/lwcf/cescf.tsv">Cooperative Endangered Species Conservation Fund, 2011-2015 data (TSV)</a>: List of individual projects and locations funded through the <a href="https://www.fws.gov/endangered/grants/">Cooperative Endangered Species Conservation Fund</a>, a <a href="https://www.fws.gov/">Fish and Wildlife Service</a> program for conservation planning and acquisition of vital habitat for threatened and endangered species.
-    </li>
-    <li>
-      <a href="{{ site.baseurl }}/data/disbursements/lwcf/grants.tsv">State and local grants, 2011-2016 data (TSV)</a>: Details about the location, amount, and purpose of all Land and Water Conservation Fund grants to state and local governments.
-    </li>
-    <li>
-      <a href="{{ site.baseurl }}/data/disbursements/lwcf/land-acquisition.tsv">Land acquisitions, 2011-2016 data (TSV)</a>: Details about the location, budget, acreage, and purpose of each federal land acquisition funded by the Land and Water Conservation Fund.
-    </li>
-  </ul>
-
-  <h4 id="hpf">Historic Preservation Fund</h4>
-
-  <p>Like the LWCF, money in the Historic Preservation Fund is subject to congressional appropriations. Some of it is spent on historic preservation projects, but some of it ultimately goes to other expenditures. The fund is authorized to receive and disburse $150 million each year, but annual appropriations have declined from $94 million to less than $60 million since 2001.</p>
-
-  <p>To see how much was disbursed to each state for preservation projects (including Hurricane Sandy recovery funds), see <a href="{{ site.baseurl }}/data/disbursements/historic-preservation.tsv">Historic Preservation grants, 2011-2016 (TSV)</a>.</p>
-
 </section>


### PR DESCRIPTION
Fixes #2774

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/clean-disbursements/explore/#federal-disbursements)

Changes proposed in this pull request:

- Creates archive section in disbursements data and documentation
- Adds derivative link pattern for "Data archive"
- Moves raw data links for disbursements sub-funds to new archive section
