### PR TITLE
Apply consistent icon styling to offshore maps

### DIFF
--- a/_includes/offshore-area-map.html
+++ b/_includes/offshore-area-map.html
@@ -111,13 +111,13 @@
           aria-controls="{{ include.toggle }}"
           aria-expanded="false">
             <span class="hide-expanded">
-              <i class="icon icon-plus-sm"></i>
+                <img class="aria-toggle-icon" alt="icon with a plus sign" src="{{ site.baseurl }}/public/img/icons/icon-circled-plus.svg"/>
               {% if include.toggle_text %}
                 {{ include.toggle_text_hidden }}
               {% else %}Show table{% endif %}
             </span>
             <span class="show-expanded">
-              <i class="icon icon-dash-sm"></i>
+              <img class="aria-toggle-icon" alt="icon with a minus sign" src="{{ site.baseurl }}/public/img/icons/icon-circled-minus.svg"/>
               {% if include.toggle_text %}
                 {{ include.toggle_text_visible }}
               {% else %}Hide table{% endif %}
@@ -152,13 +152,13 @@
       aria-controls="{{ include.toggle }}"
       aria-expanded="false">
         <span class="hide-expanded">
-          <i class="icon icon-plus-sm"></i>
+          <img class="aria-toggle-icon" alt="icon with a plus sign" src="{{ site.baseurl }}/public/img/icons/icon-circled-plus.svg"/>
           {% if include.toggle_text %}
             {{ include.toggle_text_hidden }}
           {% else %}Show table{% endif %}
         </span>
         <span class="show-expanded">
-          <i class="icon icon-dash-sm"></i>
+          <img class="aria-toggle-icon" alt="icon with a minus sign" src="{{ site.baseurl }}/public/img/icons/icon-circled-minus.svg"/>
           {% if include.toggle_text %}
             {{ include.toggle_text_visible }}
           {% else %}Hide table{% endif %}


### PR DESCRIPTION
Fixes #2915 

[:shipit: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/offshore-button-icon/)

Changes proposed in this pull request:

- Offshore area maps use a different template partial than their county-map siblings
  - For this reason, they did not inherit the icon styling we applied
  - Replaces legacy icon styling for offshore maps with SVG circle-icon style

## Current
![old offshore icon style](https://user-images.githubusercontent.com/32855580/40864145-7685788a-65a7-11e8-8eb2-d08c15ae7352.png)

## Proposed
![new offshore icon style](https://user-images.githubusercontent.com/32855580/40864162-91926b9c-65a7-11e8-843c-6bbfb9f09985.png)

