### PR TITLE
Repairs link path for placeholder image in style guide

### DIFF
--- a/nrrd-design-system/components/layouts/basic-text-page/basic-text-page.hbs
+++ b/nrrd-design-system/components/layouts/basic-text-page/basic-text-page.hbs
@@ -46,7 +46,7 @@
       <div class="bureaus">
         <article class="bureau">
           <div class="bureau-left">
-            <img class="bureau-image" src="/img/placeholder.png" alt="description">
+            <img class="bureau-image" src="../../img/placeholder.png" alt="description">
           </div>
           <div class="bureau-right">
             <h4>Subsection title</h4>


### PR DESCRIPTION
Fixes #2877 

[ 🖼 PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/repair-image-path/styleguide/components/detail/basic-text-page.html)

Changes proposed in this pull request:

- Previously, the image path was incomplete, resulting in a broken image link. This points it to the right directory so that the image displays as intended.
