### PR TITLE
Style guide: Removes case study variant and edits explanatory content accordingly

### DIFF
--- a/nrrd-design-system/components/components/breadcrumbs/README.md
+++ b/nrrd-design-system/components/components/breadcrumbs/README.md
@@ -2,4 +2,4 @@
 
 The breadcrumbs component is used for navigation and to reinforce for the user where they are within the site structure, especially for deeper site pages. Always add a slash after the text, to indicate the parent category.
 
-This type style and positioning can also be used as a non-link running subhead. It's used in the case studies section, where an icon is added for visual interest.
+Similar type styling and positioning is also used as a non-link running subhead. The [case studies section](https://revenuedata.doi.gov/case-studies/campbell/) serves as an example, where an icon is added for visual interest. Since these instances are visually similar to breadcrumbs – but don't behave like breadcrumbs – we haven't included an example here.

--- a/nrrd-design-system/components/components/breadcrumbs/breadcrumbs.config.yml
+++ b/nrrd-design-system/components/components/breadcrumbs/breadcrumbs.config.yml
@@ -7,7 +7,3 @@ status: draft
 #     context:
 #       className: breadcrumb
 #       text: Breadcrumb link /
-#   - name: Breadcrumb-iconic
-#     context:
-#       className: case-studies-content-icon
-#       text: Breadcrumb link with icon

--- a/nrrd-design-system/components/components/breadcrumbs/breadcrumbs.hbs
+++ b/nrrd-design-system/components/components/breadcrumbs/breadcrumbs.hbs
@@ -8,20 +8,4 @@
     <h1>How it works section uses this style</h1>
   </div>
 
-  <!-- case-studies-content-icon, genericize this -->
-  <!-- <div>
-    <a class="case_studies_content-icon" href="{{ site.baseurl }}/#/"><i class="icon-coal"></i>Breadcrumb link with icon</a>/
-    <h1>Title of page</h1>
-  </div> -->
-
-  <!-- case-studies-content-icon, genericize this -->
-  <!-- <div class="case_studies_content-icon">Non-link small header
-    <h1>Title of page</h1>
-  </div> -->
-
-  <!-- case-studies-content-icon, genericize this -->
-  <div class="case_studies_content-icon" href="{{ site.baseurl }}/#/"><i class="icon-coal"></i>Small header with icon
-    <h1>Case studies section uses this style</h1>
-  </div>
-
 </div>


### PR DESCRIPTION
Fixes #2832

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/style-guide-crumb/styleguide)

Changes proposed in this pull request:

- Removes case study variant from breadcrumb component and edits README accordingly
