### PR TITLE
Mostly fix up selectors

### DIFF
--- a/nrrd-design-system/components/_preview.hbs
+++ b/nrrd-design-system/components/_preview.hbs
@@ -5,6 +5,7 @@
     <link media="all" rel="stylesheet" href="{{ path '/css/main.css' }}">
     <link media="all" rel="stylesheet" href="{{ path '/css/components.css' }}">
     <link media="all" rel="stylesheet" href="{{ path '/css/styleguide.css' }}">
+    <script src="{{ path '/js/main.min.js' }}"></script>
     <title>asdf</title>
 </head>
 <body>
@@ -12,7 +13,6 @@
 <div class="preview">
   {{{ yield }}}
 </div>
-
-<script src="{{ path '/js/main.min.js' }}"></script>
+<script src="{{ path '/js/state-pages.min.js' }}"></script>
 </body>
 </html>

--- a/nrrd-design-system/components/components/selectors/selectors.config.yml
+++ b/nrrd-design-system/components/components/selectors/selectors.config.yml
@@ -1,5 +1,21 @@
 title: Selectors
 status: blocked
+context:
+  include:
+    default: A default value
+    nationwide: true
+    nationwide_url: nationwide.gov
+    nationwide_title: nationwide
+  site:
+    states:
+      - url: ak.gov
+        title: AK
+      - url: oh.gov
+        title: OH
+      - url: pa.gov
+        type: PA
+      - url: ca.gov
+        type: CA
 # collated: true
 # default: default
 # variants:

--- a/nrrd-design-system/components/components/selectors/selectors.hbs
+++ b/nrrd-design-system/components/components/selectors/selectors.hbs
@@ -28,7 +28,7 @@
      <option value="2007">2007</option>
     </select>
   </div>
-
+  {{site.baseurl}}
   <div class="container-left-4 container-margin">
     <label>State selector call to action:</label>
     <select
@@ -37,20 +37,15 @@
       onchange="window.location = '{{ site.baseurl }}' + this.value">
 
       {% if include.default %}
-        <option value="" disabled selected>{{ include.default }}</option>
+        <option value="" disabled="disabled" selected="selected">{{ include.default }}</option>
       {% endif %}
       {% if include.nationwide %}
         <option value="{{ include.nationwide_url }}">{{ include.nationwide_title }}</option>
       {% endif %}
       <optgroup label="States">
         {% for state in site.states %}
-        <option value="{{ state.url }}">{{ state.title }}</option>
-        {% endfor %}
-      </optgroup>
-      <optgroup label="Offshore Regions">
-        {% for region in site.offshore_regions %}
-        <option value="{{ region.url }}">{{ region.title }}</option>
-        {% endfor %}
+          <option value="{{ state.url }}">{{ state.title }}</option>
+        {% for %}
       </optgroup>
     </select>
   </div>


### PR DESCRIPTION
Fixes #2882

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/ab-styleguide-selectors/)

Changes proposed in this pull request:

- Alters obviously broken code in third selector. Keeps empty `state` `optgroup` because there isn't parity liquid templates and handlebars template logic

-  Add missing variables to selectors config.yml
- Some variables wont be displayed if we want the html to be
copy/pasteable

