### PR TITLE
2743 low chart values

### DIFF
--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -34,7 +34,7 @@
   var bottom = height - margin.bottom;
   var barHeight = bottom - top;
 
-  var extentPercent = 0.07; // 7%
+  var extentPercent = 0.05; // 5%
   var extentMarginOfError = 0.10; // 10%. Read as +/- the value created by extentPercent
   extentMargin = barHeight * extentPercent;
   top += extentMargin;
@@ -99,6 +99,9 @@
     )(ceilMax);
     var ceilIsLargerThanValue = sigFigCeil > +ymax;
     var ceilIsntTooBig = ( sigFigCeil / +ymax ) <= (1 + extentMarginOfError + extentPercent);
+    if(!ceilIsntTooBig){
+      ceilIsntTooBig = ((sigFigCeil - ymax) < 10); // Accomodate for small numbers if the difference is smal then this should be acceptable
+    }
     var justRight = ceilIsLargerThanValue && ceilIsntTooBig;
     return justRight ? sigFig : '';
   };

--- a/js/components/eiti-bar-chart.js
+++ b/js/components/eiti-bar-chart.js
@@ -34,7 +34,7 @@
   var bottom = height - margin.bottom;
   var barHeight = bottom - top;
 
-  var extentPercent = 0.05; // 5%
+  var extentPercent = 0.07; // 7%
   var extentMarginOfError = 0.10; // 10%. Read as +/- the value created by extentPercent
   extentMargin = barHeight * extentPercent;
   top += extentMargin;
@@ -186,16 +186,7 @@
       return d.y;
     });
 
-    var ymax;
-
-    if (extent[1] && extent[1] < 10) {
-      // If the max size of the dataset is under 10,
-      // increase the size of the ymax so the bar doesnt
-      // scale up to the height of the extent line
-      ymax = 10;
-    } else {
-      ymax = Math.max(0, extent[1]);
-    }
+    var ymax = Math.max(0, extent[1]);
 
     var ymin = 0;
 


### PR DESCRIPTION
Fixes #2743

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/2743-low-chart-values/explore/CT/#economic-impact)

Changes proposed in this pull request:

- The failure was happening with small numbers. So when are code check to make sure our ymax value was within certain percentage of the max number of the dataset it was failing due to the fact the numbers were so small. For example our code wants to make sure the ymax value was with 1.15 of the max number in the dataset, however 7/6 = 1.16 so it kept failing. So added a check to verify if the difference between the ymax value and the max value of the dataset is less then 10, then this would be an acceptable difference. This check will not affect large numbers, its just for the very small numbers probably 6 and under, since 8/7 = 1.14 it would pass the test. Hence choosing 10 will cover all the small numbers we would worry about.
-
-
