### PR TITLE
Remove super custom button class

### DIFF
--- a/_sass/components/_ribbon.scss
+++ b/_sass/components/_ribbon.scss
@@ -138,11 +138,6 @@
   padding: $base-padding;
 }
 
-.ribbon-card-button {
-  margin-bottom: $base-padding-large;
-  padding: 1em;
-}
-
 .ribbon {
   svg {
     width: 100%;
@@ -248,16 +243,6 @@ svg {
     }
   }
 
-  .ribbon-card:not(.ribbon-card-column) {
-    .ribbon-card-button {
-      bottom: 60%;
-      float: left;
-      left: 12.5%;
-      margin: 0;
-      position: absolute;
-    }
-  }
-
   .ribbon-card {
     &.ribbon-card-column {
       .ribbon-card-top {
@@ -284,11 +269,6 @@ svg {
 
     &:not(.ribbon-card-column) {
       border-top: 0;
-
-      .ribbon-card-button {
-        float: none;
-        position: static;
-      }
     }
   }
 

--- a/_sass/print/_ribbon-card.scss
+++ b/_sass/print/_ribbon-card.scss
@@ -3,13 +3,6 @@
   text-align: left;
 }
 
-.ribbon-card-button {
-  display: block;
-  float: left;
-  text-align: left;
-  width: 100%;
-}
-
 .ribbon svg {
   max-width: 300px;
 

--- a/nrrd-design-system/components/components/hero-ribbons/hero-ribbons.hbs
+++ b/nrrd-design-system/components/components/hero-ribbons/hero-ribbons.hbs
@@ -33,7 +33,7 @@
               <li><a href="#">List item</a></li>
               <li><a href="#">List item</a></li>
             </ul>
-            <a href="/preview/18f/doi-extractives-data/typography-normalizing-1/how-it-works/" class="ribbon-card-button button-primary">How it works</a>
+            <a href="/preview/18f/doi-extractives-data/typography-normalizing-1/how-it-works/" class="button-primary">How it works</a>
         </div>
       </div>
   	</div>

--- a/pages/about.html
+++ b/pages/about.html
@@ -23,7 +23,7 @@ redirect_from: /about/whats-new/
             <li><a href="{{ site.baseurl }}/how-it-works/#process">Oil, gas, minerals, and renewable energy</a></li>
             <li><a href="{{ site.baseurl }}/how-it-works/audits-and-assurances/">Audits and assurances</a></li>
           </ul>
-        <a href="{{ site.baseurl }}/how-it-works/" class="ribbon-card-button button-primary">How it works</a>
+        <a href="{{ site.baseurl }}/how-it-works/" class="button-primary">How it works</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #2818 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/simplify-buttons/about/)

Changes proposed in this pull request:

- Removes the special class `.ribbon-card-button` from the codebase and from application in the site and style guide. This removes a small custom style adjustment that makes one button on the site larger on the hero ribbons. 

**Before:**
<img width="1031" alt="screen shot 2018-05-11 at 4 07 30 pm" src="https://user-images.githubusercontent.com/11636908/39944616-4fead562-5535-11e8-8aa4-c1f91f8cc505.png">


**After:**
<img width="1073" alt="screen shot 2018-05-11 at 4 07 11 pm" src="https://user-images.githubusercontent.com/11636908/39944618-5479dee8-5535-11e8-8d23-2f6a60d432cb.png">

