### PR TITLE
Added a 0 label if no royalties were collected

### DIFF
--- a/_includes/location/revenue-type-row-oilgas.html
+++ b/_includes/location/revenue-type-row-oilgas.html
@@ -50,6 +50,18 @@
     <span data-value="{{
     revenue_types['Oil Shale'].Royalties[year] | default: 0
   }}"></span>
+    {% assign oilgas_royalties_total = revenue_types.Oil.Royalties[year] | default: 0
+      | plus: revenue_types.Gas.Royalties[year] | default: 0
+      | plus: revenue_types.NGL.Royalties[year] | default: 0
+      | plus: revenue_types['Oil Shale'].Royalties[year] | default: 0
+    %}
+    {% if oilgas_royalties_total == 0 %}
+      <span class="text table-arrow_box-subheader-value">
+      {{
+        0
+        | intcomma_dollar
+      }}</span>
+    {% endif %}
 
     {% if revenue_types.Oil.Royalties[year] %}
       <span class="text table-arrow_box-subheader-value">


### PR DESCRIPTION
Fixes #2752 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/2752-chart-missing-value/explore/MD/)

Changes proposed in this pull request:

- Display 0 if there are no roylaties
-
-
