### PR TITLE
Fixes redirect link on homepage, changes neighboring redundant link

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ selector: location
 
           <p class="card-content-subhead">How it works</p>
 
-          <a href="{{ site.baseurl }}/how-it-works/production/"><h3 class="card-title">What natural resources are extracted?</h3></a>
+          <a href="{{ site.baseurl }}/how-it-works/#production"><h3 class="card-title">What natural resources are extracted?</h3></a>
 
           <p>The U.S. is a top producer of oil, gas, and coal, as well as nonenergy minerals like gold, iron, and copper.</p>
 
@@ -132,7 +132,7 @@ selector: location
 
           <p class="card-content-subhead">How it works</p>
 
-          <a href="{{ site.baseurl }}/how-it-works#process"><h3 class="card-title">How does resource extraction result in federal revenue?</h3></a>
+          <a href="{{ site.baseurl }}/how-it-works/revenues/"><h3 class="card-title">How does resource extraction result in federal revenue?</h3></a>
 
           <p>Companies that extract resources on federal land may pay bonuses, rents, royalties, fees, taxes, or other revenues to the federal government.</p>
 


### PR DESCRIPTION
Fixes #2872

[:cat: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/link-fix/)

Changes proposed in this pull request:

- Changes destination for link that's currently an infinite redirect
- Changes neighboring link to revenue page (instead of production section) to avoid redundancy
