### PR TITLE
[WIP] Replaces duplicative page descriptions with variable references

### DIFF
--- a/_how-it-works/audits-and-assurances.md
+++ b/_how-it-works/audits-and-assurances.md
@@ -17,7 +17,7 @@ breadcrumb:
 selector: list
 ---
 
-> Data about revenue from the extractive industries is subject to a number of controls, standards, and regulations in the United States. Companies and governments are accountable to internal and external oversight that ensures correct reporting and publication of payments.
+> {{ page.description }}
 
 ## Tracking and verifying payments
 

--- a/_how-it-works/coal-excise-tax.md
+++ b/_how-it-works/coal-excise-tax.md
@@ -19,7 +19,7 @@ breadcrumb:
 selector: list
 ---
 
-In the United States, one of the taxes coal producers must pay is a federal excise tax when they mine coal. Producers pay the tax when the coal is first sold or used.[^1] The tax does not apply to lignite or to coal mined in the U.S. for export. Learn more about [how coal revenues work]({{ site.baseurl }}/how-it-works/coal/).
+> In the United States, one of the taxes coal producers must pay is a federal excise tax when they mine coal. Producers pay the tax when the coal is first sold or used.[^1] The tax does not apply to lignite or to coal mined in the U.S. for export. Learn more about [how coal revenues work]({{ site.baseurl }}/how-it-works/coal/).
 
 This tax originated in 1977 with the Black Lung Revenue Act. The excise tax is the chief source of revenue for the [Black Lung Program](https://www.dol.gov/owcp/dcmwc/) and Black Lung Disability Trust Fund (BLDTF), which pays benefits to miners disabled by black lung disease, as well as their eligible survivors and dependents.[^2]
 

--- a/_how-it-works/corporate-income-tax.md
+++ b/_how-it-works/corporate-income-tax.md
@@ -28,7 +28,7 @@ selector: list
 
 
 
-> Due to U.S. law, information about companies’ individual income tax payments is confidential. However, there are two key sources of publicly available information about federal income taxes for the extractive industries: the government and the filings of companies that are publicly listed.
+> {{ page.description }}
 
 {% include selector.html %}
 

--- a/_how-it-works/forestry.md
+++ b/_how-it-works/forestry.md
@@ -12,7 +12,7 @@ nav_items:
     title: Production
   - name: revenue
     title: Revenue
-description: The United States is home to many different natural resources, including fossil fuel, renewable energy, and nonenergy mineral resources (such as gold, copper, and iron). Since the 19th century, natural resource extraction has been a major industry in the U.S., with fluctuations over time.
+description: Forests are an important part of our ecosystems. They provide timber, store carbon, clean water, purify air, and reduce the effects of drought and floods. In the U.S., forests cover 766 million acres of land. The greatest concentrations of forests are in the South and Northeast, but Alaska has the largest total forest area of any state.
 tag:
 - how it works
 - production
@@ -23,7 +23,7 @@ title_display: Forestry
 selector: list
 ---
 
-Forests are an important part of our ecosystems. They provide timber, store carbon, clean water, purify air, and reduce the effects of drought and floods. In the U.S., forests cover 766 million acres of land. The greatest concentrations of forests are in the South and Northeast, but Alaska has the largest total forest area of any state.
+> {{ page.description }}
 
 ## Ownership and governance
 

--- a/_how-it-works/fossil-fuels.md
+++ b/_how-it-works/fossil-fuels.md
@@ -14,7 +14,7 @@ nav_items:
     title: Gas
   - name: coal
     title: Coal
-description: The United States is home to many different natural resources, including fossil fuel, renewable energy, and nonenergy mineral resources (such as gold, copper, and iron). Since the 19th century, natural resource extraction has been a major industry in the U.S., with fluctuations over time.
+description: Fossil fuels are our main source of electricity and the primary fuel for powering motor vehicles and heating homes. Fossil fuels are used to make many products. Through natural processes over hundreds of millions of years, plant and animal matter becomes energy resources in the form of oil, gas, and coal. While fossil fuels are abundant, they are not renewable.
 tag:
 - how it works
 - production
@@ -29,7 +29,7 @@ title_display: Fossil fuels
 selector: list
 ---
 
-> Fossil fuels are our main source of electricity, and the primary fuel for powering motor vehicles and heating homes. Fossil fuels are used to make many products. Through natural processes over hundreds of millions of years, plant and animal matter becomes energy resources in the form of oil, gas, and coal. While fossil fuels are abundant, they are not renewable. [Explore production data.]({{ site.baseurl }}/explore/#production)
+> {{ page.description }} [Explore production data.]({{ site.baseurl }}/explore/#production)
 
 {% include selector.html %}
 

--- a/_how-it-works/laws-and-regulations/federal-laws.md
+++ b/_how-it-works/laws-and-regulations/federal-laws.md
@@ -28,7 +28,7 @@ title_display: Federal laws and regulations
 selector: list
 ---
 
-> The legislative branch of the federal government has passed many laws that govern natural resource extraction on federal lands.
+> {{ page.description }}
 
 
 {% include selector.html %}

--- a/_how-it-works/laws-and-regulations/federal-reforms.md
+++ b/_how-it-works/laws-and-regulations/federal-reforms.md
@@ -16,7 +16,7 @@ nav_items:
     title: Proposed rules
   - name: dodd-frank
     title: 2010 Dodd–Frank Act
-description: The federal government reforms laws and regulations by enacting new legislation and proposing new rules to implement the legislation. Reforms can stem from government oversight organizations’ recommendations, including from both DOI’s Office of Inspector General and the Government Accountability Office. Below are reforms following the Deep Water Horizon oil spill, recent findings from government oversight organizations, and proposed rules.
+description: The federal government reforms laws and regulations by enacting new legislation and proposing new rules to implement the legislation. Reforms are recommended by oversight organizations, such as the Inspector General or the Government Accountability Office.
 tag:
 - How it works
 - Federal reforms
@@ -31,7 +31,7 @@ title_display: Federal reforms
 selector: list
 ---
 
-> The federal government reforms laws and regulations by enacting new legislation and proposing new rules to implement the legislation. Reforms can stem from government oversight organizations’ recommendations, including from both DOI’s Office of Inspector General and the Government Accountability Office. Below are reforms following the Deep Water Horizon oil spill, recent findings from government oversight organizations, and proposed rules.
+> {{ page.description }}
 
 {% include selector.html %}
 

--- a/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
+++ b/_how-it-works/laws-and-regulations/state-laws-and-regulations.md
@@ -16,7 +16,7 @@ nav_items:
     title: Revenue disbursements
   - name: natural-resource-trust-funds
     title: Natural resource trust funds
-description: States maintain ownership of some lands and natural resources; develop their own taxation and royalty systems applicable to oil, gas, nonenergy minerals, and renewable energy; and collect extractive revenue directly. Each state has a unique revenue system.
+description: States maintain ownership of some lands and natural resources and develop their own taxation and royalty systems for oil, gas, nonenergy minerals, and renewable energy. States collect extractive revenue directly. Each state has a unique revenue system.
 tag:
 - How it works
 - State laws and regulations
@@ -32,7 +32,7 @@ selector: list
 redirect_from: /how-it-works/state-legal-fiscal-info/
 ---
 
-> States maintain ownership of some lands and natural resources; develop their own taxation and royalty systems applicable to oil, gas, nonenergy minerals, and renewable energy; and collect extractive revenue directly. Each state has a unique revenue system.
+> {{ page.description }}
 
 {% include selector.html %}
 

--- a/_how-it-works/lease-process-offshore.md
+++ b/_how-it-works/lease-process-offshore.md
@@ -29,7 +29,7 @@ breadcrumb:
 selector: list
 ---
 
-> The Bureau of Ocean Energy Management (BOEM) manages leases for offshore energy production. BOEM manages approximately 1.7 billion acres containing about 8,000 active leases. These leases generally account for about 7% of America’s domestic natural gas production and about 24% of America’s domestic oil production.
+> {{ page.description }}
 
 {% include selector.html %}
 

--- a/_how-it-works/lease-process-onshore.md
+++ b/_how-it-works/lease-process-onshore.md
@@ -28,7 +28,7 @@ breadcrumb:
 selector: list
 ---
 
-> Bureau of Land Management (BLM) field offices award leases on designated lands for oil and gas resources. Leases are auctioned live and open to the public. Before the live auction, the BLM field office estimates the fair market value for the natural resources in question.
+> {{ page.description }}
 
 {% include selector.html %}
 

--- a/_how-it-works/natural-resources/ownership.md
+++ b/_how-it-works/natural-resources/ownership.md
@@ -22,7 +22,7 @@ nav_items:
     subnav_items:
       - name: split-ownership
         title: Split ownership
-description: Natural resource ownership in the United States is closely tied to land ownership. We'll talk about both these types of ownership here.
+description: Natural resource ownership in the United States is closely tied to land ownership.
 tag:
 - how it works
 - land ownership
@@ -39,7 +39,7 @@ title_display: Ownership
 selector: list
 ---
 
-> Natural resource ownership in the United States is closely tied to land ownership. We'll talk about both these types of ownership here.
+> {{ page.description }}
 
 {% include selector.html %}
 

--- a/_how-it-works/natural-resources/revenues.md
+++ b/_how-it-works/natural-resources/revenues.md
@@ -18,7 +18,7 @@ nav_items:
     title: Tax expenditures
   - name: federal-budget-process
     title: Federal budget process
-description: Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The amounts differ depending on what the ownership of the natural resource looks like. We'll cover some of the major types of payments companies make here. They are usually called &#8216;revenue&#8217; because they represent revenue to the American public.
+description: Companies pay a wide range of fees, rates, and taxes to extract natural resources in the U.S. The amounts differ depending on the ownership of the resources. We'll cover some of the major types of payments companies make here. They are usually called &#8216;revenue&#8217; because they represent revenue to the American public.
 tag:
 - how it works
 - revenues
@@ -35,7 +35,7 @@ title_display: Revenues
 selector: list
 ---
 
-> Companies pay a wide range of fees, rates and taxes to extract natural resources in the U.S. The amounts differ depending on what the [ownership]({{ site.baseurl }}/how-it-works/ownership/) of the natural resource looks like. We'll cover some of the major types of payments companies make here. They are usually called &#8216;revenue&#8217; because they represent revenue to the American public.
+> {{ page.description }}
 
 {% include selector.html %}
 

--- a/_how-it-works/nonenergy-minerals.md
+++ b/_how-it-works/nonenergy-minerals.md
@@ -22,7 +22,7 @@ nav_items:
     title: Silver
   - name: molybdenum
     title: Molybdenum
-description: The United States is home to many different natural resources, including fossil fuel, renewable energy", and nonenergy mineral resources (such as gold, copper, and iron). Since the 19th century, natural resource extraction has been a major industry in the U.S., with fluctuations over time.
+description: Nonenergy minerals include base and precious metals, industrial metals, and gemstones, among others. Gold, copper, iron, and zinc are the principal contributors to metal mine production.
 tag:
 - how it works
 - production
@@ -41,7 +41,7 @@ title_display: Nonenergy minerals
 selector: list
 ---
 
-> Nonenergy minerals include base and precious metals, industrial metals, and gemstones, among others. Gold, copper, iron, and zinc are the principal contributors to metal mine production. [Explore production data.]({{ site.baseurl }}/explore/#production)
+> {{ page.description }} [Explore production data.]({{ site.baseurl }}/explore/#production)
 
 {% include selector.html %}
 ### Gold

--- a/_how-it-works/renewables.md
+++ b/_how-it-works/renewables.md
@@ -18,7 +18,7 @@ nav_items:
     title: Hydroelectric energy
   - name: biomass
     title: Biomass     
-description: The United States is home to many different natural resources, including fossil fuel, renewable energy", and nonenergy mineral resources (such as gold, copper, and iron). Since the 19th century, natural resource extraction has been a major industry in the U.S., with fluctuations over time.
+description: Renewable energy comes from sources that are not depleted when used. These resources include geothermal, solar, wind, water, and biomass. All constitute growing sources of environmentally sustainable energy to meet the country’s electricity needs.
 tag:
 - how it works
 - production
@@ -34,7 +34,7 @@ title_display: Renewables
 selector: list
 ---
 
-> Renewable energy comes from sources that are not depleted when used. These resources include geothermal, solar, wind, water, and biomass. All constitute growing sources of environmentally sustainable energy to meet the country’s electricity needs. [Explore production data.]({{ site.baseurl }}/explore/#production)
+> {{ page.description }} [Explore production data.]({{ site.baseurl }}/explore/#production)
 
 {% include selector.html %}
 

--- a/_how-it-works/tribal-economic-impact.md
+++ b/_how-it-works/tribal-economic-impact.md
@@ -28,7 +28,7 @@ title_display: Impact of natural resource extraction on tribal land
 selector: list
 ---
 
-> Extraction affects tribal economies in a number of ways, though the effects can vary widely depending on the level of extraction on a given reservation and the details of the lease agreement.
+> {{ page.description }}
 
 {% include selector.html %}
 

--- a/_how-it-works/tribal-ownership-and-governance.md
+++ b/_how-it-works/tribal-ownership-and-governance.md
@@ -25,7 +25,7 @@ nav_items:
         title: Indian Mineral Development Act of 1982
       - name: tribal-energy-development--self-determination-act-of-2005
         title: Tribal Energy Development & Self-Determination Act of 2005
-description: Native American land ownership involves a complex patchwork of titles, restrictions, obligations, statutes, and regulations. Extracting natural resources on Indian lands and distributing the associated revenue necessitates the use of unique processes involving multiple stakeholders.
+description: Native American land ownership involves a complex patchwork of titles, restrictions, obligations, statutes, and regulations. Extracting natural resources on Indian lands and distributing the associated revenue is a unique processes involving multiple stakeholders.
 tag:
 - how it works
 - production
@@ -41,20 +41,18 @@ title_display: Tribal ownership and governance of natural resources
 selector: list
 ---
 
-> The federal government formally recognizes 567 Indian Tribes and Alaska Native Villages. {{ "Indian lands" | term }} have [significant natural resource extraction potential (PDF)](http://www.resourcegovernance.org/sites/default/files/RWI_Native_American_Lands_2011.pdf), containing up to 30% of coal reserves west of the Mississippi, 50% of potential uranium reserves, and 20% of known oil and gas reserves.
+> {{ page.description }}
 
 {% include selector.html %}
 
 ## Land ownership
 
-Ownership of {{ "Indian lands" | term }} involves a complex patchwork of titles, restrictions, obligations, statutes, and regulations.
-
-Today, there are [two major types of Indian land](http://teeic.indianaffairs.gov/triballand/):
+Today, there are two major types of Indian land:
 
 * {{ "Trust land" | term_end }}, in which the federal government holds legal title, but the beneficial interest remains with individual or tribe. Trust lands held on behalf of individuals are known as allotments.
 * Fee land purchased by tribes, in which the tribe acquires legal title under specific statutory authority.
 
-In general, most Indian lands are {{ "trust land" | term_end }}. Approximately [56 million acres of land (PDF)](http://www.blm.gov/public_land_statistics/pls13/pls2013.pdf) are held in trust by the United States for various Indian tribes and individuals.
+In general, most Indian lands are {{ "trust land" | term_end }}. Approximately [56 million acres of land (PDF)](https://www.blm.gov/about/data/public-land-statistics) are held in trust by the United States for various Indian tribes and individuals.
 
 ## Natural resource ownership
 

--- a/_how-it-works/tribal-production.md
+++ b/_how-it-works/tribal-production.md
@@ -19,7 +19,7 @@ nav_items:
     title: Renewable energy
   - name: production-on-indian-land
     title: Production on Indian land
-description: Native American land ownership involves a complex patchwork of titles, restrictions, obligations, statutes, and regulations. Extracting natural resources on Indian lands and distributing the associated revenue necessitates the use of unique processes involving multiple stakeholders.
+description: Extracting natural resources on Indian lands and distributing the associated revenue is a unique process involving multiple stakeholders.
 tag:
 - how it works
 - production
@@ -35,7 +35,7 @@ title_display: Natural resource production on tribal land
 selector: list
 ---
 
-> Extracting natural resources on {{ "Indian lands" | term }} and distributing the associated revenue necessitates the use of unique processes involving multiple stakeholders.
+> {{ page.description }}
 
 {% include selector.html %}
 

--- a/_how-it-works/tribal-revenue.md
+++ b/_how-it-works/tribal-revenue.md
@@ -38,7 +38,7 @@ revenue_types:
 {% assign disbursements = site.data.federal_disbursements.US["American Indian Tribes"].All %}
 {% assign disbursement_year = site.data.years.disbursements | to_s | default: default_year %}
 
-> Natural resources are increasingly a key source of income for many Native American tribes. In {{ disbursement_year }}, {{ "ONRR" | term }} and {{ "OST" | term }} disbursed {{ disbursements[disbursement_year] | round | intcomma_dollar }} to tribes and allottees.
+> {{ page.description }} In {{ disbursement_year }}, {{ "ONRR" | term }} and {{ "OST" | term }} disbursed {{ disbursements[disbursement_year] | round | intcomma_dollar }} to tribes and allottees.
 
 {% include selector.html %}
 


### PR DESCRIPTION
Fixes #2886 and #2874 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/description-variable/)

Changes proposed in this pull request:

- Many of our markdown pages have a front-matter description that is repeated verbatim in the body copy in the form of a `blockquote` intro. Instead of maintaining the content in two places, these commits replace the body content with a variable reference that pulls in the front-matter description.
