### PR TITLE
Add tabs to style guide

### DIFF
--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -33,5 +33,5 @@
 
 .eiti-tab-panel {
   padding: 0;
-  border-top: 2px solid $gray-light
+  border-top: 2px solid $gray-light;
 }

--- a/_sass/components/_tabs.scss
+++ b/_sass/components/_tabs.scss
@@ -33,4 +33,5 @@
 
 .eiti-tab-panel {
   padding: 0;
+  border-top: 2px solid $gray-light
 }

--- a/nrrd-design-system/components/components/tabs/README.md
+++ b/nrrd-design-system/components/components/tabs/README.md
@@ -2,5 +2,8 @@ Tabs manage peer groups of content within one parent category. They create short
 
 ## Types of tabs:
 - `explore-subpage-tabs` are used to separate content grouped by year. Use when the tabs need  less emphasis in relation to other navigational elements, and there are few other filters in use.
+  - Used on [pages to explore federal revenue by company](https://revenuedata.doi.gov/how-it-works/federal-revenue-by-company/2016/)
 - `revenues_subpage-tabs` are used to separate large sections or whole pages of content
+  - Used on [revenue-process pages](https://revenuedata.doi.gov/how-it-works/offshore-oil-gas/) with diving graphics
 - `eiti-tabs` are used in tables to separate views of data within a page
+  - Used on national data pages for [revenue tables](https://revenuedata.doi.gov/explore/#revenue)

--- a/nrrd-design-system/components/components/tabs/README.md
+++ b/nrrd-design-system/components/components/tabs/README.md
@@ -1,0 +1,6 @@
+Tabs manage peer groups of content within one parent category. They create shorter pages, and give users the ability to view (and load) only the content group they need. Each tab button has a corresponding content section.
+
+## Types of tabs:
+- `explore-subpage-tabs` are used to separate content grouped by year. Use when the tabs need  less emphasis in relation to other navigational elements, and there are few other filters in use.
+- `revenues_subpage-tabs` are used to separate large sections or whole pages of content
+- `eiti-tabs` are used in tables to separate views of data within a page

--- a/nrrd-design-system/components/components/tabs/README.md
+++ b/nrrd-design-system/components/components/tabs/README.md
@@ -1,9 +1,3 @@
 Tabs manage peer groups of content within one parent category. They create shorter pages, and give users the ability to view (and load) only the content group they need. Each tab button has a corresponding content section.
 
-## Types of tabs:
-- `explore-subpage-tabs` are used to separate content grouped by year. Use when the tabs need  less emphasis in relation to other navigational elements, and there are few other filters in use.
-  - Used on [pages to explore federal revenue by company](https://revenuedata.doi.gov/how-it-works/federal-revenue-by-company/2016/)
-- `revenues_subpage-tabs` are used to separate large sections or whole pages of content
-  - Used on [revenue-process pages](https://revenuedata.doi.gov/how-it-works/offshore-oil-gas/) with diving graphics
-- `eiti-tabs` are used in tables to separate views of data within a page
-  - Used on national data pages for [revenue tables](https://revenuedata.doi.gov/explore/#revenue)
+Tabs are currently in use on national data pages for [revenue tables](https://revenuedata.doi.gov/explore/#revenue)

--- a/nrrd-design-system/components/components/tabs/tabs.config.yml
+++ b/nrrd-design-system/components/components/tabs/tabs.config.yml
@@ -1,0 +1,2 @@
+title: Tabs
+status: draft

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -1,5 +1,5 @@
 <div class="container-margin">
-  <div id="fee-summaries" class="tab-interface">
+  <div class="tab-interface">
 
     <ul class="eiti-tabs info-tabs" role="tablist">
       <li role="presentation"><a href="#first" tabindex="0" role="tab" aria-controls="first" aria-selected="true">Tab 1</a></li>

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -1,5 +1,5 @@
 <div class="container-margin">
-  
+
 <!-- Tab links -->
   <div class="tab-interface">
     <ul class="eiti-tabs info-tabs" role="tablist">
@@ -10,16 +10,16 @@
   </div>
 
 <!-- Tab content -->
-    <article class="eiti-tab-panel" id="first" role="tabpanel">
+    <div class="eiti-tab-panel" id="first" role="tabpanel">
       <h2>Content in first tab</h2>
-    </article>
+    </div>
 
-    <article class="eiti-tab-panel" id="second" role="tabpanel" aria-hidden="true">
+    <div class="eiti-tab-panel" id="second" role="tabpanel" aria-hidden="true">
       <h2>Content in second tab</h2>
-    </article>
+    </div>
 
-    <article class="eiti-tab-panel" id="third" role="tabpanel" aria-hidden="true">
+    <div class="eiti-tab-panel" id="third" role="tabpanel" aria-hidden="true">
       <h2>Content in third tab</h2>
-    </article>
+    </div>
 
 </div>

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -22,3 +22,33 @@
     </section>
   </section>
 </div>
+
+
+<div class="container-margin">
+    <section class="revenues_subpage-nav container">
+      <div class="revenues_subpage-tabs">
+        <ul>
+            <li class="revenues_subpage-tab active">
+              <a href="#">Offshore</a>
+            </li>
+            </a>
+            <li class="revenues_subpage-tab">
+              <a href="#">Onshore</a>
+            </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="slab-beta revenues_subpage-intro_wrapper">
+      <div class="container-page-wrapper revenues_subpage-intro">
+        <div class="container revenues_subpage-intro_layout">
+          <div>
+            <a class="revenues_subpage-breadcrumb" href="#">How it works</a>
+            /
+          </div>
+          <h1>Offshore Oil &amp; Gas</h1>
+          <p class="revenues_subpage-intro_text">The Outer Continental Shelf Lands Act (OCSLA) of 1953 grants the Secretary of the Department of the Interior (DOI) the authority to manage offshore energy resources and to develop regulations to carry out that authority. Three agencies within DOI — BOEM, BSEE, and ONRR — work together to manage, regulate, and collect revenue from 33 million leased acres across the <span class="term term-end" data-term="Outer Continental Shelf" title="Click to define" tabindex="0">Outer Continental Shelf<icon class="icon-book"></icon></span>.</p>
+        </div>
+      </div>
+    </section>
+</div>

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -1,0 +1,24 @@
+<!-- <div class="{{ className }}">{{ text }}</div> -->
+
+<div class="container-margin">
+  <section id="companies" data-year="2016" class="explore-subpage container container-margin">
+    <section class="explore-subpage-nav container">
+      <div class="explore-subpage-tabs">
+        <ul>
+          <li class="explore-subpage-tab">
+            <a href="/how-it-works/federal-revenue-by-company/2013/">2013</a>
+          </li>
+          <li class="explore-subpage-tab">
+            <a href="/how-it-works/federal-revenue-by-company/2014/">2014</a>
+          </li>
+          <li class="explore-subpage-tab">
+            <a href="/how-it-works/federal-revenue-by-company/2015/">2015</a>
+          </li>
+          <li class="explore-subpage-tab active">
+            <a href="/how-it-works/federal-revenue-by-company/2016/">2016</a>
+          </li>
+        </ul>
+      </div>
+    </section>
+  </section>
+</div>

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -1,12 +1,15 @@
 <div class="container-margin">
+  
+<!-- Tab links -->
   <div class="tab-interface">
-
     <ul class="eiti-tabs info-tabs" role="tablist">
       <li role="presentation"><a href="#first" tabindex="0" role="tab" aria-controls="first" aria-selected="true">Tab 1</a></li>
       <li role="presentation"><a href="#second" tabindex="-1" role="tab" aria-controls="second" class="link-charlie">Tab 2</a></li>
       <li role="presentation"><a href="#third" tabindex="-2" role="tab" aria-controls="third" class="link-charlie">Tab 3</a></li>
     </ul>
+  </div>
 
+<!-- Tab content -->
     <article class="eiti-tab-panel" id="first" role="tabpanel">
       <h2>Content in first tab</h2>
     </article>
@@ -19,5 +22,4 @@
       <h2>Content in third tab</h2>
     </article>
 
-  </div>
 </div>

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -1,34 +1,4 @@
 <div class="container-margin">
-    <section class="revenues_subpage-nav container">
-      <div class="revenues_subpage-tabs">
-        <ul>
-            <li class="revenues_subpage-tab active">
-              <a href="#">Offshore</a>
-            </li>
-            </a>
-            <li class="revenues_subpage-tab">
-              <a href="#">Onshore</a>
-            </li>
-        </ul>
-      </div>
-    </section>
-
-    <section class="slab-beta revenues_subpage-intro_wrapper">
-      <div class="container-page-wrapper revenues_subpage-intro">
-        <div class="container revenues_subpage-intro_layout">
-          <div>
-            <a class="revenues_subpage-breadcrumb" href="#">How it works</a>
-            /
-          </div>
-          <h1>Offshore Oil &amp; Gas</h1>
-          <p class="revenues_subpage-intro_text">The Outer Continental Shelf Lands Act (OCSLA) of 1953 grants the Secretary of the Department of the Interior (DOI) the authority to manage offshore energy resources and to develop regulations to carry out that authority. Three agencies within DOI — BOEM, BSEE, and ONRR — work together to manage, regulate, and collect revenue from 33 million leased acres across the <span class="term term-end" data-term="Outer Continental Shelf" title="Click to define" tabindex="0">Outer Continental Shelf<icon class="icon-book"></icon></span>.</p>
-        </div>
-      </div>
-    </section>
-</div>
-
-
-<div class="container-margin">
   <div id="fee-summaries" class="tab-interface">
 
     <ul class="eiti-tabs info-tabs" role="tablist">

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -2,36 +2,21 @@
   <div id="fee-summaries" class="tab-interface">
 
     <ul class="eiti-tabs info-tabs" role="tablist">
-      <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" class="link-charlie">Federal revenue by phase (CY 2017)</a></li>
-      <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" aria-selected="true">Revenue details by phase</a></li>
+      <li role="presentation"><a href="#first" tabindex="0" role="tab" aria-controls="first" aria-selected="true">Tab 1</a></li>
+      <li role="presentation"><a href="#second" tabindex="-1" role="tab" aria-controls="second" class="link-charlie">Tab 2</a></li>
+      <li role="presentation"><a href="#third" tabindex="-2" role="tab" aria-controls="third" class="link-charlie">Tab 3</a></li>
     </ul>
 
-    <article class="eiti-tab-panel" id="revenues" role="tabpanel" aria-hidden="true">
-      <table is="bar-chart-table" class="revenue table-arrow_box" id="revenue-types">
-        <thead>
-          <tr>
-            <th class="arrow_box"><span>Commodity</span></th>
-            <th class="arrow_box"><span>1. Securing rights</span></th>
-            <th class="arrow_box"><span>2. Before production</span></th>
-            <th class="arrow_box-last"><span>3. During production</span></th>
-            <th><span>Other revenue</span></th>
-          </tr>
-        </thead>
-      </table>
+    <article class="eiti-tab-panel" id="first" role="tabpanel">
+      <h2>Content in first tab</h2>
     </article>
 
-    <article class="eiti-tab-panel" id="story" role="tabpanel">
-      <table is="bar-chart-table" class="revenue table-arrow_box" id="revenue-process">
-        <thead>
-          <tr>
-            <th class="arrow_box"><span>Commodity</span></th>
-            <th class="arrow_box"><span>1. Securing rights</span>Companies pay bonuses or other fees to secure rights to resources on federal land</th>
-            <th class="arrow_box"><span>2. Before production</span>Companies pay rent on federal land while exploring for resources</th>
-            <th class="arrow_box-last"><span>3. During production</span>Companies pay royalties after production begins</th>
-            <th><span>Other revenue</span>Minimum or estimated royalties, settlements, and interest payments</th>
-          </tr>
-        </thead>
-      </table>
+    <article class="eiti-tab-panel" id="second" role="tabpanel" aria-hidden="true">
+      <h2>Content in second tab</h2>
+    </article>
+
+    <article class="eiti-tab-panel" id="third" role="tabpanel" aria-hidden="true">
+      <h2>Content in third tab</h2>
     </article>
 
   </div>

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -1,29 +1,3 @@
-<!-- <div class="{{ className }}">{{ text }}</div> -->
-
-<div class="container-margin">
-  <section id="companies" data-year="2016" class="explore-subpage container container-margin">
-    <section class="explore-subpage-nav container">
-      <div class="explore-subpage-tabs">
-        <ul>
-          <li class="explore-subpage-tab">
-            <a href="/how-it-works/federal-revenue-by-company/2013/">2013</a>
-          </li>
-          <li class="explore-subpage-tab">
-            <a href="/how-it-works/federal-revenue-by-company/2014/">2014</a>
-          </li>
-          <li class="explore-subpage-tab">
-            <a href="/how-it-works/federal-revenue-by-company/2015/">2015</a>
-          </li>
-          <li class="explore-subpage-tab active">
-            <a href="/how-it-works/federal-revenue-by-company/2016/">2016</a>
-          </li>
-        </ul>
-      </div>
-    </section>
-  </section>
-</div>
-
-
 <div class="container-margin">
     <section class="revenues_subpage-nav container">
       <div class="revenues_subpage-tabs">

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -52,3 +52,43 @@
       </div>
     </section>
 </div>
+
+
+<div class="container-margin">
+  <div id="fee-summaries" class="tab-interface">
+
+    <ul class="eiti-tabs info-tabs" role="tablist">
+      <li role="presentation"><a href="#revenues" tabindex="0" role="tab" aria-controls="revenues" class="link-charlie">Federal revenue by phase (CY 2017)</a></li>
+      <li role="presentation"><a href="#story" tabindex="-1" role="tab" aria-controls="story" aria-selected="true">Revenue details by phase</a></li>
+    </ul>
+
+    <article class="eiti-tab-panel" id="revenues" role="tabpanel" aria-hidden="true">
+      <table is="bar-chart-table" class="revenue table-arrow_box" id="revenue-types">
+        <thead>
+          <tr>
+            <th class="arrow_box"><span>Commodity</span></th>
+            <th class="arrow_box"><span>1. Securing rights</span></th>
+            <th class="arrow_box"><span>2. Before production</span></th>
+            <th class="arrow_box-last"><span>3. During production</span></th>
+            <th><span>Other revenue</span></th>
+          </tr>
+        </thead>
+      </table>
+    </article>
+
+    <article class="eiti-tab-panel" id="story" role="tabpanel">
+      <table is="bar-chart-table" class="revenue table-arrow_box" id="revenue-process">
+        <thead>
+          <tr>
+            <th class="arrow_box"><span>Commodity</span></th>
+            <th class="arrow_box"><span>1. Securing rights</span>Companies pay bonuses or other fees to secure rights to resources on federal land</th>
+            <th class="arrow_box"><span>2. Before production</span>Companies pay rent on federal land while exploring for resources</th>
+            <th class="arrow_box-last"><span>3. During production</span>Companies pay royalties after production begins</th>
+            <th><span>Other revenue</span>Minimum or estimated royalties, settlements, and interest payments</th>
+          </tr>
+        </thead>
+      </table>
+    </article>
+
+  </div>
+</div>

--- a/nrrd-design-system/components/components/tabs/tabs.hbs
+++ b/nrrd-design-system/components/components/tabs/tabs.hbs
@@ -1,3 +1,5 @@
+<script src="{{ path '/js/aria-tabs.js' }}"></script>
+
 <div class="container-margin">
 
 <!-- Tab links -->


### PR DESCRIPTION
Makes progress toward #2814

[📁PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/styleguide-tabs/styleguide/components/detail/tabs.html) 

Changes proposed in this pull request:

- Adds the three tab styles as components to the style guide
- Adds basic documentation on how each example is currently used.

Examples of these tabs on the live site and in the codebase:
- `explore-subpage-tabs`: https://revenuedata.doi.gov/how-it-works/federal-revenue-by-company/2016/
  - Code template: https://github.com/18F/doi-extractives-data/blob/dev/_includes/explore-subpage-tabs.html#L2
- `revenues_subpage-tabs`: https://revenuedata.doi.gov/how-it-works/offshore-oil-gas/
  - Code template: https://github.com/18F/doi-extractives-data/blob/dev/_how-it-works/the-process/offshore-oil-gas.html#L17
- `eiti-tabs`: https://revenuedata.doi.gov/explore/#federal-revenue
  - Code template: https://github.com/18F/doi-extractives-data/blob/dev/_includes/location/section-revenue.html#L47


I'm submitting this as a PR early hoping to get some feedback and help with using handlebars templates. In this work, I've added example components mostly by copy & pasting canonical example HTML, but other components use a more programmatic approach of filling in different classes and styles with handlebars. 

I'm not sure how to do that ☝️ but I'll also be OOO for the next two days and want to make sure I don't wait to ask for guidance. @el-mapache usually I'd love to pair with you through this, but given time this week, is it something you'd be up for taking a crack at? A possible strategy would be to branch from this branch and PR how you'd make handlebars work better here back to this PR? That keeps the learning opportunity, and lets the work continue while I'm out? Or other ideas?


