### PR TITLE
Add icon style documentation and resources to style guide

### DIFF
--- a/nrrd-design-system/components/components/icons/README.md
+++ b/nrrd-design-system/components/components/icons/README.md
@@ -1,1 +1,18 @@
-Icons are embedded in a custom "eiti.eot" webfont, and render at 1 rem by default. Down the road, it may better to convert all of the site icons to svg files, for improved performance and flexibility. This [github issue](https://github.com/18F/doi-extractives-data/issues/2284) tracks progress toward that goal.
+## Icon styles
+Many of the site’s icons are from different contributors on [The Noun Project](https://thenounproject.com/), and are used under a Creative Commons license with attribution in the [`humans.txt`](https://github.com/18F/doi-extractives-data/blob/dev/humans.txt) file. Others are designed from scratch.
+
+Even though they are from different sets and artists, they share common style attributes. When picking or building new icons, make sure to match these characteristics:
+ - highly rounded corners
+ - default style uses heavy outlines, unfilled solid interior spaces
+ - if shapes overlap in space, lines leave a gap where they meet instead of intersecting (`.icon-cloud`, `.icon-wind`, `.icon-coal`, `.icon-copper` )
+
+## Creating new icons
+For finding or building new icons in the future, the following resources match icon characteristics used on the NRRD site. Each example is from an open source icon set, but specific licenses differ for each. After you've picked a new icon, be sure to add citations for it to [`humans.txt`](https://github.com/18F/doi-extractives-data/blob/humans-txt/humans.txt)
+
+ - Font Awesome, [regular style, free collection](https://fontawesome.com/icons?d=gallery&s=regular&m=free).
+     - Select an [individual icon](https://fontawesome.com/icons/address-book?style=regular) to download it as an SVG
+     - [License](https://fontawesome.com/license?from=io)
+ - The [Consumer Financial Protection Bureau’s icons](https://thenounproject.com/cfpb_minicons/uploads/) on the Noun Project
+ - [Feather icons](https://feathericons.com/)
+     - [MIT License](https://github.com/feathericons/feather/blob/master/LICENSE)
+     - [GitHib repository](https://github.com/feathericons/feather)  


### PR DESCRIPTION
Fixes #2894 

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/icon-guidance/styleguide/components/detail/icons.html)

**Changes proposed in this pull request:**
- Adds notes about icon styles 
- Adds list of possible open source resources for finding and creating new icons in the future that match the existing style 

