### PR TITLE
Adds guidance for open source contributors, adds subheadings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,6 +280,12 @@ When you open an issue, fill out all relevant fields in the issue template and i
 
 ### Pull requests
 
+#### Open-source contributions
+
+We welcome contributions from the open source community! If you would like to contribute, please direct your pull requests to the [`contribution`](https://github.com/18F/doi-extractives-data/tree/contribution) branch (instead of the default `dev` branch). This enables us to create a preview link for your contribution.
+
+#### Creating a pull request
+
 * Create pull requests for all commits, even typo fixes. This helps us track work and increase visibility into current work going on.
 * When you open a pull request, complete the template to make sure reviewers have all the information they need.
 
@@ -287,8 +293,13 @@ When you open an issue, fill out all relevant fields in the issue template and i
 - While working, submit `[WIP]` [pull requests](CONTRIBUTING.md#pull-requests) liberally.
 - Anyone may informally review a pull request and make comments or suggestions.
 
+#### Reviewing a pull request
+
+For more about how to responsibly review pull requests, see [How to review a PR](https://github.com/18F/doi-extractives-data/wiki/How-to-review-a-pull-request)
+
+#### Merging a pull request
+
 * Don’t merge your own pull request. Ask a colleague to review your code and merge. This helps ensure that at least two people have verified the quality of the code and content.
-* For more about how to responsibly review pull requests, see [How to review a PR](https://github.com/18F/doi-extractives-data/wiki/How-to-review-a-pull-request)
 
 ## Public domain
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,11 +291,11 @@ We welcome contributions from the open source community! If you would like to co
 
 - Assign reviewers to notify specific team members who should review a pull request.
 - While working, submit `[WIP]` [pull requests](CONTRIBUTING.md#pull-requests) liberally.
-- Anyone may informally review a pull request and make comments or suggestions.
 
 #### Reviewing a pull request
 
-For more about how to responsibly review pull requests, see [How to review a PR](https://github.com/18F/doi-extractives-data/wiki/How-to-review-a-pull-request)
+- Anyone may informally review a pull request and make comments or suggestions.
+- For more about how to responsibly review pull requests, see [How to review a PR](https://github.com/18F/doi-extractives-data/wiki/How-to-review-a-pull-request)
 
 #### Merging a pull request
 


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://github.com/18F/doi-extractives-data/blob/contributors/CONTRIBUTING.md#pull-requests)

Changes proposed in this pull request:

- Adds guidance for open-source contributors (PRs merge into `contributor` branch instead of `dev`)
- Adds subheadings

**Note:** I'm not sure how to keep the new `contributor` branch up to date. We may need to slice a new one off `dev` every now and again to avoid merge conflicts and out-of-date code.
